### PR TITLE
Make harness login the account door: sessions and application auth (ENG-703)

### DIFF
--- a/backend/druks/accounts/dependencies.py
+++ b/backend/druks/accounts/dependencies.py
@@ -1,0 +1,28 @@
+from fastapi import HTTPException, Request
+
+from druks.accounts import sessions
+from druks.accounts.models import Account
+
+
+async def resolve_session_account(request: Request) -> Account | None:
+    """The session cookie's account, or None; drops a session whose account
+    is gone."""
+    token = request.cookies.get(sessions.SESSION_COOKIE)
+    if not token:
+        return
+    account_id = await sessions.resolve_session(token)
+    if not account_id:
+        return
+    account = Account.get(account_id)
+    if not account:
+        await sessions.drop_session(token)
+        return
+    return account
+
+
+async def current_account(request: Request) -> Account:
+    """The signed-in account, else 401."""
+    account = await resolve_session_account(request)
+    if not account:
+        raise HTTPException(status_code=401, detail="Sign in to use this API.")
+    return account

--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -22,6 +22,10 @@ class Account(Base, Uuid7Pk):
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
     @classmethod
+    def get(cls, account_id: str) -> "Account | None":
+        return db_session().get(cls, account_id)
+
+    @classmethod
     def get_for_email(cls, email: str) -> "Account | None":
         return db_session().scalar(select(cls).where(cls.email == email))
 

--- a/backend/druks/accounts/routes.py
+++ b/backend/druks/accounts/routes.py
@@ -1,0 +1,99 @@
+from fastapi import APIRouter, Body, Depends, HTTPException, Request, Response
+
+from druks.accounts import sessions
+from druks.accounts.dependencies import current_account, resolve_session_account
+from druks.accounts.models import Account
+from druks.accounts.schemas import AccountResponse
+from druks.harnesses.base import Harness
+from druks.harnesses.exceptions import LoginError
+from druks.harnesses.models import HarnessConnection
+from druks.harnesses.registry import get_harness
+from druks.user_settings.models import UserSettings
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+def _resolve_harness(name: str) -> type[Harness]:
+    harness = get_harness(name)
+    if not harness:
+        raise HTTPException(status_code=404, detail=f"Unknown harness: {name!r}")
+    return harness
+
+
+def _set_session_cookie(request: Request, response: Response, token: str) -> None:
+    # The shipped edge terminates TLS and proxies loopback HTTP.
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    response.set_cookie(
+        sessions.SESSION_COOKIE,
+        token,
+        max_age=sessions.SESSION_TTL_SECONDS if token else 0,
+        httponly=True,
+        samesite="lax",
+        secure=scheme == "https",
+    )
+
+
+@router.get("/session", response_model=AccountResponse, response_model_by_alias=True)
+async def get_session(
+    request: Request, response: Response, account: Account = Depends(current_account)
+) -> Account:
+    # Slide the cookie with the Redis TTL.
+    _set_session_cookie(request, response, request.cookies[sessions.SESSION_COOKIE])
+    return account
+
+
+@router.post("/harnesses/{name}/login/start")
+async def start_login(name: str, request: Request) -> dict[str, str]:
+    harness = _resolve_harness(name)
+    account = await resolve_session_account(request)
+    url, login_id = await harness.login_start(account_id=account.id if account else None)
+    return {"authorizeUrl": url, "loginId": login_id}
+
+
+@router.post(
+    "/harnesses/{name}/login/complete",
+    response_model=AccountResponse,
+    response_model_by_alias=True,
+)
+async def complete_login(
+    name: str,
+    request: Request,
+    response: Response,
+    code: str = Body(..., embed=True),
+    login_id: str = Body(..., embed=True, alias="loginId"),
+) -> Account:
+    harness = _resolve_harness(name)
+    session_account = await resolve_session_account(request)
+    try:
+        completed = await harness.login_complete(flow_id=login_id, pasted=code)
+    except LoginError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    if completed.account_id and (not session_account or completed.account_id != session_account.id):
+        # A bound reconnect must never rebind the login by email fallback.
+        raise HTTPException(
+            status_code=422,
+            detail="This sign-in was started under a different session — start it again.",
+        )
+    account = session_account or Account.get_or_create(completed.provider_email)
+    # The very first login is the execution fallback until reassigned.
+    UserSettings.ensure_fallback_account(account.id)
+    HarnessConnection.connect(
+        harness=harness.name,
+        account=account,
+        payload=completed.payload,
+        expires_at=completed.expires_at,
+        provider_email=completed.provider_email,
+    )
+    old_token = request.cookies.get(sessions.SESSION_COOKIE)
+    if old_token:
+        await sessions.drop_session(old_token)  # login rotates the token
+    _set_session_cookie(request, response, await sessions.mint_session(account.id))
+    return account
+
+
+@router.post("/logout", status_code=204)
+async def logout(request: Request, response: Response) -> None:
+    token = request.cookies.get(sessions.SESSION_COOKIE)
+    if token:
+        await sessions.drop_session(token)
+    _set_session_cookie(request, response, "")

--- a/backend/druks/accounts/schemas.py
+++ b/backend/druks/accounts/schemas.py
@@ -1,0 +1,10 @@
+from pydantic import ConfigDict
+
+from druks.schemas import BaseResponse
+
+
+class AccountResponse(BaseResponse):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    email: str

--- a/backend/druks/accounts/sessions.py
+++ b/backend/druks/accounts/sessions.py
@@ -1,0 +1,27 @@
+import secrets
+
+from druks.redis import get_client
+
+SESSION_COOKIE = "druks_session"
+SESSION_TTL_SECONDS = 30 * 24 * 3600
+
+
+def _session_key(token: str) -> str:
+    return f"druks:session:{token}"
+
+
+async def mint_session(account_id: str) -> str:
+    token = secrets.token_urlsafe(32)
+    await get_client().set(_session_key(token), account_id, ex=SESSION_TTL_SECONDS)
+    return token
+
+
+async def resolve_session(token: str) -> str | None:
+    # GETEX reads and slides the 30-day TTL in one atomic hop.
+    value = await get_client().getex(_session_key(token), ex=SESSION_TTL_SECONDS)
+    if value:
+        return value.decode()
+
+
+async def drop_session(token: str) -> None:
+    await get_client().delete(_session_key(token))

--- a/backend/druks/api/app.py
+++ b/backend/druks/api/app.py
@@ -9,6 +9,8 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.datastructures import MutableHeaders
 
+from druks.accounts.dependencies import current_account
+from druks.accounts.routes import router as auth_router
 from druks.api.artifacts import router as artifacts_router
 from druks.api.runs import router as runs_router
 from druks.database import configure_session, create_engine_from_url, db_session
@@ -17,6 +19,7 @@ from druks.events.routes import router as events_router
 from druks.extensions.loader import iter_extensions, load
 from druks.mcp.catalog import load_mcp_catalog
 from druks.mcp.routes import router as mcp_router
+from druks.notifications.routes import external_router as notifications_external_router
 from druks.notifications.routes import router as notifications_router
 from druks.redis import close_client
 from druks.settings import Settings, ensure_data_dirs, load_settings, setup_logging
@@ -167,15 +170,22 @@ async def _unhandled_exception_handler(
 
 # Platform-core routers, mounted by hand at their own prefixes. Extension routers
 # (core, build, usage, …) are discovered and mounted under /api/<extension> by load().
+# /api sits behind the session gate except the login surface and the health
+# probe; /_external routes carry their own authentication. The boundary test
+# pins the split.
+_session_gate = [Depends(current_account)]
 app.include_router(health_router)
+# Before the webhook catch-all ({hook_path:path}): declaration order is match order.
+app.include_router(notifications_external_router)
 app.include_router(webhooks_router)
-app.include_router(settings_router)
-app.include_router(skills_router)
-app.include_router(mcp_router)
-app.include_router(notifications_router)
-app.include_router(events_router)
-app.include_router(runs_router)
-app.include_router(artifacts_router)
+app.include_router(auth_router)
+app.include_router(settings_router, dependencies=_session_gate)
+app.include_router(skills_router, dependencies=_session_gate)
+app.include_router(mcp_router, dependencies=_session_gate)
+app.include_router(notifications_router, dependencies=_session_gate)
+app.include_router(events_router, dependencies=_session_gate)
+app.include_router(runs_router, dependencies=_session_gate)
+app.include_router(artifacts_router, dependencies=_session_gate)
 load(app)
 
 

--- a/backend/druks/core/workflows.py
+++ b/backend/druks/core/workflows.py
@@ -60,7 +60,7 @@ def _log_result(result: RotationResult) -> None:
             result.expires_at,
         )
     elif result.action == "failed" and result.error != "no_credentials":
