### PR TITLE
One home for Redis key names (ENG-713)

### DIFF
--- a/backend/druks/accounts/constants.py
+++ b/backend/druks/accounts/constants.py
@@ -1,3 +1,6 @@
 # Owns every run nobody asked for: crons, background work. Seeded at first
 # start; no provider email ever collides with it.
 SYSTEM_ACCOUNT_ID = "system"
+
+# A signed-in session in Redis: token -> account_id.
+SESSION_PREFIX = "druks:session:"

--- a/backend/druks/accounts/sessions.py
+++ b/backend/druks/accounts/sessions.py
@@ -3,6 +3,8 @@ from contextvars import ContextVar
 
 from druks.redis import get_client
 
+from .constants import SESSION_PREFIX
+
 SESSION_COOKIE = "druks_session"
 SESSION_TTL_SECONDS = 30 * 24 * 3600
 
@@ -12,7 +14,7 @@ current_account_id: ContextVar[str | None] = ContextVar("current_account_id", de
 
 
 def _session_key(token: str) -> str:
-    return f"druks:session:{token}"
+    return f"{SESSION_PREFIX}{token}"
 
 
 async def mint_session(account_id: str) -> str:

--- a/backend/druks/accounts/sessions.py
+++ b/backend/druks/accounts/sessions.py
@@ -13,22 +13,18 @@ SESSION_TTL_SECONDS = 30 * 24 * 3600
 current_account_id: ContextVar[str | None] = ContextVar("current_account_id", default=None)
 
 
-def _session_key(token: str) -> str:
-    return f"{SESSION_PREFIX}{token}"
-
-
 async def mint_session(account_id: str) -> str:
     token = secrets.token_urlsafe(32)
-    await get_client().set(_session_key(token), account_id, ex=SESSION_TTL_SECONDS)
+    await get_client().set(f"{SESSION_PREFIX}{token}", account_id, ex=SESSION_TTL_SECONDS)
     return token
 
 
 async def resolve_session(token: str) -> str | None:
     # GETEX reads and slides the 30-day TTL in one atomic hop.
-    value = await get_client().getex(_session_key(token), ex=SESSION_TTL_SECONDS)
+    value = await get_client().getex(f"{SESSION_PREFIX}{token}", ex=SESSION_TTL_SECONDS)
     if value:
         return value.decode()
 
 
 async def drop_session(token: str) -> None:
-    await get_client().delete(_session_key(token))
+    await get_client().delete(f"{SESSION_PREFIX}{token}")

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -20,6 +20,7 @@ from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
 from druks.skills.models import Skill
 from druks.usage.models import UsageScrape
 
+from .constants import LOGIN_PENDING_PREFIX, REFRESH_LOCK_PREFIX
 from .datastructures import (
     AgentInvocation,
     CodexToken,
@@ -323,7 +324,7 @@ class Harness(ABC):
             )
 
         redis = get_client()
-        lock_key = _refresh_lock_key(connection_id)
+        lock_key = f"{REFRESH_LOCK_PREFIX}{connection_id}"
         if not await redis.set(lock_key, "1", nx=True, ex=_REFRESH_LOCK_TTL_SECONDS):
             return RotationResult(cls.name, "locked", connection_id=connection_id)
         try:
@@ -581,11 +582,7 @@ async def _post_grant(url: str, body: dict) -> dict:
 
 
 def _login_pending_key(flow_id: str) -> str:
-    return f"druks:login:pending:{flow_id}"
-
-
-def _refresh_lock_key(connection_id: str) -> str:
-    return f"druks:harness:refresh:{connection_id}"
+    return f"{LOGIN_PENDING_PREFIX}{flow_id}"
 
 
 def _b64url(raw: bytes) -> str:

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -228,7 +228,9 @@ class Harness(ABC):
                 "account_id": account_id,
             }
         )
-        await get_client().set(_login_pending_key(flow_id), pending, ex=_LOGIN_PENDING_TTL_SECONDS)
+        await get_client().set(
+            f"{LOGIN_PENDING_PREFIX}{flow_id}", pending, ex=_LOGIN_PENDING_TTL_SECONDS
+        )
         return url, flow_id
 
     @classmethod
@@ -236,7 +238,7 @@ class Harness(ABC):
         """Pop the flow's single-use state, parse the paste, exchange the code.
         Raises :class:`LoginError` on failure; the state is gone either way,
         so a retry re-starts cleanly."""
