### PR TITLE
Auto-disconnect harness on terminal invalid_grant (ENG-699)

### DIFF
--- a/backend/druks/core/workflows.py
+++ b/backend/druks/core/workflows.py
@@ -46,9 +46,11 @@ async def _refresh() -> dict[str, object]:
 def _log_result(result: RotationResult) -> None:
     if result.action == "refreshed":
         logger.info("refreshed %s token; expires_at=%s", result.harness, result.expires_at)
-    elif result.action == "failed":
+    elif result.action == "failed" and result.error != "no_credentials":
         # invalid_grant => operator must re-login; network/http_* => transient.
+        # no_credentials is a disconnected harness, not a failure — stay quiet so
+        # a deliberately-disconnected harness doesn't warn every tick.
         logger.warning("token refresh failed for %s: %s", result.harness, result.error)
     elif result.action == "no_refresh_token":
         logger.warning("%s credential has no refresh token; cannot keep it alive", result.harness)
-    # "fresh" is the common no-op; stay quiet.
+    # "fresh" and no_credentials are quiet no-ops.

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -310,6 +310,15 @@ class Harness(ABC):
             grant = await _post_grant(cls._TOKEN_URL, cls._grant_body(refresh_token))
             new_expiry = cls._apply_refresh(data, grant, moment)
         except GrantError as exc:
+            if exc.tag == "invalid_grant":
+                # The provider revoked the refresh lineage; presenting it again
+                # can never succeed. Drop the credential so the harness reads as
+                # disconnected — the UI shows Reconnect and the next tick
+                # short-circuits to no_credentials instead of hammering forever.
+                cls.disconnect()
+                logger.warning(
+                    "%s auto-disconnected after invalid_grant; reconnect to restore", cls.name
+                )
             return RotationResult(cls.name, "failed", error=exc.tag)
         except ValueError:
             return RotationResult(cls.name, "failed", error="bad_response")

--- a/backend/tests/test_core_workflows.py
+++ b/backend/tests/test_core_workflows.py
@@ -1,0 +1,17 @@
+import logging
+
+from druks.core.workflows import _log_result
+from druks.harnesses.datastructures import RotationResult
+
+
+def test_no_credentials_stays_quiet(caplog):
+    # A disconnected harness is not a refresh failure — no warning every tick.
+    with caplog.at_level(logging.WARNING):
+        _log_result(RotationResult("claude", "failed", error="no_credentials"))
+    assert caplog.records == []
+
+
+def test_invalid_grant_warns(caplog):
+    with caplog.at_level(logging.WARNING):
+        _log_result(RotationResult("claude", "failed", error="invalid_grant"))
+    assert "token refresh failed for claude" in caplog.text

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -8,6 +8,7 @@ from druks.harnesses import base as hbase
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.exceptions import HarnessNotConnectedError, OAuthTokenError
+from druks.harnesses.models import HarnessLogin
 
 _NOW = datetime(2026, 6, 4, 20, 0, tzinfo=UTC)
 
@@ -140,13 +141,63 @@ async def test_claude_stale_refreshes_and_persists(monkeypatch, db_session):
     assert block["expiresAt"] == int((_NOW + timedelta(seconds=28800)).timestamp() * 1000)
 
 
-async def test_claude_invalid_grant_leaves_row(monkeypatch, db_session):
+async def test_claude_invalid_grant_drops_row(monkeypatch, db_session):
     _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
     _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
     result = await ClaudeHarness.rotate_token(now=_NOW)
     assert result.action == "failed"
     assert result.error == "invalid_grant"
+    # A revoked lineage self-disconnects in the same session — no separate commit.
+    assert HarnessLogin.get("claude") is None
+    with pytest.raises(HarnessNotConnectedError):
+        ClaudeHarness.get_credentials()
+
+
+async def test_claude_network_error_keeps_row(monkeypatch, db_session):
+    _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    _mock_post(monkeypatch, httpx.ConnectError("boom"))
+    result = await ClaudeHarness.rotate_token(now=_NOW)
+    assert result.error == "network"
     assert ClaudeHarness.get_credentials()["claudeAiOauth"]["accessToken"] == "old"
