### PR TITLE
Generalize MCP servers from one bearer token to N declared headers

### DIFF
--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, ClassVar
 import httpx
 
 from druks.mcp import models as mcp_models
-from druks.mcp.constants import get_bearer_token_env_var
+from druks.mcp.helpers import get_bearer_token_env_var
 from druks.redis import get_client
 from druks.skills.models import Skill
 from druks.usage.models import UsageScrape

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -156,23 +156,23 @@ class ClaudeHarness(Harness):
 
     def _mcp_flags(self, servers: tuple[McpServer, ...]) -> tuple[str, ...]:
         """``--mcp-config`` JSON registering each MCP server for this run.
-        Claude expands ``${VAR}`` in the auth header from the run env at
-        connect time, so the bearer token never lands in the emitted config."""
+        Claude expands ``${VAR}`` refs in header values from the run env at
+        connect time, so no secret — the bearer or a secret header — ever
+        lands in the emitted config; only non-secret values ride inline."""
         if not servers:
             return ()
-        config = {
-            "mcpServers": {
-                server.name: {
-                    "type": "http",
-                    "url": server.url,
-                    "headers": {
-                        "Authorization": f"Bearer ${{{server.bearer_token_env_var}}}",
-                    },
-                }
-                for server in servers
-            }
-        }
-        return ("--mcp-config", json.dumps(config))
+        entries = {}
+        for server in servers:
+            headers = dict(server.headers)
+            if server.bearer_token_env_var:
+                headers["Authorization"] = f"Bearer ${{{server.bearer_token_env_var}}}"
+            for header, env_var in server.env_headers.items():
+                headers[header] = f"${{{env_var}}}"
+            entry: dict[str, object] = {"type": "http", "url": server.url}
+            if headers:
+                entry["headers"] = headers
+            entries[server.name] = entry
+        return ("--mcp-config", json.dumps({"mcpServers": entries}))
 
     def _command_args(self) -> tuple[str, ...]:
         args = (self.command,)

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -550,17 +550,33 @@ class CodexHarness(Harness):
 
     def _mcp_flags(self, servers: tuple[McpServer, ...]) -> tuple[str, ...]:
         """Inline ``-c`` overrides registering each MCP server on this run —
-        no persisted config, so it survives the per-run config push. Codex
-        reads the bearer token from the named env var at runtime."""
+        no persisted config, so it survives the per-run config push. Secrets
+        stay out of argv: codex reads the bearer and every env_http_headers
+        value from the named env var at runtime; only non-secret header values
+        ride inline. A header name is a quoted TOML key segment — a valid HTTP
+        header name carries no quote, so plain quoting holds."""
         flags: tuple[str, ...] = ()
         for server in servers:
-            flags = (
-                *flags,
-                "-c",
-                f'mcp_servers.{server.name}.url="{server.url}"',
-                "-c",
-                f'mcp_servers.{server.name}.bearer_token_env_var="{server.bearer_token_env_var}"',
-            )
+            flags = (*flags, "-c", f'mcp_servers.{server.name}.url="{server.url}"')
+            if server.bearer_token_env_var:
+                flags = (
+                    *flags,
+                    "-c",
+                    f"mcp_servers.{server.name}.bearer_token_env_var="
+                    f'"{server.bearer_token_env_var}"',
+                )
+            for header, value in server.headers.items():
+                flags = (
+                    *flags,
+                    "-c",
+                    f'mcp_servers.{server.name}.http_headers."{header}"="{value}"',
+                )
+            for header, env_var in server.env_headers.items():
+                flags = (
+                    *flags,
+                    "-c",
+                    f'mcp_servers.{server.name}.env_http_headers."{header}"="{env_var}"',
+                )
         return flags
 
     def _prompt_flags(self) -> tuple[str, ...]:

--- a/backend/druks/mcp/constants.py
+++ b/backend/druks/mcp/constants.py
@@ -5,26 +5,11 @@ import re
 TOKEN_ENV_PREFIX = "MCP_"
 TOKEN_ENV_SUFFIX = "_TOKEN"
 
