### PR TITLE
Move test-only init_db out of production database.py (ENG-709)

### DIFF
--- a/backend/druks/database.py
+++ b/backend/druks/database.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent / "alembic.ini"
@@ -13,8 +13,7 @@ def run_migrations(database_url: str) -> None:
     """Bring the schema to head — the migrate container's job (``druks
     init-db``). Core first, then each installed extension's own migrations: an
     external extension owns an independent history, so this order is the contract,
-    not a cross-repo revision link. Production schema is owned by Alembic;
-    ``init_db`` (create_all) is only for the pytest fixture."""
+    not a cross-repo revision link. Production schema is owned by Alembic."""
     from alembic import command
     from alembic.config import Config
 
@@ -84,32 +83,6 @@ def create_engine_from_url(database_url: str):
     # writes. Model methods ``flush()``; the boundary commits. Low pool_timeout
     # because a checkout wait blocks the event loop.
     return create_engine(database_url, pool_pre_ping=True, pool_timeout=5)
-
-
-def init_db(engine) -> None:
-    """Create any missing tables and run the first-start seeds. Used by the
-    pytest fixture; production schema is owned by Alembic (``druks init-db``
-    runs ``alembic upgrade head``). Idempotent."""
-    # cycle: every models module imports db_session from here at module
-    # top, so we can't pull them in at file scope. Extension tables (build,
-    # usage) register through import_extension_models().
-    import druks.durable.models  # noqa: F401
-    import druks.harnesses.models  # noqa: F401
-    import druks.mcp.models  # noqa: F401
-    import druks.notifications.models  # noqa: F401
-    import druks.skills.models  # noqa: F401
-    import druks.user_settings.models  # noqa: F401
-    from druks.bootstrap import seed
-    from druks.extensions.loader import import_extension_models
-    from druks.models import Base
-
-    import_extension_models()
-    # citext backs the case-insensitive email columns; create_all needs the
-    # type to exist first (production gets it from the accounts migration).
-    with engine.begin() as connection:
-        connection.execute(text("CREATE EXTENSION IF NOT EXISTS citext"))
-    Base.metadata.create_all(engine)
-    seed(engine)
 
 
 def get_session(engine) -> Session:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,16 +4,29 @@ import secrets
 from pathlib import Path
 from unittest import mock
 
+# The models modules register their tables on Base for init_db's create_all.
+import druks.durable.models  # noqa: F401
+import druks.harnesses.models  # noqa: F401
+import druks.mcp.models  # noqa: F401
+import druks.notifications.models  # noqa: F401
 import druks.redis
+import druks.skills.models  # noqa: F401
+import druks.user_settings.models  # noqa: F401
 import pytest
+from druks.bootstrap import seed
 from druks.database import (
     _session_factory,
     configure_session,
     create_engine_from_url,
-    init_db,
 )
-from druks.extensions.loader import iter_extensions, register_workflow_package
+from druks.extensions.loader import (
+    import_extension_models,
+    iter_extensions,
+    register_workflow_package,
+)
+from druks.models import Base
 from druks.settings import Settings
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 # Every Session the suite opens binds to the per-test connection (the _txn
@@ -196,6 +209,19 @@ class FakeLinear:
 
     async def get_issue(self, issue_id: str) -> dict[str, object]:
         return {"description": self._description}
+
+
+def init_db(engine) -> None:
+    """Create any missing tables and run the first-start seeds — the suite's
+    schema path. Production schema is owned by Alembic (``druks init-db`` runs
+    ``alembic upgrade head``). Idempotent."""
+    import_extension_models()
+    # citext backs the case-insensitive email columns; create_all needs the
+    # type to exist first (production gets it from the accounts migration).
+    with engine.begin() as connection:
+        connection.execute(text("CREATE EXTENSION IF NOT EXISTS citext"))
+    Base.metadata.create_all(engine)
+    seed(engine)
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/test_build_durable.py
+++ b/backend/tests/test_build_durable.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import psycopg
 import pytest
+from conftest import init_db
 from druks.database import configure_session, get_session
 from druks.durable import Run, RunState
 from druks.durable.engine import configure_engine, init_dbos, launch, shutdown
@@ -48,8 +49,6 @@ def rt():
     admin.close()
 
     engine = create_engine(URL)
-    from druks.database import init_db
-
     init_db(engine)
     configure_engine(engine)
     configure_session(engine)

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import psycopg
 import pytest
+from conftest import init_db
 from druks.agents import Agent, AgentOutput
 from druks.database import configure_session, get_session
 from druks.durable import FatalError, Run, RunState
@@ -153,8 +154,6 @@ def rt():
     admin.close()
 
     engine = create_engine(URL)
-    from druks.database import init_db
-
     init_db(engine)  # full schema incl. durable_runs + the work_items chain
     configure_engine(engine)
     configure_session(engine)

--- a/backend/tests/test_harness_login_persistence.py
+++ b/backend/tests/test_harness_login_persistence.py
@@ -2,6 +2,7 @@ import os
 
 import psycopg
 import pytest
+from conftest import init_db
 from druks.database import configure_session, db_session, get_session
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.models import HarnessConnection
@@ -31,8 +32,6 @@ pytestmark = pytest.mark.skipif(not _pg_up(), reason="test Postgres not reachabl
 
 @pytest.fixture
 def engine():
-    from druks.database import init_db
-
     admin = psycopg.connect(f"{PG_BASE}/postgres", autocommit=True)
     admin.execute(f"DROP DATABASE IF EXISTS {DB}")
     admin.execute(f"CREATE DATABASE {DB}")

--- a/backend/tests/test_notifications_durable.py
+++ b/backend/tests/test_notifications_durable.py
@@ -4,9 +4,9 @@ from types import SimpleNamespace
 
 import psycopg
 import pytest
-from conftest import configure_app_for_test, make_settings
+from conftest import configure_app_for_test, init_db, make_settings
 from dbos import DBOS
-from druks.database import configure_session, db_session, get_session, init_db
+from druks.database import configure_session, db_session, get_session
 from druks.durable.engine import configure_engine, init_dbos, launch, shutdown
 from druks.durable.enums import RunState
 from druks.extensions.registry import workflows

--- a/backend/tests/test_scope_durable.py
+++ b/backend/tests/test_scope_durable.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import psycopg
 import pytest
+from conftest import init_db
 from druks.database import configure_session, db_session, get_session
 from druks.durable import Run, RunState
 from druks.durable.engine import configure_engine, init_dbos, launch, shutdown
@@ -30,7 +31,6 @@ pytestmark = [
 
 @pytest.fixture(scope="module", autouse=True)
 def rt():
-    from druks.database import init_db
     from druks.extensions.loader import load
     from druks.extensions.registry import agents, workflows
     from fastapi import FastAPI


### PR DESCRIPTION
Moves the test-only `init_db` (create_all + citext DDL + seed) out of production `database.py` and into `tests/conftest.py` — the suite's existing helper chokepoint (`from conftest import …` is already the idiom across the suite, so no new `_schema.py`). Production `database.py` now carries only the Alembic path; the `CREATE EXTENSION citext` line lives solely in the test helper and the accounts migration that owns it in production.

Relocation details:

- The function-level model imports inside the old `init_db` existed only because `database.py` sits in an import cycle with the models modules; from conftest there is no cycle, so they hoist to module top (side-effect imports registering tables for `create_all`).
- The five test files that build their own DBs (`test_durable_sdk`, `test_scope_durable`, `test_build_durable`, `test_notifications_durable`, `test_harness_login_persistence`) import `init_db` from conftest at module top — it stays the single chokepoint.
- The ticket also lists `test_usage_durable.py` as a caller; that file doesn't exist on main (stale enumeration) — the six files in this diff are the complete caller set.

## Acceptance criteria → verification

- **No production `init_db` / test DDL remains** — `grep -rn "init_db" backend/druks` is empty (only `init_dbos` and the `druks init-db` CLI, which runs Alembic, remain).
- **Single chokepoint preserved** — every self-DB test funnels through `conftest.init_db`; codex verified caller completeness.
- **No behavior change** — the relocated body is identical (extension loading, citext, create_all, seed); codex verified a clean import with `DRUKS_SECRETS_KEY` absent, so the hoisted model imports read no settings before conftest's setdefault.
- **Backend CI green** — 865 tests collect clean locally; pytest gates on this PR's CI.

## Codex adversarial review

`gpt-5.6-sol`, effort high, read-only: **no refutations found.** Verified relocation equivalence, import-order safety around `DRUKS_SECRETS_KEY`, caller completeness, citext ownership, ruff lint + format, and full collection.

## Overlaps with other batch PRs

- `backend/tests/conftest.py` — PR #20 (ENG-707) renames two accessor call sites in the same file; textual-only overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