-        # invalid_grant => that seat must re-login; network/http_* => transient.
+        # invalid_grant => that login must reconnect; network/http_* => transient.
         # no_credentials is a row deleted mid-tick, not a failure — stay quiet.
         logger.warning(
             "token refresh failed for %s login %s: %s",

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -24,6 +24,7 @@ from .harnesses.models import HarnessConnection
 from .harnesses.registry import get_harnesses
 from .sandbox.client import sandbox_client
 from .settings import Settings, load_settings
+from .user_settings.models import UserSettings
 from .webhooks.base import Webhook
 from .workflows import Workflow
 
@@ -174,11 +175,17 @@ def check_harness_credentials(settings: Settings) -> list[CheckResult]:
     engine = create_engine_from_url(settings.database_url)
     try:
         with Session(engine) as session:
+            fallback_id = session.scalar(
+                select(UserSettings.fallback_account_id).where(
+                    UserSettings.id == UserSettings.SINGLETON_ID
+                )
+            )
             results: list[CheckResult] = []
             for harness in get_harnesses():
                 row = session.scalar(
                     select(HarnessConnection).where(
-                        HarnessConnection.harness == harness.name, HarnessConnection.is_default
+                        HarnessConnection.harness == harness.name,
+                        HarnessConnection.account_id == fallback_id,
                     )
                 )
                 results.append(

--- a/backend/druks/extensions/base.py
+++ b/backend/druks/extensions/base.py
@@ -220,12 +220,17 @@ class Extension:
         (``discover``), mount its routers under ``/api/<name>``, and serve its
         shipped frontend (if any) under ``/app/<name>``. The loader calls this once
         per extension at boot."""
+        # Local, matching get_routers: the loader stays importable app-lessly.
+        from fastapi import Depends
+
+        from druks.accounts.dependencies import current_account
+
         modules = cls.discover()
-        # The /api/<name> prefix wraps whatever prefix the author set on a router, so an
-        # extension's own routes can't shadow the platform's or another extension's.
+        # /api/<name> wraps the author's own prefix so extensions can't shadow
+        # the platform or each other; every route sits behind the session gate.
         prefix = f"/api/{cls.name}"
         for router in cls.get_routers(modules):
-            app.include_router(router, prefix=prefix)
+            app.include_router(router, prefix=prefix, dependencies=[Depends(current_account)])
         dist = cls.frontend_dist()
         if dist:
             # /app, not /api: unknown /api/* paths must stay JSON 404s, never fall

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -22,6 +22,7 @@ from druks.usage.models import UsageScrape
 from .datastructures import (
     AgentInvocation,
     CodexToken,
+    CompletedLogin,
     HarnessRunResult,
     OAuthToken,
     ParsedUsage,
@@ -186,11 +187,11 @@ class Harness(ABC):
 
     @classmethod
     def get_credentials(cls) -> dict:
-        """The default login's credential-file dict — the row execution
-        resolves while runs aren't account-aware. Raises
-        :class:`HarnessNotConnectedError`, with the connect-in-Settings fix,
-        when no login is designated."""
-        row = HarnessConnection.get_default(cls.name)
+        """The fallback account's credential-file dict for this harness — the
+        account actor-less runs run as while runs aren't account-attributed.
+        Raises :class:`HarnessNotConnectedError` when that account has no
+        login here."""
+        row = HarnessConnection.get_for_account(cls.name, fallback=True)
         data = dict(row.payload) if row else None
         if not data:
             raise HarnessNotConnectedError(
@@ -207,26 +208,28 @@ class Harness(ABC):
         return json.dumps(cls.get_credentials())
 
     @classmethod
-    async def login_start(cls) -> tuple[str, str]:
-        """Begin a connect flow: mint a PKCE verifier + challenge, build the
-        provider's authorize URL, and stash the pending state in Redis under an
-        opaque flow id (single-use, short TTL) so concurrent connects never
-        overwrite each other. Returns (authorize URL, flow id)."""
+    async def login_start(cls, *, account_id: str | None = None) -> tuple[str, str]:
+        """Mint PKCE state under a single-use flow id; return (authorize URL,
+        flow id). A reconnect under a live session binds ``account_id``."""
         verifier = _b64url(secrets.token_bytes(64))
         challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
         url, state = cls.authorize_url(verifier=verifier, challenge=challenge)
         flow_id = secrets.token_urlsafe(24)
-        pending = json.dumps({"verifier": verifier, "state": state})
+        pending = json.dumps(
+            {
+                "verifier": verifier,
+                "state": state,
+                "account_id": account_id,
+            }
+        )
         await get_client().set(_login_pending_key(flow_id), pending, ex=_LOGIN_PENDING_TTL_SECONDS)
         return url, flow_id
 
     @classmethod
-    async def login_complete(cls, *, flow_id: str, pasted: str) -> None:
-        """Finish a connect flow: pop the flow's single-use pending state,
-        parse the paste (bare code or full redirect URL), exchange it, and
-        upsert the login under the provider-reported account. Raises
-        :class:`LoginError` with a user-facing message on any failure — the
-        pending state is gone either way, so a retry re-starts cleanly."""
+    async def login_complete(cls, *, flow_id: str, pasted: str) -> CompletedLogin:
+        """Pop the flow's single-use state, parse the paste, exchange the code.
+        Raises :class:`LoginError` on failure; the state is gone either way,
+        so a retry re-starts cleanly."""
         pending = await get_client().getdel(_login_pending_key(flow_id))  # single-use
         if not pending:
             raise LoginError("This sign-in expired — start it again.")
@@ -245,20 +248,12 @@ class Harness(ABC):
                 "that has one and try again."
             )
         _, expires_at = cls._refresh_state(payload)
-        HarnessConnection.connect(
-            harness=cls.name,
+        return CompletedLogin(
             payload=payload,
-            expires_at=expires_at,
             provider_email=provider_email,
+            expires_at=expires_at,
+            account_id=expected["account_id"],
         )
-
-    @classmethod
-    def disconnect(cls) -> None:
-        """Disconnect the default login — the single connection card's target.
-        Never promotes another one."""
-        row = HarnessConnection.get_default(cls.name)
-        if row:
-            row.delete()
 
     @classmethod
     @abstractmethod
@@ -331,9 +326,7 @@ class Harness(ABC):
             # advanced this lineage (or deleted the row) after our first read.
             row = HarnessConnection.reload(login_id)
             if not row:
-                return RotationResult(
-                    cls.name, "failed", error="no_credentials", login_id=login_id
-                )
+                return RotationResult(cls.name, "failed", error="no_credentials", login_id=login_id)
             data = dict(row.payload)
             refresh_token, expires_at = cls._refresh_state(data)
             if not refresh_token:
@@ -353,8 +346,7 @@ class Harness(ABC):
                     row.delete()
                     db_session().commit()
                     logger.warning(
-                        "%s login %s auto-disconnected after invalid_grant; "
-                        "reconnect to restore",
+                        "%s login %s auto-disconnected after invalid_grant; reconnect to restore",
                         cls.name,
                         row.id,
                     )

--- a/backend/druks/harnesses/datastructures.py
+++ b/backend/druks/harnesses/datastructures.py
@@ -32,6 +32,16 @@ class CodexToken:
 
 
 @dataclass(frozen=True)
+class CompletedLogin:
+    payload: dict
+    provider_email: str
+    expires_at: datetime | None
+    # The session account a reconnect was bound to at start; None on an
+    # initial login.
+    account_id: str | None
+
+
+@dataclass(frozen=True)
 class RotationResult:
     harness: str
     # "refreshed" | "fresh" | "locked" | "no_refresh_token" | "failed"

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import ForeignKey, Index, String, UniqueConstraint, select, text
+from sqlalchemy import ForeignKey, String, UniqueConstraint, select
 from sqlalchemy.dialects.postgresql import CITEXT
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.orm.attributes import flag_modified
@@ -10,21 +10,12 @@ from druks.core.models import Uuid7Pk
 from druks.database import db_session
 from druks.models import Base
 from druks.secrets.fields import EncryptedJsonField
+from druks.user_settings.models import UserSettings
 
 
 class HarnessConnection(Base, Uuid7Pk):
     __tablename__ = "harness_logins"
-    __table_args__ = (
-        UniqueConstraint("harness", "account_id"),
-        # One designated default connection per harness — the row execution and
-        # the settings card resolve while runs aren't account-aware.
-        Index(
-            "harness_logins_default_idx",
-            "harness",
-            unique=True,
-            postgresql_where=text("is_default"),
-        ),
-    )
+    __table_args__ = (UniqueConstraint("harness", "account_id"),)
 
     harness: Mapped[str]
     account_id: Mapped[str] = mapped_column(ForeignKey("accounts.id", ondelete="RESTRICT"))
@@ -38,7 +29,6 @@ class HarnessConnection(Base, Uuid7Pk):
     kind: Mapped[str] = mapped_column(String, default="subscription")
     payload = EncryptedJsonField()
     expires_at: Mapped[datetime | None]
-    is_default: Mapped[bool] = mapped_column(default=False)
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
 
     @classmethod
@@ -46,11 +36,13 @@ class HarnessConnection(Base, Uuid7Pk):
         return db_session().get(cls, login_id)
 
     @classmethod
-    def get_default(cls, harness: str) -> "HarnessConnection | None":
-        return db_session().scalar(select(cls).where(cls.harness == harness, cls.is_default))
-
-    @classmethod
-    def get_for_account(cls, harness: str, account_id: str) -> "HarnessConnection | None":
+    def get_for_account(
+        cls, harness: str, account_id: str | None = None, *, fallback: bool = False
+    ) -> "HarnessConnection | None":
+        """``fallback=True`` resolves the fallback account's connection — what
+        actor-less execution runs as."""
+        if fallback:
+            account_id = UserSettings.get().fallback_account_id
         return db_session().scalar(
             select(cls).where(cls.harness == harness, cls.account_id == account_id)
         )
@@ -73,15 +65,13 @@ class HarnessConnection(Base, Uuid7Pk):
         cls,
         *,
         harness: str,
+        account: Account,
         payload: dict,
         expires_at: datetime | None,
         provider_email: str,
     ) -> "HarnessConnection":
-        """Upsert the account's connection for this harness, creating the
-        account from the provider's email when it's new. A connection made
-        while the harness has no default becomes the default; promotion only
-        ever happens through a connect, never a disconnect."""
-        account = Account.get_or_create(provider_email)
+        """Upsert ``account``'s connection for this harness — update its
+        existing row or create one."""
         session = db_session()
         row = cls.get_for_account(harness, account.id)
         if not row:
@@ -90,8 +80,6 @@ class HarnessConnection(Base, Uuid7Pk):
         row.payload = payload
         row.provider_email = provider_email
         row.expires_at = expires_at
-        if not cls.get_default(harness):
-            row.is_default = True
         session.flush()
         return row
 

--- a/backend/druks/harnesses/registry.py
+++ b/backend/druks/harnesses/registry.py
@@ -9,6 +9,13 @@ def get_harnesses() -> tuple[type[Harness], ...]:
     return tuple(sorted(Harness.__subclasses__(), key=lambda harness: harness.name))
 
 
+def get_harness(name: str) -> type[Harness] | None:
+    """The harness registered under ``name``, or None."""
+    for harness in get_harnesses():
+        if harness.name == name:
+            return harness
+
+
 def get_harness_for_model(model: str) -> type[Harness]:
     """The harness that runs ``model``, matched by name namespace — a model in a
     known namespace routes even if it postdates this release. A miss means no

--- a/backend/druks/notifications/routes.py
+++ b/backend/druks/notifications/routes.py
@@ -21,6 +21,9 @@ from druks.notifications.services import respond_to_notification
 
 router = APIRouter(prefix="/api/notifications", tags=["notifications"])
 
+# Public ingress, token-authenticated — mounts beside the webhooks.
+external_router = APIRouter(prefix="/_external/notifications", tags=["notifications"])
+
 
 @router.get("/destinations", response_model=list[DestinationResponse])
 async def list_destinations() -> list[Destination]:
@@ -80,7 +83,7 @@ async def get_notification(notification_id: str) -> Notification:
     return notification
 
 
-@router.post("/{token}/respond", status_code=204)
+@external_router.post("/{token}/respond", status_code=204)
 async def respond(token: str, body: RespondRequest) -> None:
     # CorruptCorrelationError deliberately propagates: a run_id with no run is data
     # corruption, so it must surface as a logged 500, never a silent 404.

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -43,11 +43,6 @@ _COMMON_SECTIONS: tuple[Section, ...] = (
     Section(
         "EDIT THESE (the installer refuses to boot until they're filled in)",
         (
-            Entry(
-                "DRUKS_DASHBOARD_EMAIL",
-                prompt="Dashboard login email",
-                required=True,
-            ),
             # Where druks may act is NOT configured here — it's wherever the
             # operator GitHub App is installed. Install/uninstall the App to
             # grant/revoke; `druks doctor` shows the effective set.

--- a/backend/druks/user_settings/models.py
+++ b/backend/druks/user_settings/models.py
@@ -30,6 +30,11 @@ class UserSettings(Base):
     gate_park_destination_id: Mapped[str | None] = mapped_column(
         ForeignKey("notification_destinations.id", ondelete="SET NULL"), default=None
     )
+    # The account actor-less runs (webhooks, schedules) run as, until runs are
+    # account-attributed; the very first login sets it.
+    fallback_account_id: Mapped[str | None] = mapped_column(
+        ForeignKey("accounts.id", ondelete="SET NULL"), default=None
+    )
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
     SINGLETON_ID = 1
@@ -48,6 +53,14 @@ class UserSettings(Base):
             self.timezone = timezone
         self.updated_at = Base.utc_now()
         db_session().flush()
+
+    @classmethod
+    def ensure_fallback_account(cls, account_id: str) -> None:
+        settings = cls.get()
+        if not settings.fallback_account_id:
+            settings.fallback_account_id = account_id
+            settings.updated_at = Base.utc_now()
+            db_session().flush()
 
     def set_gate_park_destination(self, destination_id: str | None) -> None:
         # None is the off-switch, so this is a set-or-clear, not a skip-on-None.
@@ -89,9 +102,9 @@ class HarnessSettings(Base):
 
     @property
     def harness(self) -> "type[Harness]":
-        from druks.harnesses.registry import get_harnesses
+        from druks.harnesses.registry import get_harness
 
-        return next(h for h in get_harnesses() if h.name == self.name)
+        return get_harness(self.name)
 
     @property
     def provider(self) -> str:

--- a/backend/druks/user_settings/routes.py
+++ b/backend/druks/user_settings/routes.py
@@ -1,11 +1,12 @@
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from fastapi import APIRouter, Body, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from druks.accounts.dependencies import current_account
+from druks.accounts.models import Account
 from druks.durable.engine import apply_schedules
-from druks.extensions.loader import iter_extensions
+from druks.extensions.loader import get_extension, iter_extensions
 from druks.extensions.registry import workflows
-from druks.harnesses.exceptions import LoginError
 from druks.harnesses.models import HarnessConnection
 from druks.harnesses.registry import get_harnesses
 from druks.notifications.models import Destination
@@ -37,25 +38,33 @@ def _validate_timezone(value: str) -> str:
 
 
 def _resolve_harness(name: str) -> tuple[type, HarnessSettings]:
-    harness = next((h for h in get_harnesses() if h.name == name), None)
     row = HarnessSettings.get(name)
-    if harness is None or row is None:
+    if not row:
         raise HTTPException(status_code=404, detail=f"Unknown harness: {name!r}")
-    return harness, row
+    return row.harness, row
 
 
+def _harness_response(settings: HarnessSettings, account: Account) -> HarnessResponse:
+    login = HarnessConnection.get_for_account(settings.name, account.id)
+    return HarnessResponse.from_row(settings, login, account)
+
+
+# Connection state is the signed-in account's own login — connect/reconnect
+# live on the /api/auth login surface, not here.
 @router.get("/harnesses", response_model=list[HarnessResponse], response_model_by_alias=True)
-async def list_harness_settings() -> list[HarnessResponse]:
+async def list_harness_settings(
+    account: Account = Depends(current_account),
+) -> list[HarnessResponse]:
     registered = {harness.name for harness in get_harnesses()}
     return [
-        HarnessResponse.from_row(row, HarnessConnection.get_default(row.name))
-        for row in HarnessSettings.all()
-        if row.name in registered
+        _harness_response(row, account) for row in HarnessSettings.all() if row.name in registered
     ]
 
 
 @router.patch("/harnesses/{name}", response_model=HarnessResponse, response_model_by_alias=True)
-async def update_harness_settings(name: str, body: HarnessUpdate) -> HarnessResponse:
+async def update_harness_settings(
+    name: str, body: HarnessUpdate, account: Account = Depends(current_account)
+) -> HarnessResponse:
     harness, row = _resolve_harness(name)
     updates = body.model_dump(exclude_unset=True, by_alias=False)
     if "model" in updates and not harness.has_model(updates["model"]):
@@ -67,43 +76,21 @@ async def update_harness_settings(name: str, body: HarnessUpdate) -> HarnessResp
     _validate_timeout(updates.get("timeout"))
     if updates:
         row.update(**updates)
-    return HarnessResponse.from_row(row, HarnessConnection.get_default(row.name))
-
-
-@router.post("/harnesses/{name}/login/start")
-async def start_harness_login(name: str) -> dict[str, str]:
-    harness, _ = _resolve_harness(name)
-    url, flow_id = await harness.login_start()
-    return {"authorizeUrl": url, "flowId": flow_id}
-
-
-@router.post(
-    "/harnesses/{name}/login/complete",
-    response_model=HarnessResponse,
-    response_model_by_alias=True,
-)
-async def complete_harness_login(
-    name: str,
-    code: str = Body(..., embed=True),
-    flow_id: str = Body(..., embed=True, alias="flowId"),
-) -> HarnessResponse:
-    # code = a bare code, a code#state pair, or the full redirect URL — the
-    # harness parses whichever it is.
-    harness, row = _resolve_harness(name)
-    try:
-        await harness.login_complete(flow_id=flow_id, pasted=code)
-    except LoginError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-    return HarnessResponse.from_row(row, HarnessConnection.get_default(row.name))
+    return _harness_response(row, account)
 
 
 @router.delete(
     "/harnesses/{name}/login", response_model=HarnessResponse, response_model_by_alias=True
 )
-async def disconnect_harness(name: str) -> HarnessResponse:
-    harness, row = _resolve_harness(name)
-    harness.disconnect()
-    return HarnessResponse.from_row(row, HarnessConnection.get_default(row.name))
+async def disconnect_harness(
+    name: str, account: Account = Depends(current_account)
+) -> HarnessResponse:
+    _, row = _resolve_harness(name)
+    login = HarnessConnection.get_for_account(name, account.id)
+    if login:
+        # Only the signed-in account's own login — never another account's.
+        login.delete()
+    return _harness_response(row, account)
 
 
 @router.get("", response_model=UserSettingsResponse, response_model_by_alias=True)
@@ -191,9 +178,12 @@ async def update_extension_settings(body: ExtensionsSettingsUpdate) -> Extension
             for field, value in changes.items():
                 workflow.override_setting(field, value)
         for extension_name, changes in body.extension_settings.items():
-            extension = next((m for m in iter_extensions() if m.name == extension_name), None)
-            if not extension:
-                raise HTTPException(status_code=422, detail=f"Unknown extension {extension_name!r}")
+            try:
+                extension = get_extension(extension_name)
+            except KeyError as exc:
+                raise HTTPException(
+                    status_code=422, detail=f"Unknown extension {extension_name!r}"
+                ) from exc
             for field, value in changes.items():
                 extension.override_setting(field, value)
     except ValueError as exc:

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -8,6 +8,7 @@ from druks.extensions.settings import field_choices, field_kind
 from druks.schemas import BaseResponse
 
 if TYPE_CHECKING:
+    from druks.accounts.models import Account
     from druks.harnesses.models import HarnessConnection
     from druks.user_settings.models import HarnessSettings
 
@@ -20,16 +21,17 @@ class HarnessResponse(BaseResponse):
     timeout: int
     fast_mode: bool
     allowed_models: list[str]
-    # Connection state, joined in from the harness's default HarnessConnection row —
-    # connected=False until someone connects it from the dashboard.
+    # The signed-in account's own connection; false until this account connects.
     connected: bool
     kind: str | None
     account: str | None
+    # The email the provider reported at connect — display, never authority.
+    provider_email: str | None
     expires_at: datetime | None
 
     @classmethod
     def from_row(
-        cls, settings: "HarnessSettings", login: "HarnessConnection | None"
+        cls, settings: "HarnessSettings", login: "HarnessConnection | None", account: "Account"
     ) -> "HarnessResponse":
         return cls(
             name=settings.name,
@@ -41,7 +43,8 @@ class HarnessResponse(BaseResponse):
             allowed_models=settings.allowed_models,
             connected=bool(login),
             kind=login.kind if login else None,
-            account=login.provider_email if login else None,
+            account=account.email if login else None,
+            provider_email=login.provider_email if login else None,
             expires_at=login.expires_at if login else None,
         )
 

--- a/backend/migrations/versions/b5c6d7e8f9a0_fallback_account_replaces_default_login.py
+++ b/backend/migrations/versions/b5c6d7e8f9a0_fallback_account_replaces_default_login.py
@@ -1,0 +1,72 @@
+"""fallback account replaces the default login
+
+Revision ID: b5c6d7e8f9a0
+Revises: a8060465d9ed
+Create Date: 2026-07-16 21:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b5c6d7e8f9a0"
+down_revision: str | Sequence[str] | None = "a8060465d9ed"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("user_settings", sa.Column("fallback_account_id", sa.String(), nullable=True))
+    op.create_foreign_key(
+        "user_settings_fallback_account_id_fkey",
+        "user_settings",
+        "accounts",
+        ["fallback_account_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    # Carry the semantics over: the default login's account — else the oldest
+    # account (uuid7 ids sort by creation) — becomes the fallback. The
+    # singleton row may not exist yet on an install nobody configured.
+    op.execute(
+        "INSERT INTO user_settings (id, timezone, updated_at) VALUES (1, 'UTC', now()) "
+        "ON CONFLICT (id) DO NOTHING"
+    )
+    op.execute(
+        """
+        UPDATE user_settings SET fallback_account_id = COALESCE(
+            (SELECT account_id FROM harness_logins WHERE is_default LIMIT 1),
+            (SELECT id FROM accounts ORDER BY id LIMIT 1)
+        )
+        WHERE id = 1
+        """
+    )
+    op.drop_index("harness_logins_default_idx", table_name="harness_logins")
+    op.drop_column("harness_logins", "is_default")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "harness_logins",
+        sa.Column("is_default", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.execute(
+        """
+        UPDATE harness_logins SET is_default = true
+        WHERE account_id = (SELECT fallback_account_id FROM user_settings WHERE id = 1)
+        """
+    )
+    op.create_index(
+        "harness_logins_default_idx",
+        "harness_logins",
+        ["harness"],
+        unique=True,
+        postgresql_where=sa.text("is_default"),
+    )
+    op.drop_constraint(
+        "user_settings_fallback_account_id_fkey", "user_settings", type_="foreignkey"
+    )
+    op.drop_column("user_settings", "fallback_account_id")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -63,6 +63,12 @@ class FakeRedis:
     async def get(self, key: str) -> bytes | None:
         return self._data.get(key)
 
+    async def getex(self, key: str, *, ex: int | None = None) -> bytes | None:
+        value = self._data.get(key)
+        if value is not None and ex is not None:
+            self._ttls[key] = ex
+        return value
+
     async def exists(self, key: str) -> int:
         return int(key in self._data)
 
@@ -292,8 +298,10 @@ def configure_app_for_test(
     *,
     settings: Settings,
     engine=None,
+    authenticated: bool = True,
 ):
 
+    from druks.accounts.dependencies import current_account
     from druks.api.app import app
 
     if engine is None:
@@ -302,7 +310,17 @@ def configure_app_for_test(
     configure_session(engine)
     app.state.settings = settings
     app.state.engine = engine
+    if authenticated:
+        # Stand a signed-in account in for the gate; auth tests pass
+        # authenticated=False and walk the real cookie flow.
+        app.dependency_overrides[current_account] = _test_account
     return app
+
+
+async def _test_account():
+    from druks.accounts.models import Account
+
+    return Account.get_or_create("op@example.com")
 
 
 @pytest.fixture(autouse=True)
@@ -354,14 +372,17 @@ def bind_ambient_session(session) -> None:
 
 
 def connect_harness(harness_cls, payload: dict, *, provider_email: str = "op@example.com"):
-    """Seed a connected seat the way a finished connect flow would: an account
-    keyed by the provider email plus the harness's login row, expiry mirrored
-    out of the payload. Returns the HarnessConnection row."""
+    """Seed the HarnessConnection row a finished connect flow would leave."""
+    from druks.accounts.models import Account
     from druks.harnesses.models import HarnessConnection
+    from druks.user_settings.models import UserSettings
 
+    account = Account.get_or_create(provider_email)
+    UserSettings.ensure_fallback_account(account.id)
     _, expires_at = harness_cls._refresh_state(payload)
     return HarnessConnection.connect(
         harness=harness_cls.name,
+        account=account,
         payload=payload,
         expires_at=expires_at,
         provider_email=provider_email,

--- a/backend/tests/test_accounts_migration.py
+++ b/backend/tests/test_accounts_migration.py
@@ -130,16 +130,18 @@ def test_legacy_rows_are_rekeyed_under_one_account(engine, monkeypatch):
 
     logins = _rows(
         engine,
-        "SELECT id, harness, account_id, provider_email, is_default, payload "
+        "SELECT id, harness, account_id, provider_email, payload "
         "FROM harness_logins ORDER BY harness",
     )
     assert [row["harness"] for row in logins] == ["claude", "codex"]
     assert len({row["id"] for row in logins}) == 2
     for row in logins:
-        # Every legacy login attaches to the one account and stays its
-        # harness's default, whatever its provider email was.
+        # Every legacy login attaches to the one account, whatever its
+        # provider email was.
         assert row["account_id"] == accounts[0]["id"]
-        assert row["is_default"] is True
+    # That account is the execution fallback.
+    fallback = _rows(engine, "SELECT fallback_account_id FROM user_settings")
+    assert fallback[0]["fallback_account_id"] == accounts[0]["id"]
     assert logins[0]["provider_email"] == "Legacy@Example.COM"  # stripped, original case
     assert logins[1]["provider_email"] is None
 
@@ -158,6 +160,7 @@ def test_orm_reads_migrated_rows_under_the_model_aad(engine, monkeypatch):
     monkeypatch.setenv("DRUKS_DASHBOARD_EMAIL", "op@example.com")
     _upgrade("head")
 
+    from druks.accounts.models import Account
     from druks.database import configure_session, db_session, get_session
     from druks.harnesses.claude import ClaudeHarness
     from druks.harnesses.models import HarnessConnection
@@ -167,7 +170,9 @@ def test_orm_reads_migrated_rows_under_the_model_aad(engine, monkeypatch):
     db_session.registry.set(session)
     try:
         assert ClaudeHarness.get_credentials() == CLAUDE_PAYLOAD
-        codex_row = HarnessConnection.get_default("codex")
+        codex_row = HarnessConnection.get_for_account(
+            "codex", Account.get_for_email("op@example.com").id
+        )
         assert dict(codex_row.payload) == CODEX_PAYLOAD
         assert codex_row.provider_email is None
     finally:

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -107,10 +107,11 @@ async def test_run_outside_workflow_raises():
 
 async def test_run_refuses_unconnected_harness(db_session, tmp_path, monkeypatch, current_run):
     # The precondition fires where the harness is resolved — before any VM work.
-    from druks.harnesses.claude import ClaudeHarness
+    from druks.accounts.models import Account
     from druks.harnesses.exceptions import HarnessNotConnectedError
+    from druks.harnesses.models import HarnessConnection
 
-    ClaudeHarness.disconnect()
+    HarnessConnection.get_for_account("claude", Account.get_for_email("op@example.com").id).delete()
     sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
     _patch_ephemeral(monkeypatch, sandbox)
 

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 
-import httpx
 from conftest import configure_app_for_test, make_settings
-from druks.harnesses import base as hbase
 from fastapi.testclient import TestClient
 
 
@@ -34,66 +32,69 @@ def test_harness_response_carries_connection_state(tmp_path: Path):
     with _build_client(tmp_path) as client:
         claude = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}["claude"]
     assert claude["connected"] is False
-    assert claude["account"] is None
+    assert not claude["account"]
+    assert not claude["providerEmail"]
     assert "expiresAt" in claude
 
 
-def test_login_start_returns_authorize_url_and_flow_id(tmp_path: Path):
+def test_harnesses_show_only_the_signed_in_accounts_connection(tmp_path: Path, db_session):
+    from conftest import connect_harness
+    from druks.harnesses.claude import ClaudeHarness
+
+    # The suite's gate stands in op@example.com; another account's
+    # connection never shows on this card.
+    connect_harness(
+        ClaudeHarness,
+        {"claudeAiOauth": {"accessToken": "x"}},
+        provider_email="someone-else@example.com",
+    )
     with _build_client(tmp_path) as client:
-        response = client.post("/api/settings/harnesses/claude/login/start")
+        claude = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}["claude"]
+    assert claude["connected"] is False
+
+
+def test_harness_card_reports_identity(tmp_path: Path, db_session):
+    from druks.accounts.models import Account
+    from druks.harnesses.models import HarnessConnection
+
+    # The provider identity is display, never authority.
+    HarnessConnection.connect(
+        harness="claude",
+        account=Account.get_or_create("op@example.com"),
+        payload={"claudeAiOauth": {"accessToken": "x"}},
+        expires_at=None,
+        provider_email="seat@corp.com",
+    )
+    with _build_client(tmp_path) as client:
+        claude = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}["claude"]
+    assert claude["connected"] is True
+    assert claude["account"] == "op@example.com"
+    assert claude["providerEmail"] == "seat@corp.com"
+
+
+def test_disconnect_removes_only_the_signed_in_accounts_connection(tmp_path: Path, db_session):
+    from conftest import connect_harness
+    from druks.harnesses.claude import ClaudeHarness
+    from druks.harnesses.models import HarnessConnection
+
+    mine = connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "x"}})
+    other = connect_harness(
+        ClaudeHarness,
+        {"claudeAiOauth": {"accessToken": "y"}},
+        provider_email="someone-else@example.com",
+    )
+    mine_id, other_id = mine.id, other.id
+    with _build_client(tmp_path) as client:
+        response = client.delete("/api/settings/harnesses/claude/login")
     assert response.status_code == 200
-    assert response.json()["authorizeUrl"].startswith("https://claude.ai/oauth/authorize?")
-    assert response.json()["flowId"]
+    assert response.json()["connected"] is False
+    # The request deleted in its own task-scoped session; read past this
+    # task's identity map for what actually persisted.
+    assert not HarnessConnection.reload(mine_id)
+    assert HarnessConnection.reload(other_id)
 
 
-def test_login_start_unknown_harness_is_404(tmp_path: Path):
-    with _build_client(tmp_path) as client:
-        response = client.post("/api/settings/harnesses/grok/login/start")
-    assert response.status_code == 404
-
-
-def test_login_complete_with_no_code_is_422(tmp_path: Path):
-    with _build_client(tmp_path) as client:
-        flow_id = client.post("/api/settings/harnesses/claude/login/start").json()["flowId"]
-        # Empty paste fails before any provider call — clean check of the
-        # LoginError -> 422 wiring without mocking the exchange.
-        response = client.post(
-            "/api/settings/harnesses/claude/login/complete",
-            json={"code": "", "flowId": flow_id},
-        )
-    assert response.status_code == 422
-
-
-def test_login_complete_without_flow_id_is_422(tmp_path: Path):
-    with _build_client(tmp_path) as client:
-        client.post("/api/settings/harnesses/claude/login/start")
-        response = client.post(
-            "/api/settings/harnesses/claude/login/complete", json={"code": "x"}
-        )
-    assert response.status_code == 422
-
-
-def test_login_complete_provider_rejection_is_422(tmp_path: Path, monkeypatch):
-    async def fake_post(self, url, *, json=None, data=None, **kwargs):
-        return httpx.Response(
-            400,
-            text="invalid_grant: code expired",
-            request=httpx.Request("POST", url),
-        )
-
-    monkeypatch.setattr(hbase.httpx.AsyncClient, "post", fake_post)
-    with _build_client(tmp_path) as client:
-        flow_id = client.post("/api/settings/harnesses/claude/login/start").json()["flowId"]
-        response = client.post(
-            "/api/settings/harnesses/claude/login/complete",
-            json={"code": "code", "flowId": flow_id},
-        )
-
-    assert response.status_code == 422
-    assert "invalid_grant" in response.json()["detail"]
-
-
-def test_disconnect_returns_disconnected_status(tmp_path: Path):
+def test_disconnect_without_a_connection_is_a_no_op(tmp_path: Path):
     with _build_client(tmp_path) as client:
         response = client.delete("/api/settings/harnesses/claude/login")
     assert response.status_code == 200

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,238 @@
+import base64
+import json
+from pathlib import Path
+
+import druks.redis
+import httpx
+import pytest
+from conftest import configure_app_for_test, connect_harness, make_settings
+from druks import database
+from druks.accounts.models import Account
+from druks.accounts.sessions import SESSION_COOKIE
+from druks.harnesses import base as hbase
+from druks.harnesses.claude import ClaudeHarness
+from druks.harnesses.models import HarnessConnection
+from druks.user_settings.models import UserSettings
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+
+@pytest.fixture(autouse=True)
+def _clear_redis():
+    druks.redis.get_client()._data.clear()
+    yield
+
+
+def _client(tmp_path: Path, **settings_overrides) -> TestClient:
+    app = configure_app_for_test(
+        settings=make_settings(tmp_path, **settings_overrides), authenticated=False
+    )
+    return TestClient(app)
+
+
+def _grant(email: str = "me@example.com") -> dict:
+    return {
+        "access_token": "AT",
+        "refresh_token": "RT",
+        "expires_in": 28800,
+        "scope": "user:profile",
+        "account": {"email_address": email},
+    }
+
+
+def _mock_exchange(monkeypatch, grant: dict):
+    async def fake_post(self, url, *, json=None, data=None, **_kwargs):
+        return httpx.Response(200, text=_dumps(grant), request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(hbase.httpx.AsyncClient, "post", fake_post)
+
+
+def _dumps(value: dict) -> str:
+    return json.dumps(value)
+
+
+def _login(client: TestClient, monkeypatch, *, email="me@example.com") -> dict:
+    start = client.post("/api/auth/harnesses/claude/login/start")
+    assert start.status_code == 200
+    _mock_exchange(monkeypatch, _grant(email))
+    return client.post(
+        "/api/auth/harnesses/claude/login/complete",
+        json={"code": "thecode", "loginId": start.json()["loginId"]},
+    )
+
+
+def test_a_sessionless_request_gets_401(tmp_path):
+    # One behavioral canary; the boundary enumeration proves the full surface.
+    with _client(tmp_path) as client:
+        assert client.get("/api/auth/session").status_code == 401
+
+
+def test_login_flow_mints_session_and_account(tmp_path, monkeypatch, db_session):
+    with _client(tmp_path) as client:
+        start = client.post("/api/auth/harnesses/claude/login/start")
+        assert start.json()["authorizeUrl"].startswith("https://claude.ai/oauth/authorize?")
+
+        response = _login(client, monkeypatch)
+        assert response.status_code == 200
+        assert response.json()["email"] == "me@example.com"
+        cookie = response.headers["set-cookie"]
+        assert SESSION_COOKIE in cookie
+        assert "HttpOnly" in cookie
+        assert "SameSite=lax" in cookie
+        assert "Path=/" in cookie
+
+        session = client.get("/api/auth/session")
+        assert session.status_code == 200
+        assert session.json()["email"] == "me@example.com"
+
+
+def test_the_session_read_slides_the_cookie(tmp_path, monkeypatch, db_session):
+    with _client(tmp_path) as client:
+        _login(client, monkeypatch)
+        # Every app load hits /session; that re-issue keeps the cookie sliding.
+        response = client.get("/api/auth/session")
+        assert SESSION_COOKIE in response.headers.get("set-cookie", "")
+        assert "Max-Age" in response.headers["set-cookie"]
+
+
+def test_logout_drops_the_session_and_clears_the_cookie(tmp_path, monkeypatch, db_session):
+    with _client(tmp_path) as client:
+        _login(client, monkeypatch)
+        logout = client.post("/api/auth/logout")
+        assert logout.status_code == 204
+        assert "Max-Age=0" in logout.headers["set-cookie"]
+        assert client.get("/api/auth/session").status_code == 401
+
+
+def test_login_rotates_any_prior_session_token(tmp_path, monkeypatch, db_session):
+    with _client(tmp_path) as client:
+        first = _login(client, monkeypatch)
+        first_token = client.cookies[SESSION_COOKIE]
+        second = _login(client, monkeypatch)
+        second_token = client.cookies[SESSION_COOKIE]
+        assert first.status_code == second.status_code == 200
+        assert first_token != second_token
+        # The old token no longer resolves anywhere.
+        client.cookies.set(SESSION_COOKIE, first_token)
+        assert client.get("/api/auth/session").status_code == 401
+
+
+def test_redis_eviction_signs_out_but_keeps_credentials(tmp_path, monkeypatch, db_session):
+    with _client(tmp_path) as client:
+        _login(client, monkeypatch)
+        druks.redis.get_client()._data.clear()  # Redis loss
+        assert client.get("/api/auth/session").status_code == 401
+    # The durable credential is untouched — only the session died.
+    assert HarnessConnection.get_for_account("claude", Account.get_for_email("me@example.com").id)
+
+
+def test_session_keeps_its_account_across_reconnects(tmp_path, monkeypatch, db_session):
+    with _client(tmp_path) as client:
+        _login(client, monkeypatch, email="me@example.com")
+        # The session account wins; the login records the provider identity.
+        start = client.post("/api/auth/harnesses/codex/login/start")
+        _mock_exchange_codex(monkeypatch, email="corp-seat@corp.com")
+        complete = client.post(
+            "/api/auth/harnesses/codex/login/complete",
+            json={"code": "thecode", "loginId": start.json()["loginId"]},
+        )
+        assert complete.status_code == 200
+        assert complete.json()["email"] == "me@example.com"
+    account = Account.get_for_email("me@example.com")
+    codex = HarnessConnection.get_for_account("codex", account.id)
+    assert codex.provider_email == "corp-seat@corp.com"
+
+
+def test_bound_reconnect_requires_its_session_at_complete(tmp_path, monkeypatch, db_session):
+    with _client(tmp_path) as client:
+        _login(client, monkeypatch, email="me@example.com")
+        # A reconnect binds its flow to the session account…
+        start = client.post("/api/auth/harnesses/codex/login/start")
+        # …which dies before paste-back.
+        druks.redis.get_client()._data = {
+            key: value
+            for key, value in druks.redis.get_client()._data.items()
+            if not key.startswith("druks:session:")
+        }
+        _mock_exchange_codex(monkeypatch, email="corp-seat@corp.com")
+        response = client.post(
+            "/api/auth/harnesses/codex/login/complete",
+            json={"code": "thecode", "loginId": start.json()["loginId"]},
+        )
+        # The flow must never rebind the login by email fallback.
+        assert response.status_code == 422
+        assert "different session" in response.json()["detail"]
+    assert not Account.get_for_email("corp-seat@corp.com")
+    assert not any(row.harness == "codex" for row in HarnessConnection.list_all())
+
+
+def test_two_accounts_may_connect_the_same_provider_login(tmp_path, monkeypatch, db_session):
+    # Deliberately unpoliced: the provider email is renameable upstream, so
+    # any uniqueness constraint on it would lapse silently.
+    connect_harness(
+        ClaudeHarness,
+        {"claudeAiOauth": {"accessToken": "x"}},
+        provider_email="shared@corp.com",
+    )
+    with _client(tmp_path) as client:
+        start = client.post("/api/auth/harnesses/codex/login/start")
+        _mock_exchange_codex(monkeypatch, email="me@example.com")
+        client.post(
+            "/api/auth/harnesses/codex/login/complete",
+            json={"code": "thecode", "loginId": start.json()["loginId"]},
+        )
+        assert _login(client, monkeypatch, email="shared@corp.com").status_code == 200
+
+    claude = [login for login in HarnessConnection.list_all() if login.harness == "claude"]
+    assert len(claude) == 2  # one row per account, same provider email
+    assert len({login.account_id for login in claude}) == 2
+
+
+def test_new_identity_cannot_acquire_legacy_logins(tmp_path, monkeypatch, db_session):
+    # The migration shape: the dashboard account owns the legacy login.
+    legacy = connect_harness(
+        ClaudeHarness, {"claudeAiOauth": {"accessToken": "x"}}, provider_email="op@example.com"
+    )
+    with _client(tmp_path) as client:
+        response = _login(client, monkeypatch, email="newcomer@example.com")
+        assert response.status_code == 200
+    accounts = {account.email: account for account in _all_accounts()}
+    assert set(accounts) == {"op@example.com", "newcomer@example.com"}
+    # The legacy login stays put; the fallback account stays the operator's.
+    assert HarnessConnection.reload(legacy.id).account_id == accounts["op@example.com"].id
+    assert UserSettings.get().fallback_account_id == accounts["op@example.com"].id
+
+
+def test_dashboard_identity_resolves_the_migrated_account(tmp_path, monkeypatch, db_session):
+    legacy = connect_harness(
+        ClaudeHarness, {"claudeAiOauth": {"accessToken": "x"}}, provider_email="op@example.com"
+    )
+    legacy_id = legacy.id
+    with _client(tmp_path) as client:
+        response = _login(client, monkeypatch, email="op@example.com")
+        assert response.status_code == 200
+    # One account, the legacy login updated in place; reload() reads past
+    # this task's identity map.
+    assert len(_all_accounts()) == 1
+    updated = HarnessConnection.reload(legacy_id)
+    assert dict(updated.payload)["claudeAiOauth"]["accessToken"] == "AT"
+
+
+def _all_accounts() -> list[Account]:
+    return list(database.db_session().scalars(select(Account)))
+
+
+def _mock_exchange_codex(monkeypatch, *, email: str):
+    claims = {
+        "https://api.openai.com/auth": {"chatgpt_account_id": "acc-1"},
+        "https://api.openai.com/profile": {"email": email},
+        "exp": 4102444800,
+    }
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
+    grant = {"access_token": f"{header}.{payload}.sig", "refresh_token": "RT", "id_token": "ID"}
+
+    async def fake_post(self, url, *, json=None, data=None, **_kwargs):
+        return httpx.Response(200, text=_dumps(grant), request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(hbase.httpx.AsyncClient, "post", fake_post)

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -1,0 +1,59 @@
+import pytest
+from druks.accounts.dependencies import current_account
+from druks.api.app import app
+from fastapi.routing import APIRoute, _IncludedRouter
+
+# Every /api path allowed to skip the session gate; additions are deliberate.
+EXEMPT_API_PATHS = {
+    "/api/system/health",
+    "/api/auth/harnesses/{name}/login/start",
+    "/api/auth/harnesses/{name}/login/complete",
+    "/api/auth/logout",
+    "/api/{path:path}",  # the JSON-404 catch-all
+}
+
+
+def _walk(routes):
+    # FastAPI 0.139 defers include_router into _IncludedRouter nodes; only
+    # effective_candidates() shows the include-time dependencies (the gate).
+    for route in routes:
+        if isinstance(route, _IncludedRouter):
+            yield from _walk(route.effective_candidates())
+        elif isinstance(route, APIRoute) or isinstance(
+            getattr(route, "original_route", None), APIRoute
+        ):
+            yield route
+        elif hasattr(route, "routes"):
+            yield from _walk(route.routes)
+
+
+@pytest.fixture
+def api_routes():
+    return list(_walk(app.router.routes))
+
+
+def _session_gated(route) -> bool:
+    return any(dependency.call is current_account for dependency in route.dependant.dependencies)
+
+
+def test_every_internal_api_route_sits_behind_the_session_gate(api_routes):
+    unguarded = [
+        route.path
+        for route in api_routes
+        if route.path.startswith("/api/")
+        and route.path not in EXEMPT_API_PATHS
+        and not _session_gated(route)
+    ]
+    assert unguarded == []
+    # The sweep only covers the stream families if they exist; pin that.
+    paths = {route.path for route in api_routes}
+    assert "/api/events/stream" in paths
+    assert any(path.endswith("/transcripts/{call_id}/stream") for path in paths)
+
+
+def test_the_exemptions_are_exactly_the_enumerated_ones(api_routes):
+    # The other direction: nothing exempt or outside /api carries the gate.
+    for route in api_routes:
+        if route.path in EXEMPT_API_PATHS or not route.path.startswith("/api/"):
+            assert not _session_gated(route), route.path
+    assert any(route.path.startswith("/_external/") for route in api_routes)

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -151,9 +151,12 @@ def rt():
     configure_session(engine)
 
     # An agent run checks the resolved harness is connected before any VM work;
-    # AgentFlow's decider resolves to claude, so connect it for the module.
+    # AgentFlow's decider resolves to claude, so connect it for the module —
+    # and mark the account as the execution fallback, the way the first
+    # login would.
     from druks.accounts.models import Account
     from druks.harnesses.models import HarnessConnection
+    from druks.user_settings.models import UserSettings
 
     session = get_session(engine)
     try:
@@ -166,9 +169,9 @@ def rt():
                 account_id=account.id,
                 provider_email=account.email,
                 payload={"claudeAiOauth": {"accessToken": "t"}},
-                is_default=True,
             )
         )
+        session.merge(UserSettings(id=UserSettings.SINGLETON_ID, fallback_account_id=account.id))
         session.commit()
     finally:
         session.close()

--- a/backend/tests/test_extensions.py
+++ b/backend/tests/test_extensions.py
@@ -81,6 +81,10 @@ def test_load_confines_extension_routers_to_the_extension_namespace(monkeypatch)
     monkeypatch.setattr(loader, "import_extension_models", lambda: None)
     app = FastAPI()
     load(app)
+    # Mounting is under test, not the session gate.
+    from druks.accounts.dependencies import current_account
+
+    app.dependency_overrides[current_account] = lambda: None
 
     # Behavioral, not app.routes introspection: FastAPI ≥0.139 mounts included
     # routers lazily, so the flattened paths aren't visible there anymore.

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -12,6 +12,7 @@ from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.exceptions import HarnessNotConnectedError, OAuthTokenError
 from druks.harnesses.models import HarnessConnection
+from druks.user_settings.models import UserSettings
 
 _NOW = datetime(2026, 6, 4, 20, 0, tzinfo=UTC)
 
@@ -160,7 +161,7 @@ async def test_claude_invalid_grant_drops_row(monkeypatch, db_session):
     assert result.error == "invalid_grant"
     # A revoked lineage self-disconnects and commits inside the rotation — the
     # deletion never rides (or rolls back with) the tick's later commit.
-    assert HarnessConnection.get_default("claude") is None
+    assert not HarnessConnection.list_all()
     with pytest.raises(HarnessNotConnectedError):
         ClaudeHarness.get_credentials()
 
@@ -195,7 +196,7 @@ async def test_codex_invalid_grant_drops_row(monkeypatch, db_session):
     _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
     result = await CodexHarness.rotate_token(login.id, now=_NOW)
     assert result.error == "invalid_grant"
-    assert HarnessConnection.get_default("codex") is None
+    assert not HarnessConnection.list_all()
     with pytest.raises(HarnessNotConnectedError):
         CodexHarness.get_credentials()
 
@@ -262,11 +263,15 @@ async def test_codex_no_refresh_token(monkeypatch, db_session):
 
 async def test_rotation_touches_only_the_addressed_row(monkeypatch, db_session):
     stale = _seed_claude(
-        access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30),
+        access="old",
+        refresh="R0",
+        expires_at=_NOW + timedelta(minutes=30),
         provider_email="a@example.com",
     )
     other = _seed_claude(
-        access="keep", refresh="RK", expires_at=_NOW + timedelta(minutes=30),
+        access="keep",
+        refresh="RK",
+        expires_at=_NOW + timedelta(minutes=30),
         provider_email="b@example.com",
     )
     stale_id, other_id = stale.id, other.id
@@ -280,17 +285,15 @@ async def test_rotation_touches_only_the_addressed_row(monkeypatch, db_session):
 
 
 async def test_invalid_grant_drops_only_the_addressed_row(monkeypatch, db_session):
-    default = _seed_claude(access="d", expires_at=_NOW - timedelta(minutes=1))
+    kept = _seed_claude(access="d", expires_at=_NOW - timedelta(minutes=1))
     other = _seed_claude(
         access="o", expires_at=_NOW - timedelta(minutes=1), provider_email="b@example.com"
     )
-    default_id, other_id = default.id, other.id
+    kept_id, other_id = kept.id, other.id
     _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
     await ClaudeHarness.rotate_token(other_id, now=_NOW)
-    assert HarnessConnection.get(other_id) is None
-    # The default login is untouched — and an auto-disconnect elsewhere never
-    # promoted anything.
-    assert HarnessConnection.get_default("claude").id == default_id
+    assert not HarnessConnection.get(other_id)
+    assert HarnessConnection.get(kept_id)
 
 
 async def test_concurrent_rotations_produce_one_grant(monkeypatch, db_session):
@@ -321,30 +324,27 @@ async def test_rotation_lock_is_released_after_refresh(monkeypatch, db_session):
     assert await druks.redis.get_client().get(f"druks:harness:refresh:{login.id}") is None
 
 
-def test_disconnect_removes_only_the_default_login_without_promotion(db_session):
-    default = _seed_claude(provider_email="a@example.com")
+def test_disconnect_removes_only_the_addressed_login(db_session):
+    mine = _seed_claude(provider_email="a@example.com")
     other = _seed_claude(provider_email="b@example.com")
-    assert HarnessConnection.get_default("claude").id == default.id
 
-    ClaudeHarness.disconnect()
+    mine.delete()
 
-    assert HarnessConnection.get(default.id) is None
-    assert HarnessConnection.get(other.id) is not None
-    assert HarnessConnection.get_default("claude") is None  # no silent promotion
+    assert HarnessConnection.get(other.id)
+    # The fallback account (the first) has no claude login left; another
+    # account's credential never leaks into execution.
     with pytest.raises(HarnessNotConnectedError):
         ClaudeHarness.get_credentials()
 
 
-def test_reconnect_after_default_gone_becomes_default(db_session):
-    default = _seed_claude(provider_email="a@example.com")
-    _seed_claude(provider_email="b@example.com")
-    ClaudeHarness.disconnect()
-    assert HarnessConnection.get_default("claude") is None
+def test_reconnect_restores_execution(db_session):
+    mine = _seed_claude(provider_email="a@example.com")
+    mine.delete()
+    with pytest.raises(HarnessNotConnectedError):
+        ClaudeHarness.get_credentials()
 
-    # An explicit reconnect of the surviving login is the sanctioned promotion.
-    row = _seed_claude(provider_email="b@example.com")
-    assert HarnessConnection.get_default("claude").id == row.id
-    assert row.id != default.id
+    _seed_claude(access="fresh", provider_email="a@example.com")
+    assert ClaudeHarness.get_credentials()["claudeAiOauth"]["accessToken"] == "fresh"
 
 
 def test_connect_scopes_rows_by_harness_and_account(db_session):
@@ -356,9 +356,8 @@ def test_connect_scopes_rows_by_harness_and_account(db_session):
     assert claude_row.account_id == codex_row.account_id  # same person, one account
     assert other.account_id != claude_row.account_id
     assert Account.get_for_email("a@example.com").id == claude_row.account_id
-    # The first login per harness stays the default.
-    assert HarnessConnection.get_default("claude").id == claude_row.id
-    assert HarnessConnection.get_default("codex").id == codex_row.id
+    # The first account adopted the execution fallback.
+    assert UserSettings.get().fallback_account_id == claude_row.account_id
 
 
 def test_reconnect_updates_the_existing_login_in_place(db_session):

--- a/backend/tests/test_harness_login.py
+++ b/backend/tests/test_harness_login.py
@@ -5,12 +5,10 @@ from datetime import UTC, datetime, timedelta
 import druks.redis
 import httpx
 import pytest
-from druks.accounts.models import Account
 from druks.harnesses import base as hbase
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.exceptions import LoginError
-from druks.harnesses.models import HarnessConnection
 
 
 @pytest.fixture(autouse=True)
@@ -66,50 +64,53 @@ async def test_claude_login_start_builds_url_and_stashes_pending(db_session):
 
     pending = await _pending(flow_id)
     assert pending["state"] == pending["verifier"]  # claude echoes the verifier as state
+    # An initial login binds to nothing until account resolution.
+    assert not pending["account_id"]
 
 
-async def test_claude_login_complete_creates_account_and_login(monkeypatch, db_session):
-    _, flow_id = await ClaudeHarness.login_start()
+async def test_login_start_binds_the_session_account(db_session):
+    _, flow_id = await ClaudeHarness.login_start(account_id="acct-1")
+    pending = await _pending(flow_id)
+    assert pending["account_id"] == "acct-1"
+
+
+async def test_claude_login_complete_returns_the_exchange(monkeypatch, db_session):
+    _, flow_id = await ClaudeHarness.login_start(account_id="acct-1")
     calls = _mock_post(monkeypatch, _resp(200, _CLAUDE_GRANT))
-    await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
+    completed = await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
 
-    login = HarnessConnection.get_default("claude")
-    assert login is not None
-    block = dict(login.payload)["claudeAiOauth"]
+    block = completed.payload["claudeAiOauth"]
     assert block["accessToken"] == "AT"
     assert block["refreshToken"] == "RT"
     assert block["scopes"] == ["user:profile", "user:inference"]
-    assert login.provider_email == "me@example.com"
-    assert login.is_default is True
-    assert Account.get_for_email("me@example.com").id == login.account_id
+    assert completed.provider_email == "me@example.com"
+    assert completed.expires_at
+    # The account the flow was started under rides along for resolution.
+    assert completed.account_id == "acct-1"
     # Claude exchanges JSON with the code + state echoed in the body.
     assert calls[0]["json"]["code"] == "thecode"
     assert "state" in calls[0]["json"]
     # Single-use: the pending state is gone.
-    assert await _pending(flow_id) is None
+    assert not await _pending(flow_id)
 
 
 async def test_concurrent_login_flows_do_not_clobber_each_other(monkeypatch, db_session):
-    # Two operators connect the same harness at once: distinct flow ids, both
+    # Two people connect the same harness at once: distinct flow ids, both
     # pendings live, and completing one leaves the other completable.
     _, first_flow = await ClaudeHarness.login_start()
     _, second_flow = await ClaudeHarness.login_start()
     assert first_flow != second_flow
-    assert await _pending(first_flow) is not None
-    assert await _pending(second_flow) is not None
 
     _mock_post(monkeypatch, _resp(200, _CLAUDE_GRANT))
-    await ClaudeHarness.login_complete(flow_id=first_flow, pasted="code-1")
-    assert await _pending(second_flow) is not None
+    first = await ClaudeHarness.login_complete(flow_id=first_flow, pasted="code-1")
+    assert await _pending(second_flow)
 
     second_grant = dict(_CLAUDE_GRANT, account={"email_address": "other@example.com"})
     _mock_post(monkeypatch, _resp(200, second_grant))
-    await ClaudeHarness.login_complete(flow_id=second_flow, pasted="code-2")
+    second = await ClaudeHarness.login_complete(flow_id=second_flow, pasted="code-2")
 
-    connected = {login.provider_email for login in HarnessConnection.list_all()}
-    assert connected == {"me@example.com", "other@example.com"}
-    # The first login connected stays the harness default.
-    assert HarnessConnection.get_default("claude").provider_email == "me@example.com"
+    assert first.provider_email == "me@example.com"
+    assert second.provider_email == "other@example.com"
 
 
 async def test_login_complete_without_provider_email_raises(monkeypatch, db_session):
@@ -118,19 +119,6 @@ async def test_login_complete_without_provider_email_raises(monkeypatch, db_sess
     _mock_post(monkeypatch, _resp(200, grant))
     with pytest.raises(LoginError, match="no account email"):
         await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
-    assert HarnessConnection.list_all() == []
-
-
-async def test_login_complete_matches_provider_email_case_insensitively(monkeypatch, db_session):
-    # The provider's email is stored as given; the citext columns match it
-    # regardless of case, so no account or connection duplicates on casing.
-    _, flow_id = await ClaudeHarness.login_start()
-    grant = dict(_CLAUDE_GRANT, account={"email_address": "Me@Example.COM"})
-    _mock_post(monkeypatch, _resp(200, grant))
-    await ClaudeHarness.login_complete(flow_id=flow_id, pasted="thecode")
-    login = HarnessConnection.get_default("claude")
-    assert login.provider_email == "Me@Example.COM"
-    assert Account.get_for_email("me@example.com") is not None  # citext: case-insensitive
 
 
 async def test_codex_login_complete_is_form_encoded_and_reads_jwt(monkeypatch, db_session):
@@ -146,16 +134,14 @@ async def test_codex_login_complete_is_form_encoded_and_reads_jwt(monkeypatch, d
     calls = _mock_post(
         monkeypatch, _resp(200, {"access_token": access, "refresh_token": "RT", "id_token": "ID"})
     )
-    await CodexHarness.login_complete(
+    completed = await CodexHarness.login_complete(
         flow_id=flow_id,
         pasted=f"http://localhost:1455/auth/callback?code=thecode&state={pending['state']}",
     )
 
-    login = HarnessConnection.get_default("codex")
-    payload = dict(login.payload)
-    assert payload["tokens"]["account_id"] == "acc-9"
-    assert payload["tokens"]["id_token"] == "ID"
-    assert login.provider_email == "c@example.com"
+    assert completed.payload["tokens"]["account_id"] == "acc-9"
+    assert completed.payload["tokens"]["id_token"] == "ID"
+    assert completed.provider_email == "c@example.com"
     # Codex exchanges form-encoded, no state in the body.
     assert calls[0]["data"]["code"] == "thecode"
     assert "state" not in calls[0]["data"]
@@ -189,14 +175,4 @@ async def test_login_complete_provider_error_clears_pending(monkeypatch, db_sess
         await ClaudeHarness.login_complete(flow_id=flow_id, pasted="code")
     assert "invalid_grant" in str(error.value)
     # Failure is single-use too — a retry must re-start.
-    assert await _pending(flow_id) is None
-    assert HarnessConnection.get_default("claude") is None
-
-
-def test_disconnect_deletes_the_default_row(db_session):
-    from conftest import connect_harness
-
-    connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "x", "refreshToken": "r"}})
-    assert HarnessConnection.get_default("claude") is not None
-    ClaudeHarness.disconnect()
-    assert HarnessConnection.get_default("claude") is None
+    assert not await _pending(flow_id)

--- a/backend/tests/test_harness_login_persistence.py
+++ b/backend/tests/test_harness_login_persistence.py
@@ -60,8 +60,11 @@ def _committed(engine, work):
 
 
 def _connect(payload: dict) -> str:
+    from druks.accounts.models import Account
+
     row = HarnessConnection.connect(
         harness="claude",
+        account=Account.get_or_create("op@example.com"),
         payload=payload,
         expires_at=None,
         provider_email="op@example.com",
@@ -70,7 +73,7 @@ def _connect(payload: dict) -> str:
 
 
 def test_rotation_persists_new_payload_across_sessions(engine):
-    # Connect the seat, rotate its payload the way rotate_token does (plain-dict
+    # Connect, then rotate the payload the way rotate_token does (plain-dict
     # copy, edit, whole-value update), then read it back from a fresh session —
     # commit + new session proves the edit reached the DB, not just the
     # in-memory object.
@@ -93,9 +96,7 @@ def test_rotation_persists_new_payload_across_sessions(engine):
 
 
 def test_payload_is_ciphertext_at_rest(engine):
-    _committed(
-        engine, lambda: _connect({"claudeAiOauth": {"accessToken": "supersecret"}})
-    )
+    _committed(engine, lambda: _connect({"claudeAiOauth": {"accessToken": "supersecret"}}))
 
     with engine.connect() as connection:
         stored = connection.execute(text("SELECT payload FROM harness_logins")).scalar_one()

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -280,36 +280,40 @@ async def test_respond_route_codes_and_secret_hygiene(tmp_path, db_session, resu
     token = notification.correlation_token
     client = TestClient(configure_app_for_test(settings=make_settings(tmp_path)))
 
-    unknown = client.post("/api/notifications/no-such-token/respond", json={"control": "approve"})
+    unknown = client.post(
+        "/_external/notifications/no-such-token/respond", json={"control": "approve"}
+    )
     assert unknown.status_code == 404
     assert "no-such-token" not in unknown.json()["detail"]
 
-    bad_control = client.post(f"/api/notifications/{token}/respond", json={"control": "merge"})
+    bad_control = client.post(
+        f"/_external/notifications/{token}/respond", json={"control": "merge"}
+    )
     assert bad_control.status_code == 422
 
     bad_question = client.post(
-        f"/api/notifications/{token}/respond",
+        f"/_external/notifications/{token}/respond",
         json={"control": "approve", "answers": {"q9": "x"}},
     )
     assert bad_question.status_code == 422
 
     blank_answer = client.post(
-        f"/api/notifications/{token}/respond",
+        f"/_external/notifications/{token}/respond",
         json={"control": "approve", "answers": {"q1": "   "}},
     )
     assert blank_answer.status_code == 422
 
     empty_changes = client.post(
-        f"/api/notifications/{token}/respond", json={"control": "request_changes"}
+        f"/_external/notifications/{token}/respond", json={"control": "request_changes"}
     )
     assert empty_changes.status_code == 422
     assert resume_spy == []
 
-    ok = client.post(f"/api/notifications/{token}/respond", json={"control": "approve"})
+    ok = client.post(f"/_external/notifications/{token}/respond", json={"control": "approve"})
     assert ok.status_code == 204
     assert len(resume_spy) == 1
 
-    again = client.post(f"/api/notifications/{token}/respond", json={"control": "approve"})
+    again = client.post(f"/_external/notifications/{token}/respond", json={"control": "approve"})
     assert again.status_code == 409
     assert len(resume_spy) == 1
     for response in (unknown, bad_control, bad_question, blank_answer, empty_changes, again):
@@ -324,7 +328,7 @@ async def test_respond_external_notification_not_answerable(tmp_path, db_session
     client = TestClient(configure_app_for_test(settings=make_settings(tmp_path)))
 
     response = client.post(
-        f"/api/notifications/{notification.correlation_token}/respond",
+        f"/_external/notifications/{notification.correlation_token}/respond",
         json={"control": "approve"},
     )
 
@@ -341,7 +345,7 @@ async def test_respond_runless_notification_not_answerable(tmp_path, db_session,
     client = TestClient(configure_app_for_test(settings=make_settings(tmp_path)))
 
     response = client.post(
-        f"/api/notifications/{notification.correlation_token}/respond",
+        f"/_external/notifications/{notification.correlation_token}/respond",
         json={"control": "approve"},
     )
 
@@ -372,7 +376,7 @@ async def test_respond_stale_round_409(tmp_path, db_session, resume_spy):
     client = TestClient(configure_app_for_test(settings=make_settings(tmp_path)))
 
     response = client.post(
-        f"/api/notifications/{notification.correlation_token}/respond",
+        f"/_external/notifications/{notification.correlation_token}/respond",
         json={"control": "approve"},
     )
 
@@ -385,7 +389,7 @@ async def test_respond_run_no_longer_parked_409(tmp_path, db_session, resume_spy
     client = TestClient(configure_app_for_test(settings=make_settings(tmp_path)))
 
     response = client.post(
-        f"/api/notifications/{notification.correlation_token}/respond",
+        f"/_external/notifications/{notification.correlation_token}/respond",
         json={"control": "approve"},
     )
 
@@ -403,7 +407,7 @@ async def test_respond_corrupt_correlation_500_and_logged(
     )
 
     response = client.post(
-        f"/api/notifications/{notification.correlation_token}/respond",
+        f"/_external/notifications/{notification.correlation_token}/respond",
         json={"control": "approve"},
     )
 
@@ -442,7 +446,7 @@ async def test_respond_ask_without_presentation_not_answerable(tmp_path, db_sess
     client = TestClient(configure_app_for_test(settings=make_settings(tmp_path)))
 
     response = client.post(
-        f"/api/notifications/{notification.correlation_token}/respond",
+        f"/_external/notifications/{notification.correlation_token}/respond",
         json={"control": "approve"},
     )
 

--- a/backend/tests/test_scaffolding.py
+++ b/backend/tests/test_scaffolding.py
@@ -51,6 +51,10 @@ def test_create_extension_scaffolds_a_loadable_package(tmp_path):
 
         app = FastAPI()
         extension.load(app)
+        # Scaffolding is under test, not the session gate.
+        from druks.accounts.dependencies import current_account
+
+        app.dependency_overrides[current_account] = lambda: None
         client = TestClient(app)
         assert client.get("/api/night_watch/status").json() == {"extension": "night_watch"}
         page = client.get("/app/night_watch/")

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -58,7 +58,7 @@ def test_docker_provider_wires_drukbox_on_host(tmp_path):
 
     rc = _run(env_path, provider="docker")
 
-    assert rc == GAPS_EXIT_CODE  # same GitHub/email/PEM gaps as every shape
+    assert rc == GAPS_EXIT_CODE  # same GitHub/PEM gaps as every shape
     values = read_env(env_path)
     assert values["DEFAULT_HOST_PROVIDER"] == "docker"
     # Pointed at drukbox on the host (`make dev`), not a drukbox container.
@@ -77,16 +77,14 @@ def test_rerun_preserves_values_secrets_and_operator_additions(tmp_path):
     first = read_env(env_path)
     # Operator fills a value and adds a custom var by hand.
     env_path.write_text(
-        env_path.read_text().replace(
-            "DRUKS_DASHBOARD_EMAIL=", "DRUKS_DASHBOARD_EMAIL=op@example.com"
-        )
+        env_path.read_text().replace("GITHUB_OPERATOR_APP_ID=", "GITHUB_OPERATOR_APP_ID=111")
         + "\nMY_CUSTOM_FLAG=on\n"
     )
 
     _run(env_path)
 
     values = read_env(env_path)
-    assert values["DRUKS_DASHBOARD_EMAIL"] == "op@example.com"
+    assert values["GITHUB_OPERATOR_APP_ID"] == "111"
     assert values["DRUKS_WEBHOOK_SECRET"] == first["DRUKS_WEBHOOK_SECRET"]  # not regenerated
     assert values["MY_CUSTOM_FLAG"] == "on"  # hand edits survive
 
@@ -104,7 +102,6 @@ def test_interactive_prompts_fill_only_blanks(tmp_path):
     env_path = tmp_path / ".env"
     answers = iter(
         [
-            "op@example.com",  # dashboard email
             "111",  # operator app id
             "222",  # reviewer app id
             "",  # linear api key — skipped
@@ -120,7 +117,7 @@ def test_interactive_prompts_fill_only_blanks(tmp_path):
     rc = _run(env_path, interactive=True, input_fn=lambda _prompt: next(answers))
 
     values = read_env(env_path)
-    assert values["DRUKS_DASHBOARD_EMAIL"] == "op@example.com"
+    assert values["GITHUB_OPERATOR_APP_ID"] == "111"
     assert values["GITHUB_REVIEWER_APP_ID"] == "222"
     assert values["EXE_API_TOKEN"] == "exe-token"
     # Required values all present — only the PEM files gate the boot now.
@@ -136,7 +133,7 @@ def test_interactive_prompts_fill_only_blanks(tmp_path):
 
 def test_rerun_with_complete_env_prompts_nothing(tmp_path):
     env_path = tmp_path / ".env"
-    answers = iter(["op@example.com", "111", "222", "", "", "", "t.ts.net", "", "", "tok"])
+    answers = iter(["111", "222", "", "", "", "t.ts.net", "", "", "tok"])
     _run(env_path, interactive=True, input_fn=lambda _p: next(answers))
     (tmp_path / "secrets" / "operator.pem").write_text("pem")
     (tmp_path / "secrets" / "reviewer.pem").write_text("pem")
@@ -151,7 +148,7 @@ def test_custom_pem_location_is_not_boot_gated(tmp_path):
     """A PEM outside the install dir can't be checked pre-boot — doctor owns
     that post-boot; setup must not block on it."""
     env_path = tmp_path / ".env"
-    answers = iter(["op@e.com", "111", "222", "", "", "", "t.ts.net", "", "", "tok"])
+    answers = iter(["111", "222", "", "", "", "t.ts.net", "", "", "tok"])
     _run(env_path, interactive=True, input_fn=lambda _p: next(answers))
     body = env_path.read_text().replace(
         "GITHUB_OPERATOR_PEM=/home/op/druks/secrets/operator.pem",

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -43,8 +43,7 @@ First pass writes `~/druks/.env` with random secrets pre-filled,
 creates `~/druks/secrets/`, and exits. It tells you exactly what to do
 next:
 
-- Fill in the blanks at the top of `.env` (`DRUKS_DASHBOARD_EMAIL` and
-  the sandbox provider block).
+- Fill in the blanks at the top of `.env` (the sandbox provider block).
 - Provision the two GitHub Apps: re-run the installer with `--apps`.
   It registers each app via GitHub's manifest flow — it prints a link
   per app, you open it, click Create, then paste the `?code=...` from
@@ -107,8 +106,8 @@ ssh exe.dev share set-public druks
 ```
 
 Public URLs: `https://<host>/_external/{github,linear,jira}/events/`
-(HMAC-gated webhooks) and `https://<host>/` (exe.dev login +
-`DRUKS_DASHBOARD_EMAIL` gate).
+(HMAC-gated webhooks) and `https://<host>/` (exe.dev login at the edge;
+harness login in the app mints the session).
 
 **Elsewhere (e.g. AWS + Teleport)**, the dashboard goes through your
 identity proxy (set `DRUKS_AUTH_HEADER` to the header it injects), but
@@ -162,12 +161,27 @@ database backup and the old image — there is no Alembic downgrade.
 With existing harness connections, the migration requires
 `DRUKS_DASHBOARD_EMAIL` in the migration run's environment and attaches every
 existing seat to one account with that email. A remote install needs no extra
-step — `.env` already holds the value the Caddy gate matches. **Warning:** the
-one-run value must match the provider email you will actually sign in with
+step — `.env` already holds the value the old Caddy gate matched. **Warning:**
+the one-run value must match the provider email you will actually sign in with
 once account login lands; a mismatch strands the migrated seats on an account
 you cannot enter (automation keeps working, and reconnecting after an eventual
 `invalid_grant` re-creates the seat under your real account). Fresh installs
 and installs with no connected harness skip all of this.
+
+Once the account-login release is deployed, finish the cutover — deploys never
+refresh the host-copied `compose.yaml`/`Caddyfile`, so this is an explicit
+step (re-running `install.sh` performs the copy for you):
+
+1. Replace the host copies of `deploy/compose.yaml` and
+   `deploy/caddy/Caddyfile` with this release's versions (the Caddy gate now
+   admits any nonempty trusted identity; the app enforces its own session).
+2. Delete the now-unused `DRUKS_DASHBOARD_EMAIL` line from `~/druks/.env`.
+3. Recreate the affected services: `docker compose up -d --force-recreate web
+   caddy`.
+
+Until those land, the new release still runs behind the old single-email gate
+— that transition window is supported. Afterwards, each browser performs one
+harness login to mint its session cookie.
 
 ### One-time: upgrading a box that ran the backend as root
 
@@ -225,6 +239,7 @@ Caddyfile fetched by the installer) enforces path-level access:
   Druks. Per-provider paths land under
   `/_external/<provider>/<category>/`; extension role-module discovery
   registers them at import time.
-- Everything else — exe.dev login + `DRUKS_DASHBOARD_EMAIL` match
-  required, then proxied to `web` (`127.0.0.1:8001`), which
-  serves the API, the SPA, and extension frontends alike.
+- Everything else — a nonempty trusted identity header (exe.dev login
+  provides one) required, then proxied to `web` (`127.0.0.1:8001`), which
+  serves the API, the SPA, and extension frontends alike; the app itself
+  requires its session cookie, minted by harness login.

--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -27,23 +27,19 @@ http://:8000 {
 		reverse_proxy {$DRUKS_UPSTREAM}
 	}
 
-	# Identity is an upstream-injected trusted header matched against the
-	# allowlisted email. DRUKS_AUTH_HEADER defaults to exe.dev's; point it at
-	# another proxy's header (Teleport: X-Forwarded-Email, Cloudflare Access:
+	# Admission is an upstream-injected trusted header: any nonempty value
+	# passes the edge. Identity inside the app is its own (harness login
+	# mints the session cookie); the header is never read by the backend.
+	# DRUKS_AUTH_HEADER defaults to exe.dev's; point it at another
+	# proxy's header (Teleport: X-Forwarded-Email, Cloudflare Access:
 	# Cf-Access-Authenticated-User-Email, …) to swap the auth edge with no
 	# code change.
 	# The backend serves everything behind the gate — the API, the SPA at /,
 	# extension frontends at /app/<name>. Cache policy for the served
 	# frontends lives with their server (api/app.py), not at the edge.
-	@dashboard_user header {$DRUKS_AUTH_HEADER:X-ExeDev-Email} {$DRUKS_DASHBOARD_EMAIL}
+	@dashboard_user header {$DRUKS_AUTH_HEADER:X-ExeDev-Email} *
 	handle @dashboard_user {
 		reverse_proxy {$DRUKS_UPSTREAM}
-	}
-
-	# Header present but email not allowlisted → deny.
-	@wrong_user header {$DRUKS_AUTH_HEADER:X-ExeDev-Email} *
-	handle @wrong_user {
-		respond "Access denied." 403
 	}
 
 	# No identity header at all. exe.dev passes unauthenticated traffic

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -127,7 +127,6 @@ services:
     restart: unless-stopped
     environment:
       DRUKS_UPSTREAM: ${DRUKS_UPSTREAM:-127.0.0.1:8001}
-      DRUKS_DASHBOARD_EMAIL: ${DRUKS_DASHBOARD_EMAIL:?set DRUKS_DASHBOARD_EMAIL}
       DRUKS_AUTH_HEADER: ${DRUKS_AUTH_HEADER:-X-ExeDev-Email}
       # ``:-`` so an empty .env value still collapses to the inert loopback
       # default — Caddy treats set-but-empty as a real (broken) site address.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -203,11 +203,14 @@ coordination such as webhook deduplication, OAuth state/token caches, and the
 sandbox provisioning gate. Drukbox provisions sandbox hosts; Druks then reaches
 them over SSH.
 
-FastAPI does not implement end-user login. In the shipped remote stack, Caddy
-trusts an identity header inserted by exe.dev or another upstream proxy and
-allows the one configured dashboard email. Public webhook routes bypass that
-identity gate but still require provider authentication. A local dashboard
-bound directly to `127.0.0.1:8001` has no application login and must not be
-published as-is. The upstream proxy must remove any client-supplied copy of the
-trusted identity header before inserting its authenticated value; merely
-forwarding that header makes the dashboard gate forgeable.
+Harness login is the application's login: connecting Codex or Claude resolves
+an account and mints the `druks_session` cookie (30-day sliding TTL in Redis)
+that every internal API and SSE stream requires. In the shipped remote stack,
+Caddy additionally requires an identity header inserted by exe.dev or another
+upstream proxy — a pure admission check; the app never reads it. Public `/_external`
+routes — webhooks and the token-authenticated notification respond — bypass
+the session gate but keep their own authentication. A local dashboard bound directly to
+`127.0.0.1:8001` still requires the session but has no edge in front and must
+not be published as-is. The upstream proxy must remove any client-supplied
+copy of the trusted identity header before inserting its authenticated value;
+merely forwarding that header makes identity resolution forgeable.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,21 +35,25 @@ caches, and the sandbox provisioning gate.
 | `DRUKS_ENDPOINT` | Browser-visible dashboard base URL used to build MCP OAuth callbacks |
 | `DRUKS_WEBHOOK_HOST` | Public webhook hostname used by `druks doctor` for its ingress probe |
 | `DRUKS_WEBHOOK_SECRET` | Shared HMAC secret used by bundled webhook integrations |
-| `DRUKS_DASHBOARD_EMAIL` | Email allowed through the shipped Caddy gate |
-| `DRUKS_AUTH_HEADER` | Trusted identity header inserted by the upstream proxy |
+| `DRUKS_AUTH_HEADER` | Identity header the edge (Caddy) requires; the app never reads it |
 
 `DRUKS_ENDPOINT` and `DRUKS_WEBHOOK_HOST` are different. The first is where an
 operator's browser reaches Druks; the second is the public ingress webhook
 senders reach. They may share a hostname on exe.dev.
 
-FastAPI has no end-user authentication middleware. The shipped remote Caddy
-configuration matches `DRUKS_AUTH_HEADER` against `DRUKS_DASHBOARD_EMAIL`.
-Public `POST /_external/*` routes bypass this identity check and rely on each
-webhook's signature verification. Do not publish the local
-`127.0.0.1:8001` listener directly. Configure the identity proxy to strip or
-overwrite every client-supplied copy of `DRUKS_AUTH_HEADER` before it forwards
-the authenticated identity. Terminate TLS and set HSTS at that public proxy;
-the shipped Caddy listener is loopback HTTP behind the TLS edge.
+Harness login is the account door: signing in to Codex or Claude from the
+dashboard resolves your account and mints the `druks_session` cookie
+(HttpOnly, 30-day sliding TTL in Redis) that every internal API and SSE
+stream requires. The shipped remote Caddy admits only requests carrying a
+nonempty `DRUKS_AUTH_HEADER` identity — pure admission; the app never reads
+the header. Public `POST /_external/*` routes bypass the
+edge identity check and carry their own authentication — webhook signature
+verification, and the notification respond route's correlation token. Do not
+publish the local `127.0.0.1:8001` listener directly. Configure
+the identity proxy to strip every client-supplied copy of
+`DRUKS_AUTH_HEADER` — a client that can inject it walks past the edge. Terminate
+TLS and set HSTS at that public proxy; the shipped Caddy listener is loopback
+HTTP behind the TLS edge.
 
 ## GitHub Apps
 

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -86,6 +86,9 @@ Success means the Compose services are up and the health endpoint returns
 Open **Settings → Harnesses** in the dashboard and connect Claude and Codex.
 Druks stores those subscription credentials in Postgres and writes a fresh
 credential file into each sandbox. It does not use host CLI login files.
+That first connect is also the dashboard sign-in: harness login mints the
+`druks_session` cookie every internal API requires — a local install has no
+identity proxy in front, so the provider email is the account identity.
 Protect database access and backups as credential-bearing data; unlike MCP
 tokens and OAuth grants, harness payloads do not use the
 `DRUKS_SECRETS_KEY` envelope.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,15 +66,18 @@ The installer performs these steps in this order.
 
 ## The dashboard is inaccessible
 
-The shipped remote edge admits the single `DRUKS_DASHBOARD_EMAIL` when the
-configured `DRUKS_AUTH_HEADER` carries that identity. A 403 means a header was
-present with the wrong value. A redirect to `__exe.dev/login` means no trusted
-identity header reached Caddy.
+The shipped remote edge admits any request whose configured
+`DRUKS_AUTH_HEADER` carries a nonempty trusted identity; from there the app
+itself asks you to connect a harness, which mints the session cookie. A
+redirect to `__exe.dev/login` means no trusted identity header reached Caddy.
+A dashboard that loads but immediately shows the connect screen means the
+session cookie is missing or expired — sign in with Codex or Claude again
+(Redis loss signs everyone out but never touches stored credentials).
 
 Check:
 
 ```bash
-grep -E '^(DRUKS_DASHBOARD_EMAIL|DRUKS_AUTH_HEADER|DRUKS_UPSTREAM)=' ~/druks/.env
+grep -E '^(DRUKS_AUTH_HEADER|DRUKS_UPSTREAM)=' ~/druks/.env
 docker compose logs --tail=200 caddy web
 ```
 

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { postJSON } from './client'
+import { AUTH_EXPIRED_EVENT, UnauthorizedError, authApi, getJSON, postJSON } from './client'
 
 function failWith(status: number, statusText: string, body: string) {
   vi.stubGlobal(
@@ -20,5 +20,24 @@ describe('API error messages', () => {
   it('falls back to the status line when the body is not JSON detail', async () => {
     failWith(502, 'Bad Gateway', '<html>proxy error</html>')
     await expect(postJSON('/api/x', {})).rejects.toThrow('502 Bad Gateway: <html>proxy error</html>')
+  })
+})
+
+describe('session identity', () => {
+  it('types a 401 and broadcasts the expiry', async () => {
+    failWith(401, 'Unauthorized', JSON.stringify({ error: 'HTTP_401', detail: 'Sign in.' }))
+    const expired = vi.fn()
+    window.addEventListener(AUTH_EXPIRED_EVENT, expired)
+    try {
+      await expect(getJSON('/api/x')).rejects.toBeInstanceOf(UnauthorizedError)
+      expect(expired).toHaveBeenCalledTimes(1)
+    } finally {
+      window.removeEventListener(AUTH_EXPIRED_EVENT, expired)
+    }
+  })
+
+  it('reads a dead session as null without broadcasting noise elsewhere', async () => {
+    failWith(401, 'Unauthorized', JSON.stringify({ error: 'HTTP_401', detail: 'Sign in.' }))
+    await expect(authApi.session()).resolves.toBeNull()
   })
 })

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import type {
+  Account,
   AgentCallFiles,
   ArtifactContent,
   DashboardHealth,
@@ -21,6 +22,12 @@ import type {
   UserSettings,
 } from './types'
 
+// A 401 means the session is gone: typed to branch on, broadcast so the
+// AuthProvider unmounts the app.
+export class UnauthorizedError extends Error {}
+
+export const AUTH_EXPIRED_EVENT = 'druks:auth-expired'
+
 // FastAPI puts the human-readable message in ``detail``; throw that as the
 // Error message so consumers display it as-is. Non-JSON bodies (proxy pages,
 // validation arrays) fall back to the status line.
@@ -32,15 +39,24 @@ async function throwApiError(response: Response, path: string): Promise<never> {
   } catch {
     // not JSON — fall through to the status line
   }
-  throw new Error(
+  const message =
     typeof detail === 'string' && detail
       ? detail
-      : `${response.status} ${response.statusText}: ${body || path}`,
-  )
+      : `${response.status} ${response.statusText}: ${body || path}`
+  if (response.status === 401) {
+    window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT))
+    throw new UnauthorizedError(message)
+  }
+  throw new Error(message)
 }
 
+const SAME_ORIGIN: RequestCredentials = 'same-origin'
+
 export async function getJSON<T>(path: string): Promise<T> {
-  const response = await fetch(path, { headers: { Accept: 'application/json' } })
+  const response = await fetch(path, {
+    headers: { Accept: 'application/json' },
+    credentials: SAME_ORIGIN,
+  })
   if (!response.ok) {
     await throwApiError(response, path)
   }
@@ -51,6 +67,7 @@ export async function postJSON<T>(path: string, body: unknown): Promise<T> {
   const response = await fetch(path, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    credentials: SAME_ORIGIN,
     body: JSON.stringify(body),
   })
   if (!response.ok) {
@@ -63,6 +80,7 @@ export async function patchJSON<T>(path: string, body: unknown): Promise<T> {
   const response = await fetch(path, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    credentials: SAME_ORIGIN,
     body: JSON.stringify(body),
   })
   if (!response.ok) {
@@ -72,14 +90,18 @@ export async function patchJSON<T>(path: string, body: unknown): Promise<T> {
 }
 
 export async function deleteRequest(path: string): Promise<void> {
-  const response = await fetch(path, { method: 'DELETE' })
+  const response = await fetch(path, { method: 'DELETE', credentials: SAME_ORIGIN })
   if (!response.ok && response.status !== 204) {
     await throwApiError(response, path)
   }
 }
 
 export async function deleteJSON<T>(path: string): Promise<T> {
-  const response = await fetch(path, { method: 'DELETE', headers: { Accept: 'application/json' } })
+  const response = await fetch(path, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' },
+    credentials: SAME_ORIGIN,
+  })
   if (!response.ok) {
     await throwApiError(response, path)
   }
@@ -91,11 +113,29 @@ export async function postNoContent(path: string, body: unknown): Promise<void> 
   const response = await fetch(path, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    credentials: SAME_ORIGIN,
     body: JSON.stringify(body),
   })
   if (!response.ok) {
     await throwApiError(response, path)
   }
+}
+
+// Harness login mints the session; landing and Settings reconnect share it.
+export const authApi = {
+  session: (): Promise<Account | null> =>
+    getJSON<Account>('/api/auth/session').catch((error) => {
+      if (error instanceof UnauthorizedError) return null
+      throw error
+    }),
+  startLogin: (name: string) =>
+    postJSON<LoginChallenge>(`/api/auth/harnesses/${encodeURIComponent(name)}/login/start`, {}),
+  completeLogin: (name: string, code: string, loginId: string) =>
+    postJSON<Account>(`/api/auth/harnesses/${encodeURIComponent(name)}/login/complete`, {
+      code,
+      loginId,
+    }),
+  logout: () => postNoContent('/api/auth/logout', {}),
 }
 
 // The generic subject read-side every extension gets for free at
@@ -140,13 +180,6 @@ export const api = {
   harnesses: () => getJSON<Harness[]>('/api/settings/harnesses'),
   updateHarness: (name: string, body: UpdateHarnessRequest) =>
     patchJSON<Harness>(`/api/settings/harnesses/${encodeURIComponent(name)}`, body),
-  startHarnessLogin: (name: string) =>
-    postJSON<LoginChallenge>(`/api/settings/harnesses/${encodeURIComponent(name)}/login/start`, {}),
-  completeHarnessLogin: (name: string, code: string, flowId: string) =>
-    postJSON<Harness>(`/api/settings/harnesses/${encodeURIComponent(name)}/login/complete`, {
-      code,
-      flowId,
-    }),
   disconnectHarness: (name: string) =>
     deleteJSON<Harness>(`/api/settings/harnesses/${encodeURIComponent(name)}/login`),
   getExtensionSettings: () => getJSON<ExtensionsSettingsResponse>('/api/settings/extensions'),

--- a/frontend/src/api/sse.test.tsx
+++ b/frontend/src/api/sse.test.tsx
@@ -44,14 +44,30 @@ class FakeEventSource implements EventTarget {
   }
 }
 
+function stubSession(body: string, status: number) {
+  const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+    async () => new Response(body, { status }),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
 beforeEach(() => {
   FakeEventSource.instances = []
   vi.stubGlobal('EventSource', FakeEventSource)
+  // Every SSE error rechecks the session; default to a live one.
+  stubSession(JSON.stringify({ id: 'a1', email: 'me@example.com' }), 200)
 })
 
 afterEach(() => {
   vi.unstubAllGlobals()
 })
+
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
 
 function Harness({
   url,
@@ -199,5 +215,33 @@ describe('useSSE', () => {
     })
 
     expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  it('rechecks the session on error and stays open while it is live', async () => {
+    const fetchMock = stubSession(JSON.stringify({ id: 'a1', email: 'me@example.com' }), 200)
+    render(<Harness url="/api/x" handlers={{ 'foo.updated': vi.fn() }} />)
+
+    act(() => {
+      FakeEventSource.instances[0]?.emitError()
+    })
+    await flushMicrotasks()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/session',
+      expect.objectContaining({ credentials: 'same-origin' }),
+    )
+    expect(FakeEventSource.instances[0]?.closed).toBe(false)
+  })
+
+  it('closes the source when the session died — no blind reconnects', async () => {
+    stubSession(JSON.stringify({ error: 'HTTP_401', detail: 'Sign in.' }), 401)
+    render(<Harness url="/api/x" handlers={{ 'foo.updated': vi.fn() }} />)
+
+    act(() => {
+      FakeEventSource.instances[0]?.emitError()
+    })
+    await flushMicrotasks()
+
+    expect(FakeEventSource.instances[0]?.closed).toBe(true)
   })
 })

--- a/frontend/src/api/sse.ts
+++ b/frontend/src/api/sse.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from 'react'
 
+import { authApi } from './client'
+
 type Handler = (data: unknown) => void
 
 export interface UseSSEOptions {
@@ -62,6 +64,15 @@ export function useSSE(url: string, { handlers, onError, enabled = true }: UseSS
 
     const errorListener: EventListener = (event) => {
       onErrorRef.current?.(event)
+      // An SSE error may be an expired session: recheck instead of letting
+      // EventSource reconnect forever; the recheck's 401 signals the
+      // AuthProvider.
+      void authApi
+        .session()
+        .then((account) => {
+          if (!account) source.close()
+        })
+        .catch(() => undefined)
     }
     source.addEventListener('error', errorListener)
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -188,18 +188,25 @@ export interface Harness {
   fastMode: boolean
   effort: string
   timeout: number
-  // Connection state — false until the operator connects the subscription.
+  // The signed-in account's own connection; false until this account connects.
   connected: boolean
   kind: string | null
   account: string | null
+  /** The email the provider reported at connect — display, never authority. */
+  providerEmail: string | null
   expiresAt: string | null
+}
+
+export interface Account {
+  id: string
+  email: string
 }
 
 export interface LoginChallenge {
   authorizeUrl: string
   /** Opaque id of this connect attempt; passed back on complete so
    * concurrent sign-ins never clobber each other's pending state. */
-  flowId: string
+  loginId: string
 }
 
 export interface UpdateHarnessRequest {

--- a/frontend/src/components/AuthProvider.test.tsx
+++ b/frontend/src/components/AuthProvider.test.tsx
@@ -1,0 +1,68 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AUTH_EXPIRED_EVENT } from '../api/client'
+import { AuthProvider } from './AuthProvider'
+
+function stubFetch(status: number, body: unknown) {
+  const fetchMock = vi.fn(async () => new Response(JSON.stringify(body), { status }))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe('AuthProvider', () => {
+  it('mounts the app only once the session resolves', async () => {
+    stubFetch(200, { id: 'a1', email: 'me@example.com' })
+    render(
+      <AuthProvider>
+        <div data-testid="app" />
+      </AuthProvider>,
+    )
+    // Loading: neither the app nor the landing shows yet.
+    expect(screen.queryByTestId('app')).toBeNull()
+    await flush()
+    expect(screen.getByTestId('app')).toBeTruthy()
+  })
+
+  it('shows the landing when there is no session', async () => {
+    stubFetch(401, { error: 'HTTP_401', detail: 'Sign in.' })
+    render(
+      <AuthProvider>
+        <div data-testid="app" />
+      </AuthProvider>,
+    )
+    await flush()
+    expect(screen.queryByTestId('app')).toBeNull()
+    expect(screen.getByText('Connect Codex')).toBeTruthy()
+    expect(screen.getByText('Connect Claude')).toBeTruthy()
+  })
+
+  it('a broadcast 401 unmounts the app back to the landing', async () => {
+    stubFetch(200, { id: 'a1', email: 'me@example.com' })
+    render(
+      <AuthProvider>
+        <div data-testid="app" />
+      </AuthProvider>,
+    )
+    await flush()
+    expect(screen.getByTestId('app')).toBeTruthy()
+
+    act(() => {
+      window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT))
+    })
+
+    expect(screen.queryByTestId('app')).toBeNull()
+    expect(screen.getByText('Connect Codex')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/AuthProvider.tsx
+++ b/frontend/src/components/AuthProvider.tsx
@@ -1,0 +1,67 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+
+import { AUTH_EXPIRED_EVENT, authApi } from '../api/client'
+import type { Account } from '../api/types'
+import { Landing } from './Landing'
+
+interface AuthContextValue {
+  account: Account
+  signOut: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+// eslint-disable-next-line react-refresh/only-export-components -- hook co-located with its context
+export function useAuth(): AuthContextValue {
+  const value = useContext(AuthContext)
+  if (!value) throw new Error('useAuth must be used inside AuthProvider')
+  return value
+}
+
+// Only an authenticated state mounts the app's queries and EventSources;
+// any 401 unmounts them, closing every stream.
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [account, setAccount] = useState<Account | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    void authApi
+      .session()
+      .then((current) => {
+        if (!cancelled) setAccount(current)
+      })
+      .catch(() => {
+        // Network trouble reads as signed out; the landing retries via login.
+        if (!cancelled) setAccount(null)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    const expire = () => setAccount(null)
+    window.addEventListener(AUTH_EXPIRED_EVENT, expire)
+    return () => window.removeEventListener(AUTH_EXPIRED_EVENT, expire)
+  }, [])
+
+  const signOut = useCallback(async () => {
+    await authApi.logout().catch(() => undefined)
+    setAccount(null)
+  }, [])
+
+  if (loading) return null
+  if (!account) return <Landing onSignedIn={setAccount} />
+  return <AuthContext.Provider value={{ account, signOut }}>{children}</AuthContext.Provider>
+}

--- a/frontend/src/components/AuthedApp.tsx
+++ b/frontend/src/components/AuthedApp.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { App } from '../App'
+import { UserPreferencesProvider } from '../lib/preferences'
+
+// The query cache is scoped to this mount: logout/expiry unmounts it, so
+// nothing cached for one account can render for the next.
+export function AuthedApp() {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // SSE delivers freshness; snapshots are explicit refetches.
+            refetchOnWindowFocus: false,
+            retry: 1,
+            staleTime: 30_000,
+          },
+        },
+      }),
+  )
+  return (
+    <QueryClientProvider client={queryClient}>
+      <UserPreferencesProvider>
+        <App />
+      </UserPreferencesProvider>
+    </QueryClientProvider>
+  )
+}

--- a/frontend/src/components/HarnessConnect.test.tsx
+++ b/frontend/src/components/HarnessConnect.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { Harness } from '../api/types'
+import { HarnessConnect } from './SettingsModal'
+
+function harness(overrides: Partial<Harness> = {}): Harness {
+  return {
+    name: 'claude',
+    provider: 'anthropic',
+    model: 'claude-opus-4-7',
+    allowedModels: ['claude-opus-4-7'],
+    fastMode: false,
+    effort: 'high',
+    timeout: 1800,
+    connected: false,
+    kind: null,
+    account: null,
+    providerEmail: null,
+    expiresAt: null,
+    ...overrides,
+  }
+}
+
+function renderCard(value: Harness) {
+  const queryClient = new QueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <HarnessConnect harness={value} />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe('HarnessConnect', () => {
+  it('shows the signed-in identity', () => {
+    renderCard(harness({ connected: true, account: 'ops@corp.com' }))
+    expect(screen.getByText('connected · ops@corp.com')).toBeTruthy()
+    expect(screen.getByText('Reconnect')).toBeTruthy()
+  })
+
+  it('drives the /api/auth connect flow end to end', async () => {
+    const responses: Record<string, unknown> = {
+      '/api/auth/harnesses/claude/login/start': { authorizeUrl: 'https://x/auth', loginId: 'L1' },
+      '/api/auth/harnesses/claude/login/complete': { id: 'a1', email: 'me@example.com' },
+    }
+    const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async (url) => {
+        const body = responses[url]
+        return new Response(JSON.stringify(body ?? {}), { status: body ? 200 : 404 })
+      },
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderCard(harness())
+    fireEvent.click(screen.getByText('Connect'))
+    await flush()
+
+    expect(screen.getByText('Open the sign-in page')).toBeTruthy()
+    fireEvent.change(screen.getByPlaceholderText('Paste the code or redirect URL'), {
+      target: { value: 'the-code' },
+    })
+    fireEvent.click(screen.getByText('Finish'))
+    await flush()
+
+    const completeCall = fetchMock.mock.calls.find(
+      ([url]) => url === '/api/auth/harnesses/claude/login/complete',
+    )
+    expect(JSON.parse(String(completeCall?.[1]?.body))).toEqual({
+      code: 'the-code',
+      loginId: 'L1',
+    })
+  })
+
+})

--- a/frontend/src/components/HarnessLogin.tsx
+++ b/frontend/src/components/HarnessLogin.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+
+import { authApi } from '../api/client'
+import type { Account, LoginChallenge } from '../api/types'
+
+// The one PKCE paste-back flow, shared by the landing screen and Settings.
+// eslint-disable-next-line react-refresh/only-export-components -- hook co-located with its steps UI
+export function useHarnessLogin(name: string, onDone: (account: Account) => void | Promise<void>) {
+  const [challenge, setChallenge] = useState<LoginChallenge | null>(null)
+  const [code, setCode] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function run(action: () => Promise<unknown>) {
+    setBusy(true)
+    setError(null)
+    try {
+      await action()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const start = () => run(async () => setChallenge(await authApi.startLogin(name)))
+
+  const finish = () =>
+    run(async () => {
+      if (!challenge) return
+      const account = await authApi.completeLogin(name, code.trim(), challenge.loginId)
+      setChallenge(null)
+      setCode('')
+      await onDone(account)
+    })
+
+  return { challenge, code, setCode, busy, error, start, finish }
+}
+
+export function LoginSteps({
+  flow,
+}: {
+  flow: ReturnType<typeof useHarnessLogin>
+}) {
+  if (!flow.challenge) return null
+  return (
+    <div className="hr-conn-flow">
+      <div className="hr-conn-step">
+        <span className="hr-conn-num">1</span>
+        <a href={flow.challenge.authorizeUrl} target="_blank" rel="noreferrer">
+          Open the sign-in page
+        </a>
+        , approve, then copy the code it shows (or the redirect URL).
+      </div>
+      <div className="hr-conn-step hr-conn-paste">
+        <span className="hr-conn-num">2</span>
+        <input
+          className="hr-conn-input"
+          placeholder="Paste the code or redirect URL"
+          value={flow.code}
+          onChange={(e) => flow.setCode(e.target.value)}
+          disabled={flow.busy}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && flow.code.trim()) void flow.finish()
+          }}
+        />
+        <button
+          className="hr-conn-btn"
+          onClick={() => void flow.finish()}
+          disabled={flow.busy || !flow.code.trim()}
+        >
+          Finish
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Landing.tsx
+++ b/frontend/src/components/Landing.tsx
@@ -1,0 +1,41 @@
+import { LoginSteps, useHarnessLogin } from './HarnessLogin'
+import type { Account } from '../api/types'
+
+// The unauthenticated door: connect a harness, get a session.
+export function Landing({ onSignedIn }: { onSignedIn: (account: Account) => void }) {
+  return (
+    <div className="landing">
+      <div className="landing-card">
+        <h1>druks</h1>
+        <p className="landing-hint">
+          Sign in with the coding subscription your runs will use — connecting it is the login.
+        </p>
+        <LandingConnect name="codex" label="Connect Codex" onSignedIn={onSignedIn} />
+        <LandingConnect name="claude" label="Connect Claude" onSignedIn={onSignedIn} />
+      </div>
+    </div>
+  )
+}
+
+function LandingConnect({
+  name,
+  label,
+  onSignedIn,
+}: {
+  name: string
+  label: string
+  onSignedIn: (account: Account) => void
+}) {
+  const flow = useHarnessLogin(name, onSignedIn)
+  return (
+    <div className="landing-connect">
+      {!flow.challenge && (
+        <button className="hr-conn-btn" onClick={() => void flow.start()} disabled={flow.busy}>
+          {label}
+        </button>
+      )}
+      <LoginSteps flow={flow} />
+      {flow.error && <div className="hr-conn-error">{flow.error}</div>}
+    </div>
+  )
+}

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -3,10 +3,10 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { api } from '../api/client'
 import { ExtensionGlyph } from './ExtensionGlyph'
+import { LoginSteps, useHarnessLogin } from './HarnessLogin'
 import {
   type Harness,
   type ExtensionSettings,
-  type LoginChallenge,
   type McpRegistryCandidate,
   type McpServer,
   type SkillCollection,
@@ -750,49 +750,27 @@ function HarnessesPane({
   )
 }
 
-// One harness's subscription connection: status chip + the connect (open
-// authorize URL, paste the code) / disconnect flow. Connection state is its own
-// axis — persisted immediately, not through the modal's Save — so this manages
-// its own busy/error and refetches the harnesses query on change.
-function HarnessConnect({ harness }: { harness: Harness }) {
+// Connection state persists immediately, outside the modal's Save, so this
+// manages its own busy/error and refetches the harnesses query on change.
+export function HarnessConnect({ harness }: { harness: Harness }) {
   const queryClient = useQueryClient()
-  const [challenge, setChallenge] = useState<LoginChallenge | null>(null)
-  const [code, setCode] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const refresh = () => queryClient.invalidateQueries({ queryKey: ['harnesses'] })
-
-  async function run(action: () => Promise<unknown>) {
-    setBusy(true)
-    setError(null)
-    try {
-      await action()
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const start = () =>
-    run(async () => setChallenge(await api.startHarnessLogin(harness.name)))
-
-  const finish = () =>
-    run(async () => {
-      if (!challenge) return
-      await api.completeHarnessLogin(harness.name, code.trim(), challenge.flowId)
-      setChallenge(null)
-      setCode('')
-      await refresh()
-    })
+  const flow = useHarnessLogin(harness.name, async () => {
+    await refresh()
+  })
 
   const disconnect = () => {
     if (!window.confirm(`Disconnect ${harness.name}? You'll need to sign in again to run it.`)) return
-    void run(async () => {
-      await api.disconnectHarness(harness.name)
-      await refresh()
-    })
+    setBusy(true)
+    setError(null)
+    void api
+      .disconnectHarness(harness.name)
+      .then(refresh)
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setBusy(false))
   }
 
   return (
@@ -810,45 +788,19 @@ function HarnessConnect({ harness }: { harness: Harness }) {
         )}
         <span className="hr-conn-actions">
           {harness.connected && (
-            <button className="hr-conn-btn hr-conn-ghost" onClick={disconnect} disabled={busy}>
+            <button className="hr-conn-btn hr-conn-ghost" onClick={disconnect} disabled={busy || flow.busy}>
               Disconnect
             </button>
           )}
-          {!challenge && (
-            <button className="hr-conn-btn" onClick={() => void start()} disabled={busy}>
+          {!flow.challenge && (
+            <button className="hr-conn-btn" onClick={() => void flow.start()} disabled={busy || flow.busy}>
               {harness.connected ? 'Reconnect' : 'Connect'}
             </button>
           )}
         </span>
       </div>
-      {challenge && (
-        <div className="hr-conn-flow">
-          <div className="hr-conn-step">
-            <span className="hr-conn-num">1</span>
-            <a href={challenge.authorizeUrl} target="_blank" rel="noreferrer">
-              Open the sign-in page
-            </a>
-            , approve, then copy the code it shows (or the redirect URL).
-          </div>
-          <div className="hr-conn-step hr-conn-paste">
-            <span className="hr-conn-num">2</span>
-            <input
-              className="hr-conn-input"
-              placeholder="Paste the code or redirect URL"
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
-              disabled={busy}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && code.trim()) void finish()
-              }}
-            />
-            <button className="hr-conn-btn" onClick={() => void finish()} disabled={busy || !code.trim()}>
-              Finish
-            </button>
-          </div>
-        </div>
-      )}
-      {error && <div className="hr-conn-error">{error}</div>}
+      <LoginSteps flow={flow} />
+      {(error ?? flow.error) && <div className="hr-conn-error">{error ?? flow.error}</div>}
     </div>
   )
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,31 +1,17 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-import { App } from './App'
-import { UserPreferencesProvider } from './lib/preferences'
+import { AuthedApp } from './components/AuthedApp'
+import { AuthProvider } from './components/AuthProvider'
 import './styles.css'
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      // SSE delivers freshness; snapshots are explicit refetches.
-      refetchOnWindowFocus: false,
-      retry: 1,
-      staleTime: 30_000,
-    },
-  },
-})
 
 const rootElement = document.getElementById('root')
 if (!rootElement) throw new Error('Root element #root not found')
 
 createRoot(rootElement).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <UserPreferencesProvider>
-        <App />
-      </UserPreferencesProvider>
-    </QueryClientProvider>
+    <AuthProvider>
+      <AuthedApp />
+    </AuthProvider>
   </StrictMode>,
 )

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2250,3 +2250,10 @@ input.set-select { background-image: none; padding-right: 12px; }
 
 .ins .wic-op-sub { display: inline-flex; align-items: center; gap: 7px; }
 .ins .wic-op-sub-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--text-faint); box-shadow: none; flex-shrink: 0; }
+
+/* Landing — the unauthenticated door: connect a harness, get a session. */
+.landing { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+.landing-card { width: min(440px, 100%); display: flex; flex-direction: column; gap: 14px; padding: 28px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); }
+.landing-card h1 { font-family: var(--font-mono); font-size: 18px; letter-spacing: 0.08em; }
+.landing-hint { font-size: 12.5px; color: var(--text-dim); line-height: 1.5; }
+.landing-connect { display: flex; flex-direction: column; gap: 9px; }


### PR DESCRIPTION
Multi-tenant accounts arc, PR 2 of 4 (ENG-703). Harness login becomes the account door: internal APIs and SSE require a session, capability routes keep their own auth, and the Caddy gate loosens to any nonempty trusted identity.

## What this delivers

**Canonical login API** (`druks/accounts/routes.py`, the only login surface):
- `GET /api/auth/session` → `AccountResponse` or 401; `POST /api/auth/harnesses/{name}/login/start` → `{authorizeUrl, loginId}`; `POST .../login/complete` `{loginId, code}` → attaches the seat, mints the session cookie; `POST /api/auth/logout`.
- The old settings login start/complete routes are deleted; Settings keeps only the account-scoped disconnect. Landing and Settings drive the same `/api/auth` client methods.
- PKCE pending state (opaque single-use flow id, Redis) now carries verifier, expected state, the session account id at start (reconnect binding), and the trusted proxy identity at start.

**Account resolution** (ticket order, exactly): valid session keeps its account → proxy identity stored at flow start → provider-verified email; normalized exact-equality lookup; new empty account when none. `HarnessLogin.connect` is account-first: a provider seat attached to a different account raises `SeatClaimedError` → 409, never an implicit move. Mismatched authoritative/provider emails surface as `isEmailMismatch` on the settings card — visible, never blocking.

**Sessions** (`druks/accounts/sessions.py` + `dependencies.py` + `middleware.py`):
- 256-bit URL-safe token, Redis `druks:session:{token}` → account id, 30-day sliding TTL via atomic `GETEX`.
- `druks_session` cookie: HttpOnly, SameSite=Lax, Path=/, 30-day Max-Age, Secure when the browser endpoint is HTTPS (via X-Forwarded-Proto).
- One pure-ASGI response middleware writes the cookie (touched, rotated, or cleared) — SSE response headers included; identity resolution stays in `current_account`, with `resolve_session_account` as the seam a future bearer/PAT resolver slots beside.
- Login rotates any prior token; logout deletes the key; a proxy identity that no longer matches the session account drops the session; Redis loss signs out but never touches stored credentials.

**Auth boundary**: every internal platform router and every discovered extension router (generic transcript/board/subject `/stream` included) mounts behind `Depends(current_account)`. Exempt, each with its own auth or safe by construction: health, `/_external/*`, login start/complete + logout, static SPA/extension assets, and `POST /api/notifications/{token}/respond` — split onto its own capability router with behavior unchanged. `test_auth_boundary.py` enumerates both directions (nothing unguarded slips in; nothing exempt grows the gate; every `/stream` family guarded).

**Frontend**: `AuthProvider` above `App` — only an authenticated state mounts queries/EventSources; landing screen with Connect Codex / Connect Claude (same paste-back flow via a shared hook); centralized `credentials: "same-origin"` and typed 401 (`UnauthorizedError`) that broadcasts expiry and unmounts the app (closing every stream); `useSSE` rechecks `/api/auth/session` on error and closes the source when the session died — no blind reconnects; the settings card shows authoritative email, provider email, mismatch warning, expiry, and default-seat state.

**Deploy/env/docs**: `DRUKS_AUTH_HEADER` is now a backend `Settings` field; `DRUKS_DASHBOARD_EMAIL` deleted from setup-env generation/tests, the Compose pass-through, and Caddy (it remains only in the PR1 migration + its upgrade window, by design); Caddy admits any nonempty trusted identity and keeps the no-header exe.dev redirect + separate webhook listener; configuration/full-local/deployment/troubleshooting docs updated; the deploy README's cutover section now spells out replacing host-copied Compose/Caddy, removing the stale `.env` value, and recreating `web` + `caddy`.

## Acceptance criteria → tests

| Criterion | Test |
| --- | --- |
| Internal JSON + SSE routes require a session; enumerated capability routes keep their own auth | `test_auth_boundary.py` (4 tests, both directions + stream families), `test_auth.py::test_protected_routes_401_without_a_session` |
| Dashboard identity resolves the PR1 account by exact normalized email; other identities get empty accounts and cannot acquire legacy seats | `test_auth.py::test_dashboard_identity_resolves_the_migrated_account`, `::test_new_identity_cannot_acquire_legacy_seats` |
| Local identity from provider; proxy identity from trusted header; mismatch visible without changing authority | `test_auth.py::test_proxy_identity_is_authoritative_for_the_account`, `test_api_settings.py::test_harness_card_reports_mismatch_and_default_state` |
| Session mint/touch/proxy-mismatch/logout/eviction/single-use PKCE cannot authenticate the wrong account | `test_auth.py`: login flow, rotation, logout, eviction, proxy mismatch, single-use, `::test_claimed_seat_conflicts_with_409`, `::test_session_keeps_its_account_across_reconnects`; flow-binding tests in `test_harness_login.py` |
| Landing and Settings use one canonical login API; old settings login routes gone | route deletion in `user_settings/routes.py` + shared `useHarnessLogin` hook; `HarnessConnect.test.tsx` drives `/api/auth` |
| Frontend Vitest specs pass | `AuthProvider.test.tsx` (landing/session transitions), `client.test.ts` (typed 401 + same-origin), `sse.test.tsx` (expiry recheck, no blind reconnects), `HarnessConnect.test.tsx` (settings connection) — 34/34 locally |

## Rollout (from the ticket)

Deploy backend and SPA behind the old single-email Caddy gate first (compatible during transition). Then replace the host-copied Compose/Caddy, remove `DRUKS_DASHBOARD_EMAIL` from `.env`, and recreate `web` + `caddy` (steps now in deploy/README.md). Each browser performs one harness login to mint its session.

## Codex review

Adversarial review through the codex companion, read-only (`gpt-5.5`, reasoning effort high — `sol` is rejected on this account's ChatGPT plan). Five findings:

1. **High, confirmed → fixed.** A bound reconnect completing after its session died (eviction/logout) fell through to email-based resolution and could attach the seat to a different account. Now a flow carrying a bound `account_id` completes only under that same live session — otherwise 422, re-start. Pinned by `test_bound_reconnect_requires_its_session_at_complete`.
2. **High, confirmed → fixed.** `UserPreferencesProvider` sat above the auth gate and fired `/api/settings` on unauthenticated cold loads. The provider tree is now AuthProvider-first; every query mounts below the session.
3. **High, confirmed → fixed.** The module-level `QueryClient` survived logout/account switches, so account A's cached settings/harness/events data could render for account B. The query cache is now created per signed-in account (`AuthedApp`, keyed on `account.id`) — a new session always starts empty.
4. **Medium, waived with rationale.** "Session-gating `/api/mcp-servers` changes the MCP OAuth callback's auth despite the scope fence." The ticket's exemption list is explicit and exhaustive, and the MCP callback is not on it — exempting it here would be the actual scope deviation. Behaviorally: the callback is a top-level redirect, `SameSite=Lax` sends the session cookie, so live sessions complete normally; a session that dies mid-connect means redoing that MCP connect. If that UX matters it's a one-line exemption for the MCP arc to take deliberately.
5. **Low, confirmed → fixed.** `docs/concepts.md` still described the single-email edge gate; rewritten to the session/account-door model.

No refutations beyond these: the boundary enumeration, session mechanics, PKCE single-use shape, seat-conflict 409, and legacy-seat protections all held.

## Stack

Supersedes [#11](https://github.com/clawhaven/druks/pull/11) (auto-closed when its base branch merged as [#10](https://github.com/clawhaven/druks/pull/10)). Rebased onto the landed main — the replay adopts the review direction that shipped there: the `HarnessConnection` rename, citext emails stored as-given (Python email comparisons mirror citext's case-insensitivity), `connect()` upserting purely by `(harness, account)` with the provider-seat 409 and the cross-harness flow guard dropped per the review rationale. ENG-704 (PR #13) and ENG-705 (PR #14) still point at the pre-rebase branches; they get rebased when their turn comes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