-
-def get_bearer_token_env_var(name: str) -> str:
-    return f"{TOKEN_ENV_PREFIX}{name.upper()}{TOKEN_ENV_SUFFIX}"
-
-
 # A server name is one identifier reused as the MCP config key (a bare TOML path
 # segment for codex, a JSON object key for claude) and the stem of the bearer env
 # var — a lowercase shell/TOML-safe token, letter-led so no rendering breaks and
 # two names never collapse to one env var.
 NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
-
-# How a server's bearer token is sourced: a token the operator stored on the
-# row, one read at delivery from a named var in druks' own process env (the
-# deployment's secret manager holds it; druks stores nothing), or one minted at
-# delivery from a stored OAuth grant (the operator connected the server once).
-# Run-scoped tokens an extension mints itself don't appear here — the workspace
-# declares those via get_required_mcp_servers, outside the registry.
-TOKEN_SOURCE_STATIC = "static"
-TOKEN_SOURCE_STATIC_FROM_ENV = "static_from_env"
-TOKEN_SOURCE_OAUTH = "oauth"
 
 # The official MCP registry the picker resolves against; search results
 # cache briefly in Redis so typing in the picker doesn't hammer it.

--- a/backend/druks/mcp/enums.py
+++ b/backend/druks/mcp/enums.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class TokenSource(StrEnum):
+    STATIC = "static"
+    STATIC_FROM_ENV = "static_from_env"
+    OAUTH = "oauth"

--- a/backend/druks/mcp/helpers.py
+++ b/backend/druks/mcp/helpers.py
@@ -1,0 +1,5 @@
+from druks.mcp.constants import TOKEN_ENV_PREFIX, TOKEN_ENV_SUFFIX
+
+
+def get_bearer_token_env_var(name: str) -> str:
+    return f"{TOKEN_ENV_PREFIX}{name.upper()}{TOKEN_ENV_SUFFIX}"

--- a/backend/druks/mcp/models.py
+++ b/backend/druks/mcp/models.py
@@ -1,22 +1,19 @@
 import os
 from datetime import datetime
+from typing import Any
 
 from sqlalchemy import Boolean, String, select
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from druks.core.models import Uuid7Pk
 from druks.database import db_session
 from druks.extensions.registry import mcp_servers
-from druks.mcp.constants import (
-    NAME_PATTERN,
-    TOKEN_SOURCE_OAUTH,
-    TOKEN_SOURCE_STATIC,
-    TOKEN_SOURCE_STATIC_FROM_ENV,
-    get_bearer_token_env_var,
-)
+from druks.mcp.constants import NAME_PATTERN
+from druks.mcp.enums import TokenSource
 from druks.mcp.exceptions import InvalidServerNameError
 from druks.models import Base
-from druks.secrets.fields import EncryptedTextField, Secret
+from druks.secrets.fields import EncryptedJsonField, EncryptedTextField, Secret
 
 
 class McpServer(Base, Uuid7Pk):
@@ -28,6 +25,16 @@ class McpServer(Base, Uuid7Pk):
     name: Mapped[str] = mapped_column(String, unique=True)
     url: Mapped[str] = mapped_column(String)
     token = EncryptedTextField(default="")
+    # How delivery sources this row's Authorization bearer (a TokenSource), or
+    # "" for no bearer — the server authenticates through its declared headers,
+    # or takes none. A catalog-managed name reads its source from the registry
+    # definition instead; static_from_env exists only there.
+    token_source: Mapped[str] = mapped_column(String, default=TokenSource.STATIC)
+    # Declared header values from the server's spec, split by secrecy at
+    # install time — the split *is* the secrecy record delivery and the API
+    # read from: plain values inline, secret ones ciphertext at rest.
+    headers: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict)
+    secret_headers = EncryptedJsonField()
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
@@ -44,21 +51,11 @@ class McpServer(Base, Uuid7Pk):
     def list_resolved(cls) -> list[dict]:
         # The full view the API reads and delivery resolves from: each built-in
         # definition (url + auth from the registry) overlaid with its operator
