### PR TITLE
Introduce accounts and re-key harness credentials per account (ENG-702)

### DIFF
--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from sqlalchemy import String, select
+from sqlalchemy.orm import Mapped, mapped_column
+
+from druks.core.models import Uuid7Pk
+from druks.database import db_session
+from druks.models import Base
+
+
+class Account(Base, Uuid7Pk):
+    __tablename__ = "accounts"
+
+    email: Mapped[str] = mapped_column(String, unique=True)
+    created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
+    updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
+
+    @staticmethod
+    def normalize_email(value: str) -> str:
+        return value.strip().lower()
+
+    @classmethod
+    def get_by_email(cls, email: str) -> "Account | None":
+        return db_session().scalar(select(cls).where(cls.email == cls.normalize_email(email)))
+
+    @classmethod
+    def get_or_create(cls, email: str) -> "Account":
+        account = cls.get_by_email(email)
+        if account:
+            return account
+        account = cls(email=cls.normalize_email(email))
+        session = db_session()
+        session.add(account)
+        session.flush()
+        return account

--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -8,6 +8,13 @@ from druks.database import db_session
 from druks.models import Base
 
 
+def canonical_email(value: str) -> str:
+    """The one email shape stored, compared, and displayed — no second form
+    anywhere. Every write goes through it (the model validators) and so does
+    every lookup key."""
+    return value.strip().lower()
+
+
 class Account(Base, Uuid7Pk):
     __tablename__ = "accounts"
 
@@ -19,13 +26,11 @@ class Account(Base, Uuid7Pk):
 
     @validates("email")
     def _canonical_email(self, _key: str, value: str) -> str:
-        # Canonical on write, so the stored value is the one every reader
-        # compares, displays, and keys on — no second shape anywhere.
-        return value.strip().lower()
+        return canonical_email(value)
 
     @classmethod
     def get_for_email(cls, email: str) -> "Account | None":
-        return db_session().scalar(select(cls).where(cls.email == email.strip().lower()))
+        return db_session().scalar(select(cls).where(cls.email == canonical_email(email)))
 
     @classmethod
     def get_or_create(cls, email: str) -> "Account":

--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -12,8 +12,10 @@ class Account(Base, Uuid7Pk):
     __tablename__ = "accounts"
 
     email: Mapped[str] = mapped_column(String, unique=True)
+    # No updated_at: an account is insert-once — email never changes and there
+    # is no other field to mutate — so the column would only ever equal
+    # created_at, and nothing reads it.
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
-    updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
 
     @validates("email")
     def _canonical_email(self, _key: str, value: str) -> str:

--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -1,36 +1,29 @@
 from datetime import datetime
 
-from sqlalchemy import String, select
-from sqlalchemy.orm import Mapped, mapped_column, validates
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import CITEXT
+from sqlalchemy.orm import Mapped, mapped_column
 
 from druks.core.models import Uuid7Pk
 from druks.database import db_session
 from druks.models import Base
 
 
-def canonical_email(value: str) -> str:
-    """The one email shape stored, compared, and displayed — no second form
-    anywhere. Every write goes through it (the model validators) and so does
-    every lookup key."""
-    return value.strip().lower()
-
-
 class Account(Base, Uuid7Pk):
     __tablename__ = "accounts"
 
-    email: Mapped[str] = mapped_column(String, unique=True)
+    # citext: the column compares and enforces uniqueness case-insensitively,
+    # so a lookup or a duplicate check needs no normalization — the email is
+    # stored as the provider gave it and matched regardless of case.
+    email: Mapped[str] = mapped_column(CITEXT, unique=True)
     # No updated_at: an account is insert-once — email never changes and there
     # is no other field to mutate — so the column would only ever equal
     # created_at, and nothing reads it.
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
-    @validates("email")
-    def _canonical_email(self, _key: str, value: str) -> str:
-        return canonical_email(value)
-
     @classmethod
     def get_for_email(cls, email: str) -> "Account | None":
-        return db_session().scalar(select(cls).where(cls.email == canonical_email(email)))
+        return db_session().scalar(select(cls).where(cls.email == email))
 
     @classmethod
     def get_or_create(cls, email: str) -> "Account":

--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from sqlalchemy import String, select
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, validates
 
 from druks.core.models import Uuid7Pk
 from druks.database import db_session
@@ -15,20 +15,22 @@ class Account(Base, Uuid7Pk):
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
 
-    @staticmethod
-    def normalize_email(value: str) -> str:
+    @validates("email")
+    def _canonical_email(self, _key: str, value: str) -> str:
+        # Canonical on write, so the stored value is the one every reader
+        # compares, displays, and keys on — no second shape anywhere.
         return value.strip().lower()
 
     @classmethod
-    def get_by_email(cls, email: str) -> "Account | None":
-        return db_session().scalar(select(cls).where(cls.email == cls.normalize_email(email)))
+    def get_for_email(cls, email: str) -> "Account | None":
+        return db_session().scalar(select(cls).where(cls.email == email.strip().lower()))
 
     @classmethod
     def get_or_create(cls, email: str) -> "Account":
-        account = cls.get_by_email(email)
+        account = cls.get_for_email(email)
         if account:
             return account
-        account = cls(email=cls.normalize_email(email))
+        account = cls(email=email)
         session = db_session()
         session.add(account)
         session.flush()

--- a/backend/druks/core/workflows.py
+++ b/backend/druks/core/workflows.py
@@ -2,7 +2,7 @@ import contextlib
 import logging
 
 from druks.harnesses.datastructures import RotationResult
-from druks.harnesses.models import HarnessLogin
+from druks.harnesses.models import HarnessConnection
 from druks.harnesses.registry import get_harnesses
 from druks.sandbox import gate
 from druks.workflows import Workflow
@@ -22,7 +22,7 @@ class RefreshTokens(Workflow):
 
 async def _refresh() -> dict[str, object]:
     by_name = {harness.name: harness for harness in get_harnesses()}
-    logins = [login for login in HarnessLogin.list_all() if login.harness in by_name]
+    logins = [login for login in HarnessConnection.list_all() if login.harness in by_name]
 
     # rotate_token is the source of truth for what's due: it no-ops ("fresh", no
     # server call, no invalidation) any row outside its margin, so rotating all

--- a/backend/druks/core/workflows.py
+++ b/backend/druks/core/workflows.py
@@ -2,6 +2,7 @@ import contextlib
 import logging
 
 from druks.harnesses.datastructures import RotationResult
+from druks.harnesses.models import HarnessLogin
 from druks.harnesses.registry import get_harnesses
 from druks.sandbox import gate
 from druks.workflows import Workflow
@@ -20,37 +21,57 @@ class RefreshTokens(Workflow):
 
 
 async def _refresh() -> dict[str, object]:
-    harnesses = get_harnesses()
+    by_name = {harness.name: harness for harness in get_harnesses()}
+    logins = [login for login in HarnessLogin.list_all() if login.harness in by_name]
 
     # rotate_token is the source of truth for what's due: it no-ops ("fresh", no
-    # server call, no invalidation) any harness outside its margin, so rotating
-    # all only refreshes the one(s) actually expiring. A refresh invalidates the
+    # server call, no invalidation) any row outside its margin, so rotating all
+    # only refreshes the one(s) actually expiring. A refresh invalidates the
     # old token server-side and would 401 a VM mid-run holding a pushed copy,
     # so close the gate around it — but only when a rotation is
     # coming, since the common no-op tick shouldn't stall provisioning.
-    coming = any(harness.needs_refresh() for harness in harnesses)
+    coming = any(by_name[login.harness].needs_refresh(login) for login in logins)
+    # Snapshot plain values before rotating: each refreshed row commits as it
+    # lands, which expires every ORM object in the session mid-loop.
+    rows = [(login.harness, login.id) for login in logins]
     gate_ctx = gate.hold() if coming else contextlib.nullcontext()
 
     results: list[RotationResult] = []
     async with gate_ctx:
-        for harness in harnesses:
-            result = await harness.rotate_token()
+        for harness_name, login_id in rows:
+            result = await by_name[harness_name].rotate_token(login_id)
             _log_result(result)
             results.append(result)
 
     return {
-        "results": [{"harness": r.harness, "action": r.action, "error": r.error} for r in results],
+        "results": [
+            {"harness": r.harness, "login_id": r.login_id, "action": r.action, "error": r.error}
+            for r in results
+        ],
     }
 
 
 def _log_result(result: RotationResult) -> None:
     if result.action == "refreshed":
-        logger.info("refreshed %s token; expires_at=%s", result.harness, result.expires_at)
+        logger.info(
+            "refreshed %s token for login %s; expires_at=%s",
+            result.harness,
+            result.login_id,
+            result.expires_at,
+        )
     elif result.action == "failed" and result.error != "no_credentials":
-        # invalid_grant => operator must re-login; network/http_* => transient.
-        # no_credentials is a disconnected harness, not a failure — stay quiet so
-        # a deliberately-disconnected harness doesn't warn every tick.
-        logger.warning("token refresh failed for %s: %s", result.harness, result.error)
+        # invalid_grant => that seat must re-login; network/http_* => transient.
+        # no_credentials is a row deleted mid-tick, not a failure — stay quiet.
+        logger.warning(
+            "token refresh failed for %s login %s: %s",
+            result.harness,
+            result.login_id,
+            result.error,
+        )
     elif result.action == "no_refresh_token":
-        logger.warning("%s credential has no refresh token; cannot keep it alive", result.harness)
-    # "fresh" and no_credentials are quiet no-ops.
+        logger.warning(
+            "%s login %s has no refresh token; cannot keep it alive",
+            result.harness,
+            result.login_id,
+        )
+    # "fresh" and "locked" (another worker owns this row's refresh) are quiet no-ops.

--- a/backend/druks/database.py
+++ b/backend/druks/database.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent / "alembic.ini"
@@ -104,6 +104,10 @@ def init_db(engine) -> None:
     from druks.user_settings.models import seed_harnesses
 
     import_extension_models()
+    # citext backs the case-insensitive email columns; create_all needs the
+    # type to exist first (production gets it from the accounts migration).
+    with engine.begin() as connection:
+        connection.execute(text("CREATE EXTENSION IF NOT EXISTS citext"))
     Base.metadata.create_all(engine)
     seed_harnesses(engine)
 

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -20,7 +20,7 @@ from .core.apis.github import get_github_client
 from .database import create_engine_from_url
 from .extensions.loader import iter_extensions
 from .extensions.registry import _ROLES, agents, autodiscover, webhooks, workflows
-from .harnesses.models import HarnessLogin
+from .harnesses.models import HarnessConnection
 from .harnesses.registry import get_harnesses
 from .sandbox.client import sandbox_client
 from .settings import Settings, load_settings
