### PR TITLE
Route models by harness namespace, not a curated allow-list

### DIFF
--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -59,8 +59,14 @@ class Harness(ABC):
     name: str
     # Harness identity + shipped config, the seed source for the per-harness
     # ``HarnessSettings`` row the operator then tunes. Subclasses set provider,
-    # models and default_model; effort/timeout default to the shipped values.
+    # model_prefixes, models and default_model; effort/timeout default to the
+    # shipped values.
     provider: ClassVar[str]
+    # The model-name namespaces this harness runs — a model routes to the harness
+    # that owns its namespace, so a new model in a known one runs with no release.
+    model_prefixes: ClassVar[tuple[str, ...]]
+    # Suggested models for the settings picker and the ``default_model`` seed —
+    # advisory: any string in a matching namespace runs.
     models: ClassVar[tuple[str, ...]]
     default_model: ClassVar[str]
     default_effort: ClassVar[str] = "high"
@@ -69,6 +75,12 @@ class Harness(ABC):
     REFRESH_MARGIN: timedelta
     _TOKEN_URL: str
     _CLIENT_ID: str
+
+    @classmethod
+    def has_model(cls, model: str) -> bool:
+        """Whether ``model`` runs on this harness — matched by name namespace, so
+        a new model in a known namespace routes with no release."""
+        return model == cls.name or model.startswith(cls.model_prefixes)
 
     def __init__(
         self,

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -36,6 +36,7 @@ class ClaudeHarness(Harness):
     # (``--output-format stream-json``), so the transcript is the stdout.
     name = "claude"
     provider = "anthropic"
+    model_prefixes = ("claude-",)
     models = ("claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5")
     default_model = "claude-opus-4-7"
     command = "claude"

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -271,6 +271,7 @@ class CodexHarness(Harness):
     # symmetric with claude. session.jsonl is still snapshotted for cost.
     name = "codex"
     provider = "openai"
+    model_prefixes = ("gpt-", "o1", "o3", "o4")
     models = ("gpt-5.5",)
     default_model = "gpt-5.5"
     command = "codex"

--- a/backend/druks/harnesses/registry.py
+++ b/backend/druks/harnesses/registry.py
@@ -1,4 +1,5 @@
 from .base import Harness
+from .exceptions import HarnessError
 
 
 def get_harnesses() -> tuple[type[Harness], ...]:
@@ -9,15 +10,10 @@ def get_harnesses() -> tuple[type[Harness], ...]:
 
 
 def get_harness_for_model(model: str) -> type[Harness]:
-    """The harness class that runs ``model``."""
+    """The harness that runs ``model``, matched by name namespace — a model in a
+    known namespace routes even if it postdates this release. A miss means no
+    installed harness owns its namespace."""
     for harness in get_harnesses():
-        if model in harness.models:
+        if harness.has_model(model):
             return harness
-    # Models are registry-validated on write (allowed_models is the union), so a
-    # miss is a real bug — a stale override or a model dropped from a harness —
-    # not something to paper over by silently running it on the wrong CLI.
-    raise ValueError(f"no registered harness handles model {model!r}")
-
-
-def allowed_models() -> tuple[str, ...]:
-    return tuple(model for harness in get_harnesses() for model in harness.models)
+    raise HarnessError(f"no harness runs model {model!r}")

--- a/backend/druks/user_settings/routes.py
+++ b/backend/druks/user_settings/routes.py
@@ -7,7 +7,7 @@ from druks.extensions.loader import iter_extensions
 from druks.extensions.registry import workflows
 from druks.harnesses.exceptions import LoginError
 from druks.harnesses.models import HarnessLogin
-from druks.harnesses.registry import allowed_models, get_harnesses
+from druks.harnesses.registry import get_harnesses
 from druks.notifications.models import Destination
 
 from . import reads
@@ -58,10 +58,10 @@ async def list_harness_settings() -> list[HarnessResponse]:
 async def update_harness_settings(name: str, body: HarnessUpdate) -> HarnessResponse:
     harness, row = _resolve_harness(name)
     updates = body.model_dump(exclude_unset=True, by_alias=False)
-    if "model" in updates and updates["model"] not in harness.models:
+    if "model" in updates and not harness.has_model(updates["model"]):
         raise HTTPException(
             status_code=422,
-            detail=f"Unknown model {updates['model']!r}. Allowed: {list(harness.models)}",
+            detail=f"{updates['model']!r} is not a {harness.name} model.",
         )
     _validate_effort(updates.get("effort"))
     _validate_timeout(updates.get("timeout"))
@@ -130,19 +130,19 @@ async def update_user_settings(
 async def get_extension_settings() -> ExtensionsSettingsResponse:
     projected = (reads.get_extension_settings(m) for m in iter_extensions())
     return ExtensionsSettingsResponse(
-        allowed_models=list(allowed_models()),
         allowed_efforts=list(ALLOWED_EFFORTS),
         extensions=[out for out in projected if out.agents or out.workflows or out.settings],
     )
 
 
-# The agent knobs have no Settings model to round-trip through — their allowed
-# values come from the harness registry — so the boundary validates them here.
+# An agent's model override is client data — reject a model no installed harness
+# can run (nothing owns its namespace). A model new to a known namespace passes,
+# so new models need no release.
 def _validate_model(value: str | None) -> None:
-    if value is not None and value not in allowed_models():
+    if value is not None and not any(harness.has_model(value) for harness in get_harnesses()):
         raise HTTPException(
             status_code=422,
-            detail=f"Unknown model {value!r}. Allowed: {list(allowed_models())}",
+            detail=f"No installed harness runs model {value!r}.",
         )
 
 

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -140,7 +140,6 @@ class ExtensionSettingsResponse(BaseResponse):
 
 
 class ExtensionsSettingsResponse(BaseResponse):
-    allowed_models: list[str]
     allowed_efforts: list[str]
     extensions: list[ExtensionSettingsResponse]
 

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -364,12 +364,13 @@ def test_extensions_clearing_an_override_reverts_to_the_family_default(tmp_path:
 
 def test_extensions_reject_unknown_agent_model(tmp_path: Path):
     with _build_client(tmp_path) as client:
+        # No installed harness owns this namespace, so nothing could run it.
         response = client.patch(
             "/api/settings/extensions",
-            json={"agentModels": {"implement": "gpt-9-imaginary"}},
+            json={"agentModels": {"implement": "llama-3-70b"}},
         )
     assert response.status_code == 422
-    assert "gpt-9-imaginary" in response.json()["detail"]
+    assert "llama-3-70b" in response.json()["detail"]
 
 
 def test_extensions_override_workflow_setting_persists(tmp_path: Path):

--- a/backend/tests/test_harness_model_routing.py
+++ b/backend/tests/test_harness_model_routing.py
@@ -1,0 +1,23 @@
+import pytest
+from druks.harnesses.claude import ClaudeHarness
+from druks.harnesses.codex import CodexHarness
+from druks.harnesses.exceptions import HarnessError
+from druks.harnesses.registry import get_harness_for_model
+
+
+def test_new_model_in_known_namespace_routes_without_a_release():
+    # Models absent from the shipped ``models`` tuples still route by namespace,
+    # so a provider's new model runs the day it ships.
+    assert get_harness_for_model("claude-opus-5") is ClaudeHarness
+    assert get_harness_for_model("gpt-6") is CodexHarness
+    assert get_harness_for_model("o4-mini") is CodexHarness
+
+
+def test_family_token_routes_to_its_harness():
+    assert get_harness_for_model("claude") is ClaudeHarness
+    assert get_harness_for_model("codex") is CodexHarness
+
+
+def test_unroutable_model_raises():
+    with pytest.raises(HarnessError):
+        get_harness_for_model("llama-3-70b")

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -178,7 +178,8 @@ export interface DashboardHealth {
 export type AgentEffort = 'low' | 'medium' | 'high'
 
 /** One coding-agent harness's operator config — a DB record seeded from the
- * registry. `allowedModels` are the models this harness can run. */
+ * registry. `allowedModels` are the harness's suggested models for the picker —
+ * advisory, not a gate; any model in the harness's namespace runs. */
 export interface Harness {
   name: string
   provider: string
@@ -271,7 +272,6 @@ export interface ExtensionSettings {
 }
 
 export interface ExtensionsSettingsResponse {
-  allowedModels: string[]
   allowedEfforts: string[]
   extensions: ExtensionSettings[]
 }
@@ -365,27 +365,7 @@ export interface UsageTodayResponse {
   harnesses: UsageHarnessToday[]
 }
 
-// Family membership lists — kept for typing + the rare callsite
-// that needs to know which family a model lives in (the backend's
-// harness factory does the actual dispatch). Stay in lockstep with
-// the backend's matching tuples.
-export const ALLOWED_CODEX_MODELS: readonly string[] = ['gpt-5.5']
-export const ALLOWED_CLAUDE_MODELS: readonly string[] = [
-  'claude-opus-4-7',
-  'claude-sonnet-4-6',
-  'claude-haiku-4-5',
-]
 export const ALLOWED_EFFORTS: readonly AgentEffort[] = ['low', 'medium', 'high']
-// Single allow-list for every per-slot / per-op model knob. Every
-// model selector in the Settings modal renders from this — operator
-// picks any Claude or Codex model for any role. The two
-// family-default knobs (``codex_model`` / ``claude_model``) still
-// constrain to their respective family because their names commit
-// to a family.
-export const ALLOWED_MODELS: readonly string[] = [
-  ...ALLOWED_CLAUDE_MODELS,
-  ...ALLOWED_CODEX_MODELS,
-]
 
 export interface Skill {
   name: string


### PR DESCRIPTION
## Why

Adding any new model — a new Claude or Codex release — currently means editing hardcoded `models` tuples on each harness and cutting a druks release. Codex CLI never does this: it passes the model string through and routes by provider, so a new model works the day it ships. This does the same.

## What

- **Routing is by name namespace, not a list.** Each harness declares `model_prefixes`; `Harness.has_model(model)` matches on them (or the family token). `get_harness_for_model` uses it, so `claude-opus-5` / `gpt-6` route with no code change.
- **`models` demotes from allow-list → picker suggestions** (advisory). The `HarnessResponse.allowedModels` the settings UI renders is unchanged, so the dropdowns keep working.
- **Write-boundary validation stays, as namespace checks** (client data, trust boundary): a harness row's model must be in its *own* namespace (no `gpt-5.5` on the claude row), and an agent override must be runnable by *some* installed harness (else it 500s the settings read). Neither is a curated list — a new in-namespace model passes.
- **Deletions:** the unused `ExtensionsSettingsResponse.allowed_models` union + its registry function, and the dead frontend `ALLOWED_*_MODELS` constants (zero consumers).
- `get_harness_for_model` now raises the typed `HarnessError` (was `ValueError`).

## Not in this PR

The settings model pickers are still suggestion dropdowns — the new-model-without-release path is via the settings API / config (like codex's `config.toml`), not free-text in the UI yet. A free-text combobox is an easy follow-up if wanted.

## Verification

- `ruff check backend` clean; frontend `tsc -b` + `eslint` clean.
- New `test_harness_model_routing.py` covers namespace routing, the family token, and the unroutable-model raise.
- DB-backed settings tests (incl. the two adjusted coherence tests) gate via CI per the shared-DB convention.

The one line that'd ever need touching for a *brand-new* provider namespace: `CodexHarness.model_prefixes` / `ClaudeHarness.model_prefixes`.