-        # row's enable choice and secrets, then any fully custom rows. has_token
-        # means "can authenticate at delivery", wherever the secret lives — the
-        # source var set in druks' env for an env-sourced server, a stored
-        # grant for a connected one, the stored token otherwise.
+        # row's enable choice and secrets, then any fully custom rows.
         rows = {server.name: server for server in cls.list_all()}
         servers: list[dict] = []
         for definition in mcp_servers.all():
             row = rows.pop(definition["name"], None)
-            token = row.token if row else Secret(b"", "")
-            if definition["token_source"] == TOKEN_SOURCE_STATIC_FROM_ENV:
-                has_token = bool(os.environ.get(definition["source_env_var"]))
-            elif definition["token_source"] == TOKEN_SOURCE_OAUTH:
-                has_token = bool(McpOauthGrant.get_by_server(definition["name"]))
-            else:
-                has_token = bool(token)
             servers.append(
                 {
                     "name": definition["name"],
@@ -66,8 +63,9 @@ class McpServer(Base, Uuid7Pk):
                     "token_source": definition["token_source"],
                     "source_env_var": definition["source_env_var"],
                     "is_enabled": row.is_enabled if row else definition["enabled"],
-                    "token": token,
-                    "has_token": has_token,
+                    "token": row.token if row else Secret(b"", ""),
+                    "headers": row.headers if row else {},
+                    "secret_headers": row.secret_headers if row else {},
                     "builtin": True,
                 }
             )
@@ -76,14 +74,29 @@ class McpServer(Base, Uuid7Pk):
                 {
                     "name": row.name,
                     "url": row.url,
-                    "token_source": TOKEN_SOURCE_STATIC,
+                    "token_source": row.token_source,
                     "source_env_var": "",
                     "is_enabled": row.is_enabled,
                     "token": row.token,
-                    "has_token": bool(row.token),
+                    "headers": row.headers,
+                    "secret_headers": row.secret_headers,
                     "builtin": False,
                 }
             )
+        # has_token = nothing blocks this server's auth at delivery, read from
+        # wherever its source keeps the secret: druks' env for an env-sourced
+        # server, a stored grant for a connected one, the stored token for a
+        # static one; a bearerless server has none to miss.
+        for server in servers:
+            source = server["token_source"]
+            if not source:
+                server["has_token"] = True
+            elif source == TokenSource.STATIC_FROM_ENV:
+                server["has_token"] = bool(os.environ.get(server["source_env_var"]))
+            elif source == TokenSource.OAUTH:
+                server["has_token"] = bool(McpOauthGrant.get_by_server(server["name"]))
+            else:
+                server["has_token"] = bool(server["token"])
         return servers
 
     @classmethod
@@ -107,12 +120,28 @@ class McpServer(Base, Uuid7Pk):
 
     @classmethod
     def create(
-        cls, *, name: str, url: str, token: str = "", is_enabled: bool = True
+        cls,
+        *,
+        name: str,
+        url: str,
+        token: str = "",
+        token_source: str = TokenSource.STATIC,
+        headers: dict[str, str] | None = None,
+        secret_headers: dict[str, str] | None = None,
+        is_enabled: bool = True,
     ) -> "McpServer":
         if not NAME_PATTERN.match(name):
             raise InvalidServerNameError(name)
         session = db_session()
-        server = cls(name=name, url=url, token=token, is_enabled=is_enabled)
+        server = cls(
+            name=name,
+            url=url,
+            token=token,
+            token_source=token_source,
+            headers=headers or {},
+            secret_headers=secret_headers or {},
+            is_enabled=is_enabled,
+        )
         session.add(server)
         session.flush()
         return server
@@ -121,10 +150,6 @@ class McpServer(Base, Uuid7Pk):
         session = db_session()
         session.delete(self)
         session.flush()
