### PR TITLE
Redesign the login landing page

### DIFF
--- a/frontend/src/components/HarnessLogin.tsx
+++ b/frontend/src/components/HarnessLogin.tsx
@@ -34,7 +34,13 @@ export function useHarnessLogin(name: string, onDone: (account: Account) => void
       await onDone(account)
     })
 
-  return { challenge, code, setCode, busy, error, start, finish }
+  const cancel = () => {
+    setChallenge(null)
+    setCode('')
+    setError(null)
+  }
+
+  return { challenge, code, setCode, busy, error, start, finish, cancel }
 }
 
 export function LoginSteps({

--- a/frontend/src/components/Landing.test.tsx
+++ b/frontend/src/components/Landing.test.tsx
@@ -1,0 +1,40 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { Landing } from './Landing'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe('Landing', () => {
+  it('an active flow takes over the stage; cancel restores the harness cards', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ authorizeUrl: 'https://x/auth', loginId: 'L1' }), {
+          status: 200,
+        }),
+      ),
+    )
+
+    render(<Landing onSignedIn={() => undefined} />)
+    fireEvent.click(screen.getByText('Connect Codex'))
+    await flush()
+
+    // The challenge panel replaces both cards, not just its own.
+    expect(screen.getByText('Open the sign-in page')).toBeTruthy()
+    expect(screen.queryByText('Connect Claude')).toBeNull()
+
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(screen.queryByText('Open the sign-in page')).toBeNull()
+    expect(screen.getByText('Connect Claude')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/Landing.tsx
+++ b/frontend/src/components/Landing.tsx
@@ -1,41 +1,106 @@
+import type { CSSProperties } from 'react'
+
 import { LoginSteps, useHarnessLogin } from './HarnessLogin'
+import { harnessColors } from '../lib/harnessColors'
 import type { Account } from '../api/types'
+
+type LandingEntry = {
+  title: string
+  mark: string
+  fam: string
+  flow: ReturnType<typeof useHarnessLogin>
+}
 
 // The unauthenticated door: connect a harness, get a session.
 export function Landing({ onSignedIn }: { onSignedIn: (account: Account) => void }) {
+  const codex = useHarnessLogin('codex', onSignedIn)
+  const claude = useHarnessLogin('claude', onSignedIn)
+  // Accent slots follow registry enrolment order (claude, codex) so each
+  // harness keeps the colour it has everywhere in the signed-in app.
+  const color = harnessColors(['claude', 'codex'])
+  const entries: LandingEntry[] = [
+    { title: 'Codex', mark: 'Cx', fam: color.codex!, flow: codex },
+    { title: 'Claude', mark: 'Cl', fam: color.claude!, flow: claude },
+  ]
+  const active = entries.find((e) => e.flow.busy || e.flow.challenge)
+
   return (
     <div className="landing">
-      <div className="landing-card">
-        <h1>druks</h1>
-        <p className="landing-hint">
-          Sign in with the coding subscription your runs will use — connecting it is the login.
-        </p>
-        <LandingConnect name="codex" label="Connect Codex" onSignedIn={onSignedIn} />
-        <LandingConnect name="claude" label="Connect Claude" onSignedIn={onSignedIn} />
+      <div className="landing-col">
+        <div className="landing-word">
+          druks<span>.</span>
+        </div>
+        <div className="landing-tag">durable agent orchestration</div>
+        <div className="landing-head">
+          <h1>Connect a harness to sign in</h1>
+          <p>
+            There's no password here — <b>connecting the coding subscription your runs will use is the login</b>. Pick
+            a harness to authorize.
+          </p>
+        </div>
+        <div className="landing-stage">
+          {active ? (
+            <ConnectPanel entry={active} />
+          ) : (
+            entries.map((entry) => <HarnessCard key={entry.title} entry={entry} />)
+          )}
+        </div>
       </div>
     </div>
   )
 }
 
-function LandingConnect({
-  name,
-  label,
-  onSignedIn,
-}: {
-  name: string
-  label: string
-  onSignedIn: (account: Account) => void
-}) {
-  const flow = useHarnessLogin(name, onSignedIn)
+function HarnessCard({ entry }: { entry: LandingEntry }) {
   return (
-    <div className="landing-connect">
-      {!flow.challenge && (
-        <button className="hr-conn-btn" onClick={() => void flow.start()} disabled={flow.busy}>
-          {label}
-        </button>
+    <div className="landing-choice" style={{ '--fam': entry.fam } as CSSProperties}>
+      <button className="landing-card" onClick={() => void entry.flow.start()}>
+        <span className="landing-chip">{entry.mark}</span>
+        <span className="landing-lbl">
+          <span className="landing-lbl-t">Connect {entry.title}</span>
+          <span className="landing-lbl-d">Sign in with your {entry.title} subscription</span>
+        </span>
+        <span className="landing-arrow">→</span>
+      </button>
+      {entry.flow.error && <LandingError message={entry.flow.error} />}
+    </div>
+  )
+}
+
+function ConnectPanel({ entry }: { entry: LandingEntry }) {
+  const { flow } = entry
+  return (
+    <div className="landing-panel" style={{ '--fam': entry.fam } as CSSProperties}>
+      <div className="landing-panel-top">
+        <span className="landing-chip">{entry.mark}</span>
+        <span className="landing-who">
+          <span className="landing-who-t">Connect {entry.title}</span>
+          <span className="landing-who-s">oauth · paste-back</span>
+        </span>
+        <span className="landing-badge">{flow.challenge ? 'authorize' : 'connecting'}</span>
+      </div>
+      {flow.challenge ? (
+        <>
+          <LoginSteps flow={flow} />
+          {flow.error && <LandingError message={flow.error} />}
+          <button className="landing-cancel" onClick={flow.cancel} disabled={flow.busy}>
+            Cancel
+          </button>
+        </>
+      ) : (
+        <div className="landing-busy">
+          <span className="landing-spin" />
+          <span>Opening a secure authorization session…</span>
+        </div>
       )}
-      <LoginSteps flow={flow} />
-      {flow.error && <div className="hr-conn-error">{flow.error}</div>}
+    </div>
+  )
+}
+
+function LandingError({ message }: { message: string }) {
+  return (
+    <div className="landing-err">
+      <span className="landing-err-x">!</span>
+      <span>{message}</span>
     </div>
   )
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2254,8 +2254,47 @@ input.set-select { background-image: none; padding-right: 12px; }
 .ins .wic-op-sub-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--text-faint); box-shadow: none; flex-shrink: 0; }
 
 /* Landing — the unauthenticated door: connect a harness, get a session. */
-.landing { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
-.landing-card { width: min(440px, 100%); display: flex; flex-direction: column; gap: 14px; padding: 28px; border-radius: 8px; background: var(--surface); border: 1px solid var(--border); }
-.landing-card h1 { font-family: var(--font-mono); font-size: 18px; letter-spacing: 0.08em; }
-.landing-hint { font-size: 12.5px; color: var(--text-dim); line-height: 1.5; }
-.landing-connect { display: flex; flex-direction: column; gap: 9px; }
+.landing { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 40px 20px; position: relative; overflow: hidden; }
+.landing::before { content: ""; position: absolute; inset: 0; background-image: linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px); background-size: 56px 56px; opacity: 0.28; mask-image: radial-gradient(120% 100% at 50% 42%, #000 0%, transparent 70%); }
+.landing::after { content: ""; position: absolute; top: -20%; left: 50%; width: 70%; height: 70%; background: radial-gradient(circle, color-mix(in oklch, var(--accent-violet) 12%, transparent), transparent 66%); filter: blur(24px); animation: landing-drift 16s ease-in-out infinite alternate; }
+@keyframes landing-drift { from { transform: translate(-52%, 0) scale(1); } to { transform: translate(-48%, 10%) scale(1.12); } }
+.landing-col { position: relative; z-index: 1; width: min(452px, 100%); }
+.landing-word { font-family: var(--font-mono); font-size: 19px; font-weight: 600; letter-spacing: 0.42em; padding-left: 0.2em; }
+.landing-word span { color: var(--text-faint); }
+.landing-tag { margin-top: 9px; font-family: var(--font-mono); font-size: 12px; letter-spacing: 0.06em; color: var(--text-faint); }
+.landing-head { margin: 38px 0 30px; }
+.landing-head h1 { font-size: 26px; letter-spacing: -0.02em; font-weight: 600; }
+.landing-head p { margin-top: 12px; font-size: 15px; line-height: 1.6; color: var(--text-mid); }
+.landing-head b { color: var(--text); font-weight: 600; }
+.landing-stage { min-height: 284px; display: flex; flex-direction: column; gap: 14px; }
+.landing-choice { display: flex; flex-direction: column; gap: 10px; }
+.landing-card { display: flex; align-items: center; gap: 16px; width: 100%; text-align: left; padding: 18px 20px; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; font-size: 15px; position: relative; overflow: hidden; transition: all 180ms ease; }
+.landing-card::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 3px; background: var(--fam); opacity: 0.55; transition: all 180ms ease; }
+.landing-card:hover { background: var(--surface-2); border-color: var(--border-loud); transform: translateY(-1px); }
+.landing-card:hover::before { opacity: 1; width: 4px; }
+.landing-card:focus-visible { outline: 2px solid var(--fam); outline-offset: 2px; }
+.landing-chip { flex: none; width: 38px; height: 38px; border-radius: 9px; background: var(--surface-2); border: 1px solid var(--border-loud); display: grid; place-items: center; font-family: var(--font-mono); font-size: 15px; font-weight: 600; color: var(--fam); }
+.landing-lbl { flex: 1; display: flex; flex-direction: column; gap: 3px; }
+.landing-lbl-t { font-weight: 600; letter-spacing: -0.01em; }
+.landing-lbl-d { font-size: 12.5px; color: var(--text-faint); }
+.landing-arrow { flex: none; color: var(--text-faint); transition: all 180ms ease; }
+.landing-card:hover .landing-arrow { color: var(--fam); transform: translateX(3px); }
+.landing-panel { background: var(--surface); border: 1px solid var(--border); border-radius: 14px; padding: 26px; }
+.landing-panel-top { display: flex; align-items: center; gap: 13px; padding-bottom: 22px; margin-bottom: 22px; border-bottom: 1px solid var(--border); }
+.landing-panel-top .landing-chip { width: 40px; height: 40px; }
+.landing-who { display: flex; flex-direction: column; gap: 2px; }
+.landing-who-t { font-weight: 600; font-size: 15px; }
+.landing-who-s { font-size: 12.5px; color: var(--text-faint); font-family: var(--font-mono); }
+.landing-badge { margin-left: auto; font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; padding: 5px 10px; border-radius: 999px; border: 1px solid var(--border-loud); color: var(--text-dim); }
+.landing-busy { display: flex; align-items: center; gap: 11px; font-size: 14px; color: var(--text-mid); }
+.landing-spin { flex: none; width: 16px; height: 16px; border-radius: 50%; border: 2px solid var(--border-loud); border-top-color: var(--fam); animation: landing-spin 800ms linear infinite; }
+@keyframes landing-spin { to { transform: rotate(360deg); } }
+.landing-panel .hr-conn-flow { background: none; border: none; padding: 0; gap: 14px; }
+.landing-panel .hr-conn-step { font-size: 13.5px; }
+.landing-cancel { margin-top: 22px; width: 100%; padding: 11px 18px; border-radius: 10px; font-size: 13.5px; font-weight: 600; color: var(--text-mid); border: 1px solid var(--border-loud); transition: all 160ms ease; }
+.landing-cancel:hover:not(:disabled) { background: var(--surface-2); color: var(--text); }
+.landing-cancel:disabled { opacity: 0.45; cursor: default; }
+.landing-err { display: flex; gap: 10px; align-items: flex-start; font-size: 13px; line-height: 1.55; color: var(--text-mid); background: color-mix(in oklch, var(--outcome-failed) 7%, transparent); border: 1px solid color-mix(in oklch, var(--outcome-failed) 28%, transparent); border-radius: 10px; padding: 12px 14px; animation: landing-shake 400ms ease; }
+.landing-err-x { flex: none; font-family: var(--font-mono); font-weight: 700; color: var(--outcome-failed); }
+.landing-panel .landing-err { margin-top: 14px; }
+@keyframes landing-shake { 0%, 100% { transform: translateX(0); } 20% { transform: translateX(-4px); } 40% { transform: translateX(4px); } 60% { transform: translateX(-2px); } 80% { transform: translateX(2px); } }


### PR DESCRIPTION
## What

Replaces the bare landing card (two text links in a void) with a designed sign-in screen, ported from the approved Claude Design mockup (`druks Login.html`) and adapted to the real flow.

- **Idle** — wordmark + "durable agent orchestration", the no-password explanation, one card per harness: accent edge, monogram chip (`Cx`/`Cl`), subtitle, arrow, hover/focus states. Grid + drifting glow atmosphere behind the column.
- **Connecting** — the active flow takes over the stage as a panel (chip, harness, `connecting` badge, spinner) so the column never jumps.
- **Challenge** — same panel wraps the existing shared `LoginSteps` paste-back UI (restyled contextually via `.landing-panel .hr-conn-*`), plus a new Cancel that returns to the cards.
- **Error** — tinted shake-in box under the card that failed; the other harness stays available.

## Conventions

- Accents via `harnessColors` in registry enrolment order (claude → amber, codex → violet) passed as `--fam`, zero harness names in CSS — the mockup's cyan/amber got swapped to match the signed-in app.
- `LoginSteps`/`useHarnessLogin` untouched except one additive `cancel()`; Settings keeps working as-is.
- Tokens only (`--surface`, `--border*`, `--text*`, `--outcome-failed`, `--accent-violet` for the decoration glow), one-line rule style, `landing-*` namespace.

## Verification

Vite dev server against the worktree: all four states exercised in the browser (error via real dead-backend proxy path, connecting/challenge via stubbed fetch), cancel round-trips back to the cards. `npm test` 33 passed (adds a Landing test pinning panel-takeover + cancel), `eslint` and `tsc -b && vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
