### PR TITLE
Add the registry picker to the MCP settings pane

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -14,6 +14,7 @@ import type {
   UsageHistoryResponse,
   UsageResponse,
   UsageTodayResponse,
+  McpRegistryCandidate,
   McpServer,
   Skill,
   SkillCollection,
@@ -173,6 +174,13 @@ export const api = {
   mcpServers: () => getJSON<McpServer[]>('/api/mcp-servers'),
   createMcpServer: (body: { name: string; url: string; token: string }) =>
     postJSON<McpServer>('/api/mcp-servers', body),
+  // The official-registry picker: resolved candidates (badge + declared
+  // inputs), then an install that sends only the druks name, the registry
+  // name, and the filled header values — the url never comes from the client.
+  searchMcpRegistry: (query: string) =>
+    getJSON<McpRegistryCandidate[]>(`/api/mcp-servers/registry?query=${encodeURIComponent(query)}`),
+  installMcpServer: (body: { name: string; registry: string; headers: Record<string, string> }) =>
+    postJSON<McpServer>('/api/mcp-servers/registry', body),
   setMcpServerEnabled: (name: string, isEnabled: boolean) =>
     patchJSON<McpServer>(`/api/mcp-servers/${encodeURIComponent(name)}`, { is_enabled: isEnabled }),
   removeMcpServer: (name: string) => deleteRequest(`/api/mcp-servers/${encodeURIComponent(name)}`),

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -380,6 +380,30 @@ export interface SkillCollection {
   skills: Skill[]
 }
 
+export interface RegistryHeader {
+  // One declared input of a registry remote, verbatim from the registry —
+  // only the name is guaranteed, the rest is omitted freely.
+  name: string
+  description?: string
+  placeholder?: string
+  isRequired?: boolean
+  isSecret?: boolean
+  format?: string
+}
+
+export interface McpRegistryCandidate {
+  // The druks-side name an install will use (the row's config key); display
+  // identity is registryName.
+  name: string
+  registryName: string
+  description: string
+  url: string
+  // Trust badge: the publisher provably owns the endpoint's domain, or a
+  // druks pin vouches for it.
+  official: boolean
+  headers: RegistryHeader[]
+}
+
 export interface McpServer {
   name: string
   url: string

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -6,6 +6,7 @@ import { ExtensionGlyph } from './ExtensionGlyph'
 import {
   type Harness,
   type ExtensionSettings,
+  type McpRegistryCandidate,
   type McpServer,
   type SkillCollection,
   type UpdateHarnessRequest,
@@ -1018,6 +1019,11 @@ function McpServersPane() {
   const [token, setToken] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [registryQuery, setRegistryQuery] = useState('')
+  const [searching, setSearching] = useState(false)
+  const [candidates, setCandidates] = useState<McpRegistryCandidate[] | null>(null)
+  const [selected, setSelected] = useState<McpRegistryCandidate | null>(null)
+  const [headerValues, setHeaderValues] = useState<Record<string, string>>({})
   const servers = serversQuery.data ?? []
 
   const refresh = () => queryClient.invalidateQueries({ queryKey: ['mcpServers'] })
@@ -1029,6 +1035,47 @@ function McpServersPane() {
     channel.onmessage = () => void queryClient.invalidateQueries({ queryKey: ['mcpServers'] })
     return () => channel.close()
   }, [queryClient])
+
+  async function searchRegistry() {
+    if (!registryQuery.trim()) return
+    setSearching(true)
+    setError(null)
+    setSelected(null)
+    try {
+      setCandidates(await api.searchMcpRegistry(registryQuery.trim()))
+    } catch (e) {
+      setCandidates(null)
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  function select(candidate: McpRegistryCandidate) {
+    setSelected(candidate)
+    setHeaderValues({})
+    setError(null)
+  }
+
+  async function install(candidate: McpRegistryCandidate) {
+    setBusy(true)
+    setError(null)
+    try {
+      await api.installMcpServer({
+        name: candidate.name,
+        registry: candidate.registryName,
+        headers: headerValues,
+      })
+      setSelected(null)
+      setCandidates(null)
+      setRegistryQuery('')
+      await refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
 
   async function add() {
     // A custom server is static — the backend requires a bearer token, so gate
@@ -1108,16 +1155,120 @@ function McpServersPane() {
     }
   }
 
+  const missingRequired = (selected?.headers ?? []).some(
+    (header) => header.isRequired && !(headerValues[header.name] ?? '').trim(),
+  )
+
   return (
     <div className="set-pane">
       <div className="set-pane-head">
         <div className="set-pane-sub">
-          Add an <b>MCP server</b> your agents can call — url plus a bearer token. Enabled servers are
-          carried into every sandbox VM; the token rides the run env and never lands in emitted config.
+          Add an <b>MCP server</b> your agents can call. Enabled servers are carried into every
+          sandbox VM; secrets ride the run env and never land in emitted config.
         </div>
       </div>
       <div className="set-group">
-        <div className="set-group-label">add server</div>
+        <div className="set-group-label">add from registry</div>
+        <div className="mcp-reg-search">
+          <input
+            className="skill-add-input"
+            placeholder="search the official MCP registry — grafana, sentry, …"
+            value={registryQuery}
+            onChange={(e) => setRegistryQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void searchRegistry()
+            }}
+            autoComplete="off"
+            data-1p-ignore=""
+            data-lpignore="true"
+            disabled={searching}
+          />
+          <button
+            className="set-btn ghost"
+            disabled={searching || !registryQuery.trim()}
+            onClick={() => void searchRegistry()}
+          >
+            {searching ? 'searching…' : 'search'}
+          </button>
+        </div>
+        {candidates && candidates.length === 0 && (
+          <div className="set-field-help">
+            No matching servers with a hosted (HTTP) endpoint in the registry.
+          </div>
+        )}
+        {candidates && candidates.length > 0 && (
+          <div className="mcp-reg-results">
+            {candidates.map((candidate) => (
+              <div key={candidate.registryName}>
+                <button
+                  className={
+                    'mcp-reg-row' +
+                    (selected?.registryName === candidate.registryName ? ' is-selected' : '')
+                  }
+                  onClick={() => select(candidate)}
+                  disabled={busy}
+                >
+                  <span className="mcp-name">{candidate.name}</span>
+                  <span className={'mcp-reg-badge' + (candidate.official ? ' official' : '')}>
+                    {candidate.official ? 'official' : 'community'}
+                  </span>
+                  <span className="mcp-reg-desc" title={candidate.registryName}>
+                    {candidate.description}
+                  </span>
+                  <span className="mcp-url">{candidate.url}</span>
+                </button>
+                {selected?.registryName === candidate.registryName && (
+                  <div className="mcp-reg-form">
+                    {selected.headers.map((header) => (
+                      <div className="set-field" key={header.name}>
+                        <span className="set-field-label">
+                          {header.name}
+                          {header.isRequired ? ' *' : ''}
+                        </span>
+                        <input
+                          className="skill-add-input"
+                          type={header.isSecret ? 'password' : 'text'}
+                          placeholder={header.placeholder}
+                          value={headerValues[header.name] ?? ''}
+                          onChange={(e) =>
+                            setHeaderValues((values) => ({
+                              ...values,
+                              [header.name]: e.target.value,
+                            }))
+                          }
+                          autoComplete={header.isSecret ? 'new-password' : 'off'}
+                          data-1p-ignore=""
+                          data-lpignore="true"
+                          disabled={busy}
+                        />
+                        {header.description && (
+                          <span className="set-field-help">{header.description}</span>
+                        )}
+                      </div>
+                    ))}
+                    {!selected.headers.some((header) => header.isSecret) && (
+                      <div className="set-field-help">
+                        Uses OAuth — click <b>connect</b> on the added server to authorize it.
+                      </div>
+                    )}
+                    <div>
+                      <button
+                        className="set-btn primary"
+                        disabled={busy || missingRequired}
+                        onClick={() => void install(selected)}
+                      >
+                        {busy ? 'installing…' : 'install'}
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="set-group">
+        <div className="set-group-label">add custom server</div>
         <div className="mcp-add">
           <div className="set-field">
             <span className="set-field-label">name</span>
@@ -1201,6 +1352,20 @@ function McpServersPane() {
   )
 }
 
+function tokenStatusLabel(server: McpServer): string {
+  if (server.tokenSource === 'static_from_env') {
+    return `${server.sourceEnvVar}${server.hasToken ? ' set' : ' unset'}`
+  }
+  if (server.tokenSource === 'oauth') {
+    return server.hasToken ? 'connected' : 'not connected'
+  }
+  if (!server.tokenSource) {
+    // No bearer — header-auth'd (or auth-free): nothing to connect or store.
+    return 'ready'
+  }
+  return server.hasToken ? 'token set' : 'no token'
+}
+
 function McpServerRow({
   server,
   busy,
@@ -1224,15 +1389,7 @@ function McpServerRow({
         <span className="mcp-url">{server.url}</span>
       </div>
       <span className={'mcp-tok' + (server.hasToken ? ' ok' : ' missing')}>
-        {server.tokenSource === 'static_from_env'
-          ? `${server.sourceEnvVar}${server.hasToken ? ' set' : ' unset'}`
-          : server.tokenSource === 'oauth'
-            ? server.hasToken
-              ? 'connected'
-              : 'not connected'
-            : server.hasToken
-              ? 'token set'
-              : 'no token'}
+        {tokenStatusLabel(server)}
       </span>
       {server.tokenSource === 'oauth' &&
         (server.hasToken ? (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1105,6 +1105,17 @@ input.set-select { background-image: none; padding-right: 12px; }
    height. Neutralize it so height: 36px holds. */
 .mcp-add .skill-add-input { flex: none; }
 .mcp-add .set-btn { height: 36px; }
+.mcp-reg-search { display: flex; gap: 12px; max-width: 760px; }
+.mcp-reg-search .skill-add-input { flex: 1; }
+.mcp-reg-results { display: flex; flex-direction: column; gap: 8px; max-width: 760px; }
+.mcp-reg-row { display: grid; grid-template-columns: auto auto minmax(0, 1fr) auto; gap: 12px; align-items: center; width: 100%; padding: 10px 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); cursor: pointer; text-align: left; font: inherit; }
+.mcp-reg-row:hover { border-color: var(--border-loud); }
+.mcp-reg-row.is-selected { border-color: color-mix(in oklch, var(--accent) 50%, transparent); border-radius: 7px 7px 0 0; }
+.mcp-reg-badge { font-family: var(--font-mono); font-size: 10px; padding: 2px 7px; border-radius: 4px; border: 1px solid var(--border); color: var(--text-dim); }
+.mcp-reg-badge.official { color: var(--accent-violet); border-color: color-mix(in oklch, var(--accent-violet) 40%, transparent); }
+.mcp-reg-desc { font-size: 12px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mcp-reg-form { display: flex; flex-direction: column; gap: 12px; max-width: 760px; padding: 12px 14px; border: 1px solid color-mix(in oklch, var(--accent) 50%, transparent); border-top: none; border-radius: 0 0 7px 7px; background: var(--surface); }
+.mcp-reg-form .skill-add-input { flex: none; }
 .mcp-servers { display: flex; flex-direction: column; gap: 8px; }
 .mcp-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto auto; gap: 14px; align-items: center; padding: 10px 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); }
 .mcp-row.is-off { opacity: 0.6; }
@@ -1124,6 +1135,8 @@ input.set-select { background-image: none; padding-right: 12px; }
   .skill-row .sk-desc { display: none; }
   .mcp-row { grid-template-columns: 1fr auto; row-gap: 8px; }
   .mcp-add { grid-template-columns: 1fr; align-items: stretch; }
+  .mcp-reg-row { grid-template-columns: auto auto; row-gap: 6px; }
+  .mcp-reg-row .mcp-url { display: none; }
 }
 
 


### PR DESCRIPTION
Stack 4/4 of the registry install feature (resolver → headers → install API → **UI**). Base: `mcp-registry-3-install-api`.

## What

Settings → MCP gains an **add from registry** group above the (unchanged, relabeled) custom add:

- **Search box** → `GET /api/mcp-servers/registry?q=` → candidate rows: druks name, **trust badge** (`official` in accent-violet when the publisher provably owns the endpoint's domain or a druks pin vouches; `community` otherwise — no `--bucket-*` tokens), registry description, url.
- **Selecting a candidate expands a form generated from its declared inputs**: label from the header `name`, helper from `description`, `placeholder` carried through, `isRequired` gates the install button, `isSecret` renders a password field. No per-server hand-coded form anywhere.
- OAuth candidates say "Uses OAuth — click connect on the added server to authorize it" and install dark; **the added row reuses the existing Connect button**. A header-auth'd row reads `ready` (label logic extracted to a plain if/else helper instead of extending the ternary chain).
- `client.ts` + `types.ts`: `searchMcpRegistry` / `installMcpServer`, `McpRegistryCandidate` / `RegistryHeader`.

## Verified in the browser, against the live registry

Backend + Vite from this branch, real `registry.modelcontextprotocol.io`:

1. Typed **grafana** → exactly one candidate, **official** badge, registry description + `https://mcp.grafana.com/mcp` (the aggregator's stdio-only entries drop out).
2. Selected it → the generated form rendered **X-GRAFANA-URL** with the registry's helper text ("URL of your Grafana Cloud instance") and placeholder, plus the OAuth hint.
3. Filled it, clicked **install** → row appeared dark ("not connected") with Connect + remove; the search cleared.
4. Clicked **connect** → the existing `mcp/oauth.py` flow ran RFC 9728 discovery + dynamic client registration against `mcp.grafana.com` and landed on grafana's real **"Connect to Grafana — Grafana Cloud MCP"** consent page. (Stopped there — no account authorized.)
5. Console clean throughout.

Gates: `eslint` clean · `23 tests passed` · `vite build` OK.

## Follow-ups (out of scope, noted only)

- sandbox-spawned stdio servers (npx/uvx) and docker/OCI-in-sandbox — deferred, gated on a per-server trust opt-in.
- fetching trust pins from a remote URL — the settings seam already covers it as a config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