-
-    @property
-    def bearer_token_env_var(self) -> str:
-        return get_bearer_token_env_var(self.name)
 
 
 class McpOauthGrant(Base, Uuid7Pk):

--- a/backend/druks/mcp/routes.py
+++ b/backend/druks/mcp/routes.py
@@ -3,7 +3,7 @@ from fastapi.responses import HTMLResponse
 
 from druks.extensions.registry import mcp_servers
 from druks.mcp import oauth
-from druks.mcp.constants import TOKEN_SOURCE_OAUTH
+from druks.mcp.enums import TokenSource
 from druks.mcp.exceptions import InvalidServerNameError, OauthConnectError
 from druks.mcp.models import McpOauthGrant, McpServer
 from druks.mcp.schemas import (
@@ -79,7 +79,7 @@ async def remove_mcp_server(name: str) -> None:
 @router.post("/{name}/connect", response_model=ConnectMcpServerResponse)
 async def connect_mcp_server(name: str, request: Request) -> ConnectMcpServerResponse:
     definition = mcp_servers.get(name)
-    if not definition or definition["token_source"] != TOKEN_SOURCE_OAUTH:
+    if not definition or definition["token_source"] != TokenSource.OAUTH:
         raise HTTPException(status_code=404, detail=f"MCP server {name!r} is not an OAuth server.")
     endpoint = request.app.state.settings.endpoint
     if not endpoint:

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -9,12 +9,10 @@ from pydantic import BaseModel, Field
 from druks.database import db_session
 from druks.mcp import models as mcp_models
 from druks.mcp import oauth
-from druks.mcp.constants import (
-    TOKEN_SOURCE_STATIC,
-    TOKEN_SOURCE_STATIC_FROM_ENV,
-    get_bearer_token_env_var,
-)
+from druks.mcp.constants import TOKEN_ENV_PREFIX
+from druks.mcp.enums import TokenSource
 from druks.mcp.exceptions import MissingTokenError, SourceEnvVarUnsetError
+from druks.mcp.helpers import get_bearer_token_env_var
 
 if TYPE_CHECKING:
     from druks.durable.enums import AgentCallStatus
@@ -91,14 +89,21 @@ class AgentInvocation:
 
 @dataclass(frozen=True)
 class McpServer:
-    """A streamable-HTTP MCP server the agent talks to. The harness reads the
-    bearer token from ``bearer_token_env_var`` at runtime (the value rides in
-    via the run's env), so the token never lands in any emitted config — only
-    the var name does."""
+    """A streamable-HTTP MCP server the agent talks to. Config-safe by
+    construction: no secret value appears here — the bearer token and every
+    secret header value ride the run's env, and this shape names only their
+    env vars; the harness reads them at runtime. Only non-secret declared
+    header values are carried inline."""
 
     name: str
     url: str
-    bearer_token_env_var: str
+    # "" when the server carries no Authorization bearer — its auth, if any,
+    # rides the declared headers.
+    bearer_token_env_var: str = ""
+    # Non-secret declared headers, emitted inline: header name -> value.
+    headers: dict[str, str] = field(default_factory=dict)
+    # Secret declared headers: header name -> the env var carrying its value.
+    env_headers: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -173,27 +178,41 @@ class Workspace:
                 # A required server owns its name: the registry twin is neither
                 # resolved (no raise, no env clobber) nor delivered.
                 continue
-            # Per-strategy token resolution, loud when a server can't
+            # Per-strategy bearer resolution, loud when a server can't
             # authenticate — delivery never ships a header the harness
             # can't fill.
-            if server["token_source"] == TOKEN_SOURCE_STATIC:
-                # A stored token is ciphertext everywhere else; decrypted
-                # only here, entering the run env.
+            source = server["token_source"]
+            if not source:
+                # No bearer; auth, if any, rides the declared headers below.
+                token = ""
+            elif source == TokenSource.STATIC:
+                # A stored token is ciphertext everywhere else; decrypted only
+                # here, entering the run env.
                 if not server["token"]:
                     raise MissingTokenError(server["name"])
                 token = server["token"].decrypt()
-            elif server["token_source"] == TOKEN_SOURCE_STATIC_FROM_ENV:
+            elif source == TokenSource.STATIC_FROM_ENV:
                 token = os.environ.get(server["source_env_var"], "")
                 if not token:
                     raise SourceEnvVarUnsetError(server["name"], server["source_env_var"])
-            else:
+            else:  # oauth
                 token = await oauth.mint_access_token(server["name"])
-            env[get_bearer_token_env_var(server["name"])] = token
+            bearer_token_env_var = ""
+            if token:
+                bearer_token_env_var = get_bearer_token_env_var(server["name"])
+                env[bearer_token_env_var] = token
+            env_headers = {}
+            for index, (header, value) in enumerate(server["secret_headers"].items()):
+                env_var = f"{TOKEN_ENV_PREFIX}{server['name'].upper()}_HEADER_{index}"
+                env[env_var] = value
+                env_headers[header] = env_var
             wire.append(
                 McpServer(
                     name=server["name"],
                     url=server["url"],
-                    bearer_token_env_var=get_bearer_token_env_var(server["name"]),
+                    bearer_token_env_var=bearer_token_env_var,
+                    headers=dict(server["headers"]),
+                    env_headers=env_headers,
                 )
             )
         kwargs["mcp_servers"] = tuple(wire)

--- a/backend/migrations/versions/619e34746ef3_mcp_server_declared_headers.py
+++ b/backend/migrations/versions/619e34746ef3_mcp_server_declared_headers.py
@@ -1,0 +1,52 @@
+"""mcp server declared headers
+
+Revision ID: 619e34746ef3
+Revises: d7e8f9a0b1c2
+Create Date: 2026-07-13 17:57:12.632385
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "619e34746ef3"
+down_revision: str | Sequence[str] | None = "d7e8f9a0b1c2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Server defaults backfill existing rows — every pre-existing row is a
+    # static custom server with no declared headers.
+    op.add_column(
+        "mcp_servers",
+        sa.Column("token_source", sa.String(), nullable=False, server_default="static"),
+    )
+    op.add_column(
+        "mcp_servers",
+        sa.Column(
+            "headers",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "mcp_servers",
+        sa.Column(
+            "secret_headers",
+            sa.LargeBinary(),
+            nullable=False,
+            server_default=sa.text("''::bytea"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_servers", "secret_headers")
+    op.drop_column("mcp_servers", "headers")
+    op.drop_column("mcp_servers", "token_source")

--- a/backend/tests/test_build_workspace.py
+++ b/backend/tests/test_build_workspace.py
@@ -8,7 +8,7 @@ from druks.build.workflows import (
     BuildWorkflow,
     BuildWorkspace,
 )
-from druks.mcp.constants import get_bearer_token_env_var
+from druks.mcp.helpers import get_bearer_token_env_var
 from druks.sandbox import host as host_mod
 from druks.sandbox.layout import get_related_root
 from druks.workflows import FatalError

--- a/backend/tests/test_manifest.py
+++ b/backend/tests/test_manifest.py
@@ -7,7 +7,7 @@ from druks.harnesses.artifacts import persist_manifest
 from druks.harnesses.base import Harness
 from druks.harnesses.claude import ClaudeHarness
 from druks.mcp import models
-from druks.mcp.constants import get_bearer_token_env_var
+from druks.mcp.helpers import get_bearer_token_env_var
 from druks.sandbox.datastructures import McpServer
 from druks.skills.datastructures import InstalledSkill
 from druks.skills.models import Skill, SkillCollection
@@ -186,6 +186,38 @@ def test_manifest_records_token_presence_never_the_value(db_session):
     serialized = json.dumps(manifest)
     assert _TOKEN not in serialized
     assert _LINEAR_ENV in serialized  # the var name is safe to record
+
+
+def test_manifest_stays_presence_only_for_a_declared_header_server(db_session):
+    """A server delivered with declared headers records the same presence-only
+    entry: no header value — plain or secret — lands in the manifest, and a
+    bearer-less server simply reads token_present False."""
+    models.McpServer.create(
+        name="grafana",
+        url="https://mcp.grafana.com/mcp",
+        token_source="",
+        headers={"X-Grafana-URL": "https://acme.grafana.net"},
+        secret_headers={"X-Api-Key": "grafana-api-secret"},
+    )
+    delivered = McpServer(
+        name="grafana",
+        url="https://mcp.grafana.com/mcp",
+        headers={"X-Grafana-URL": "https://acme.grafana.net"},
+        env_headers={"X-Api-Key": "MCP_GRAFANA_HEADER_X_API_KEY"},
+    )
+
+    manifest = _build(
+        mcp_servers=(delivered,),
+        extra_env={"MCP_GRAFANA_HEADER_X_API_KEY": "grafana-api-secret"},
+    )
+
+    serialized = json.dumps(manifest)
+    assert "grafana-api-secret" not in serialized
+    assert "acme.grafana.net" not in serialized
+    grafana_entry = next(s for s in manifest["mcp_servers"] if s["name"] == "grafana")
+    assert grafana_entry["declared"] is True
+    assert grafana_entry["delivered"] is True
+    assert grafana_entry["token_present"] is False
 
 
 # --- persistence + surfacing in transcript files -------------------------

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -9,13 +9,10 @@ import pytest
 from conftest import configure_app_for_test, make_settings
 from druks.extensions.registry import mcp_servers
 from druks.mcp import oauth
-from druks.mcp.constants import (
-    OAUTH_ACCESS_TOKEN_PREFIX,
-    OAUTH_CONNECT_STATE_PREFIX,
-    TOKEN_SOURCE_OAUTH,
-    get_bearer_token_env_var,
-)
+from druks.mcp.constants import OAUTH_ACCESS_TOKEN_PREFIX, OAUTH_CONNECT_STATE_PREFIX
+from druks.mcp.enums import TokenSource
 from druks.mcp.exceptions import GrantRefreshError, MissingGrantError, OauthConnectError
+from druks.mcp.helpers import get_bearer_token_env_var
 from druks.mcp.models import McpOauthGrant, McpServer
 from druks.redis import get_client
 from druks.sandbox.datastructures import Workspace
@@ -108,7 +105,7 @@ def _register_oauth_server(name: str = _NAME, enabled: bool = True) -> None:
         {
             "name": name,
             "url": _SERVER_URL,
-            "token_source": TOKEN_SOURCE_OAUTH,
+            "token_source": TokenSource.OAUTH,
             "source_env_var": "",
             "enabled": enabled,
         }

--- a/backend/tests/test_mcp_servers.py
+++ b/backend/tests/test_mcp_servers.py
@@ -8,13 +8,13 @@ from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.datastructures import SandboxSettings
 from druks.mcp.catalog import load_mcp_catalog
-from druks.mcp.constants import get_bearer_token_env_var
 from druks.mcp.exceptions import (
     InvalidCatalogError,
     InvalidServerNameError,
     MissingTokenError,
     SourceEnvVarUnsetError,
 )
+from druks.mcp.helpers import get_bearer_token_env_var
 from druks.mcp.models import McpServer
 from druks.sandbox.datastructures import RequiredMcpServer, Workspace
 from druks.settings import PACKAGED_MCP_CATALOG
@@ -97,7 +97,7 @@ def test_create_rejects_names_that_break_env_or_config(db_session):
 def test_valid_name_derives_shell_safe_env_var(db_session):
     server = McpServer.create(name="linear_app", url=_LINEAR_URL, token=_TOKEN)
     # Every char of the derived var is a valid shell identifier char.
-    var = server.bearer_token_env_var
+    var = get_bearer_token_env_var(server.name)
     assert var == "MCP_LINEAR_APP_TOKEN"
     assert all(ch.isalnum() or ch == "_" for ch in var)
     assert not var[0].isdigit()
@@ -238,6 +238,111 @@ async def test_delivery_tolerates_explicit_none_extra_env(db_session):
     kwargs = await _delivery(extra_env=None)
     assert "linear" in {s.name for s in kwargs["mcp_servers"]}
     assert kwargs["extra_env"][get_bearer_token_env_var("linear")] == _TOKEN
+
+
+# --- declared headers: N per server, secret values via env refs -----------
+
+
+def _grafana_shaped_server() -> None:
+    # A registry-installed shape: no bearer (empty token_source), one plain
+    # declared header and one secret one.
+    McpServer.create(
+        name="grafana",
+        url="https://mcp.grafana.com/mcp",
+        token_source="",
+        headers={"X-Grafana-URL": "https://acme.grafana.net"},
+        secret_headers={"X-Api-Key": "grafana-api-secret"},
+    )
+
+
+async def test_declared_headers_deliver_inline_and_secret_values_ride_env(db_session):
+    _grafana_shaped_server()
+
+    kwargs = await _delivery()
+
+    grafana = next(s for s in kwargs["mcp_servers"] if s.name == "grafana")
+    # The wire shape names the env var carrying each secret header; the value
+    # rides only in the run env under that name, never inline.
+    assert grafana.headers == {"X-Grafana-URL": "https://acme.grafana.net"}
+    assert set(grafana.env_headers) == {"X-Api-Key"}
+    header_env_var = grafana.env_headers["X-Api-Key"]
+    assert kwargs["extra_env"][header_env_var] == "grafana-api-secret"
+    assert "grafana-api-secret" not in repr(grafana)
+    # No bearer: neither the wire shape nor the env carries an Authorization var.
+    assert grafana.bearer_token_env_var == ""
+    assert get_bearer_token_env_var("grafana") not in kwargs["extra_env"]
+
+
+async def test_two_header_server_emits_both_headers_in_each_harness_config(db_session):
+    _grafana_shaped_server()
+    kwargs = await _delivery()
+    servers = kwargs["mcp_servers"]
+    header_env_var = servers[0].env_headers["X-Api-Key"]
+
+    claude_flags = ClaudeHarness(
+        model="claude-x", fast_mode=False, effort=None, sandbox=_sandbox_config()
+    )._mcp_flags(servers)
+    headers = json.loads(claude_flags[1])["mcpServers"]["grafana"]["headers"]
+    assert headers == {
+        "X-Grafana-URL": "https://acme.grafana.net",
+        "X-Api-Key": f"${{{header_env_var}}}",
+    }
+    assert "grafana-api-secret" not in " ".join(claude_flags)
+
+    codex_config = " ".join(
+        CodexHarness(
+            model=CodexHarness.models[0], fast_mode=False, effort=None, sandbox=_sandbox_config()
+        )._mcp_flags(servers)
+    )
+    assert 'http_headers."X-Grafana-URL"="https://acme.grafana.net"' in codex_config
+    assert f'env_http_headers."X-Api-Key"="{header_env_var}"' in codex_config
+    assert "bearer_token_env_var" not in codex_config
+    assert "grafana-api-secret" not in codex_config
+
+
+async def test_bearer_and_declared_headers_combine_on_one_server(db_session):
+    # A static-token server may also declare plain headers; the Authorization
+    # bearer keeps its env-ref form beside them.
+    McpServer.create(
+        name="acme", url="https://mcp.acme.com/mcp", token=_TOKEN, headers={"X-Region": "eu"}
+    )
+
+    kwargs = await _delivery()
+    servers = kwargs["mcp_servers"]
+
+    claude_flags = ClaudeHarness(
+        model="claude-x", fast_mode=False, effort=None, sandbox=_sandbox_config()
+    )._mcp_flags(servers)
+    headers = json.loads(claude_flags[1])["mcpServers"]["acme"]["headers"]
+    assert headers == {
+        "Authorization": f"Bearer ${{{get_bearer_token_env_var('acme')}}}",
+        "X-Region": "eu",
+    }
+    assert kwargs["extra_env"][get_bearer_token_env_var("acme")] == _TOKEN
+
+
+async def test_bearerless_server_delivers_without_a_bearer(db_session):
+    # The loud MissingTokenError is a static-source contract; a bearerless
+    # server (auth in its headers, or no auth) delivers without any bearer.
+    McpServer.create(name="public_docs", url="https://docs.example.com/mcp", token_source="")
+
+    kwargs = await _delivery()
+
+    docs = next(s for s in kwargs["mcp_servers"] if s.name == "public_docs")
+    assert docs.bearer_token_env_var == ""
+    assert "extra_env" not in kwargs
+
+
+def test_bearerless_server_resolves_ready_with_its_headers(db_session):
+    _grafana_shaped_server()
+
+    grafana = next(s for s in McpServer.list_resolved() if s["name"] == "grafana")
+    assert grafana["token_source"] == ""
+    assert grafana["headers"] == {"X-Grafana-URL": "https://acme.grafana.net"}
+    # Nothing blocks delivery auth — the secret header is stored — so the
+    # API reads it ready.
+    assert grafana["has_token"] is True
+    assert grafana["secret_headers"]["X-Api-Key"] == "grafana-api-secret"
 
 
 # --- API: CRUD + enable/disable + redaction ------------------------------


### PR DESCRIPTION
Stack 2/4 of the registry install feature (resolver → **headers** → install API → UI). Base: `mcp-registry-1-resolver`.

Generalizes the single `Authorization: Bearer ${MCP_<NAME>_TOKEN}` model to N declared header values — what a registry remote actually declares (grafana's `X-Grafana-URL` beside its OAuth bearer; an API-key server's secret header with no bearer at all).

## What

- **Row** (`McpServer`): + `token_source` (`static` / `oauth` / `none` — none = auth rides the declared headers, or the server takes no auth), + `headers` (JSONB, plain values), + `secret_headers` (encrypted via `druks.secrets`' `EncryptedJsonField`, ciphertext at rest). The plain/secret **column split is the secrecy record**, stamped once at write time from the spec's `isSecret` flags — delivery and the API never re-derive it. Migration backfills every existing row as a headerless static server.
- **Delivery** (`Workspace.with_mcp_servers`): secret header values decrypt only into the run env, under `MCP_<NAME>_HEADER_<HEADER>` vars (disjoint from the bearer's `_TOKEN` namespace); the wire `McpServer` names only the vars and carries plain values inline. `none`-source servers ship with no bearer; `static` without a token still raises `MissingTokenError` exactly as before.
- **Emission**:
  - claude: `--mcp-config` headers map — `Authorization: Bearer ${VAR}` when a bearer exists, inline literals for plain headers, `${VAR}` refs for secret ones.
  - codex: existing `bearer_token_env_var` when a bearer exists, plus `http_headers."X-…"="…"` (inline) and `env_http_headers."X-…"="VAR"` (secret) `-c` overrides; header names ride as quoted TOML key segments.
- **Manifest** (`get_manifest`): unchanged shape, still presence-only — no header value, plain or secret, lands in it (pinned by test).

## Reconciliation with the existing auth model

`static` / `static_from_env` / `oauth` behave byte-for-byte as before (all existing emission/delivery tests pass unmodified). `none` is additive, for servers whose auth is entirely declared headers — the shape PR3 installs from the registry. Custom rows keep defaulting to `static`.

## Verify

- New: 2-header server (one plain, one secret) → both harnesses emit both headers, the secret value appears **only** in the run env, never in argv/config; bearer+headers combine on one server; `none`-source delivers without a token; manifest records presence only.
- `746 passed, 49 skipped` (full backend suite), migration up/down/up verified against a scratch DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