-        pending = await get_client().getdel(_login_pending_key(flow_id))  # single-use
+        pending = await get_client().getdel(f"{LOGIN_PENDING_PREFIX}{flow_id}")  # single-use
         if not pending:
             raise LoginError("This sign-in expired — start it again.")
         expected = json.loads(pending)
@@ -579,10 +581,6 @@ async def _post_grant(url: str, body: dict) -> dict:
         return response.json()
     except ValueError as exc:
         raise GrantError("bad_response") from exc
-
-
-def _login_pending_key(flow_id: str) -> str:
-    return f"{LOGIN_PENDING_PREFIX}{flow_id}"
 
 
 def _b64url(raw: bytes) -> str:

--- a/backend/druks/harnesses/constants.py
+++ b/backend/druks/harnesses/constants.py
@@ -1,0 +1,4 @@
+# Redis keys for harness logins: a pending flow's state while the operator
+# completes it, and the per-connection SET NX lock that serializes refresh.
+LOGIN_PENDING_PREFIX = "druks:login:pending:"
+REFRESH_LOCK_PREFIX = "druks:harness:refresh:"

--- a/backend/druks/mcp/oauth.py
+++ b/backend/druks/mcp/oauth.py
@@ -139,18 +139,6 @@ async def _register_client(
     return registration
 
 
-def _connect_state_key(state: str) -> str:
-    return f"{OAUTH_CONNECT_STATE_PREFIX}{state}"
-
-
-def _access_token_key(name: str) -> str:
-    return f"{OAUTH_ACCESS_TOKEN_PREFIX}{name}"
-
-
-def _refresh_lock_key(name: str) -> str:
-    return f"{OAUTH_REFRESH_LOCK_PREFIX}{name}"
-
-
 async def begin_connect(name: str, server_url: str, endpoint: str) -> str:
     """Start the operator's authorization-code + PKCE flow for one server:
     discover the authorization server, register druks as a public client, stash
@@ -183,7 +171,9 @@ async def begin_connect(name: str, server_url: str, endpoint: str) -> str:
         "redirect_uri": redirect_uri,
     }
     await get_client().set(
-        _connect_state_key(state), json.dumps(pending), ex=OAUTH_CONNECT_STATE_TTL_SECONDS
+        f"{OAUTH_CONNECT_STATE_PREFIX}{state}",
+        json.dumps(pending),
+        ex=OAUTH_CONNECT_STATE_TTL_SECONDS,
     )
     query = urlencode(
         {
@@ -207,7 +197,7 @@ async def complete_connect(*, state: str, code: str) -> str:
     real only when this request's transaction commits, and a cache filled
     ahead of that would outlive its failure. The first delivery mints from the
     committed grant."""
-    raw = await get_client().getdel(_connect_state_key(state))
+    raw = await get_client().getdel(f"{OAUTH_CONNECT_STATE_PREFIX}{state}")
     if not raw:
         raise OauthConnectError("unknown", "unknown or expired state; start the connect flow again")
     pending = json.loads(raw)
@@ -249,7 +239,7 @@ async def complete_connect(*, state: str, code: str) -> str:
 
 
 async def evict_access_token(name: str) -> None:
-    await get_client().delete(_access_token_key(name))
+    await get_client().delete(f"{OAUTH_ACCESS_TOKEN_PREFIX}{name}")
 
 
 async def mint_access_token(name: str) -> str:
@@ -263,13 +253,13 @@ async def mint_access_token(name: str) -> str:
     fail loudly — delivery never ships a server the agent can't authenticate
     to."""
     redis = get_client()
+    token_key = f"{OAUTH_ACCESS_TOKEN_PREFIX}{name}"
+    lock_key = f"{OAUTH_REFRESH_LOCK_PREFIX}{name}"
     for _ in range(OAUTH_MINT_WAIT_ATTEMPTS):
-        cached = await redis.get(_access_token_key(name))
+        cached = await redis.get(token_key)
         if cached:
             return cached.decode()
-        if await redis.set(
-            _refresh_lock_key(name), "1", nx=True, ex=OAUTH_REFRESH_LOCK_TTL_SECONDS
-        ):
+        if await redis.set(lock_key, "1", nx=True, ex=OAUTH_REFRESH_LOCK_TTL_SECONDS):
             break
         await asyncio.sleep(OAUTH_MINT_WAIT_INTERVAL_SECONDS)
     else:
@@ -322,7 +312,7 @@ async def mint_access_token(name: str) -> str:
                 name, "the token endpoint returned a malformed expires_in"
             ) from error
         if ttl > 0:
-            await redis.set(_access_token_key(name), tokens["access_token"], ex=ttl)
+            await redis.set(token_key, tokens["access_token"], ex=ttl)
         return tokens["access_token"]
     finally:
-        await redis.delete(_refresh_lock_key(name))
+        await redis.delete(lock_key)

--- a/backend/druks/sandbox/constants.py
+++ b/backend/druks/sandbox/constants.py
@@ -6,3 +6,8 @@
 MAX_AGENT_TIMEOUT_SECONDS = 65 * 60  # 65 min — the existing sandbox-run horizon
 SANDBOX_HOST_LEASE_SECONDS = 150 * 60  # 150 min — fits two back-to-back worst-case calls
 SANDBOX_HOST_ROTATE_BEFORE_SECONDS = MAX_AGENT_TIMEOUT_SECONDS + 10 * 60  # 75 min (65 + 10 margin)
+
+# The per-connection rotation gate in Redis: the flag that shuts the gate while
+# a refresh runs, and the zset of active users scored by expiry.
+ROTATING_PREFIX = "druks:sandbox:rotating:"
+GATE_USERS_PREFIX = "druks:sandbox:gate:users:"

--- a/backend/druks/sandbox/gate.py
+++ b/backend/druks/sandbox/gate.py
@@ -17,33 +17,27 @@ _POLL = 2.0
 _SHUT_TTL_SECONDS = 60
 
 
-def _rotating_key(connection_id: str) -> str:
-    return f"{ROTATING_PREFIX}{connection_id}"
-
-
-def _users_key(connection_id: str) -> str:
-    return f"{GATE_USERS_PREFIX}{connection_id}"
-
-
 @asynccontextmanager
 async def use(connection_id: str, call_id: str) -> AsyncIterator[None]:
     """Register the call as an active user of its connection for its span."""
     client = get_client()
+    rotating = f"{ROTATING_PREFIX}{connection_id}"
+    users = f"{GATE_USERS_PREFIX}{connection_id}"
     while True:
         waited = 0.0
-        while waited < _RUN_HORIZON and await client.exists(_rotating_key(connection_id)):
+        while waited < _RUN_HORIZON and await client.exists(rotating):
             await asyncio.sleep(_POLL)
             waited += _POLL
-        await client.zadd(_users_key(connection_id), {call_id: time.time() + _RUN_HORIZON})
+        await client.zadd(users, {call_id: time.time() + _RUN_HORIZON})
         # A flag landing between the wait and the add must not race the
         # rotation: back out and re-wait.
-        if not await client.exists(_rotating_key(connection_id)):
+        if not await client.exists(rotating):
             break
-        await client.zrem(_users_key(connection_id), call_id)
+        await client.zrem(users, call_id)
     try:
         yield
     finally:
-        await client.zrem(_users_key(connection_id), call_id)
+        await client.zrem(users, call_id)
 
 
 @asynccontextmanager
@@ -51,9 +45,11 @@ async def shut(connection_id: str) -> AsyncIterator[bool]:
     """Shut the connection's gate; yield True when idle — rotate now — else
     defer to the next tick. Reopens on exit either way."""
     client = get_client()
-    await client.set(_rotating_key(connection_id), "1", ex=_SHUT_TTL_SECONDS)
+    rotating = f"{ROTATING_PREFIX}{connection_id}"
+    users = f"{GATE_USERS_PREFIX}{connection_id}"
+    await client.set(rotating, "1", ex=_SHUT_TTL_SECONDS)
     try:
-        await client.zremrangebyscore(_users_key(connection_id), "-inf", time.time())
-        yield not await client.zcard(_users_key(connection_id))
+        await client.zremrangebyscore(users, "-inf", time.time())
+        yield not await client.zcard(users)
     finally:
-        await client.delete(_rotating_key(connection_id))
+        await client.delete(rotating)

--- a/backend/druks/sandbox/gate.py
+++ b/backend/druks/sandbox/gate.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 
 from druks.redis import get_client
 
-from .constants import MAX_AGENT_TIMEOUT_SECONDS
+from .constants import GATE_USERS_PREFIX, MAX_AGENT_TIMEOUT_SECONDS, ROTATING_PREFIX
 
 # One gate per credential: rotation runs only while its connection is idle
 # (busy defers to the next tick); other connections never block. Active calls
@@ -18,11 +18,11 @@ _SHUT_TTL_SECONDS = 60
 
 
 def _rotating_key(connection_id: str) -> str:
-    return f"druks:sandbox:rotating:{connection_id}"
+    return f"{ROTATING_PREFIX}{connection_id}"
 
 
 def _users_key(connection_id: str) -> str:
-    return f"druks:sandbox:gate:users:{connection_id}"
+    return f"{GATE_USERS_PREFIX}{connection_id}"
 
 
 @asynccontextmanager

--- a/backend/druks/webhooks/constants.py
+++ b/backend/druks/webhooks/constants.py
@@ -1,0 +1,4 @@
+# Delivery bookkeeping per provider: the dedup claim for one delivery key and
+# the freshness timestamp of the latest arrival.
+DELIVERY_SEEN_PREFIX = "druks:webhook:seen:"
+DELIVERY_LAST_PREFIX = "druks:webhook:last:"

--- a/backend/druks/webhooks/deliveries.py
+++ b/backend/druks/webhooks/deliveries.py
@@ -7,21 +7,17 @@ from .constants import DELIVERY_LAST_PREFIX, DELIVERY_SEEN_PREFIX
 _DEDUP_TTL_SECONDS = 24 * 60 * 60
 
 
-def _seen_key(provider: str, key: str) -> str:
-    return f"{DELIVERY_SEEN_PREFIX}{provider}:{key}"
-
-
-def _last_key(provider: str) -> str:
-    return f"{DELIVERY_LAST_PREFIX}{provider}"
-
-
 async def mark_delivery(provider: str, key: str | None) -> bool:
     """A duplicate still bumps freshness — a replay proves the pipe works."""
     client = get_client()
-    await client.set(_last_key(provider), datetime.now(UTC).isoformat())
+    await client.set(f"{DELIVERY_LAST_PREFIX}{provider}", datetime.now(UTC).isoformat())
     if key is None:
         return True
-    return bool(await client.set(_seen_key(provider, key), "1", nx=True, ex=_DEDUP_TTL_SECONDS))
+    return bool(
+        await client.set(
+            f"{DELIVERY_SEEN_PREFIX}{provider}:{key}", "1", nx=True, ex=_DEDUP_TTL_SECONDS
+        )
+    )
 
 
 async def release_delivery(provider: str, key: str | None) -> None:
@@ -30,9 +26,9 @@ async def release_delivery(provider: str, key: str | None) -> None:
     # the delivery did arrive.
     if key is None:
         return
-    await get_client().delete(_seen_key(provider, key))
+    await get_client().delete(f"{DELIVERY_SEEN_PREFIX}{provider}:{key}")
 
 
 async def last_delivery_at(provider: str) -> datetime | None:
-    raw = await get_client().get(_last_key(provider))
+    raw = await get_client().get(f"{DELIVERY_LAST_PREFIX}{provider}")
     return datetime.fromisoformat(raw.decode()) if raw else None

--- a/backend/druks/webhooks/deliveries.py
+++ b/backend/druks/webhooks/deliveries.py
@@ -2,17 +2,23 @@ from datetime import UTC, datetime
 
 from druks.redis import get_client
 
+from .constants import DELIVERY_LAST_PREFIX, DELIVERY_SEEN_PREFIX
+
 _DEDUP_TTL_SECONDS = 24 * 60 * 60
 
 
 def _seen_key(provider: str, key: str) -> str:
-    return f"druks:webhook:seen:{provider}:{key}"
+    return f"{DELIVERY_SEEN_PREFIX}{provider}:{key}"
+
+
+def _last_key(provider: str) -> str:
+    return f"{DELIVERY_LAST_PREFIX}{provider}"
 
 
 async def mark_delivery(provider: str, key: str | None) -> bool:
     """A duplicate still bumps freshness — a replay proves the pipe works."""
     client = get_client()
-    await client.set(f"druks:webhook:last:{provider}", datetime.now(UTC).isoformat())
+    await client.set(_last_key(provider), datetime.now(UTC).isoformat())
     if key is None:
         return True
     return bool(await client.set(_seen_key(provider, key), "1", nx=True, ex=_DEDUP_TTL_SECONDS))
@@ -28,5 +34,5 @@ async def release_delivery(provider: str, key: str | None) -> None:
 
 
 async def last_delivery_at(provider: str) -> datetime | None:
-    raw = await get_client().get(f"druks:webhook:last:{provider}")
+    raw = await get_client().get(_last_key(provider))
     return datetime.fromisoformat(raw.decode()) if raw else None

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -9,7 +9,11 @@ import pytest
 from conftest import configure_app_for_test, make_settings
 from druks.extensions.registry import mcp_servers
 from druks.mcp import oauth
-from druks.mcp.constants import OAUTH_ACCESS_TOKEN_PREFIX, OAUTH_CONNECT_STATE_PREFIX
+from druks.mcp.constants import (
+    OAUTH_ACCESS_TOKEN_PREFIX,
+    OAUTH_CONNECT_STATE_PREFIX,
+    OAUTH_REFRESH_LOCK_PREFIX,
+)
 from druks.mcp.enums import TokenSource
 from druks.mcp.exceptions import GrantRefreshError, MissingGrantError, OauthConnectError
 from druks.mcp.helpers import get_bearer_token_env_var
@@ -294,11 +298,11 @@ async def test_mint_losing_the_refresh_lock_polls_for_the_winners_token(
     _store_grant()
     redis = get_client()
     monkeypatch.setattr(oauth, "OAUTH_MINT_WAIT_INTERVAL_SECONDS", 0)
-    await redis.set(oauth._refresh_lock_key(_NAME), "1")
+    await redis.set(f"{OAUTH_REFRESH_LOCK_PREFIX}{_NAME}", "1")
 
     async def _winner_finishes():
         await redis.set(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}", "at-winner")
-        await redis.delete(oauth._refresh_lock_key(_NAME))
+        await redis.delete(f"{OAUTH_REFRESH_LOCK_PREFIX}{_NAME}")
 
     winner = asyncio.create_task(_winner_finishes())
     assert await oauth.mint_access_token(_NAME) == "at-winner"
@@ -310,7 +314,7 @@ async def test_mint_times_out_loudly_when_the_refresh_lock_never_frees(db_sessio
     _store_grant()
     monkeypatch.setattr(oauth, "OAUTH_MINT_WAIT_INTERVAL_SECONDS", 0)
     monkeypatch.setattr(oauth, "OAUTH_MINT_WAIT_ATTEMPTS", 3)
-    await get_client().set(oauth._refresh_lock_key(_NAME), "1")
+    await get_client().set(f"{OAUTH_REFRESH_LOCK_PREFIX}{_NAME}", "1")
 
     with pytest.raises(GrantRefreshError, match="concurrent refresh"):
         await oauth.mint_access_token(_NAME)


### PR DESCRIPTION
Gives every `druks:*` Redis key format one home: the owning package's `constants.py`, matching the existing in-repo precedent — `mcp/constants.py` already declares its prefixes (`OAUTH_CONNECT_STATE_PREFIX` etc.) the same way. The namespace is now auditable with one grep: `grep -rn "druks:" backend/druks --include="*.py"` hits only `*/constants.py`.

- `harnesses/constants.py` (new): `LOGIN_PENDING_PREFIX`, `REFRESH_LOCK_PREFIX`
- `accounts/constants.py`: `SESSION_PREFIX`
- `sandbox/constants.py`: `ROTATING_PREFIX`, `GATE_USERS_PREFIX`
- `webhooks/constants.py` (new): `DELIVERY_SEEN_PREFIX`, `DELIVERY_LAST_PREFIX`

Keys are composed **inline at the call site** (`f"{SESSION_PREFIX}{token}"`); a function that reuses a key binds it to a local once (the sandbox gate, the OAuth mint). Per review, every one-f-string composer helper is gone — including the three pre-existing ones in `mcp/oauth.py` (`_connect_state_key`, `_access_token_key`, `_refresh_lock_key`), so the pattern is dead repo-wide, not just in the four relocated modules. TTL constants stay where they were — the ticket's ask covers key names.

## Verification

- Key formats are byte-for-byte identical after relocation (codex verified all seven; existing tests assert the literal strings — `test_auth` `druks:session:`, `test_gate` `druks:sandbox:gate:users:`, `test_harness_login` `druks:login:pending:`, `test_harness_auth` `druks:harness:refresh:` — so drift fails CI).
- `ruff check` + `ruff format --check` pass; all 865 backend tests collect clean; pytest gates on this PR's CI.

## Codex adversarial review

`gpt-5.6-sol`, effort high, read-only, on the relocation commit: **no refutations found.** Verified byte-identical key formats, no missed `druks:*` mints, constants files remain import-free leaf modules. The inline-composition follow-up commit is a review-driven mechanical reshape of the same call sites.

## Overlaps with other batch PRs

None — no other open batch PR touches these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