@@ -177,8 +177,8 @@ def check_harness_credentials(settings: Settings) -> list[CheckResult]:
             results: list[CheckResult] = []
             for harness in get_harnesses():
                 row = session.scalar(
-                    select(HarnessLogin).where(
-                        HarnessLogin.harness == harness.name, HarnessLogin.is_default
+                    select(HarnessConnection).where(
+                        HarnessConnection.harness == harness.name, HarnessConnection.is_default
                     )
                 )
                 results.append(

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 import httpx
 from drukbox_sdk import SandboxAPI
 from githubkit import AppAuthStrategy, GitHub
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
 from .agents import Agent
@@ -176,7 +176,11 @@ def check_harness_credentials(settings: Settings) -> list[CheckResult]:
         with Session(engine) as session:
             results: list[CheckResult] = []
             for harness in get_harnesses():
-                row = session.get(HarnessLogin, harness.name)
+                row = session.scalar(
+                    select(HarnessLogin).where(
+                        HarnessLogin.harness == harness.name, HarnessLogin.is_default
+                    )
+                )
                 results.append(
                     _harness_credential_check(
                         harness.name,

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -186,9 +186,10 @@ class Harness(ABC):
 
     @classmethod
     def get_credentials(cls) -> dict:
-        """The default seat's credential-file dict — the row execution resolves
-        while runs aren't seat-aware. Raises :class:`HarnessNotConnectedError`,
-        with the connect-in-Settings fix, when no seat is designated."""
+        """The default login's credential-file dict — the row execution
+        resolves while runs aren't account-aware. Raises
+        :class:`HarnessNotConnectedError`, with the connect-in-Settings fix,
+        when no login is designated."""
         row = HarnessLogin.get_default(cls.name)
         data = dict(row.payload) if row else None
         if not data:
@@ -215,7 +216,7 @@ class Harness(ABC):
         challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
         url, state = cls.authorize_url(verifier=verifier, challenge=challenge)
         flow_id = secrets.token_urlsafe(24)
-        pending = json.dumps({"harness": cls.name, "verifier": verifier, "state": state})
+        pending = json.dumps({"verifier": verifier, "state": state})
         await get_client().set(_login_pending_key(flow_id), pending, ex=_LOGIN_PENDING_TTL_SECONDS)
         return url, flow_id
 
@@ -223,15 +224,13 @@ class Harness(ABC):
     async def login_complete(cls, *, flow_id: str, pasted: str) -> None:
         """Finish a connect flow: pop the flow's single-use pending state,
         parse the paste (bare code or full redirect URL), exchange it, and
-        upsert the seat under the provider-reported account. Raises
+        upsert the login under the provider-reported account. Raises
         :class:`LoginError` with a user-facing message on any failure — the
         pending state is gone either way, so a retry re-starts cleanly."""
         pending = await get_client().getdel(_login_pending_key(flow_id))  # single-use
         if not pending:
             raise LoginError("This sign-in expired — start it again.")
         expected = json.loads(pending)
-        if expected["harness"] != cls.name:
-            raise LoginError("That sign-in belongs to a different harness — start it again.")
 
         code, pasted_state = _parse_pasted(pasted)
         if not code:
@@ -255,8 +254,8 @@ class Harness(ABC):
 
     @classmethod
     def disconnect(cls) -> None:
-        """Disconnect the default seat — the single connection card's target.
-        Never promotes another seat."""
+        """Disconnect the default login — the single connection card's target.
+        Never promotes another one."""
         row = HarnessLogin.get_default(cls.name)
         if row:
             row.delete()
@@ -349,7 +348,7 @@ class Harness(ABC):
                 if exc.tag == "invalid_grant":
                     # The provider revoked this row's refresh lineage;
                     # presenting it again can never succeed. Drop only this
-                    # credential so the seat reads as disconnected — the UI
+                    # credential so the login reads as disconnected — the UI
                     # shows Reconnect and the next tick has no row to hammer.
                     row.delete()
                     db_session().commit()

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import httpx
 
+from druks.database import db_session
 from druks.mcp import models as mcp_models
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.redis import get_client
@@ -46,6 +47,9 @@ _USAGE_TIMEOUT_SECONDS = 20.0
 # The connect-flow pending state (PKCE verifier + state) lives in Redis this long
 # — enough to sign in and paste, short enough that an abandoned attempt clears.
 _LOGIN_PENDING_TTL_SECONDS = 600
+# Per-row refresh lock: five minutes outlives the provider grant timeout and
+# expires before the next 15-minute cron tick if the holder dies mid-refresh.
+_REFRESH_LOCK_TTL_SECONDS = 300
 
 # The capability manifest is a plain JSON dict written per AgentCall. Bump when
 # the recorded shape changes so a reader can tell manifests apart across
@@ -182,23 +186,16 @@ class Harness(ABC):
 
     @classmethod
     def get_credentials(cls) -> dict:
-        """The stored credential-file dict. Raises
-        :class:`HarnessNotConnectedError`, with the connect-in-Settings fix,
-        when the harness was never connected."""
-        row = HarnessLogin.get(cls.name)
-        data = row.payload if row else None
+        """The default seat's credential-file dict — the row execution resolves
+        while runs aren't seat-aware. Raises :class:`HarnessNotConnectedError`,
+        with the connect-in-Settings fix, when no seat is designated."""
+        row = HarnessLogin.get_default(cls.name)
+        data = dict(row.payload) if row else None
         if not data:
             raise HarnessNotConnectedError(
                 f"{cls.name} is not connected — connect it in Settings → Harnesses."
             )
         return data
-
-    @classmethod
-    def store_credentials(cls, data: dict) -> None:
-        """Persist the credential-file dict as this harness's row, mirroring the
-        access-token expiry out of it for the refresh cron and doctor to read."""
-        _, expires_at = cls._refresh_state(data)
-        HarnessLogin.store(harness=cls.name, payload=data, expires_at=expires_at)
 
     @classmethod
     def render_credentials_file(cls) -> str:
@@ -209,28 +206,32 @@ class Harness(ABC):
         return json.dumps(cls.get_credentials())
 
     @classmethod
-    async def login_start(cls) -> str:
+    async def login_start(cls) -> tuple[str, str]:
         """Begin a connect flow: mint a PKCE verifier + challenge, build the
-        provider's authorize URL, stash the pending state in Redis (single-use,
-        short TTL), and return the URL for the operator to open in a browser."""
+        provider's authorize URL, and stash the pending state in Redis under an
+        opaque flow id (single-use, short TTL) so concurrent connects never
+        overwrite each other. Returns (authorize URL, flow id)."""
         verifier = _b64url(secrets.token_bytes(64))
         challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
         url, state = cls.authorize_url(verifier=verifier, challenge=challenge)
-        pending = json.dumps({"verifier": verifier, "state": state})
-        await get_client().set(_login_pending_key(cls.name), pending, ex=_LOGIN_PENDING_TTL_SECONDS)
-        return url
+        flow_id = secrets.token_urlsafe(24)
+        pending = json.dumps({"harness": cls.name, "verifier": verifier, "state": state})
+        await get_client().set(_login_pending_key(flow_id), pending, ex=_LOGIN_PENDING_TTL_SECONDS)
+        return url, flow_id
 
     @classmethod
-    async def login_complete(cls, pasted: str) -> None:
-        """Finish a connect flow: pop the single-use pending state, parse the
-        paste (bare code or full redirect URL), exchange it, and persist the
-        credential + account. Raises :class:`LoginError` with a user-facing
-        message on any failure — the pending state is gone either way, so a
-        retry re-starts cleanly."""
-        pending = await get_client().getdel(_login_pending_key(cls.name))  # single-use
+    async def login_complete(cls, *, flow_id: str, pasted: str) -> None:
+        """Finish a connect flow: pop the flow's single-use pending state,
+        parse the paste (bare code or full redirect URL), exchange it, and
+        upsert the seat under the provider-reported account. Raises
+        :class:`LoginError` with a user-facing message on any failure — the
+        pending state is gone either way, so a retry re-starts cleanly."""
+        pending = await get_client().getdel(_login_pending_key(flow_id))  # single-use
         if not pending:
             raise LoginError("This sign-in expired — start it again.")
         expected = json.loads(pending)
+        if expected["harness"] != cls.name:
+            raise LoginError("That sign-in belongs to a different harness — start it again.")
 
         code, pasted_state = _parse_pasted(pasted)
         if not code:
@@ -238,15 +239,27 @@ class Harness(ABC):
         if pasted_state and pasted_state != expected["state"]:
             raise LoginError("That code is from a different sign-in — start it again.")
 
-        payload, account = await cls.exchange(code=code, verifier=expected["verifier"])
+        payload, provider_email = await cls.exchange(code=code, verifier=expected["verifier"])
+        if not provider_email:
+            raise LoginError(
+                "The provider returned no account email — sign in with an account "
+                "that has one and try again."
+            )
         _, expires_at = cls._refresh_state(payload)
-        HarnessLogin.store(
-            harness=cls.name, payload=payload, expires_at=expires_at, account=account
+        HarnessLogin.connect(
+            harness=cls.name,
+            payload=payload,
+            expires_at=expires_at,
+            provider_email=provider_email,
         )
 
     @classmethod
     def disconnect(cls) -> None:
-        HarnessLogin.delete(cls.name)
+        """Disconnect the default seat — the single connection card's target.
+        Never promotes another seat."""
+        row = HarnessLogin.get_default(cls.name)
+        if row:
+            row.delete()
 
     @classmethod
     @abstractmethod
@@ -259,7 +272,7 @@ class Harness(ABC):
     @abstractmethod
     async def exchange(cls, *, code: str, verifier: str) -> tuple[dict, str | None]:
         """Exchange the authorization code for tokens; return (credential-file
-        payload, account label)."""
+        payload, provider-reported account email)."""
 
     @classmethod
     def load_token(cls, *, now: datetime | None = None) -> Token:
@@ -286,60 +299,98 @@ class Harness(ABC):
     @classmethod
     async def rotate_token(
         cls,
+        login_id: str,
         *,
         now: datetime | None = None,
         margin: timedelta | None = None,
     ) -> RotationResult:
-        """Refresh the stored token in place if it's within the expiry margin,
-        persisting the new token back to the row."""
+        """Refresh one login row's token if it's within the expiry margin,
+        persisting the new token back to that row. Addressed by row id and
+        read fresh — the caller's tick may span other rows' commits. One
+        refresher per row: a Redis lock elects the winner, and the loser
+        reports ``locked`` without touching the provider — two concurrent
+        grants on one refresh lineage trip the provider's reuse detection."""
         moment = now or _utc_now()
-        try:
-            data = cls.get_credentials()
-        except HarnessNotConnectedError:
-            return RotationResult(cls.name, "failed", error="no_credentials")
-
+        row = HarnessLogin.reload(login_id)
+        if not row:
+            return RotationResult(cls.name, "failed", error="no_credentials", login_id=login_id)
+        data = dict(row.payload)
         refresh_token, expires_at = cls._refresh_state(data)
         if not refresh_token:
-            return RotationResult(cls.name, "no_refresh_token")
+            return RotationResult(cls.name, "no_refresh_token", login_id=login_id)
 
         limit = margin if margin is not None else cls.REFRESH_MARGIN
         if expires_at and expires_at - moment > limit:
-            return RotationResult(cls.name, "fresh", expires_at=expires_at)
+            return RotationResult(cls.name, "fresh", expires_at=expires_at, login_id=login_id)
 
+        redis = get_client()
+        lock_key = _refresh_lock_key(login_id)
+        if not await redis.set(lock_key, "1", nx=True, ex=_REFRESH_LOCK_TTL_SECONDS):
+            return RotationResult(cls.name, "locked", login_id=login_id)
         try:
-            grant = await _post_grant(cls._TOKEN_URL, cls._grant_body(refresh_token))
-            new_expiry = cls._apply_refresh(data, grant, moment)
-        except GrantError as exc:
-            if exc.tag == "invalid_grant":
-                # The provider revoked the refresh lineage; presenting it again
-                # can never succeed. Drop the credential so the harness reads as
-                # disconnected — the UI shows Reconnect and the next tick
-                # short-circuits to no_credentials instead of hammering forever.
-                cls.disconnect()
-                logger.warning(
-                    "%s auto-disconnected after invalid_grant; reconnect to restore", cls.name
+            # Re-read after winning the lock: the previous holder may have
+            # advanced this lineage (or deleted the row) after our first read.
+            row = HarnessLogin.reload(login_id)
+            if not row:
+                return RotationResult(
+                    cls.name, "failed", error="no_credentials", login_id=login_id
                 )
-            return RotationResult(cls.name, "failed", error=exc.tag)
-        except ValueError:
-            return RotationResult(cls.name, "failed", error="bad_response")
+            data = dict(row.payload)
+            refresh_token, expires_at = cls._refresh_state(data)
+            if not refresh_token:
+                return RotationResult(cls.name, "no_refresh_token", login_id=row.id)
+            if expires_at and expires_at - moment > limit:
+                return RotationResult(cls.name, "fresh", expires_at=expires_at, login_id=row.id)
 
-        cls.store_credentials(data)
-        return RotationResult(cls.name, "refreshed", expires_at=new_expiry)
+            try:
+                grant = await _post_grant(cls._TOKEN_URL, cls._grant_body(refresh_token))
+                new_expiry = cls._apply_refresh(data, grant, moment)
+            except GrantError as exc:
+                if exc.tag == "invalid_grant":
+                    # The provider revoked this row's refresh lineage;
+                    # presenting it again can never succeed. Drop only this
+                    # credential so the seat reads as disconnected — the UI
+                    # shows Reconnect and the next tick has no row to hammer.
+                    row.delete()
+                    db_session().commit()
+                    logger.warning(
+                        "%s login %s auto-disconnected after invalid_grant; "
+                        "reconnect to restore",
+                        cls.name,
+                        row.id,
+                    )
+                return RotationResult(cls.name, "failed", error=exc.tag, login_id=row.id)
+            except ValueError:
+                return RotationResult(cls.name, "failed", error="bad_response", login_id=row.id)
+
+            row.update_payload(data, expires_at=new_expiry)
+            # The grant is externally anchored — the provider may have killed
+            # the old refresh token the moment it issued this one — so the new
+            # lineage must be committed before the lock releases; deferring to
+            # the step's own commit would let a concurrent refresher take the
+            # freed lock and re-present the superseded token.
+            db_session().commit()
+            return RotationResult(cls.name, "refreshed", expires_at=new_expiry, login_id=row.id)
+        finally:
+            await redis.delete(lock_key)
 
     @classmethod
-    def needs_refresh(cls) -> bool:
-        """Whether the access token is within its refresh margin — the cheap
-        read the refresh workflow uses to decide whether to gate provisioning
-        before rotating. An unreadable/expired credential reads as False:
-        there's nothing live to protect, so let the rotation sort it out
-        ungated."""
+    def needs_refresh(cls, login: HarnessLogin) -> bool:
+        """Whether the row's access token is within its refresh margin — the
+        cheap read the refresh workflow uses to decide whether to gate
+        provisioning before rotating. An unreadable/expired credential reads
+        as False: there's nothing live to protect, so let the rotation sort it
+        out ungated."""
         try:
-            token = cls.load_token()
+            token = cls._token_from_credentials(dict(login.payload))
         except OAuthTokenError:
             return False
         if not token.expires_at:
             return False
-        return token.expires_at - _utc_now() <= cls.REFRESH_MARGIN
+        now = _utc_now()
+        if token.expires_at <= now:
+            return False
+        return token.expires_at - now <= cls.REFRESH_MARGIN
 
     @classmethod
     @abstractmethod
@@ -502,8 +553,12 @@ async def _post_grant(url: str, body: dict) -> dict:
         raise GrantError("bad_response") from exc
 
 
-def _login_pending_key(harness: str) -> str:
-    return f"druks:login:pending:{harness}"
+def _login_pending_key(flow_id: str) -> str:
+    return f"druks:login:pending:{flow_id}"
+
+
+def _refresh_lock_key(login_id: str) -> str:
+    return f"druks:harness:refresh:{login_id}"
 
 
 def _b64url(raw: bytes) -> str:

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -35,7 +35,7 @@ from .exceptions import (
     LoginError,
     OAuthTokenError,
 )
-from .models import HarnessLogin
+from .models import HarnessConnection
 
 if TYPE_CHECKING:
     from druks.sandbox.datastructures import McpServer
@@ -190,7 +190,7 @@ class Harness(ABC):
         resolves while runs aren't account-aware. Raises
         :class:`HarnessNotConnectedError`, with the connect-in-Settings fix,
         when no login is designated."""
-        row = HarnessLogin.get_default(cls.name)
+        row = HarnessConnection.get_default(cls.name)
         data = dict(row.payload) if row else None
         if not data:
             raise HarnessNotConnectedError(
@@ -245,7 +245,7 @@ class Harness(ABC):
                 "that has one and try again."
             )
         _, expires_at = cls._refresh_state(payload)
-        HarnessLogin.connect(
+        HarnessConnection.connect(
             harness=cls.name,
             payload=payload,
             expires_at=expires_at,
@@ -256,7 +256,7 @@ class Harness(ABC):
     def disconnect(cls) -> None:
         """Disconnect the default login — the single connection card's target.
         Never promotes another one."""
-        row = HarnessLogin.get_default(cls.name)
+        row = HarnessConnection.get_default(cls.name)
         if row:
             row.delete()
 
@@ -310,7 +310,7 @@ class Harness(ABC):
         reports ``locked`` without touching the provider — two concurrent
         grants on one refresh lineage trip the provider's reuse detection."""
         moment = now or _utc_now()
-        row = HarnessLogin.reload(login_id)
+        row = HarnessConnection.reload(login_id)
         if not row:
             return RotationResult(cls.name, "failed", error="no_credentials", login_id=login_id)
         data = dict(row.payload)
@@ -329,7 +329,7 @@ class Harness(ABC):
         try:
             # Re-read after winning the lock: the previous holder may have
             # advanced this lineage (or deleted the row) after our first read.
-            row = HarnessLogin.reload(login_id)
+            row = HarnessConnection.reload(login_id)
             if not row:
                 return RotationResult(
                     cls.name, "failed", error="no_credentials", login_id=login_id
@@ -374,7 +374,7 @@ class Harness(ABC):
             await redis.delete(lock_key)
 
     @classmethod
-    def needs_refresh(cls, login: HarnessLogin) -> bool:
+    def needs_refresh(cls, login: HarnessConnection) -> bool:
         """Whether the row's access token is within its refresh margin — the
         cheap read the refresh workflow uses to decide whether to gate
         provisioning before rotating. An unreadable/expired credential reads

--- a/backend/druks/harnesses/datastructures.py
+++ b/backend/druks/harnesses/datastructures.py
@@ -34,10 +34,11 @@ class CodexToken:
 @dataclass(frozen=True)
 class RotationResult:
     harness: str
-    # "refreshed" | "fresh" | "no_refresh_token" | "failed"
+    # "refreshed" | "fresh" | "locked" | "no_refresh_token" | "failed"
     action: str
     error: str | None = None
     expires_at: datetime | None = None
+    login_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, String, UniqueConstraint, select, text
 from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm.attributes import flag_modified
 
 from druks.accounts.models import Account
 from druks.core.models import Uuid7Pk
@@ -108,9 +109,13 @@ class HarnessLogin(Base, Uuid7Pk):
 
     def update_payload(self, payload: dict, *, expires_at: datetime | None) -> None:
         # Whole-value reassignment is the write path: the encrypted column
-        # re-encrypts what it's handed, and an in-place edit of a nested block
-        # would not mark the column dirty.
+        # re-encrypts what it's handed. The caller's dict may alias the live
+        # mapping's nested blocks (a dict() copy is shallow), making old and
+        # new compare content-equal at flush and the UPDATE get skipped —
+        # force the write; this is a secrets store, not somewhere to lose a
+        # token.
         self.payload = payload
+        flag_modified(self, "payload")
         self.expires_at = expires_at
         db_session().flush()
 

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, String, UniqueConstraint, select, text
-from sqlalchemy.orm import Mapped, mapped_column, validates
+from sqlalchemy.dialects.postgresql import CITEXT
+from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.orm.attributes import flag_modified
 
-from druks.accounts.models import Account, canonical_email
+from druks.accounts.models import Account
 from druks.core.models import Uuid7Pk
 from druks.database import db_session
 from druks.models import Base
@@ -27,22 +28,18 @@ class HarnessConnection(Base, Uuid7Pk):
 
     harness: Mapped[str]
     account_id: Mapped[str] = mapped_column(ForeignKey("accounts.id", ondelete="RESTRICT"))
-    # The email the provider reported at the token exchange. Cached because
-    # Claude states it once and its stored payload carries no identity at all —
-    # without this the connection is anonymous forever. A connect-time
-    # snapshot, not an identifier: it goes stale if the account is renamed
-    # upstream, and refreshes on the next connect. Null on a row migrated
-    # without one.
-    provider_email: Mapped[str | None]
+    # The email the provider reported at the token exchange (citext — matched
+    # case-insensitively). Cached because Claude states it once and its stored
+    # payload carries no identity at all — without this the connection is
+    # anonymous forever. A connect-time snapshot, not an identifier: it goes
+    # stale if the account is renamed upstream, and refreshes on the next
+    # connect. Null on a row migrated without one.
+    provider_email: Mapped[str | None] = mapped_column(CITEXT)
     kind: Mapped[str] = mapped_column(String, default="subscription")
     payload = EncryptedJsonField()
     expires_at: Mapped[datetime | None]
     is_default: Mapped[bool] = mapped_column(default=False)
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
-
-    @validates("provider_email")
-    def _canonical_provider_email(self, _key: str, value: str | None) -> str | None:
-        return canonical_email(value) if value else None
 
     @classmethod
     def get(cls, login_id: str) -> "HarnessConnection | None":

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -4,7 +4,7 @@ from sqlalchemy import ForeignKey, Index, String, UniqueConstraint, select, text
 from sqlalchemy.orm import Mapped, mapped_column, validates
 from sqlalchemy.orm.attributes import flag_modified
 
-from druks.accounts.models import Account
+from druks.accounts.models import Account, canonical_email
 from druks.core.models import Uuid7Pk
 from druks.database import db_session
 from druks.models import Base
@@ -41,9 +41,7 @@ class HarnessLogin(Base, Uuid7Pk):
 
     @validates("provider_email")
     def _canonical_provider_email(self, _key: str, value: str | None) -> str | None:
-        if not value:
-            return None
-        return value.strip().lower()
+        return canonical_email(value) if value else None
 
     @classmethod
     def get(cls, login_id: str) -> "HarnessLogin | None":

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, String, UniqueConstraint, select, text
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, validates
 from sqlalchemy.orm.attributes import flag_modified
 
 from druks.accounts.models import Account
@@ -15,15 +15,8 @@ class HarnessLogin(Base, Uuid7Pk):
     __tablename__ = "harness_logins"
     __table_args__ = (
         UniqueConstraint("harness", "account_id"),
-        Index(
-            "harness_logins_provider_email_idx",
-            "harness",
-            "provider_email",
-            unique=True,
-            postgresql_where=text("provider_email IS NOT NULL"),
-        ),
-        # One designated default seat per harness — the row execution and the
-        # settings card resolve while runs aren't seat-aware.
+        # One designated default login per harness — the row execution and the
+        # settings card resolve while runs aren't account-aware.
         Index(
             "harness_logins_default_idx",
             "harness",
@@ -34,14 +27,23 @@ class HarnessLogin(Base, Uuid7Pk):
 
     harness: Mapped[str]
     account_id: Mapped[str] = mapped_column(ForeignKey("accounts.id", ondelete="RESTRICT"))
-    # The identity the provider reported for this seat, normalized lowercase.
-    # Null on a row migrated without one — filled in on reconnect.
+    # The email the provider reported at the token exchange. Cached because
+    # Claude states it once and its stored payload carries no identity at all —
+    # without this the login is anonymous forever. A connect-time snapshot, not
+    # an identifier: it goes stale if the account is renamed upstream, and
+    # refreshes on the next connect. Null on a row migrated without one.
     provider_email: Mapped[str | None]
     kind: Mapped[str] = mapped_column(String, default="subscription")
     payload = EncryptedJsonField()
     expires_at: Mapped[datetime | None]
     is_default: Mapped[bool] = mapped_column(default=False)
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
+
+    @validates("provider_email")
+    def _canonical_provider_email(self, _key: str, value: str | None) -> str | None:
+        if not value:
+            return None
+        return value.strip().lower()
 
     @classmethod
     def get(cls, login_id: str) -> "HarnessLogin | None":
@@ -55,12 +57,6 @@ class HarnessLogin(Base, Uuid7Pk):
     def get_for_account(cls, harness: str, account_id: str) -> "HarnessLogin | None":
         return db_session().scalar(
             select(cls).where(cls.harness == harness, cls.account_id == account_id)
-        )
-
-    @classmethod
-    def get_by_provider_email(cls, harness: str, provider_email: str) -> "HarnessLogin | None":
-        return db_session().scalar(
-            select(cls).where(cls.harness == harness, cls.provider_email == provider_email)
         )
 
     @classmethod
@@ -85,22 +81,18 @@ class HarnessLogin(Base, Uuid7Pk):
         expires_at: datetime | None,
         provider_email: str,
     ) -> "HarnessLogin":
-        """Upsert the seat a finished connect flow authenticated: the row
-        already carrying this provider email, else the account's row for this
-        harness — creating the account from the provider email when it's new.
-        A seat connected while the harness has no default becomes the default;
-        promotion only ever happens through a connect, never a disconnect."""
-        email = Account.normalize_email(provider_email)
+        """Upsert the account's login for this harness, creating the account
+        from the provider's email when it's new. A login connected while the
+        harness has no default becomes the default; promotion only ever
+        happens through a connect, never a disconnect."""
+        account = Account.get_or_create(provider_email)
         session = db_session()
-        row = cls.get_by_provider_email(harness, email)
+        row = cls.get_for_account(harness, account.id)
         if not row:
-            account = Account.get_or_create(email)
-            row = cls.get_for_account(harness, account.id)
-            if not row:
-                row = cls(harness=harness, account_id=account.id)
-                session.add(row)
+            row = cls(harness=harness, account_id=account.id)
+            session.add(row)
         row.payload = payload
-        row.provider_email = email
+        row.provider_email = provider_email
         row.expires_at = expires_at
         if not cls.get_default(harness):
             row.is_default = True

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -1,68 +1,120 @@
 from datetime import datetime
 
-from sqlalchemy import JSON, String, delete
+from sqlalchemy import ForeignKey, Index, String, UniqueConstraint, select, text
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy.orm.attributes import flag_modified
 
+from druks.accounts.models import Account
+from druks.core.models import Uuid7Pk
 from druks.database import db_session
 from druks.models import Base
-
-# store()'s ``account`` sentinel: rotation/import leave the label the connect
-# flow set alone; only the connect flow passes an explicit account.
-_KEEP_ACCOUNT: str = "\x00keep-account"
+from druks.secrets.fields import EncryptedJsonField
 
 
-class HarnessLogin(Base):
+class HarnessLogin(Base, Uuid7Pk):
     __tablename__ = "harness_logins"
+    __table_args__ = (
+        UniqueConstraint("harness", "account_id"),
+        Index(
+            "harness_logins_provider_email_idx",
+            "harness",
+            "provider_email",
+            unique=True,
+            postgresql_where=text("provider_email IS NOT NULL"),
+        ),
+        # One designated default seat per harness — the row execution and the
+        # settings card resolve while runs aren't seat-aware.
+        Index(
+            "harness_logins_default_idx",
+            "harness",
+            unique=True,
+            postgresql_where=text("is_default"),
+        ),
+    )
 
-    harness: Mapped[str] = mapped_column(String, primary_key=True)
+    harness: Mapped[str]
+    account_id: Mapped[str] = mapped_column(ForeignKey("accounts.id", ondelete="RESTRICT"))
+    # The identity the provider reported for this seat, normalized lowercase.
+    # Null on a row migrated without one — filled in on reconnect.
+    provider_email: Mapped[str | None]
     kind: Mapped[str] = mapped_column(String, default="subscription")
-    payload: Mapped[dict] = mapped_column(JSON)
+    payload = EncryptedJsonField()
     expires_at: Mapped[datetime | None]
-    account: Mapped[str | None]
+    is_default: Mapped[bool] = mapped_column(default=False)
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
 
     @classmethod
-    def get(cls, harness: str) -> "HarnessLogin | None":
-        return db_session().get(cls, harness)
+    def get(cls, login_id: str) -> "HarnessLogin | None":
+        return db_session().get(cls, login_id)
 
     @classmethod
-    def store(
+    def get_default(cls, harness: str) -> "HarnessLogin | None":
+        return db_session().scalar(select(cls).where(cls.harness == harness, cls.is_default))
+
+    @classmethod
+    def get_for_account(cls, harness: str, account_id: str) -> "HarnessLogin | None":
+        return db_session().scalar(
+            select(cls).where(cls.harness == harness, cls.account_id == account_id)
+        )
+
+    @classmethod
+    def get_by_provider_email(cls, harness: str, provider_email: str) -> "HarnessLogin | None":
+        return db_session().scalar(
+            select(cls).where(cls.harness == harness, cls.provider_email == provider_email)
+        )
+
+    @classmethod
+    def list_all(cls) -> list["HarnessLogin"]:
+        return list(db_session().scalars(select(cls).order_by(cls.harness, cls.id)))
+
+    @classmethod
+    def reload(cls, login_id: str) -> "HarnessLogin | None":
+        """Fresh-from-DB read of one row, past the identity map's cached state
+        — the post-lock re-read that keeps a refresher from re-presenting a
+        refresh token a concurrent winner already advanced."""
+        return db_session().scalar(
+            select(cls).where(cls.id == login_id).execution_options(populate_existing=True)
+        )
+
+    @classmethod
+    def connect(
         cls,
         *,
         harness: str,
         payload: dict,
         expires_at: datetime | None,
-        account: str | None = _KEEP_ACCOUNT,
-    ) -> None:
-        """Upsert the harness row's payload + expiry. ``account`` defaults to
-        keep-what's-there so a rotation tick never wipes the label the connect
-        flow set; the connect flow passes it explicitly."""
+        provider_email: str,
+    ) -> "HarnessLogin":
+        """Upsert the seat a finished connect flow authenticated: the row
+        already carrying this provider email, else the account's row for this
+        harness — creating the account from the provider email when it's new.
+        A seat connected while the harness has no default becomes the default;
+        promotion only ever happens through a connect, never a disconnect."""
+        email = Account.normalize_email(provider_email)
         session = db_session()
-        row = session.get(cls, harness)
-        if row:
-            row.payload = payload
-            # rotate_token loads this row, mutates the payload dict in place, and
-            # hands the same object back — a JSON column can't see a same-identity
-            # change, so persisting it would ride on another column happening to
-            # change too. Flag it so the refreshed token is written on its own
-            # merit; this is a secrets store, not somewhere to lose a token.
-            flag_modified(row, "payload")
-            row.expires_at = expires_at
-            if account != _KEEP_ACCOUNT:
-                row.account = account
-        else:
-            row = cls(
-                harness=harness,
-                payload=payload,
-                expires_at=expires_at,
-                account=None if account == _KEEP_ACCOUNT else account,
-            )
-            session.add(row)
+        row = cls.get_by_provider_email(harness, email)
+        if not row:
+            account = Account.get_or_create(email)
+            row = cls.get_for_account(harness, account.id)
+            if not row:
+                row = cls(harness=harness, account_id=account.id)
+                session.add(row)
+        row.payload = payload
+        row.provider_email = email
+        row.expires_at = expires_at
+        if not cls.get_default(harness):
+            row.is_default = True
         session.flush()
+        return row
 
-    @classmethod
-    def delete(cls, harness: str) -> None:
+    def update_payload(self, payload: dict, *, expires_at: datetime | None) -> None:
+        # Whole-value reassignment is the write path: the encrypted column
+        # re-encrypts what it's handed, and an in-place edit of a nested block
+        # would not mark the column dirty.
+        self.payload = payload
+        self.expires_at = expires_at
+        db_session().flush()
+
+    def delete(self) -> None:
         session = db_session()
-        session.execute(delete(cls).where(cls.harness == harness))
+        session.delete(self)
         session.flush()

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -11,12 +11,12 @@ from druks.models import Base
 from druks.secrets.fields import EncryptedJsonField
 
 
-class HarnessLogin(Base, Uuid7Pk):
+class HarnessConnection(Base, Uuid7Pk):
     __tablename__ = "harness_logins"
     __table_args__ = (
         UniqueConstraint("harness", "account_id"),
-        # One designated default login per harness — the row execution and the
-        # settings card resolve while runs aren't account-aware.
+        # One designated default connection per harness — the row execution and
+        # the settings card resolve while runs aren't account-aware.
         Index(
             "harness_logins_default_idx",
             "harness",
@@ -29,9 +29,10 @@ class HarnessLogin(Base, Uuid7Pk):
     account_id: Mapped[str] = mapped_column(ForeignKey("accounts.id", ondelete="RESTRICT"))
     # The email the provider reported at the token exchange. Cached because
     # Claude states it once and its stored payload carries no identity at all —
-    # without this the login is anonymous forever. A connect-time snapshot, not
-    # an identifier: it goes stale if the account is renamed upstream, and
-    # refreshes on the next connect. Null on a row migrated without one.
+    # without this the connection is anonymous forever. A connect-time
+    # snapshot, not an identifier: it goes stale if the account is renamed
+    # upstream, and refreshes on the next connect. Null on a row migrated
+    # without one.
     provider_email: Mapped[str | None]
     kind: Mapped[str] = mapped_column(String, default="subscription")
     payload = EncryptedJsonField()
@@ -44,25 +45,25 @@ class HarnessLogin(Base, Uuid7Pk):
         return canonical_email(value) if value else None
 
     @classmethod
-    def get(cls, login_id: str) -> "HarnessLogin | None":
+    def get(cls, login_id: str) -> "HarnessConnection | None":
         return db_session().get(cls, login_id)
 
     @classmethod
-    def get_default(cls, harness: str) -> "HarnessLogin | None":
+    def get_default(cls, harness: str) -> "HarnessConnection | None":
         return db_session().scalar(select(cls).where(cls.harness == harness, cls.is_default))
 
     @classmethod
-    def get_for_account(cls, harness: str, account_id: str) -> "HarnessLogin | None":
+    def get_for_account(cls, harness: str, account_id: str) -> "HarnessConnection | None":
         return db_session().scalar(
             select(cls).where(cls.harness == harness, cls.account_id == account_id)
         )
 
     @classmethod
-    def list_all(cls) -> list["HarnessLogin"]:
+    def list_all(cls) -> list["HarnessConnection"]:
         return list(db_session().scalars(select(cls).order_by(cls.harness, cls.id)))
 
     @classmethod
-    def reload(cls, login_id: str) -> "HarnessLogin | None":
+    def reload(cls, login_id: str) -> "HarnessConnection | None":
         """Fresh-from-DB read of one row, past the identity map's cached state
         — the post-lock re-read that keeps a refresher from re-presenting a
         refresh token a concurrent winner already advanced."""
@@ -78,11 +79,11 @@ class HarnessLogin(Base, Uuid7Pk):
         payload: dict,
         expires_at: datetime | None,
         provider_email: str,
-    ) -> "HarnessLogin":
-        """Upsert the account's login for this harness, creating the account
-        from the provider's email when it's new. A login connected while the
-        harness has no default becomes the default; promotion only ever
-        happens through a connect, never a disconnect."""
+    ) -> "HarnessConnection":
+        """Upsert the account's connection for this harness, creating the
+        account from the provider's email when it's new. A connection made
+        while the harness has no default becomes the default; promotion only
+        ever happens through a connect, never a disconnect."""
         account = Account.get_or_create(provider_email)
         session = db_session()
         row = cls.get_for_account(harness, account.id)

--- a/backend/druks/user_settings/routes.py
+++ b/backend/druks/user_settings/routes.py
@@ -48,7 +48,7 @@ def _resolve_harness(name: str) -> tuple[type, HarnessSettings]:
 async def list_harness_settings() -> list[HarnessResponse]:
     registered = {harness.name for harness in get_harnesses()}
     return [
-        HarnessResponse.from_row(row, HarnessLogin.get(row.name))
+        HarnessResponse.from_row(row, HarnessLogin.get_default(row.name))
         for row in HarnessSettings.all()
         if row.name in registered
     ]
@@ -67,13 +67,14 @@ async def update_harness_settings(name: str, body: HarnessUpdate) -> HarnessResp
     _validate_timeout(updates.get("timeout"))
     if updates:
         row.update(**updates)
-    return HarnessResponse.from_row(row, HarnessLogin.get(row.name))
+    return HarnessResponse.from_row(row, HarnessLogin.get_default(row.name))
 
 
 @router.post("/harnesses/{name}/login/start")
 async def start_harness_login(name: str) -> dict[str, str]:
     harness, _ = _resolve_harness(name)
-    return {"authorizeUrl": await harness.login_start()}
+    url, flow_id = await harness.login_start()
+    return {"authorizeUrl": url, "flowId": flow_id}
 
 
 @router.post(
@@ -81,15 +82,19 @@ async def start_harness_login(name: str) -> dict[str, str]:
     response_model=HarnessResponse,
     response_model_by_alias=True,
 )
-async def complete_harness_login(name: str, code: str = Body(..., embed=True)) -> HarnessResponse:
+async def complete_harness_login(
+    name: str,
+    code: str = Body(..., embed=True),
+    flow_id: str = Body(..., embed=True, alias="flowId"),
+) -> HarnessResponse:
     # code = a bare code, a code#state pair, or the full redirect URL — the
     # harness parses whichever it is.
     harness, row = _resolve_harness(name)
     try:
-        await harness.login_complete(code)
+        await harness.login_complete(flow_id=flow_id, pasted=code)
     except LoginError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    return HarnessResponse.from_row(row, HarnessLogin.get(row.name))
+    return HarnessResponse.from_row(row, HarnessLogin.get_default(row.name))
 
 
 @router.delete(
@@ -98,7 +103,7 @@ async def complete_harness_login(name: str, code: str = Body(..., embed=True)) -
 async def disconnect_harness(name: str) -> HarnessResponse:
     harness, row = _resolve_harness(name)
     harness.disconnect()
-    return HarnessResponse.from_row(row, HarnessLogin.get(row.name))
+    return HarnessResponse.from_row(row, HarnessLogin.get_default(row.name))
 
 
 @router.get("", response_model=UserSettingsResponse, response_model_by_alias=True)

--- a/backend/druks/user_settings/routes.py
+++ b/backend/druks/user_settings/routes.py
@@ -6,7 +6,7 @@ from druks.durable.engine import apply_schedules
 from druks.extensions.loader import iter_extensions
 from druks.extensions.registry import workflows
 from druks.harnesses.exceptions import LoginError
-from druks.harnesses.models import HarnessLogin
+from druks.harnesses.models import HarnessConnection
 from druks.harnesses.registry import get_harnesses
 from druks.notifications.models import Destination
 
@@ -48,7 +48,7 @@ def _resolve_harness(name: str) -> tuple[type, HarnessSettings]:
 async def list_harness_settings() -> list[HarnessResponse]:
     registered = {harness.name for harness in get_harnesses()}
     return [
-        HarnessResponse.from_row(row, HarnessLogin.get_default(row.name))
+        HarnessResponse.from_row(row, HarnessConnection.get_default(row.name))
         for row in HarnessSettings.all()
         if row.name in registered
     ]
@@ -67,7 +67,7 @@ async def update_harness_settings(name: str, body: HarnessUpdate) -> HarnessResp
     _validate_timeout(updates.get("timeout"))
     if updates:
         row.update(**updates)
-    return HarnessResponse.from_row(row, HarnessLogin.get_default(row.name))
+    return HarnessResponse.from_row(row, HarnessConnection.get_default(row.name))
 
 
 @router.post("/harnesses/{name}/login/start")
@@ -94,7 +94,7 @@ async def complete_harness_login(
         await harness.login_complete(flow_id=flow_id, pasted=code)
     except LoginError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
-    return HarnessResponse.from_row(row, HarnessLogin.get_default(row.name))
+    return HarnessResponse.from_row(row, HarnessConnection.get_default(row.name))
 
 
 @router.delete(
@@ -103,7 +103,7 @@ async def complete_harness_login(
 async def disconnect_harness(name: str) -> HarnessResponse:
     harness, row = _resolve_harness(name)
     harness.disconnect()
-    return HarnessResponse.from_row(row, HarnessLogin.get_default(row.name))
+    return HarnessResponse.from_row(row, HarnessConnection.get_default(row.name))
 
 
 @router.get("", response_model=UserSettingsResponse, response_model_by_alias=True)

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -8,7 +8,7 @@ from druks.extensions.settings import field_choices, field_kind
 from druks.schemas import BaseResponse
 
 if TYPE_CHECKING:
-    from druks.harnesses.models import HarnessLogin
+    from druks.harnesses.models import HarnessConnection
     from druks.user_settings.models import HarnessSettings
 
 
@@ -20,7 +20,7 @@ class HarnessResponse(BaseResponse):
     timeout: int
     fast_mode: bool
     allowed_models: list[str]
-    # Connection state, joined in from the harness's default HarnessLogin row —
+    # Connection state, joined in from the harness's default HarnessConnection row —
     # connected=False until someone connects it from the dashboard.
     connected: bool
     kind: str | None
@@ -29,7 +29,7 @@ class HarnessResponse(BaseResponse):
 
     @classmethod
     def from_row(
-        cls, settings: "HarnessSettings", login: "HarnessLogin | None"
+        cls, settings: "HarnessSettings", login: "HarnessConnection | None"
     ) -> "HarnessResponse":
         return cls(
             name=settings.name,

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -21,7 +21,7 @@ class HarnessResponse(BaseResponse):
     fast_mode: bool
     allowed_models: list[str]
     # Connection state, joined in from the harness's default HarnessLogin row —
-    # connected=False until someone connects a seat from the dashboard.
+    # connected=False until someone connects it from the dashboard.
     connected: bool
     kind: str | None
     account: str | None

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -20,8 +20,8 @@ class HarnessResponse(BaseResponse):
     timeout: int
     fast_mode: bool
     allowed_models: list[str]
-    # Connection state, joined in from the HarnessLogin row — connected=False
-    # until the operator connects the harness from the dashboard.
+    # Connection state, joined in from the harness's default HarnessLogin row —
+    # connected=False until someone connects a seat from the dashboard.
     connected: bool
     kind: str | None
     account: str | None
@@ -41,7 +41,7 @@ class HarnessResponse(BaseResponse):
             allowed_models=settings.allowed_models,
             connected=bool(login),
             kind=login.kind if login else None,
-            account=login.account if login else None,
+            account=login.provider_email if login else None,
             expires_at=login.expires_at if login else None,
         )
 

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -12,6 +12,8 @@ from alembic import context
 from druks.alembic_support import run_alembic_env
 
 if context.config.config_file_name is not None:
-    fileConfig(context.config.config_file_name)
+    # In-process upgrades (init-db, the migration tests) must not mute the
+    # app's already-created loggers.
+    fileConfig(context.config.config_file_name, disable_existing_loggers=False)
 
 run_alembic_env()

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,5 +1,6 @@
 from logging.config import fileConfig
 
+import druks.accounts.models  # noqa: F401
 import druks.build.models  # noqa: F401
 import druks.durable.models  # noqa: F401
 import druks.harnesses.models  # noqa: F401

--- a/backend/migrations/versions/a8060465d9ed_accounts_and_seat_keyed_harness_logins.py
+++ b/backend/migrations/versions/a8060465d9ed_accounts_and_seat_keyed_harness_logins.py
@@ -1,0 +1,162 @@
+"""accounts and seat-keyed harness logins
+
+Revision ID: a8060465d9ed
+Revises: 619e34746ef3
+Create Date: 2026-07-15 20:10:00.000000
+
+"""
+
+import json
+import os
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic import op
+from uuid_utils import uuid7
+
+from druks.secrets import utils as secrets
+
+# revision identifiers, used by Alembic.
+revision: str = "a8060465d9ed"
+down_revision: str | Sequence[str] | None = "619e34746ef3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# The envelope AAD is the FINAL ``table.column`` — encrypting under the
+# temporary column's name would brick every ciphertext at the rename.
+_PAYLOAD_AAD = "harness_logins.payload"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    legacy = (
+        bind.execute(sa.text("SELECT harness, payload, account FROM harness_logins"))
+        .mappings()
+        .all()
+    )
+
+    email = ""
+    if legacy:
+        # Fail before any mutation: existing seats are re-keyed under one
+        # account, and only the operator knows which identity that is.
+        email = os.environ.get("DRUKS_DASHBOARD_EMAIL", "").strip().lower()
+        if not email:
+            raise RuntimeError(
+                "DRUKS_DASHBOARD_EMAIL must be set (non-blank) for this migration: "
+                "existing harness logins are re-keyed under one account with that "
+                "email. Export it for this one run, set to the provider email you "
+                "will sign in with once account login lands."
+            )
+
+    op.create_table(
+        "accounts",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+
+    op.add_column("harness_logins", sa.Column("id", sa.String(), nullable=True))
+    op.add_column("harness_logins", sa.Column("account_id", sa.String(), nullable=True))
+    op.add_column("harness_logins", sa.Column("provider_email", sa.String(), nullable=True))
+    op.add_column("harness_logins", sa.Column("is_default", sa.Boolean(), nullable=True))
+    op.add_column(
+        "harness_logins", sa.Column("payload_ciphertext", sa.LargeBinary(), nullable=True)
+    )
+
+    if legacy:
+        now = datetime.now(UTC)
+        account_id = str(uuid7())
+        bind.execute(
+            sa.text(
+                "INSERT INTO accounts (id, email, created_at, updated_at) "
+                "VALUES (:id, :email, :now, :now)"
+            ),
+            {"id": account_id, "email": email, "now": now},
+        )
+        for row in legacy:
+            # Canonical serialization matches EncryptedJson's bind exactly, so
+            # the decrypt-verify below compares like for like.
+            canonical = json.dumps(row["payload"], separators=(",", ":"), sort_keys=True)
+            provider_email = (row["account"] or "").strip().lower()
+            bind.execute(
+                sa.text(
+                    "UPDATE harness_logins SET id = :id, account_id = :account_id, "
+                    "provider_email = :provider_email, is_default = true, "
+                    "payload_ciphertext = :ciphertext WHERE harness = :harness"
+                ),
+                {
+                    "id": str(uuid7()),
+                    "account_id": account_id,
+                    "provider_email": provider_email or None,
+                    "ciphertext": secrets.encrypt(canonical.encode(), _PAYLOAD_AAD),
+                    "harness": row["harness"],
+                },
+            )
+
+    op.drop_constraint("harness_logins_pkey", "harness_logins", type_="primary")
+    op.drop_column("harness_logins", "payload")
+    op.drop_column("harness_logins", "account")
+
+    op.alter_column("harness_logins", "payload_ciphertext", new_column_name="payload")
+    op.alter_column("harness_logins", "id", existing_type=sa.String(), nullable=False)
+    op.alter_column("harness_logins", "account_id", existing_type=sa.String(), nullable=False)
+    op.alter_column("harness_logins", "payload", existing_type=sa.LargeBinary(), nullable=False)
+    op.alter_column(
+        "harness_logins",
+        "is_default",
+        existing_type=sa.Boolean(),
+        nullable=False,
+        server_default=sa.false(),
+    )
+    op.create_primary_key("harness_logins_pkey", "harness_logins", ["id"])
+    op.create_foreign_key(
+        "harness_logins_account_id_fkey",
+        "harness_logins",
+        "accounts",
+        ["account_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_unique_constraint(
+        "harness_logins_harness_account_id_key", "harness_logins", ["harness", "account_id"]
+    )
+    op.create_index(
+        "harness_logins_provider_email_idx",
+        "harness_logins",
+        ["harness", "provider_email"],
+        unique=True,
+        postgresql_where=sa.text("provider_email IS NOT NULL"),
+    )
+    op.create_index(
+        "harness_logins_default_idx",
+        "harness_logins",
+        ["harness"],
+        unique=True,
+        postgresql_where=sa.text("is_default"),
+    )
+
+    # Decrypt-verify every migrated value under the final AAD before this
+    # revision commits — a payload that can't round-trip must abort here, not
+    # surface as a dead credential at the next run.
+    originals = {row["harness"]: row["payload"] for row in legacy}
+    migrated = (
+        bind.execute(sa.text("SELECT harness, payload FROM harness_logins")).mappings().all()
+    )
+    for row in migrated:
+        stored = json.loads(secrets.decrypt(bytes(row["payload"]), _PAYLOAD_AAD))
+        if stored != originals[row["harness"]]:
+            raise RuntimeError(
+                f"harness login {row['harness']!r} did not round-trip through encryption"
+            )
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "irreversible: re-keyed, encrypted harness logins cannot be collapsed back "
+        "to one plaintext row per harness — restore the pre-migration database "
+        "backup and the old image instead"
+    )

--- a/backend/migrations/versions/a8060465d9ed_accounts_and_seat_keyed_harness_logins.py
+++ b/backend/migrations/versions/a8060465d9ed_accounts_and_seat_keyed_harness_logins.py
@@ -54,7 +54,6 @@ def upgrade() -> None:
         sa.Column("id", sa.String(), nullable=False),
         sa.Column("email", sa.String(), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("email"),
     )
@@ -72,8 +71,7 @@ def upgrade() -> None:
         account_id = str(uuid7())
         bind.execute(
             sa.text(
-                "INSERT INTO accounts (id, email, created_at, updated_at) "
-                "VALUES (:id, :email, :now, :now)"
+                "INSERT INTO accounts (id, email, created_at) VALUES (:id, :email, :now)"
             ),
             {"id": account_id, "email": email, "now": now},
         )

--- a/backend/migrations/versions/a8060465d9ed_accounts_and_seat_keyed_harness_logins.py
+++ b/backend/migrations/versions/a8060465d9ed_accounts_and_seat_keyed_harness_logins.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 from uuid_utils import uuid7
 
 from druks.secrets import utils as secrets
@@ -30,6 +31,8 @@ _PAYLOAD_AAD = "harness_logins.payload"
 
 def upgrade() -> None:
     bind = op.get_bind()
+    # citext backs the case-insensitive email columns below.
+    bind.execute(sa.text("CREATE EXTENSION IF NOT EXISTS citext"))
     legacy = (
         bind.execute(sa.text("SELECT harness, payload, account FROM harness_logins"))
         .mappings()
@@ -40,7 +43,8 @@ def upgrade() -> None:
     if legacy:
         # Fail before any mutation: existing logins are re-keyed under one
         # account, and only the operator knows which identity that is.
-        email = os.environ.get("DRUKS_DASHBOARD_EMAIL", "").strip().lower()
+        # Strip whitespace (hand-edited .env); case is citext's job, not ours.
+        email = os.environ.get("DRUKS_DASHBOARD_EMAIL", "").strip()
         if not email:
             raise RuntimeError(
                 "DRUKS_DASHBOARD_EMAIL must be set (non-blank) for this migration: "
@@ -52,7 +56,7 @@ def upgrade() -> None:
     op.create_table(
         "accounts",
         sa.Column("id", sa.String(), nullable=False),
-        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("email", postgresql.CITEXT(), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("email"),
@@ -60,7 +64,7 @@ def upgrade() -> None:
 
     op.add_column("harness_logins", sa.Column("id", sa.String(), nullable=True))
     op.add_column("harness_logins", sa.Column("account_id", sa.String(), nullable=True))
-    op.add_column("harness_logins", sa.Column("provider_email", sa.String(), nullable=True))
+    op.add_column("harness_logins", sa.Column("provider_email", postgresql.CITEXT(), nullable=True))
     op.add_column("harness_logins", sa.Column("is_default", sa.Boolean(), nullable=True))
     op.add_column(
         "harness_logins", sa.Column("payload_ciphertext", sa.LargeBinary(), nullable=True)
@@ -79,7 +83,7 @@ def upgrade() -> None:
             # Canonical serialization matches EncryptedJson's bind exactly, so
             # the decrypt-verify below compares like for like.
             canonical = json.dumps(row["payload"], separators=(",", ":"), sort_keys=True)
-            provider_email = (row["account"] or "").strip().lower()
+            provider_email = (row["account"] or "").strip()
             bind.execute(
                 sa.text(
                     "UPDATE harness_logins SET id = :id, account_id = :account_id, "

--- a/backend/migrations/versions/a8060465d9ed_accounts_and_seat_keyed_harness_logins.py
+++ b/backend/migrations/versions/a8060465d9ed_accounts_and_seat_keyed_harness_logins.py
@@ -38,7 +38,7 @@ def upgrade() -> None:
 
     email = ""
     if legacy:
-        # Fail before any mutation: existing seats are re-keyed under one
+        # Fail before any mutation: existing logins are re-keyed under one
         # account, and only the operator knows which identity that is.
         email = os.environ.get("DRUKS_DASHBOARD_EMAIL", "").strip().lower()
         if not email:
@@ -123,13 +123,6 @@ def upgrade() -> None:
     )
     op.create_unique_constraint(
         "harness_logins_harness_account_id_key", "harness_logins", ["harness", "account_id"]
-    )
-    op.create_index(
-        "harness_logins_provider_email_idx",
-        "harness_logins",
-        ["harness", "provider_email"],
-        unique=True,
-        postgresql_where=sa.text("provider_email IS NOT NULL"),
     )
     op.create_index(
         "harness_logins_default_idx",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -353,6 +353,21 @@ def bind_ambient_session(session) -> None:
     db_session.registry.set(session)
 
 
+def connect_harness(harness_cls, payload: dict, *, provider_email: str = "op@example.com"):
+    """Seed a connected seat the way a finished connect flow would: an account
+    keyed by the provider email plus the harness's login row, expiry mirrored
+    out of the payload. Returns the HarnessLogin row."""
+    from druks.harnesses.models import HarnessLogin
+
+    _, expires_at = harness_cls._refresh_state(payload)
+    return HarnessLogin.connect(
+        harness=harness_cls.name,
+        payload=payload,
+        expires_at=expires_at,
+        provider_email=provider_email,
+    )
+
+
 def seed_dbos_status(session, workflow_id: str, state: str, *, subject=None) -> None:
     """Write the ``dbos.workflow_status`` row a Run's derived ``state`` reads,
     carrying the subject attributes ``start()`` stamps — the paired half of

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -356,11 +356,11 @@ def bind_ambient_session(session) -> None:
 def connect_harness(harness_cls, payload: dict, *, provider_email: str = "op@example.com"):
     """Seed a connected seat the way a finished connect flow would: an account
     keyed by the provider email plus the harness's login row, expiry mirrored
-    out of the payload. Returns the HarnessLogin row."""
-    from druks.harnesses.models import HarnessLogin
+    out of the payload. Returns the HarnessConnection row."""
+    from druks.harnesses.models import HarnessConnection
 
     _, expires_at = harness_cls._refresh_state(payload)
-    return HarnessLogin.connect(
+    return HarnessConnection.connect(
         harness=harness_cls.name,
         payload=payload,
         expires_at=expires_at,

--- a/backend/tests/test_accounts_migration.py
+++ b/backend/tests/test_accounts_migration.py
@@ -158,14 +158,14 @@ def test_orm_reads_migrated_rows_under_the_model_aad(engine, monkeypatch):
 
     from druks.database import configure_session, db_session, get_session
     from druks.harnesses.claude import ClaudeHarness
-    from druks.harnesses.models import HarnessLogin
+    from druks.harnesses.models import HarnessConnection
 
     configure_session(engine)
     session = get_session(engine)
     db_session.registry.set(session)
     try:
         assert ClaudeHarness.get_credentials() == CLAUDE_PAYLOAD
-        codex_row = HarnessLogin.get_default("codex")
+        codex_row = HarnessConnection.get_default("codex")
         assert dict(codex_row.payload) == CODEX_PAYLOAD
         assert codex_row.provider_email is None
     finally:

--- a/backend/tests/test_accounts_migration.py
+++ b/backend/tests/test_accounts_migration.py
@@ -12,7 +12,7 @@ from druks.secrets.utils import decrypt
 from sqlalchemy import create_engine, text
 
 # The re-key migration is the one shot at existing credentials: it must fail
-# closed without the operator identity, attach every legacy seat when given
+# closed without the operator identity, attach every legacy login when given
 # one, and produce ciphertexts the ORM can read under the final AAD. That only
 # proves out against a real Postgres walked from the previous head — so this
 # module owns its database and drives Alembic directly.
@@ -134,7 +134,7 @@ def test_legacy_rows_are_rekeyed_under_one_account(engine, monkeypatch):
     assert [row["harness"] for row in logins] == ["claude", "codex"]
     assert len({row["id"] for row in logins}) == 2
     for row in logins:
-        # Every legacy seat attaches to the one account and stays its
+        # Every legacy login attaches to the one account and stays its
         # harness's default, whatever its provider email was.
         assert row["account_id"] == accounts[0]["id"]
         assert row["is_default"] is True

--- a/backend/tests/test_accounts_migration.py
+++ b/backend/tests/test_accounts_migration.py
@@ -1,0 +1,182 @@
+import json
+import os
+from pathlib import Path
+
+import druks
+import psycopg
+import pytest
+from alembic import command
+from alembic.config import Config
+from druks.secrets.exceptions import SecretDecryptError
+from druks.secrets.utils import decrypt
+from sqlalchemy import create_engine, text
+
+# The re-key migration is the one shot at existing credentials: it must fail
+# closed without the operator identity, attach every legacy seat when given
+# one, and produce ciphertexts the ORM can read under the final AAD. That only
+# proves out against a real Postgres walked from the previous head — so this
+# module owns its database and drives Alembic directly.
+
+PG_BASE = os.environ.get("DRUKS_TEST_PG", "postgresql://druks:druks@localhost:5432")
+DB = "druks_accounts_migration_test"
+URL = f"{PG_BASE.replace('postgresql://', 'postgresql+psycopg://')}/{DB}"
+
+PREVIOUS_HEAD = "619e34746ef3"
+_ALEMBIC_INI = Path(druks.__file__).resolve().parent.parent / "alembic.ini"
+
+CLAUDE_PAYLOAD = {"claudeAiOauth": {"accessToken": "A0", "refreshToken": "R0"}}
+CODEX_PAYLOAD = {"tokens": {"access_token": "T0", "refresh_token": "R0"}}
+
+
+def _pg_up() -> bool:
+    try:
+        psycopg.connect(f"{PG_BASE}/postgres", connect_timeout=2).close()
+        return True
+    except psycopg.Error:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _pg_up(), reason="test Postgres not reachable")
+
+
+def _upgrade(revision: str) -> None:
+    config = Config(str(_ALEMBIC_INI))
+    config.set_main_option("sqlalchemy.url", URL)
+    command.upgrade(config, revision)
+
+
+@pytest.fixture
+def engine():
+    admin = psycopg.connect(f"{PG_BASE}/postgres", autocommit=True)
+    admin.execute(f"DROP DATABASE IF EXISTS {DB}")
+    admin.execute(f"CREATE DATABASE {DB}")
+    admin.close()
+
+    _upgrade(PREVIOUS_HEAD)
+    created = create_engine(URL)
+    try:
+        yield created
+    finally:
+        created.dispose()
+
+
+def _seed_legacy(engine) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO harness_logins (harness, kind, payload, expires_at, account, "
+                "updated_at) VALUES (:harness, 'subscription', CAST(:payload AS json), NULL, "
+                ":account, now())"
+            ),
+            [
+                {
+                    "harness": "claude",
+                    "payload": json.dumps(CLAUDE_PAYLOAD),
+                    # Mixed case + padding: the migration must normalize it.
+                    "account": " Legacy@Example.COM ",
+                },
+                {
+                    # A legacy row that never recorded a provider email.
+                    "harness": "codex",
+                    "payload": json.dumps(CODEX_PAYLOAD),
+                    "account": None,
+                },
+            ],
+        )
+
+
+def _rows(engine, query: str) -> list:
+    with engine.connect() as connection:
+        return connection.execute(text(query)).mappings().all()
+
+
+def test_missing_dashboard_email_fails_before_data_mutation(engine, monkeypatch):
+    _seed_legacy(engine)
+    monkeypatch.delenv("DRUKS_DASHBOARD_EMAIL", raising=False)
+
+    with pytest.raises(Exception, match="DRUKS_DASHBOARD_EMAIL"):
+        _upgrade("head")
+
+    # Nothing mutated: the old shape survives intact, no accounts table exists.
+    legacy = _rows(engine, "SELECT harness, payload, account FROM harness_logins ORDER BY harness")
+    assert [row["harness"] for row in legacy] == ["claude", "codex"]
+    assert legacy[0]["payload"] == CLAUDE_PAYLOAD
+    assert legacy[0]["account"] == " Legacy@Example.COM "
+    tables = _rows(
+        engine, "SELECT table_name FROM information_schema.tables WHERE table_name = 'accounts'"
+    )
+    assert tables == []
+
+
+def test_blank_dashboard_email_fails_too(engine, monkeypatch):
+    _seed_legacy(engine)
+    monkeypatch.setenv("DRUKS_DASHBOARD_EMAIL", "   ")
+
+    with pytest.raises(Exception, match="DRUKS_DASHBOARD_EMAIL"):
+        _upgrade("head")
+
+
+def test_legacy_rows_are_rekeyed_under_one_account(engine, monkeypatch):
+    _seed_legacy(engine)
+    monkeypatch.setenv("DRUKS_DASHBOARD_EMAIL", " Op@Example.COM ")
+
+    _upgrade("head")
+
+    accounts = _rows(engine, "SELECT id, email FROM accounts")
+    assert len(accounts) == 1
+    assert accounts[0]["email"] == "op@example.com"
+
+    logins = _rows(
+        engine,
+        "SELECT id, harness, account_id, provider_email, is_default, payload "
+        "FROM harness_logins ORDER BY harness",
+    )
+    assert [row["harness"] for row in logins] == ["claude", "codex"]
+    assert len({row["id"] for row in logins}) == 2
+    for row in logins:
+        # Every legacy seat attaches to the one account and stays its
+        # harness's default, whatever its provider email was.
+        assert row["account_id"] == accounts[0]["id"]
+        assert row["is_default"] is True
+    assert logins[0]["provider_email"] == "legacy@example.com"
+    assert logins[1]["provider_email"] is None
+
+    # Payloads decrypt under the final AAD only — an envelope minted against
+    # the temporary column name would brick at the rename.
+    originals = {"claude": CLAUDE_PAYLOAD, "codex": CODEX_PAYLOAD}
+    for row in logins:
+        envelope = bytes(row["payload"])
+        assert json.loads(decrypt(envelope, "harness_logins.payload")) == originals[row["harness"]]
+        with pytest.raises(SecretDecryptError):
+            decrypt(envelope, "harness_logins.payload_ciphertext")
+
+
+def test_orm_reads_migrated_rows_under_the_model_aad(engine, monkeypatch):
+    _seed_legacy(engine)
+    monkeypatch.setenv("DRUKS_DASHBOARD_EMAIL", "op@example.com")
+    _upgrade("head")
+
+    from druks.database import configure_session, db_session, get_session
+    from druks.harnesses.claude import ClaudeHarness
+    from druks.harnesses.models import HarnessLogin
+
+    configure_session(engine)
+    session = get_session(engine)
+    db_session.registry.set(session)
+    try:
+        assert ClaudeHarness.get_credentials() == CLAUDE_PAYLOAD
+        codex_row = HarnessLogin.get_default("codex")
+        assert dict(codex_row.payload) == CODEX_PAYLOAD
+        assert codex_row.provider_email is None
+    finally:
+        db_session.remove()
+        session.close()
+
+
+def test_fresh_install_migrates_without_the_variable(engine, monkeypatch):
+    monkeypatch.delenv("DRUKS_DASHBOARD_EMAIL", raising=False)
+
+    _upgrade("head")
+
+    assert _rows(engine, "SELECT id FROM accounts") == []
+    assert _rows(engine, "SELECT id FROM harness_logins") == []

--- a/backend/tests/test_accounts_migration.py
+++ b/backend/tests/test_accounts_migration.py
@@ -72,7 +72,7 @@ def _seed_legacy(engine) -> None:
                 {
                     "harness": "claude",
                     "payload": json.dumps(CLAUDE_PAYLOAD),
-                    # Mixed case + padding: the migration must normalize it.
+                    # Padding the migration strips; case is citext's to handle.
                     "account": " Legacy@Example.COM ",
                 },
                 {
@@ -124,7 +124,9 @@ def test_legacy_rows_are_rekeyed_under_one_account(engine, monkeypatch):
 
     accounts = _rows(engine, "SELECT id, email FROM accounts")
     assert len(accounts) == 1
-    assert accounts[0]["email"] == "op@example.com"
+    # Stored stripped, original case; citext matches it regardless of case.
+    assert accounts[0]["email"] == "Op@Example.COM"
+    assert _rows(engine, "SELECT id FROM accounts WHERE email = 'op@example.com'")
 
     logins = _rows(
         engine,
@@ -138,7 +140,7 @@ def test_legacy_rows_are_rekeyed_under_one_account(engine, monkeypatch):
         # harness's default, whatever its provider email was.
         assert row["account_id"] == accounts[0]["id"]
         assert row["is_default"] is True
-    assert logins[0]["provider_email"] == "legacy@example.com"
+    assert logins[0]["provider_email"] == "Legacy@Example.COM"  # stripped, original case
     assert logins[1]["provider_email"] is None
 
     # Payloads decrypt under the final AAD only — an envelope minted against

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -54,9 +54,10 @@ def _seed_run_for_record(db_session):
 def _connected_claude(db_session):
     # A run refuses to dispatch on an unconnected harness; the runtime tests
     # here resolve to claude models, so connect it once.
+    from conftest import connect_harness
     from druks.harnesses.claude import ClaudeHarness
 
-    ClaudeHarness.store_credentials({"claudeAiOauth": {"accessToken": "test-token"}})
+    connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "test-token"}})
 
 
 def _patch_runtime(monkeypatch, tmp_path, payload):

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -38,11 +38,12 @@ def test_harness_response_carries_connection_state(tmp_path: Path):
     assert "expiresAt" in claude
 
 
-def test_login_start_returns_authorize_url(tmp_path: Path):
+def test_login_start_returns_authorize_url_and_flow_id(tmp_path: Path):
     with _build_client(tmp_path) as client:
         response = client.post("/api/settings/harnesses/claude/login/start")
     assert response.status_code == 200
     assert response.json()["authorizeUrl"].startswith("https://claude.ai/oauth/authorize?")
+    assert response.json()["flowId"]
 
 
 def test_login_start_unknown_harness_is_404(tmp_path: Path):
@@ -53,10 +54,22 @@ def test_login_start_unknown_harness_is_404(tmp_path: Path):
 
 def test_login_complete_with_no_code_is_422(tmp_path: Path):
     with _build_client(tmp_path) as client:
-        client.post("/api/settings/harnesses/claude/login/start")
+        flow_id = client.post("/api/settings/harnesses/claude/login/start").json()["flowId"]
         # Empty paste fails before any provider call — clean check of the
         # LoginError -> 422 wiring without mocking the exchange.
-        response = client.post("/api/settings/harnesses/claude/login/complete", json={"code": ""})
+        response = client.post(
+            "/api/settings/harnesses/claude/login/complete",
+            json={"code": "", "flowId": flow_id},
+        )
+    assert response.status_code == 422
+
+
+def test_login_complete_without_flow_id_is_422(tmp_path: Path):
+    with _build_client(tmp_path) as client:
+        client.post("/api/settings/harnesses/claude/login/start")
+        response = client.post(
+            "/api/settings/harnesses/claude/login/complete", json={"code": "x"}
+        )
     assert response.status_code == 422
 
 
@@ -70,9 +83,10 @@ def test_login_complete_provider_rejection_is_422(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(hbase.httpx.AsyncClient, "post", fake_post)
     with _build_client(tmp_path) as client:
-        client.post("/api/settings/harnesses/claude/login/start")
+        flow_id = client.post("/api/settings/harnesses/claude/login/start").json()["flowId"]
         response = client.post(
-            "/api/settings/harnesses/claude/login/complete", json={"code": "code"}
+            "/api/settings/harnesses/claude/login/complete",
+            json={"code": "code", "flowId": flow_id},
         )
 
     assert response.status_code == 422

--- a/backend/tests/test_core_workflows.py
+++ b/backend/tests/test_core_workflows.py
@@ -15,3 +15,10 @@ def test_invalid_grant_warns(caplog):
     with caplog.at_level(logging.WARNING):
         _log_result(RotationResult("claude", "failed", error="invalid_grant"))
     assert "token refresh failed for claude" in caplog.text
+
+
+def test_locked_stays_quiet(caplog):
+    # Another worker owns that row's refresh — losing the election is routine.
+    with caplog.at_level(logging.WARNING):
+        _log_result(RotationResult("claude", "locked", login_id="L1"))
+    assert caplog.records == []

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -153,7 +153,7 @@ def rt():
     # An agent run checks the resolved harness is connected before any VM work;
     # AgentFlow's decider resolves to claude, so connect it for the module.
     from druks.accounts.models import Account
-    from druks.harnesses.models import HarnessLogin
+    from druks.harnesses.models import HarnessConnection
 
     session = get_session(engine)
     try:
@@ -161,7 +161,7 @@ def rt():
         session.add(account)
         session.flush()
         session.add(
-            HarnessLogin(
+            HarnessConnection(
                 harness="claude",
                 account_id=account.id,
                 provider_email=account.email,

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -152,11 +152,23 @@ def rt():
 
     # An agent run checks the resolved harness is connected before any VM work;
     # AgentFlow's decider resolves to claude, so connect it for the module.
+    from druks.accounts.models import Account
     from druks.harnesses.models import HarnessLogin
 
     session = get_session(engine)
     try:
-        session.add(HarnessLogin(harness="claude", payload={"claudeAiOauth": {"accessToken": "t"}}))
+        account = Account(email="op@example.com")
+        session.add(account)
+        session.flush()
+        session.add(
+            HarnessLogin(
+                harness="claude",
+                account_id=account.id,
+                provider_email=account.email,
+                payload={"claudeAiOauth": {"accessToken": "t"}},
+                is_default=True,
+            )
+        )
         session.commit()
     finally:
         session.close()

--- a/backend/tests/test_gate.py
+++ b/backend/tests/test_gate.py
@@ -36,12 +36,23 @@ class _FakeHarness:
     refresh_due = True
 
     @classmethod
-    def needs_refresh(cls, **kwargs):
+    def needs_refresh(cls, login):
         return cls.refresh_due
 
     @classmethod
-    async def rotate_token(cls, **kwargs):
-        return RotationResult(cls.name, "refreshed")
+    async def rotate_token(cls, login_id):
+        return RotationResult(cls.name, "refreshed", login_id=login_id)
+
+
+class _FakeLogin:
+    harness = "fake"
+    id = "login-1"
+
+
+class _FakeLogins:
+    @staticmethod
+    def list_all():
+        return [_FakeLogin()]
 
 
 class _TrackingGate:
@@ -64,6 +75,7 @@ class _TrackingGate:
 async def test_refresh_closes_gate_when_a_rotation_is_due(monkeypatch):
     hold = _TrackingGate()
     monkeypatch.setattr(harness_workflows, "get_harnesses", lambda: (_FakeHarness,))
+    monkeypatch.setattr(harness_workflows, "HarnessLogin", _FakeLogins)
     monkeypatch.setattr(harness_workflows.gate, "hold", hold)
     _FakeHarness.refresh_due = True
 
@@ -75,6 +87,7 @@ async def test_refresh_closes_gate_when_a_rotation_is_due(monkeypatch):
 async def test_refresh_leaves_gate_open_on_a_no_op_tick(monkeypatch):
     hold = _TrackingGate()
     monkeypatch.setattr(harness_workflows, "get_harnesses", lambda: (_FakeHarness,))
+    monkeypatch.setattr(harness_workflows, "HarnessLogin", _FakeLogins)
     monkeypatch.setattr(harness_workflows.gate, "hold", hold)
     _FakeHarness.refresh_due = False
 

--- a/backend/tests/test_gate.py
+++ b/backend/tests/test_gate.py
@@ -75,7 +75,7 @@ class _TrackingGate:
 async def test_refresh_closes_gate_when_a_rotation_is_due(monkeypatch):
     hold = _TrackingGate()
     monkeypatch.setattr(harness_workflows, "get_harnesses", lambda: (_FakeHarness,))
-    monkeypatch.setattr(harness_workflows, "HarnessLogin", _FakeLogins)
+    monkeypatch.setattr(harness_workflows, "HarnessConnection", _FakeLogins)
     monkeypatch.setattr(harness_workflows.gate, "hold", hold)
     _FakeHarness.refresh_due = True
 
@@ -87,7 +87,7 @@ async def test_refresh_closes_gate_when_a_rotation_is_due(monkeypatch):
 async def test_refresh_leaves_gate_open_on_a_no_op_tick(monkeypatch):
     hold = _TrackingGate()
     monkeypatch.setattr(harness_workflows, "get_harnesses", lambda: (_FakeHarness,))
-    monkeypatch.setattr(harness_workflows, "HarnessLogin", _FakeLogins)
+    monkeypatch.setattr(harness_workflows, "HarnessConnection", _FakeLogins)
     monkeypatch.setattr(harness_workflows.gate, "hold", hold)
     _FakeHarness.refresh_due = False
 

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -1,9 +1,12 @@
+import asyncio
 import base64
 import json
 from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
+from conftest import connect_harness
+from druks.accounts.models import Account
 from druks.harnesses import base as hbase
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
@@ -19,7 +22,7 @@ def _jwt(exp: int) -> str:
     return f"{header}.{payload}.sig"
 
 
-def _seed_claude(*, access="A0", refresh="R0", expires_at=None, extra=None) -> dict:
+def _claude_payload(*, access="A0", refresh="R0", expires_at=None, extra=None) -> dict:
     block = {"accessToken": access, "scopes": ["user:profile"], "subscriptionType": "max"}
     if refresh is not None:
         block["refreshToken"] = refresh
@@ -27,19 +30,23 @@ def _seed_claude(*, access="A0", refresh="R0", expires_at=None, extra=None) -> d
         block["expiresAt"] = int(expires_at.timestamp() * 1000)
     if extra:
         block.update(extra)
-    data = {"claudeAiOauth": block}
-    ClaudeHarness.store_credentials(data)
-    return data
+    return {"claudeAiOauth": block}
 
 
-def _seed_codex(*, access=None, refresh="R0", account_id="acc-1", id_token="id-0") -> dict:
+def _seed_claude(*, provider_email="op@example.com", **kwargs) -> HarnessLogin:
+    return connect_harness(ClaudeHarness, _claude_payload(**kwargs), provider_email=provider_email)
+
+
+def _codex_payload(*, access=None, refresh="R0", account_id="acc-1", id_token="id-0") -> dict:
     access = access or _jwt(int((_NOW + timedelta(days=9)).timestamp()))
     tokens = {"access_token": access, "id_token": id_token, "account_id": account_id}
     if refresh is not None:
         tokens["refresh_token"] = refresh
-    data = {"auth_mode": "chatgpt", "OPENAI_API_KEY": None, "tokens": tokens}
-    CodexHarness.store_credentials(data)
-    return data
+    return {"auth_mode": "chatgpt", "OPENAI_API_KEY": None, "tokens": tokens}
+
+
+def _seed_codex(*, provider_email="op@example.com", **kwargs) -> HarnessLogin:
+    return connect_harness(CodexHarness, _codex_payload(**kwargs), provider_email=provider_email)
 
 
 def _resp(status: int, body: object) -> httpx.Response:
@@ -52,6 +59,9 @@ def _mock_post(monkeypatch, response):
 
     async def fake_post(self, url, *, json=None, **_kwargs):
         calls.append({"url": url, "json": json})
+        # Yield to the event loop so a concurrent rotation attempt can run
+        # while this grant is "in flight" — the shape the lock exists for.
+        await asyncio.sleep(0)
         if isinstance(response, Exception):
             raise response
         return response
@@ -96,7 +106,7 @@ def test_claude_load_token_missing(db_session):
 
 
 def test_claude_load_token_no_access(db_session):
-    ClaudeHarness.store_credentials({"claudeAiOauth": {"subscriptionType": "max"}})
+    connect_harness(ClaudeHarness, {"claudeAiOauth": {"subscriptionType": "max"}})
     with pytest.raises(OAuthTokenError) as e:
         ClaudeHarness.load_token(now=_NOW)
     assert e.value.tag == "no_token"
@@ -117,20 +127,21 @@ def test_codex_load_token_expired(db_session):
 
 
 async def test_claude_fresh_not_refreshed(monkeypatch, db_session):
-    _seed_claude(expires_at=_NOW + timedelta(hours=6))
+    login = _seed_claude(expires_at=_NOW + timedelta(hours=6))
     calls = _mock_post(monkeypatch, _resp(200, {}))
-    result = await ClaudeHarness.rotate_token(now=_NOW)
+    result = await ClaudeHarness.rotate_token(login.id, now=_NOW)
     assert result.action == "fresh"
+    assert result.login_id == login.id
     assert calls == []
 
 
 async def test_claude_stale_refreshes_and_persists(monkeypatch, db_session):
     soon = _NOW + timedelta(minutes=30)
-    _seed_claude(access="old", refresh="R0", expires_at=soon)
+    login = _seed_claude(access="old", refresh="R0", expires_at=soon)
     calls = _mock_post(
         monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 28800})
     )
-    result = await ClaudeHarness.rotate_token(now=_NOW)
+    result = await ClaudeHarness.rotate_token(login.id, now=_NOW)
     assert result.action == "refreshed"
     assert calls[0]["json"]["refresh_token"] == "R0"
     block = ClaudeHarness.get_credentials()["claudeAiOauth"]
@@ -142,89 +153,84 @@ async def test_claude_stale_refreshes_and_persists(monkeypatch, db_session):
 
 
 async def test_claude_invalid_grant_drops_row(monkeypatch, db_session):
-    _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    login = _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
     _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
-    result = await ClaudeHarness.rotate_token(now=_NOW)
+    result = await ClaudeHarness.rotate_token(login.id, now=_NOW)
     assert result.action == "failed"
     assert result.error == "invalid_grant"
-    # A revoked lineage self-disconnects in the same session — no separate commit.
-    assert HarnessLogin.get("claude") is None
+    # A revoked lineage self-disconnects and commits inside the rotation — the
+    # deletion never rides (or rolls back with) the tick's later commit.
+    assert HarnessLogin.get_default("claude") is None
     with pytest.raises(HarnessNotConnectedError):
         ClaudeHarness.get_credentials()
 
 
 async def test_claude_network_error_keeps_row(monkeypatch, db_session):
-    _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    login = _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
     _mock_post(monkeypatch, httpx.ConnectError("boom"))
-    result = await ClaudeHarness.rotate_token(now=_NOW)
+    result = await ClaudeHarness.rotate_token(login.id, now=_NOW)
     assert result.error == "network"
     assert ClaudeHarness.get_credentials()["claudeAiOauth"]["accessToken"] == "old"
 
 
 async def test_claude_http_500_keeps_row(monkeypatch, db_session):
-    _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    login = _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
     _mock_post(monkeypatch, _resp(500, ""))
-    result = await ClaudeHarness.rotate_token(now=_NOW)
+    result = await ClaudeHarness.rotate_token(login.id, now=_NOW)
     assert result.error == "http_500"
     assert ClaudeHarness.get_credentials()["claudeAiOauth"]["accessToken"] == "old"
 
 
 async def test_claude_bad_response_keeps_row(monkeypatch, db_session):
-    _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    login = _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
     _mock_post(monkeypatch, _resp(200, "not json"))
-    result = await ClaudeHarness.rotate_token(now=_NOW)
+    result = await ClaudeHarness.rotate_token(login.id, now=_NOW)
     assert result.error == "bad_response"
     assert ClaudeHarness.get_credentials()["claudeAiOauth"]["accessToken"] == "old"
 
 
 async def test_codex_invalid_grant_drops_row(monkeypatch, db_session):
     stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
-    _seed_codex(access=stale, refresh="R0")
+    login = _seed_codex(access=stale, refresh="R0")
     _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
-    result = await CodexHarness.rotate_token(now=_NOW)
+    result = await CodexHarness.rotate_token(login.id, now=_NOW)
     assert result.error == "invalid_grant"
-    assert HarnessLogin.get("codex") is None
+    assert HarnessLogin.get_default("codex") is None
     with pytest.raises(HarnessNotConnectedError):
         CodexHarness.get_credentials()
 
 
-async def test_next_rotation_after_disconnect_is_no_op(monkeypatch, db_session):
-    _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+async def test_rotation_of_a_deleted_row_is_a_no_op(monkeypatch, db_session):
+    login = _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    login_id = login.id
     _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
-    await ClaudeHarness.rotate_token(now=_NOW)
-    # Row is gone; the next tick must short-circuit before any grant POST.
+    await ClaudeHarness.rotate_token(login_id, now=_NOW)
+    # Row is gone; rotating the stale id must short-circuit before any
+    # grant POST.
     calls = _mock_post(monkeypatch, _resp(200, {"access_token": "x"}))
-    result = await ClaudeHarness.rotate_token(now=_NOW)
-    assert result.action == "failed"
-    assert result.error == "no_credentials"
-    assert calls == []
-
-
-async def test_claude_rotate_without_credentials(monkeypatch, db_session):
-    calls = _mock_post(monkeypatch, _resp(200, {"access_token": "new"}))
-    result = await ClaudeHarness.rotate_token(now=_NOW)
+    result = await ClaudeHarness.rotate_token(login_id, now=_NOW)
     assert result.action == "failed"
     assert result.error == "no_credentials"
     assert calls == []
 
 
 async def test_claude_relogin_overwrite_picked_up(monkeypatch, db_session):
-    _seed_claude(refresh="R_NEW", expires_at=_NOW - timedelta(minutes=1))
+    login = _seed_claude(refresh="R_NEW", expires_at=_NOW - timedelta(minutes=1))
     calls = _mock_post(
         monkeypatch, _resp(200, {"access_token": "a", "refresh_token": "b", "expires_in": 100})
     )
-    await ClaudeHarness.rotate_token(now=_NOW)
+    await ClaudeHarness.rotate_token(login.id, now=_NOW)
     assert calls[0]["json"]["refresh_token"] == "R_NEW"
 
 
 async def test_codex_stale_refreshes_and_preserves(monkeypatch, db_session):
     stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
     fresh = _jwt(int((_NOW + timedelta(days=10)).timestamp()))
-    _seed_codex(access=stale, refresh="R0", account_id="acc-9")
+    login = _seed_codex(access=stale, refresh="R0", account_id="acc-9")
     calls = _mock_post(
         monkeypatch, _resp(200, {"access_token": fresh, "refresh_token": "R1", "id_token": "id-1"})
     )
-    result = await CodexHarness.rotate_token(now=_NOW)
+    result = await CodexHarness.rotate_token(login.id, now=_NOW)
     assert result.action == "refreshed"
     assert calls[0]["json"]["client_id"] == "app_EMoamEEZ73f0CkXaXp7hrann"
     data = CodexHarness.get_credentials()
@@ -239,19 +245,125 @@ async def test_codex_stale_refreshes_and_preserves(monkeypatch, db_session):
 async def test_codex_keeps_refresh_when_omitted(monkeypatch, db_session):
     stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
     fresh = _jwt(int((_NOW + timedelta(days=10)).timestamp()))
-    _seed_codex(access=stale, refresh="KEEP")
+    login = _seed_codex(access=stale, refresh="KEEP")
     _mock_post(monkeypatch, _resp(200, {"access_token": fresh}))
-    await CodexHarness.rotate_token(now=_NOW)
+    await CodexHarness.rotate_token(login.id, now=_NOW)
     assert CodexHarness.get_credentials()["tokens"]["refresh_token"] == "KEEP"
 
 
 async def test_codex_no_refresh_token(monkeypatch, db_session):
     stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
-    _seed_codex(access=stale, refresh=None)
+    login = _seed_codex(refresh=None, access=stale)
     calls = _mock_post(monkeypatch, _resp(200, {}))
-    result = await CodexHarness.rotate_token(now=_NOW)
+    result = await CodexHarness.rotate_token(login.id, now=_NOW)
     assert result.action == "no_refresh_token"
     assert calls == []
+
+
+async def test_rotation_touches_only_the_addressed_row(monkeypatch, db_session):
+    stale = _seed_claude(
+        access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30),
+        provider_email="a@example.com",
+    )
+    other = _seed_claude(
+        access="keep", refresh="RK", expires_at=_NOW + timedelta(minutes=30),
+        provider_email="b@example.com",
+    )
+    stale_id, other_id = stale.id, other.id
+    _mock_post(
+        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 100})
+    )
+    result = await ClaudeHarness.rotate_token(stale_id, now=_NOW)
+    assert result.action == "refreshed"
+    assert dict(HarnessLogin.get(stale_id).payload)["claudeAiOauth"]["accessToken"] == "new"
+    assert dict(HarnessLogin.get(other_id).payload)["claudeAiOauth"]["accessToken"] == "keep"
+
+
+async def test_invalid_grant_drops_only_the_addressed_row(monkeypatch, db_session):
+    default = _seed_claude(access="d", expires_at=_NOW - timedelta(minutes=1))
+    other = _seed_claude(
+        access="o", expires_at=_NOW - timedelta(minutes=1), provider_email="b@example.com"
+    )
+    default_id, other_id = default.id, other.id
+    _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
+    await ClaudeHarness.rotate_token(other_id, now=_NOW)
+    assert HarnessLogin.get(other_id) is None
+    # The default seat is untouched — and an auto-disconnect elsewhere never
+    # promoted anything.
+    assert HarnessLogin.get_default("claude").id == default_id
+
+
+async def test_concurrent_rotations_produce_one_grant(monkeypatch, db_session):
+    login = _seed_claude(access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30))
+    calls = _mock_post(
+        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 100})
+    )
+    first, second = await asyncio.gather(
+        ClaudeHarness.rotate_token(login.id, now=_NOW),
+        ClaudeHarness.rotate_token(login.id, now=_NOW),
+    )
+    assert len(calls) == 1  # one provider grant, one persisted lineage
+    assert {first.action, second.action} == {"refreshed", "locked"}
+    assert dict(HarnessLogin.get(login.id).payload)["claudeAiOauth"]["refreshToken"] == "R1"
+
+
+async def test_rotation_lock_is_released_after_refresh(monkeypatch, db_session):
+    login = _seed_claude(access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30))
+    _mock_post(
+        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 100})
+    )
+    await ClaudeHarness.rotate_token(login.id, now=_NOW)
+    import druks.redis
+
+    assert await druks.redis.get_client().get(f"druks:harness:refresh:{login.id}") is None
+
+
+def test_disconnect_removes_only_the_default_seat_without_promotion(db_session):
+    default = _seed_claude(provider_email="a@example.com")
+    other = _seed_claude(provider_email="b@example.com")
+    assert HarnessLogin.get_default("claude").id == default.id
+
+    ClaudeHarness.disconnect()
+
+    assert HarnessLogin.get(default.id) is None
+    assert HarnessLogin.get(other.id) is not None
+    assert HarnessLogin.get_default("claude") is None  # no silent promotion
+    with pytest.raises(HarnessNotConnectedError):
+        ClaudeHarness.get_credentials()
+
+
+def test_reconnect_after_default_gone_becomes_default(db_session):
+    default = _seed_claude(provider_email="a@example.com")
+    _seed_claude(provider_email="b@example.com")
+    ClaudeHarness.disconnect()
+    assert HarnessLogin.get_default("claude") is None
+
+    # An explicit reconnect of the surviving seat is the sanctioned promotion.
+    row = _seed_claude(provider_email="b@example.com")
+    assert HarnessLogin.get_default("claude").id == row.id
+    assert row.id != default.id
+
+
+def test_connect_scopes_rows_by_harness_and_account(db_session):
+    claude_row = _seed_claude(provider_email="a@example.com")
+    codex_row = _seed_codex(provider_email="a@example.com")
+    other = _seed_claude(provider_email="b@example.com")
+
+    assert len({claude_row.id, codex_row.id, other.id}) == 3
+    assert claude_row.account_id == codex_row.account_id  # same person, one account
+    assert other.account_id != claude_row.account_id
+    assert Account.get_by_email("a@example.com").id == claude_row.account_id
+    # First seat per harness stays the default.
+    assert HarnessLogin.get_default("claude").id == claude_row.id
+    assert HarnessLogin.get_default("codex").id == codex_row.id
+
+
+def test_reconnect_updates_the_existing_seat_in_place(db_session):
+    row = _seed_claude(access="old", provider_email="a@example.com")
+    again = _seed_claude(access="new", provider_email="A@Example.com ")
+    assert again.id == row.id  # normalized email finds the same seat
+    assert dict(again.payload)["claudeAiOauth"]["accessToken"] == "new"
+    assert again.provider_email == "a@example.com"
 
 
 async def test_claude_fetch_usage_success(monkeypatch, db_session):

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -295,16 +295,19 @@ async def test_invalid_grant_drops_only_the_addressed_row(monkeypatch, db_sessio
 
 async def test_concurrent_rotations_produce_one_grant(monkeypatch, db_session):
     login = _seed_claude(access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30))
+    login_id = login.id
     calls = _mock_post(
         monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 100})
     )
     first, second = await asyncio.gather(
-        ClaudeHarness.rotate_token(login.id, now=_NOW),
-        ClaudeHarness.rotate_token(login.id, now=_NOW),
+        ClaudeHarness.rotate_token(login_id, now=_NOW),
+        ClaudeHarness.rotate_token(login_id, now=_NOW),
     )
     assert len(calls) == 1  # one provider grant, one persisted lineage
     assert {first.action, second.action} == {"refreshed", "locked"}
-    assert dict(HarnessLogin.get(login.id).payload)["claudeAiOauth"]["refreshToken"] == "R1"
+    # Sessions are task-scoped: the winner ran (and committed) inside its own
+    # gather task, so read past this task's identity map for what persisted.
+    assert dict(HarnessLogin.reload(login_id).payload)["claudeAiOauth"]["refreshToken"] == "R1"
 
 
 async def test_rotation_lock_is_released_after_refresh(monkeypatch, db_session):

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -11,7 +11,7 @@ from druks.harnesses import base as hbase
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.exceptions import HarnessNotConnectedError, OAuthTokenError
-from druks.harnesses.models import HarnessLogin
+from druks.harnesses.models import HarnessConnection
 
 _NOW = datetime(2026, 6, 4, 20, 0, tzinfo=UTC)
 
@@ -33,7 +33,7 @@ def _claude_payload(*, access="A0", refresh="R0", expires_at=None, extra=None) -
     return {"claudeAiOauth": block}
 
 
-def _seed_claude(*, provider_email="op@example.com", **kwargs) -> HarnessLogin:
+def _seed_claude(*, provider_email="op@example.com", **kwargs) -> HarnessConnection:
     return connect_harness(ClaudeHarness, _claude_payload(**kwargs), provider_email=provider_email)
 
 
@@ -45,7 +45,7 @@ def _codex_payload(*, access=None, refresh="R0", account_id="acc-1", id_token="i
     return {"auth_mode": "chatgpt", "OPENAI_API_KEY": None, "tokens": tokens}
 
 
-def _seed_codex(*, provider_email="op@example.com", **kwargs) -> HarnessLogin:
+def _seed_codex(*, provider_email="op@example.com", **kwargs) -> HarnessConnection:
     return connect_harness(CodexHarness, _codex_payload(**kwargs), provider_email=provider_email)
 
 
@@ -160,7 +160,7 @@ async def test_claude_invalid_grant_drops_row(monkeypatch, db_session):
     assert result.error == "invalid_grant"
     # A revoked lineage self-disconnects and commits inside the rotation — the
     # deletion never rides (or rolls back with) the tick's later commit.
-    assert HarnessLogin.get_default("claude") is None
+    assert HarnessConnection.get_default("claude") is None
     with pytest.raises(HarnessNotConnectedError):
         ClaudeHarness.get_credentials()
 
@@ -195,7 +195,7 @@ async def test_codex_invalid_grant_drops_row(monkeypatch, db_session):
     _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
     result = await CodexHarness.rotate_token(login.id, now=_NOW)
     assert result.error == "invalid_grant"
-    assert HarnessLogin.get_default("codex") is None
+    assert HarnessConnection.get_default("codex") is None
     with pytest.raises(HarnessNotConnectedError):
         CodexHarness.get_credentials()
 
@@ -275,8 +275,8 @@ async def test_rotation_touches_only_the_addressed_row(monkeypatch, db_session):
     )
     result = await ClaudeHarness.rotate_token(stale_id, now=_NOW)
     assert result.action == "refreshed"
-    assert dict(HarnessLogin.get(stale_id).payload)["claudeAiOauth"]["accessToken"] == "new"
-    assert dict(HarnessLogin.get(other_id).payload)["claudeAiOauth"]["accessToken"] == "keep"
+    assert dict(HarnessConnection.get(stale_id).payload)["claudeAiOauth"]["accessToken"] == "new"
+    assert dict(HarnessConnection.get(other_id).payload)["claudeAiOauth"]["accessToken"] == "keep"
 
 
 async def test_invalid_grant_drops_only_the_addressed_row(monkeypatch, db_session):
@@ -287,10 +287,10 @@ async def test_invalid_grant_drops_only_the_addressed_row(monkeypatch, db_sessio
     default_id, other_id = default.id, other.id
     _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
     await ClaudeHarness.rotate_token(other_id, now=_NOW)
-    assert HarnessLogin.get(other_id) is None
+    assert HarnessConnection.get(other_id) is None
     # The default login is untouched — and an auto-disconnect elsewhere never
     # promoted anything.
-    assert HarnessLogin.get_default("claude").id == default_id
+    assert HarnessConnection.get_default("claude").id == default_id
 
 
 async def test_concurrent_rotations_produce_one_grant(monkeypatch, db_session):
@@ -307,7 +307,7 @@ async def test_concurrent_rotations_produce_one_grant(monkeypatch, db_session):
     assert {first.action, second.action} == {"refreshed", "locked"}
     # Sessions are task-scoped: the winner ran (and committed) inside its own
     # gather task, so read past this task's identity map for what persisted.
-    assert dict(HarnessLogin.reload(login_id).payload)["claudeAiOauth"]["refreshToken"] == "R1"
+    assert dict(HarnessConnection.reload(login_id).payload)["claudeAiOauth"]["refreshToken"] == "R1"
 
 
 async def test_rotation_lock_is_released_after_refresh(monkeypatch, db_session):
@@ -324,13 +324,13 @@ async def test_rotation_lock_is_released_after_refresh(monkeypatch, db_session):
 def test_disconnect_removes_only_the_default_login_without_promotion(db_session):
     default = _seed_claude(provider_email="a@example.com")
     other = _seed_claude(provider_email="b@example.com")
-    assert HarnessLogin.get_default("claude").id == default.id
+    assert HarnessConnection.get_default("claude").id == default.id
 
     ClaudeHarness.disconnect()
 
-    assert HarnessLogin.get(default.id) is None
-    assert HarnessLogin.get(other.id) is not None
-    assert HarnessLogin.get_default("claude") is None  # no silent promotion
+    assert HarnessConnection.get(default.id) is None
+    assert HarnessConnection.get(other.id) is not None
+    assert HarnessConnection.get_default("claude") is None  # no silent promotion
     with pytest.raises(HarnessNotConnectedError):
         ClaudeHarness.get_credentials()
 
@@ -339,11 +339,11 @@ def test_reconnect_after_default_gone_becomes_default(db_session):
     default = _seed_claude(provider_email="a@example.com")
     _seed_claude(provider_email="b@example.com")
     ClaudeHarness.disconnect()
-    assert HarnessLogin.get_default("claude") is None
+    assert HarnessConnection.get_default("claude") is None
 
     # An explicit reconnect of the surviving login is the sanctioned promotion.
     row = _seed_claude(provider_email="b@example.com")
-    assert HarnessLogin.get_default("claude").id == row.id
+    assert HarnessConnection.get_default("claude").id == row.id
     assert row.id != default.id
 
 
@@ -357,8 +357,8 @@ def test_connect_scopes_rows_by_harness_and_account(db_session):
     assert other.account_id != claude_row.account_id
     assert Account.get_for_email("a@example.com").id == claude_row.account_id
     # The first login per harness stays the default.
-    assert HarnessLogin.get_default("claude").id == claude_row.id
-    assert HarnessLogin.get_default("codex").id == codex_row.id
+    assert HarnessConnection.get_default("claude").id == claude_row.id
+    assert HarnessConnection.get_default("codex").id == codex_row.id
 
 
 def test_reconnect_updates_the_existing_login_in_place(db_session):

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -288,7 +288,7 @@ async def test_invalid_grant_drops_only_the_addressed_row(monkeypatch, db_sessio
     _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
     await ClaudeHarness.rotate_token(other_id, now=_NOW)
     assert HarnessLogin.get(other_id) is None
-    # The default seat is untouched — and an auto-disconnect elsewhere never
+    # The default login is untouched — and an auto-disconnect elsewhere never
     # promoted anything.
     assert HarnessLogin.get_default("claude").id == default_id
 
@@ -321,7 +321,7 @@ async def test_rotation_lock_is_released_after_refresh(monkeypatch, db_session):
     assert await druks.redis.get_client().get(f"druks:harness:refresh:{login.id}") is None
 
 
-def test_disconnect_removes_only_the_default_seat_without_promotion(db_session):
+def test_disconnect_removes_only_the_default_login_without_promotion(db_session):
     default = _seed_claude(provider_email="a@example.com")
     other = _seed_claude(provider_email="b@example.com")
     assert HarnessLogin.get_default("claude").id == default.id
@@ -341,7 +341,7 @@ def test_reconnect_after_default_gone_becomes_default(db_session):
     ClaudeHarness.disconnect()
     assert HarnessLogin.get_default("claude") is None
 
-    # An explicit reconnect of the surviving seat is the sanctioned promotion.
+    # An explicit reconnect of the surviving login is the sanctioned promotion.
     row = _seed_claude(provider_email="b@example.com")
     assert HarnessLogin.get_default("claude").id == row.id
     assert row.id != default.id
@@ -355,16 +355,16 @@ def test_connect_scopes_rows_by_harness_and_account(db_session):
     assert len({claude_row.id, codex_row.id, other.id}) == 3
     assert claude_row.account_id == codex_row.account_id  # same person, one account
     assert other.account_id != claude_row.account_id
-    assert Account.get_by_email("a@example.com").id == claude_row.account_id
-    # First seat per harness stays the default.
+    assert Account.get_for_email("a@example.com").id == claude_row.account_id
+    # The first login per harness stays the default.
     assert HarnessLogin.get_default("claude").id == claude_row.id
     assert HarnessLogin.get_default("codex").id == codex_row.id
 
 
-def test_reconnect_updates_the_existing_seat_in_place(db_session):
+def test_reconnect_updates_the_existing_login_in_place(db_session):
     row = _seed_claude(access="old", provider_email="a@example.com")
     again = _seed_claude(access="new", provider_email="A@Example.com ")
-    assert again.id == row.id  # normalized email finds the same seat
+    assert again.id == row.id  # normalized email finds the same login
     assert dict(again.payload)["claudeAiOauth"]["accessToken"] == "new"
     assert again.provider_email == "a@example.com"
 

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -363,10 +363,12 @@ def test_connect_scopes_rows_by_harness_and_account(db_session):
 
 def test_reconnect_updates_the_existing_login_in_place(db_session):
     row = _seed_claude(access="old", provider_email="a@example.com")
-    again = _seed_claude(access="new", provider_email="A@Example.com ")
-    assert again.id == row.id  # normalized email finds the same login
+    # Same email, different case — citext matches it to the existing account,
+    # so the reconnect updates that one connection rather than making a second.
+    again = _seed_claude(access="new", provider_email="A@Example.com")
+    assert again.id == row.id
     assert dict(again.payload)["claudeAiOauth"]["accessToken"] == "new"
-    assert again.provider_email == "a@example.com"
+    assert again.provider_email == "A@Example.com"  # stored as last given
 
 
 async def test_claude_fetch_usage_success(monkeypatch, db_session):

--- a/backend/tests/test_harness_login.py
+++ b/backend/tests/test_harness_login.py
@@ -65,11 +65,10 @@ async def test_claude_login_start_builds_url_and_stashes_pending(db_session):
     assert "client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e" in url
 
     pending = await _pending(flow_id)
-    assert pending["harness"] == "claude"
     assert pending["state"] == pending["verifier"]  # claude echoes the verifier as state
 
 
-async def test_claude_login_complete_creates_account_and_seat(monkeypatch, db_session):
+async def test_claude_login_complete_creates_account_and_login(monkeypatch, db_session):
     _, flow_id = await ClaudeHarness.login_start()
     calls = _mock_post(monkeypatch, _resp(200, _CLAUDE_GRANT))
     await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
@@ -82,7 +81,7 @@ async def test_claude_login_complete_creates_account_and_seat(monkeypatch, db_se
     assert block["scopes"] == ["user:profile", "user:inference"]
     assert login.provider_email == "me@example.com"
     assert login.is_default is True
-    assert Account.get_by_email("me@example.com").id == login.account_id
+    assert Account.get_for_email("me@example.com").id == login.account_id
     # Claude exchanges JSON with the code + state echoed in the body.
     assert calls[0]["json"]["code"] == "thecode"
     assert "state" in calls[0]["json"]
@@ -107,18 +106,10 @@ async def test_concurrent_login_flows_do_not_clobber_each_other(monkeypatch, db_
     _mock_post(monkeypatch, _resp(200, second_grant))
     await ClaudeHarness.login_complete(flow_id=second_flow, pasted="code-2")
 
-    seats = {login.provider_email for login in HarnessLogin.list_all()}
-    assert seats == {"me@example.com", "other@example.com"}
-    # First seat connected stays the harness default.
+    connected = {login.provider_email for login in HarnessLogin.list_all()}
+    assert connected == {"me@example.com", "other@example.com"}
+    # The first login connected stays the harness default.
     assert HarnessLogin.get_default("claude").provider_email == "me@example.com"
-
-
-async def test_login_complete_rejects_a_foreign_harness_flow(db_session):
-    _, flow_id = await ClaudeHarness.login_start()
-    with pytest.raises(LoginError, match="different harness"):
-        await CodexHarness.login_complete(flow_id=flow_id, pasted="code")
-    # The pending state is spent either way — a retry re-starts.
-    assert await _pending(flow_id) is None
 
 
 async def test_login_complete_without_provider_email_raises(monkeypatch, db_session):
@@ -137,7 +128,7 @@ async def test_login_complete_normalizes_provider_email(monkeypatch, db_session)
     await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
     login = HarnessLogin.get_default("claude")
     assert login.provider_email == "me@example.com"
-    assert Account.get_by_email("me@example.com") is not None
+    assert Account.get_for_email("me@example.com") is not None
 
 
 async def test_codex_login_complete_is_form_encoded_and_reads_jwt(monkeypatch, db_session):

--- a/backend/tests/test_harness_login.py
+++ b/backend/tests/test_harness_login.py
@@ -10,7 +10,7 @@ from druks.harnesses import base as hbase
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.exceptions import LoginError
-from druks.harnesses.models import HarnessLogin
+from druks.harnesses.models import HarnessConnection
 
 
 @pytest.fixture(autouse=True)
@@ -73,7 +73,7 @@ async def test_claude_login_complete_creates_account_and_login(monkeypatch, db_s
     calls = _mock_post(monkeypatch, _resp(200, _CLAUDE_GRANT))
     await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
 
-    login = HarnessLogin.get_default("claude")
+    login = HarnessConnection.get_default("claude")
     assert login is not None
     block = dict(login.payload)["claudeAiOauth"]
     assert block["accessToken"] == "AT"
@@ -106,10 +106,10 @@ async def test_concurrent_login_flows_do_not_clobber_each_other(monkeypatch, db_
     _mock_post(monkeypatch, _resp(200, second_grant))
     await ClaudeHarness.login_complete(flow_id=second_flow, pasted="code-2")
 
-    connected = {login.provider_email for login in HarnessLogin.list_all()}
+    connected = {login.provider_email for login in HarnessConnection.list_all()}
     assert connected == {"me@example.com", "other@example.com"}
     # The first login connected stays the harness default.
-    assert HarnessLogin.get_default("claude").provider_email == "me@example.com"
+    assert HarnessConnection.get_default("claude").provider_email == "me@example.com"
 
 
 async def test_login_complete_without_provider_email_raises(monkeypatch, db_session):
@@ -118,7 +118,7 @@ async def test_login_complete_without_provider_email_raises(monkeypatch, db_sess
     _mock_post(monkeypatch, _resp(200, grant))
     with pytest.raises(LoginError, match="no account email"):
         await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
-    assert HarnessLogin.list_all() == []
+    assert HarnessConnection.list_all() == []
 
 
 async def test_login_complete_normalizes_provider_email(monkeypatch, db_session):
@@ -126,7 +126,7 @@ async def test_login_complete_normalizes_provider_email(monkeypatch, db_session)
     grant = dict(_CLAUDE_GRANT, account={"email_address": " Me@Example.COM "})
     _mock_post(monkeypatch, _resp(200, grant))
     await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
-    login = HarnessLogin.get_default("claude")
+    login = HarnessConnection.get_default("claude")
     assert login.provider_email == "me@example.com"
     assert Account.get_for_email("me@example.com") is not None
 
@@ -149,7 +149,7 @@ async def test_codex_login_complete_is_form_encoded_and_reads_jwt(monkeypatch, d
         pasted=f"http://localhost:1455/auth/callback?code=thecode&state={pending['state']}",
     )
 
-    login = HarnessLogin.get_default("codex")
+    login = HarnessConnection.get_default("codex")
     payload = dict(login.payload)
     assert payload["tokens"]["account_id"] == "acc-9"
     assert payload["tokens"]["id_token"] == "ID"
@@ -188,13 +188,13 @@ async def test_login_complete_provider_error_clears_pending(monkeypatch, db_sess
     assert "invalid_grant" in str(error.value)
     # Failure is single-use too — a retry must re-start.
     assert await _pending(flow_id) is None
-    assert HarnessLogin.get_default("claude") is None
+    assert HarnessConnection.get_default("claude") is None
 
 
 def test_disconnect_deletes_the_default_row(db_session):
     from conftest import connect_harness
 
     connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "x", "refreshToken": "r"}})
-    assert HarnessLogin.get_default("claude") is not None
+    assert HarnessConnection.get_default("claude") is not None
     ClaudeHarness.disconnect()
-    assert HarnessLogin.get_default("claude") is None
+    assert HarnessConnection.get_default("claude") is None

--- a/backend/tests/test_harness_login.py
+++ b/backend/tests/test_harness_login.py
@@ -121,14 +121,16 @@ async def test_login_complete_without_provider_email_raises(monkeypatch, db_sess
     assert HarnessConnection.list_all() == []
 
 
-async def test_login_complete_normalizes_provider_email(monkeypatch, db_session):
+async def test_login_complete_matches_provider_email_case_insensitively(monkeypatch, db_session):
+    # The provider's email is stored as given; the citext columns match it
+    # regardless of case, so no account or connection duplicates on casing.
     _, flow_id = await ClaudeHarness.login_start()
-    grant = dict(_CLAUDE_GRANT, account={"email_address": " Me@Example.COM "})
+    grant = dict(_CLAUDE_GRANT, account={"email_address": "Me@Example.COM"})
     _mock_post(monkeypatch, _resp(200, grant))
     await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
     login = HarnessConnection.get_default("claude")
-    assert login.provider_email == "me@example.com"
-    assert Account.get_for_email("me@example.com") is not None
+    assert login.provider_email == "Me@Example.COM"
+    assert Account.get_for_email("me@example.com") is not None  # citext: case-insensitive
 
 
 async def test_codex_login_complete_is_form_encoded_and_reads_jwt(monkeypatch, db_session):

--- a/backend/tests/test_harness_login.py
+++ b/backend/tests/test_harness_login.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 import druks.redis
 import httpx
 import pytest
+from druks.accounts.models import Account
 from druks.harnesses import base as hbase
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
@@ -42,56 +43,106 @@ def _mock_post(monkeypatch, response):
     return calls
 
 
-async def _pending(harness: str) -> dict | None:
-    raw = await druks.redis.get_client().get(f"druks:login:pending:{harness}")
+async def _pending(flow_id: str) -> dict | None:
+    raw = await druks.redis.get_client().get(f"druks:login:pending:{flow_id}")
     return json.loads(raw) if raw else None
 
 
+_CLAUDE_GRANT = {
+    "access_token": "AT",
+    "refresh_token": "RT",
+    "expires_in": 28800,
+    "scope": "user:profile user:inference",
+    "account": {"email_address": "me@example.com"},
+}
+
+
 async def test_claude_login_start_builds_url_and_stashes_pending(db_session):
-    url = await ClaudeHarness.login_start()
+    url, flow_id = await ClaudeHarness.login_start()
     assert url.startswith("https://claude.ai/oauth/authorize?")
     assert "code=true" in url
     assert "code_challenge_method=S256" in url
     assert "client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e" in url
 
-    pending = await _pending("claude")
+    pending = await _pending(flow_id)
+    assert pending["harness"] == "claude"
     assert pending["state"] == pending["verifier"]  # claude echoes the verifier as state
 
 
-async def test_claude_login_complete_stores_credential_and_account(monkeypatch, db_session):
-    await ClaudeHarness.login_start()
-    calls = _mock_post(
-        monkeypatch,
-        _resp(
-            200,
-            {
-                "access_token": "AT",
-                "refresh_token": "RT",
-                "expires_in": 28800,
-                "scope": "user:profile user:inference",
-                "account": {"email_address": "me@example.com"},
-            },
-        ),
-    )
-    await ClaudeHarness.login_complete("thecode")
+async def test_claude_login_complete_creates_account_and_seat(monkeypatch, db_session):
+    _, flow_id = await ClaudeHarness.login_start()
+    calls = _mock_post(monkeypatch, _resp(200, _CLAUDE_GRANT))
+    await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
 
-    login = HarnessLogin.get("claude")
+    login = HarnessLogin.get_default("claude")
     assert login is not None
-    block = login.payload["claudeAiOauth"]
+    block = dict(login.payload)["claudeAiOauth"]
     assert block["accessToken"] == "AT"
     assert block["refreshToken"] == "RT"
     assert block["scopes"] == ["user:profile", "user:inference"]
-    assert login.account == "me@example.com"
+    assert login.provider_email == "me@example.com"
+    assert login.is_default is True
+    assert Account.get_by_email("me@example.com").id == login.account_id
     # Claude exchanges JSON with the code + state echoed in the body.
     assert calls[0]["json"]["code"] == "thecode"
     assert "state" in calls[0]["json"]
     # Single-use: the pending state is gone.
-    assert await _pending("claude") is None
+    assert await _pending(flow_id) is None
+
+
+async def test_concurrent_login_flows_do_not_clobber_each_other(monkeypatch, db_session):
+    # Two operators connect the same harness at once: distinct flow ids, both
+    # pendings live, and completing one leaves the other completable.
+    _, first_flow = await ClaudeHarness.login_start()
+    _, second_flow = await ClaudeHarness.login_start()
+    assert first_flow != second_flow
+    assert await _pending(first_flow) is not None
+    assert await _pending(second_flow) is not None
+
+    _mock_post(monkeypatch, _resp(200, _CLAUDE_GRANT))
+    await ClaudeHarness.login_complete(flow_id=first_flow, pasted="code-1")
+    assert await _pending(second_flow) is not None
+
+    second_grant = dict(_CLAUDE_GRANT, account={"email_address": "other@example.com"})
+    _mock_post(monkeypatch, _resp(200, second_grant))
+    await ClaudeHarness.login_complete(flow_id=second_flow, pasted="code-2")
+
+    seats = {login.provider_email for login in HarnessLogin.list_all()}
+    assert seats == {"me@example.com", "other@example.com"}
+    # First seat connected stays the harness default.
+    assert HarnessLogin.get_default("claude").provider_email == "me@example.com"
+
+
+async def test_login_complete_rejects_a_foreign_harness_flow(db_session):
+    _, flow_id = await ClaudeHarness.login_start()
+    with pytest.raises(LoginError, match="different harness"):
+        await CodexHarness.login_complete(flow_id=flow_id, pasted="code")
+    # The pending state is spent either way — a retry re-starts.
+    assert await _pending(flow_id) is None
+
+
+async def test_login_complete_without_provider_email_raises(monkeypatch, db_session):
+    _, flow_id = await ClaudeHarness.login_start()
+    grant = dict(_CLAUDE_GRANT, account={})
+    _mock_post(monkeypatch, _resp(200, grant))
+    with pytest.raises(LoginError, match="no account email"):
+        await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
+    assert HarnessLogin.list_all() == []
+
+
+async def test_login_complete_normalizes_provider_email(monkeypatch, db_session):
+    _, flow_id = await ClaudeHarness.login_start()
+    grant = dict(_CLAUDE_GRANT, account={"email_address": " Me@Example.COM "})
+    _mock_post(monkeypatch, _resp(200, grant))
+    await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
+    login = HarnessLogin.get_default("claude")
+    assert login.provider_email == "me@example.com"
+    assert Account.get_by_email("me@example.com") is not None
 
 
 async def test_codex_login_complete_is_form_encoded_and_reads_jwt(monkeypatch, db_session):
-    await CodexHarness.login_start()
-    pending = await _pending("codex")
+    _, flow_id = await CodexHarness.login_start()
+    pending = await _pending(flow_id)
     access = _jwt(
         {
             "https://api.openai.com/auth": {"chatgpt_account_id": "acc-9"},
@@ -103,52 +154,56 @@ async def test_codex_login_complete_is_form_encoded_and_reads_jwt(monkeypatch, d
         monkeypatch, _resp(200, {"access_token": access, "refresh_token": "RT", "id_token": "ID"})
     )
     await CodexHarness.login_complete(
-        f"http://localhost:1455/auth/callback?code=thecode&state={pending['state']}"
+        flow_id=flow_id,
+        pasted=f"http://localhost:1455/auth/callback?code=thecode&state={pending['state']}",
     )
 
-    login = HarnessLogin.get("codex")
-    assert login.payload["tokens"]["account_id"] == "acc-9"
-    assert login.payload["tokens"]["id_token"] == "ID"
-    assert login.account == "c@example.com"
+    login = HarnessLogin.get_default("codex")
+    payload = dict(login.payload)
+    assert payload["tokens"]["account_id"] == "acc-9"
+    assert payload["tokens"]["id_token"] == "ID"
+    assert login.provider_email == "c@example.com"
     # Codex exchanges form-encoded, no state in the body.
     assert calls[0]["data"]["code"] == "thecode"
     assert "state" not in calls[0]["data"]
 
 
 async def test_login_complete_unreadable_provider_json_raises_login_error(monkeypatch, db_session):
-    await ClaudeHarness.login_start()
+    _, flow_id = await ClaudeHarness.login_start()
     _mock_post(monkeypatch, _resp(200, "not json"))
 
     with pytest.raises(LoginError) as error:
-        await ClaudeHarness.login_complete("code")
+        await ClaudeHarness.login_complete(flow_id=flow_id, pasted="code")
 
     assert "unreadable response" in str(error.value)
 
 
 async def test_login_complete_without_pending_raises(db_session):
     with pytest.raises(LoginError):
-        await ClaudeHarness.login_complete("code")
+        await ClaudeHarness.login_complete(flow_id="not-a-flow", pasted="code")
 
 
 async def test_login_complete_state_mismatch_raises(db_session):
-    await ClaudeHarness.login_start()
+    _, flow_id = await ClaudeHarness.login_start()
     with pytest.raises(LoginError):
-        await ClaudeHarness.login_complete("code#not-the-state")
+        await ClaudeHarness.login_complete(flow_id=flow_id, pasted="code#not-the-state")
 
 
 async def test_login_complete_provider_error_clears_pending(monkeypatch, db_session):
-    await ClaudeHarness.login_start()
+    _, flow_id = await ClaudeHarness.login_start()
     _mock_post(monkeypatch, _resp(400, "invalid_grant: code expired"))
     with pytest.raises(LoginError) as error:
-        await ClaudeHarness.login_complete("code")
+        await ClaudeHarness.login_complete(flow_id=flow_id, pasted="code")
     assert "invalid_grant" in str(error.value)
     # Failure is single-use too — a retry must re-start.
-    assert await _pending("claude") is None
-    assert HarnessLogin.get("claude") is None
+    assert await _pending(flow_id) is None
+    assert HarnessLogin.get_default("claude") is None
 
 
-def test_disconnect_deletes_the_row(db_session):
-    ClaudeHarness.store_credentials({"claudeAiOauth": {"accessToken": "x", "refreshToken": "r"}})
-    assert HarnessLogin.get("claude") is not None
+def test_disconnect_deletes_the_default_row(db_session):
+    from conftest import connect_harness
+
+    connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "x", "refreshToken": "r"}})
+    assert HarnessLogin.get_default("claude") is not None
     ClaudeHarness.disconnect()
-    assert HarnessLogin.get("claude") is None
+    assert HarnessLogin.get_default("claude") is None

--- a/backend/tests/test_harness_login_persistence.py
+++ b/backend/tests/test_harness_login_persistence.py
@@ -5,9 +5,9 @@ import pytest
 from druks.database import configure_session, db_session, get_session
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.models import HarnessLogin
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 
-# The credential store's whole job is to persist a mutated credential-file dict
+# The credential store's whole job is to persist a rotated credential dict
 # through a real commit. The rollback-based suite can't verify that — its identity
 # map hands back the mutated in-memory object no matter what reached the DB — so
 # this module runs against its own database with real commits and fresh sessions,
@@ -59,23 +59,49 @@ def _committed(engine, work):
         session.close()
 
 
-def test_store_persists_mutated_payload_across_sessions(engine):
-    # Load the row, edit the payload in place, store it, then read it back from a
-    # fresh session — the round-trip refresh actually makes. Commit + new session
-    # proves the edit reached the DB, not just the in-memory object.
-    _committed(
-        engine,
-        lambda: ClaudeHarness.store_credentials(
-            {"claudeAiOauth": {"accessToken": "old", "refreshToken": "R0"}}
-        ),
+def _connect(payload: dict) -> str:
+    row = HarnessLogin.connect(
+        harness="claude",
+        payload=payload,
+        expires_at=None,
+        provider_email="op@example.com",
+    )
+    return row.id
+
+
+def test_rotation_persists_new_payload_across_sessions(engine):
+    # Connect the seat, rotate its payload the way rotate_token does (plain-dict
+    # copy, edit, whole-value update), then read it back from a fresh session —
+    # commit + new session proves the edit reached the DB, not just the
+    # in-memory object.
+    login_id = _committed(
+        engine, lambda: _connect({"claudeAiOauth": {"accessToken": "old", "refreshToken": "R0"}})
     )
 
-    def mutate_in_place():
-        data = ClaudeHarness.get_credentials()
+    def rotate_in_place():
+        row = HarnessLogin.get(login_id)
+        data = dict(row.payload)
         data["claudeAiOauth"]["accessToken"] = "new"
-        ClaudeHarness.store_credentials(data)
+        row.update_payload(data, expires_at=None)
 
-    _committed(engine, mutate_in_place)
+    _committed(engine, rotate_in_place)
 
-    block = _committed(engine, lambda: HarnessLogin.get("claude").payload["claudeAiOauth"])
+    block = _committed(
+        engine, lambda: dict(HarnessLogin.get(login_id).payload)["claudeAiOauth"]
+    )
     assert block["accessToken"] == "new"
+
+
+def test_payload_is_ciphertext_at_rest(engine):
+    _committed(
+        engine, lambda: _connect({"claudeAiOauth": {"accessToken": "supersecret"}})
+    )
+
+    with engine.connect() as connection:
+        stored = connection.execute(text("SELECT payload FROM harness_logins")).scalar_one()
+    raw = bytes(stored)
+    assert b"supersecret" not in raw
+    assert b"claudeAiOauth" not in raw
+
+    block = _committed(engine, lambda: ClaudeHarness.get_credentials()["claudeAiOauth"])
+    assert block["accessToken"] == "supersecret"

--- a/backend/tests/test_harness_login_persistence.py
+++ b/backend/tests/test_harness_login_persistence.py
@@ -4,7 +4,7 @@ import psycopg
 import pytest
 from druks.database import configure_session, db_session, get_session
 from druks.harnesses.claude import ClaudeHarness
-from druks.harnesses.models import HarnessLogin
+from druks.harnesses.models import HarnessConnection
 from sqlalchemy import create_engine, text
 
 # The credential store's whole job is to persist a rotated credential dict
@@ -60,7 +60,7 @@ def _committed(engine, work):
 
 
 def _connect(payload: dict) -> str:
-    row = HarnessLogin.connect(
+    row = HarnessConnection.connect(
         harness="claude",
         payload=payload,
         expires_at=None,
@@ -79,7 +79,7 @@ def test_rotation_persists_new_payload_across_sessions(engine):
     )
 
     def rotate_in_place():
-        row = HarnessLogin.get(login_id)
+        row = HarnessConnection.get(login_id)
         data = dict(row.payload)
         data["claudeAiOauth"]["accessToken"] = "new"
         row.update_payload(data, expires_at=None)
@@ -87,7 +87,7 @@ def test_rotation_persists_new_payload_across_sessions(engine):
     _committed(engine, rotate_in_place)
 
     block = _committed(
-        engine, lambda: dict(HarnessLogin.get(login_id).payload)["claudeAiOauth"]
+        engine, lambda: dict(HarnessConnection.get(login_id).payload)["claudeAiOauth"]
     )
     assert block["accessToken"] == "new"
 

--- a/backend/tests/test_harness_reasoning_flags.py
+++ b/backend/tests/test_harness_reasoning_flags.py
@@ -1,4 +1,5 @@
 import pytest
+from conftest import connect_harness
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 
@@ -9,8 +10,8 @@ _CODEX_MODEL = CodexHarness.models[0]
 def _connected_harnesses(db_session):
     # build_invocation renders each credential bundle from the DB row and
     # raises when that harness isn't connected.
-    ClaudeHarness.store_credentials({"claudeAiOauth": {"accessToken": "t"}})
-    CodexHarness.store_credentials({"tokens": {"access_token": "t"}})
+    connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "t"}})
+    connect_harness(CodexHarness, {"tokens": {"access_token": "t"}})
 
 
 def _sandbox_config():

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -148,6 +148,27 @@ code until they finish. Recovery does not preserve a live agent process inside
 a sandbox; it follows the operation boundary described in
 [Concepts](../docs/concepts.md#durability-and-recovery).
 
+### One-time: upgrading across the accounts migration
+
+The accounts release re-keys `harness_logins` per account and encrypts the
+stored credentials in place — a destructive schema change. Upgrade it as a
+maintenance cutover: stop the stack (`docker compose down`), wait for active
+calls to end, **back up Postgres**, run the migration with the new image
+(`docker compose run --rm web druks init-db`), then `docker compose up -d`.
+Never run old and new processes across this migration; parked workflows may
+stay parked. Rolling back afterwards means restoring the pre-migration
+database backup and the old image — there is no Alembic downgrade.
+
+With existing harness connections, the migration requires
+`DRUKS_DASHBOARD_EMAIL` in the migration run's environment and attaches every
+existing seat to one account with that email. A remote install needs no extra
+step — `.env` already holds the value the Caddy gate matches. **Warning:** the
+one-run value must match the provider email you will actually sign in with
+once account login lands; a mismatch strands the migrated seats on an account
+you cannot enter (automation keeps working, and reconnecting after an eventual
+`invalid_grant` re-creates the seat under your real account). Fresh installs
+and installs with no connected harness skip all of this.
+
 ### One-time: upgrading a box that ran the backend as root
 
 The backend containers now run as the deploy user (`DRUKS_UID`/`DRUKS_GID`),

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,6 +15,11 @@ python3 -c 'import base64, os; print("DRUKS_SECRETS_KEY=" + base64.b64encode(os.
 uv run druks init-db
 ```
 
+Upgrading a dev database that already holds connected harnesses across the
+accounts migration needs `DRUKS_DASHBOARD_EMAIL` exported for that one
+`druks init-db` run — set it to the provider email you will sign in with once
+account login lands. Fresh databases don't need it.
+
 The dev Compose project creates two databases:
 
 - `druks_dev` for the host-run application

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -142,9 +142,10 @@ export const api = {
     patchJSON<Harness>(`/api/settings/harnesses/${encodeURIComponent(name)}`, body),
   startHarnessLogin: (name: string) =>
     postJSON<LoginChallenge>(`/api/settings/harnesses/${encodeURIComponent(name)}/login/start`, {}),
-  completeHarnessLogin: (name: string, code: string) =>
+  completeHarnessLogin: (name: string, code: string, flowId: string) =>
     postJSON<Harness>(`/api/settings/harnesses/${encodeURIComponent(name)}/login/complete`, {
       code,
+      flowId,
     }),
   disconnectHarness: (name: string) =>
     deleteJSON<Harness>(`/api/settings/harnesses/${encodeURIComponent(name)}/login`),

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -197,6 +197,9 @@ export interface Harness {
 
 export interface LoginChallenge {
   authorizeUrl: string
+  /** Opaque id of this connect attempt; passed back on complete so
+   * concurrent sign-ins never clobber each other's pending state. */
+  flowId: string
 }
 
 export interface UpdateHarnessRequest {

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -6,6 +6,7 @@ import { ExtensionGlyph } from './ExtensionGlyph'
 import {
   type Harness,
   type ExtensionSettings,
+  type LoginChallenge,
   type McpRegistryCandidate,
   type McpServer,
   type SkillCollection,
@@ -755,7 +756,7 @@ function HarnessesPane({
 // its own busy/error and refetches the harnesses query on change.
 function HarnessConnect({ harness }: { harness: Harness }) {
   const queryClient = useQueryClient()
-  const [authorizeUrl, setAuthorizeUrl] = useState<string | null>(null)
+  const [challenge, setChallenge] = useState<LoginChallenge | null>(null)
   const [code, setCode] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -775,12 +776,13 @@ function HarnessConnect({ harness }: { harness: Harness }) {
   }
 
   const start = () =>
-    run(async () => setAuthorizeUrl((await api.startHarnessLogin(harness.name)).authorizeUrl))
+    run(async () => setChallenge(await api.startHarnessLogin(harness.name)))
 
   const finish = () =>
     run(async () => {
-      await api.completeHarnessLogin(harness.name, code.trim())
-      setAuthorizeUrl(null)
+      if (!challenge) return
+      await api.completeHarnessLogin(harness.name, code.trim(), challenge.flowId)
+      setChallenge(null)
       setCode('')
       await refresh()
     })
@@ -812,18 +814,18 @@ function HarnessConnect({ harness }: { harness: Harness }) {
               Disconnect
             </button>
           )}
-          {!authorizeUrl && (
+          {!challenge && (
             <button className="hr-conn-btn" onClick={() => void start()} disabled={busy}>
               {harness.connected ? 'Reconnect' : 'Connect'}
             </button>
           )}
         </span>
       </div>
-      {authorizeUrl && (
+      {challenge && (
         <div className="hr-conn-flow">
           <div className="hr-conn-step">
             <span className="hr-conn-num">1</span>
-            <a href={authorizeUrl} target="_blank" rel="noreferrer">
+            <a href={challenge.authorizeUrl} target="_blank" rel="noreferrer">
               Open the sign-in page
             </a>
             , approve, then copy the code it shows (or the redirect URL).


### PR DESCRIPTION
Multi-tenant accounts arc, PR 1 of 4 (ENG-702). Makes the credential store multi-seat, encrypted at rest, and refresh-safe — browser access is untouched until PR 2.

## What this delivers

- **`accounts` table** (`druks/accounts/`): UUIDv7 id + unique normalized email, nothing else. `Account.get_or_create` / `get_by_email` normalize (strip + lowercase) at the boundary.
- **`harness_logins` re-keyed per seat**: UUIDv7 row id, `account_id` FK (`ON DELETE RESTRICT`), nullable normalized `provider_email`, `payload` now `BYTEA` through `EncryptedJsonField` (AES-GCM, AAD `harness_logins.payload`), `is_default` flag. Constraints: `UNIQUE(harness, account_id)`, partial unique `(harness, provider_email) WHERE provider_email IS NOT NULL`, partial unique `(harness) WHERE is_default`.
- **One coordinated migration** (`a8060465d9ed`) executing the ticket's exact temp-column + final-AAD + rename dance, with a decrypt-verify pass under the final AAD before the revision completes. With legacy rows it requires `DRUKS_DASHBOARD_EMAIL` (read straight from the process env, not Settings) and fails before any mutation without it; with no legacy rows it never reads the variable and creates no account. `downgrade()` refuses — rollback is the pre-migration backup, per ticket.
- **Row-addressed credential ops**: `rotate_token(login)`, `needs_refresh(login)`, `invalid_grant` deletes only the addressed row (ENG-699 preserved row-by-row). Connect upserts by `(harness, provider_email)` → `(harness, account)`, creating the account from the provider email; the first seat connected while a harness has no default becomes default; disconnect (manual or auto) never promotes another seat.
- **Per-row refresh lock**: `druks:harness:refresh:{login_id}` via `SET NX`, 5-minute crash TTL, `finally` cleanup, and a post-lock fresh-from-DB re-read so a losing refresher never re-presents a refresh token the winner already advanced.
- **PKCE flow ids**: the singleton per-harness pending key is replaced by an opaque single-use flow id (harness-bound), so concurrent connects can't clobber each other. Wire: `login/start` returns `{authorizeUrl, flowId}`; `login/complete` takes `{code, flowId}`.
- **`RefreshTokens` iterates login rows** instead of harness classes; gate-hold logic unchanged (any due row closes the gate).
- **Execution + Settings still resolve the default seat** (this intermediate PR): `get_credentials`/`render_credentials_file`/`load_token`/usage polling read the harness's default row; the settings card projects it (its `account` field now carries the seat's provider email).
- **Frontend**: same single connection card; it just threads `flowId` through the connect flow.
- **Upgrade guide**: maintenance-cutover section in `deploy/README.md` (backup, no old/new overlap, `DRUKS_DASHBOARD_EMAIL` one-run value must match the identity used after PR 2) + the local one-run export note in `docs/development.md`.

## Acceptance criteria → tests

| Criterion | Test |
| --- | --- |
| Legacy rows + missing/blank `DRUKS_DASHBOARD_EMAIL` fail before data mutation | `test_accounts_migration.py::test_missing_dashboard_email_fails_before_data_mutation`, `::test_blank_dashboard_email_fails_too` |
| Valid value → one account, every legacy seat attached regardless of provider email, payloads decrypt only under final AAD | `test_accounts_migration.py::test_legacy_rows_are_rekeyed_under_one_account` (includes wrong-AAD refusal), `::test_orm_reads_migrated_rows_under_the_model_aad` |
| No legacy rows → migration succeeds with no variable, creates no account | `test_accounts_migration.py::test_fresh_install_migrates_without_the_variable` |
| Refresh/reconnect/disconnect/`invalid_grant` affect only the addressed row | `test_harness_auth.py::test_rotation_touches_only_the_addressed_row`, `::test_invalid_grant_drops_only_the_addressed_row`, `::test_disconnect_removes_only_the_default_seat_without_promotion`, `::test_reconnect_updates_the_existing_seat_in_place` |
| Concurrent refresh → one provider grant, one persisted lineage | `test_harness_auth.py::test_concurrent_rotations_produce_one_grant`, `::test_rotation_lock_is_released_after_refresh` |
| Real-Postgres migration test from previous head | the whole `test_accounts_migration.py` module drives Alembic from `619e34746ef3` on its own database |

Plus: flow-id lifecycle + account-door connect tests in `test_harness_login.py` (concurrent flows, harness-bound flows, email normalization, no-email grant refusal), encrypted-at-rest + real-commit persistence in `test_harness_login_persistence.py`.

## Rollout (from the ticket)

Maintenance cutover: stop the old embedded web/executor, wait for active calls, back up Postgres, run `druks init-db` with the new image, restart. Never overlap old and new processes across this destructive schema change. Parked workflows may remain parked. Local/dev upgrades with legacy rows export `DRUKS_DASHBOARD_EMAIL` only for the migration run, set to the provider email that will be used to log in after PR2; remote installs need no extra step (their deployment `.env` already holds the value the Caddy gate matches — compose loads the whole `.env` into the migrate container).

## Codex review

Adversarial review ran through the codex companion, read-only. Model note: `sol` (as specified) is rejected on this account's ChatGPT plan (`invalid_request_error`), so the review re-ran with `gpt-5.5` at reasoning effort high. Two high-severity findings:

1. **Confirmed → fixed.** The per-row refresh lock was released before the refreshed lineage committed (durable steps commit after the method returns), so a concurrent process could take the freed lock, still read the old refresh token under READ COMMITTED, and post a second grant — exactly the reuse-detection hazard the lock exists for. Fix: rotation is now addressed by row id with a fresh read at entry and after winning the lock, and both mutation arms (grant persist, `invalid_grant` delete) commit before the lock releases.
2. **Refuted per the ticket.** "Reconnecting a migrated `provider_email IS NULL` row creates a second row instead of adopting it." The adoption path is the account-email match: the upgrade guide instructs setting `DRUKS_DASHBOARD_EMAIL` to the provider email that will be used to sign in, so that reconnect resolves the migration-created account, finds its `(harness, account)` row, updates it in place, and fills `provider_email` — the ticket's "gets its provider email on reconnect." Codex's scenario uses a *mismatched* identity, which the ticket explicitly specifies as: legacy seat stays default on the dashboard account ("automation still works — the rows remain per-harness defaults"), the new seat lands on a new account, and recovery is `invalid_grant` → reconnect (pinned by `test_reconnect_after_default_gone_becomes_default`).

No further refutations: migration AAD ordering, pre-mutation env failure, PKCE flow-id shape, no-promotion disconnect semantics, and the scope fence all passed.

## Stack

PR 1/4 of the multi-tenant arc (base: `main`). ENG-703 (sessions + app auth) stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