+
+
+async def test_claude_http_500_keeps_row(monkeypatch, db_session):
+    _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    _mock_post(monkeypatch, _resp(500, ""))
+    result = await ClaudeHarness.rotate_token(now=_NOW)
+    assert result.error == "http_500"
+    assert ClaudeHarness.get_credentials()["claudeAiOauth"]["accessToken"] == "old"
+
+
+async def test_claude_bad_response_keeps_row(monkeypatch, db_session):
+    _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    _mock_post(monkeypatch, _resp(200, "not json"))
+    result = await ClaudeHarness.rotate_token(now=_NOW)
+    assert result.error == "bad_response"
+    assert ClaudeHarness.get_credentials()["claudeAiOauth"]["accessToken"] == "old"
+
+
+async def test_codex_invalid_grant_drops_row(monkeypatch, db_session):
+    stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
+    _seed_codex(access=stale, refresh="R0")
+    _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
+    result = await CodexHarness.rotate_token(now=_NOW)
+    assert result.error == "invalid_grant"
+    assert HarnessLogin.get("codex") is None
+    with pytest.raises(HarnessNotConnectedError):
+        CodexHarness.get_credentials()
+
+
+async def test_next_rotation_after_disconnect_is_no_op(monkeypatch, db_session):
+    _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
+    await ClaudeHarness.rotate_token(now=_NOW)
+    # Row is gone; the next tick must short-circuit before any grant POST.
+    calls = _mock_post(monkeypatch, _resp(200, {"access_token": "x"}))
+    result = await ClaudeHarness.rotate_token(now=_NOW)
+    assert result.action == "failed"
+    assert result.error == "no_credentials"
+    assert calls == []
 
 
 async def test_claude_rotate_without_credentials(monkeypatch, db_session):


### PR DESCRIPTION
Closes ENG-699.

## Why

When Anthropic (or the Codex provider) returns a terminal `invalid_grant` from the refresh grant, the refresh lineage has been revoked — presenting it again can never succeed. Today `rotate_token` just returns `RotationResult(failed)` and leaves the credential row in place, which:

1. **Lies in the UI** — `HarnessResponse.connected` derives from `bool(login)`, so the Settings card keeps showing a green **connected** badge (with an already-past expiry) even though auth is dead. The operator gets no signal to reconnect.
2. **Hammers the provider forever** — the `*/15` refresh cron re-POSTs the same dead token every 15 min indefinitely, burying the one actionable warning under identical repeating noise.

Observed on the live host 2026-07-14: 8 clean rotations over two days, then a hard cliff to `invalid_grant` every tick after the lineage was revoked externally (no agent runs involved).

## Change

On `GrantError.tag == "invalid_grant"`, `rotate_token` calls `cls.disconnect()` (drops the `harness_logins` row) and logs a single actionable warning. Everything else falls out of the existing disconnected path for free:

- card flips to **not connected / Reconnect**
- `poll_usage` → `no_credentials` instead of the dead-end `token_expired`
- next cron tick short-circuits to `no_credentials` **before any HTTP call** — the hammering stops on its own (no separate backoff needed)
- `HarnessSettings` (model/effort/timeout/agents) lives in a separate table, untouched

`_log_result` no longer warns on `no_credentials`, so a deliberately-disconnected harness doesn't warn every tick (also silences pre-existing noise for never-connected harnesses).

### Guardrails
- Only the terminal `invalid_grant` tag disconnects. `network` / `http_5xx` / `bad_response` stay retryable.
- A merely past-expiry access token does **not** disconnect — that self-heals on the next refresh while the lineage is alive; the trigger is a terminal *grant* response.

## Tests
- `test_claude_invalid_grant_drops_row` (rewritten from `_leaves_row`) — row gone + `get_credentials()` raises, in the same session.
- `test_codex_invalid_grant_drops_row` — proves the base-class behavior for both harnesses.
- `test_claude_{network_error,http_500,bad_response}_keeps_row` — transient tags preserve the row.
- `test_next_rotation_after_disconnect_is_no_op` — post-disconnect tick returns `no_credentials` with zero HTTP.
- `test_core_workflows.py` — `no_credentials` stays quiet; `invalid_grant` still warns.

Out of scope (noted in ENG-699): run-path token precondition (ENG-693), reducing refresh-token exposure in `render_credentials_file`, and any `revoked`-flag state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
