### PR TITLE
Rename account_email to account_username on the read side (ENG-714)

### DIFF
--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -13,10 +13,11 @@ class Account(Base, Uuid7Pk):
     __tablename__ = "accounts"
 
     # citext: the column compares and enforces uniqueness case-insensitively,
-    # so a lookup or a duplicate check needs no normalization — the email is
-    # stored as the provider gave it and matched regardless of case.
-    email: Mapped[str] = mapped_column(CITEXT, unique=True)
-    # No updated_at: an account is insert-once — email never changes and there
+    # so a lookup or a duplicate check needs no normalization — the username is
+    # stored as the provider gave it and matched regardless of case. Usually a
+    # provider email, but not always: the system account holds "system".
+    username: Mapped[str] = mapped_column(CITEXT, unique=True)
+    # No updated_at: an account is insert-once — username never changes and there
     # is no other field to mutate — so the column would only ever equal
     # created_at, and nothing reads it.
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
@@ -26,15 +27,15 @@ class Account(Base, Uuid7Pk):
         return db_session().get(cls, account_id)
 
     @classmethod
-    def get_for_email(cls, email: str) -> "Account | None":
-        return db_session().scalar(select(cls).where(cls.email == email))
+    def get_for_username(cls, username: str) -> "Account | None":
+        return db_session().scalar(select(cls).where(cls.username == username))
 
     @classmethod
-    def get_or_create(cls, email: str) -> "Account":
-        account = cls.get_for_email(email)
+    def get_or_create(cls, username: str) -> "Account":
+        account = cls.get_for_username(username)
         if account:
             return account
-        account = cls(email=email)
+        account = cls(username=username)
         session = db_session()
         session.add(account)
         session.flush()

--- a/backend/druks/accounts/schemas.py
+++ b/backend/druks/accounts/schemas.py
@@ -7,4 +7,4 @@ class AccountResponse(BaseResponse):
     model_config = ConfigDict(from_attributes=True)
 
     id: str
-    email: str
+    username: str

--- a/backend/druks/bootstrap.py
+++ b/backend/druks/bootstrap.py
@@ -38,5 +38,5 @@ def seed_system_account(engine) -> None:
     # Owns every run nobody asked for: crons, background work.
     with get_session(engine) as session:
         if not session.get(Account, SYSTEM_ACCOUNT_ID):
-            session.add(Account(id=SYSTEM_ACCOUNT_ID, email="system"))
+            session.add(Account(id=SYSTEM_ACCOUNT_ID, username="system"))
             session.commit()

--- a/backend/druks/build/scoping/workflows.py
+++ b/backend/druks/build/scoping/workflows.py
@@ -47,7 +47,7 @@ class Scope(Workflow):
             )
         assignee = None
         if ticket.assignee_email:
-            assignee = Account.get_for_email(ticket.assignee_email.strip())
+            assignee = Account.get_for_username(ticket.assignee_email.strip())
         return await cls.start(
             subject=WorkItem.subject_for(item.id),
             account_id=assignee.id if assignee else None,

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -147,7 +147,7 @@ class BuildWorkflow(Workflow):
         if not item:
             raise ValueError(f"dispatching a build for unknown work item {work_item_id}")
         # The assignee's account runs the calls; the owner fields stay input.
-        assignee = Account.get_for_email(assignee_email.strip()) if assignee_email else None
+        assignee = Account.get_for_username(assignee_email.strip()) if assignee_email else None
         run_id = await cls.start(
             subject=WorkItem.subject_for(item.id),
             account_id=assignee.id if assignee else None,

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -36,7 +36,7 @@ class AgentCallResponse(BaseResponse):
     agent: str | None = None
     label: str = ""
     # The account charged — differs from the run's on fallback.
-    account_email: str
+    account_username: str
     status: Literal["running", "succeeded", "failed", "abandoned"]
     # started_at + finished_at are the facts; the client derives elapsed (a live
     # tick off started_at while running), so nothing here churns between polls.
@@ -61,7 +61,7 @@ class AgentCallResponse(BaseResponse):
             id=call.id,
             agent=call.agent,
             label=get_display_label(call.agent) if call.agent else "Agent",
-            account_email=call.account.email,
+            account_username=call.account.username,
             status=status,  # type: ignore[arg-type]
             started_at=call.started_at,
             finished_at=call.finished_at,
@@ -144,7 +144,7 @@ class RunResponse(BaseResponse):
     created_at: datetime
     updated_at: datetime
     # Who asked; "system" when nobody did.
-    account_email: str
+    account_username: str
     agent_calls: list[AgentCallResponse] = Field(default_factory=list)
 
     @classmethod
@@ -158,7 +158,7 @@ class RunResponse(BaseResponse):
             input_request=run.get_ask() if run.input_request else None,
             created_at=run.created_at,
             updated_at=run.updated_at,
-            account_email=run.account.email,
+            account_username=run.account.username,
             agent_calls=[AgentCallResponse.from_call(c) for c in calls],
         )
 

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -43,7 +43,7 @@ class HarnessResponse(BaseResponse):
             allowed_models=settings.allowed_models,
             connected=bool(login),
             kind=login.kind if login else None,
-            account=account.email if login else None,
+            account=account.username if login else None,
             provider_email=login.provider_email if login else None,
             expires_at=login.expires_at if login else None,
         )

--- a/backend/migrations/versions/e8f9a0b1c2d3_rename_account_email_to_username.py
+++ b/backend/migrations/versions/e8f9a0b1c2d3_rename_account_email_to_username.py
@@ -1,0 +1,35 @@
+"""rename account email to username
+
+Revision ID: e8f9a0b1c2d3
+Revises: ccebfa4ee1e2
+Create Date: 2026-07-18 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e8f9a0b1c2d3"
+down_revision: str | Sequence[str] | None = "ccebfa4ee1e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # The value was never only an email: the system account holds "system", and
+    # other identity providers may hand usernames. Pure rename — citext,
+    # uniqueness, and every row survive; the constraint follows so a migrated
+    # database and a fresh create_all converge on one name.
+    op.alter_column("accounts", "email", new_column_name="username")
+    op.execute(
+        "ALTER TABLE accounts RENAME CONSTRAINT accounts_email_key TO accounts_username_key"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER TABLE accounts RENAME CONSTRAINT accounts_username_key TO accounts_email_key"
+    )
+    op.alter_column("accounts", "username", new_column_name="email")

--- a/backend/tests/test_accounts_migration.py
+++ b/backend/tests/test_accounts_migration.py
@@ -122,11 +122,11 @@ def test_legacy_rows_are_rekeyed_under_one_account(engine, monkeypatch):
 
     _upgrade("head")
 
-    accounts = _rows(engine, "SELECT id, email FROM accounts WHERE id != 'system'")
+    accounts = _rows(engine, "SELECT id, username FROM accounts WHERE id != 'system'")
     assert len(accounts) == 1
     # Stored stripped, original case; citext matches it regardless of case.
-    assert accounts[0]["email"] == "Op@Example.COM"
-    assert _rows(engine, "SELECT id FROM accounts WHERE email = 'op@example.com'")
+    assert accounts[0]["username"] == "Op@Example.COM"
+    assert _rows(engine, "SELECT id FROM accounts WHERE username = 'op@example.com'")
 
     logins = _rows(
         engine,
@@ -171,7 +171,7 @@ def test_orm_reads_migrated_rows_under_the_model_aad(engine, monkeypatch):
     try:
         assert ClaudeHarness.get_credentials() == CLAUDE_PAYLOAD
         codex_row = HarnessConnection.get_for_account(
-            "codex", Account.get_for_email("op@example.com").id
+            "codex", Account.get_for_username("op@example.com").id
         )
         assert dict(codex_row.payload) == CODEX_PAYLOAD
         assert codex_row.provider_email is None

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -111,7 +111,9 @@ async def test_run_refuses_unconnected_harness(db_session, tmp_path, monkeypatch
     from druks.harnesses.exceptions import HarnessNotConnectedError
     from druks.harnesses.models import HarnessConnection
 
-    HarnessConnection.get_for_account("claude", Account.get_for_email("op@example.com").id).delete()
+    HarnessConnection.get_for_account(
+        "claude", Account.get_for_username("op@example.com").id
+    ).delete()
     sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
     _patch_ephemeral(monkeypatch, sandbox)
 

--- a/backend/tests/test_attribution.py
+++ b/backend/tests/test_attribution.py
@@ -11,7 +11,7 @@ def test_run_projects_its_account(db_session):
 
     run = db_session.get(Run, "run-attr-1")
     assert run.account_id == account.id
-    assert RunResponse.from_run(run, []).account_email == "dev@example.com"
+    assert RunResponse.from_run(run, []).account_username == "dev@example.com"
 
 
 def test_an_unowned_run_belongs_to_system(db_session):
@@ -20,4 +20,4 @@ def test_an_unowned_run_belongs_to_system(db_session):
 
     run = db_session.get(Run, "run-attr-2")
     assert run.account_id == "system"
-    assert RunResponse.from_run(run, []).account_email == "system"
+    assert RunResponse.from_run(run, []).account_username == "system"

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -74,7 +74,7 @@ def test_login_flow_mints_session_and_account(tmp_path, monkeypatch, db_session)
 
         response = _login(client, monkeypatch)
         assert response.status_code == 200
-        assert response.json()["email"] == "me@example.com"
+        assert response.json()["username"] == "me@example.com"
         cookie = response.headers["set-cookie"]
         assert SESSION_COOKIE in cookie
         assert "HttpOnly" in cookie
@@ -83,7 +83,7 @@ def test_login_flow_mints_session_and_account(tmp_path, monkeypatch, db_session)
 
         session = client.get("/api/auth/session")
         assert session.status_code == 200
-        assert session.json()["email"] == "me@example.com"
+        assert session.json()["username"] == "me@example.com"
 
 
 def test_the_session_read_slides_the_cookie(tmp_path, monkeypatch, db_session):
@@ -123,7 +123,9 @@ def test_redis_eviction_signs_out_but_keeps_credentials(tmp_path, monkeypatch, d
         druks.redis.get_client()._data.clear()  # Redis loss
         assert client.get("/api/auth/session").status_code == 401
     # The durable credential is untouched — only the session died.
-    assert HarnessConnection.get_for_account("claude", Account.get_for_email("me@example.com").id)
+    assert HarnessConnection.get_for_account(
+        "claude", Account.get_for_username("me@example.com").id
+    )
 
 
 def test_session_keeps_its_account_across_reconnects(tmp_path, monkeypatch, db_session):
@@ -137,8 +139,8 @@ def test_session_keeps_its_account_across_reconnects(tmp_path, monkeypatch, db_s
             json={"code": "thecode", "loginId": start.json()["loginId"]},
         )
         assert complete.status_code == 200
-        assert complete.json()["email"] == "me@example.com"
-    account = Account.get_for_email("me@example.com")
+        assert complete.json()["username"] == "me@example.com"
+    account = Account.get_for_username("me@example.com")
     codex = HarnessConnection.get_for_account("codex", account.id)
     assert codex.provider_email == "corp-seat@corp.com"
 
@@ -162,7 +164,7 @@ def test_bound_reconnect_requires_its_session_at_complete(tmp_path, monkeypatch,
         # The flow must never rebind the login by email fallback.
         assert response.status_code == 422
         assert "different session" in response.json()["detail"]
-    assert not Account.get_for_email("corp-seat@corp.com")
+    assert not Account.get_for_username("corp-seat@corp.com")
     assert not any(row.harness == "codex" for row in HarnessConnection.list_all())
 
 
@@ -196,7 +198,7 @@ def test_new_identity_cannot_acquire_legacy_logins(tmp_path, monkeypatch, db_ses
     with _client(tmp_path) as client:
         response = _login(client, monkeypatch, email="newcomer@example.com")
         assert response.status_code == 200
-    accounts = {account.email: account for account in _all_accounts()}
+    accounts = {account.username: account for account in _all_accounts()}
     assert set(accounts) == {"op@example.com", "newcomer@example.com", "system"}
     # The legacy login stays put; the fallback account stays the operator's.
     assert HarnessConnection.reload(legacy.id).account_id == accounts["op@example.com"].id
@@ -213,7 +215,7 @@ def test_dashboard_identity_resolves_the_migrated_account(tmp_path, monkeypatch,
         assert response.status_code == 200
     # No second account minted, the legacy login updated in place; reload()
     # reads past this task's identity map.
-    assert {account.email for account in _all_accounts()} == {"op@example.com", "system"}
+    assert {account.username for account in _all_accounts()} == {"op@example.com", "system"}
     updated = HarnessConnection.reload(legacy_id)
     assert dict(updated.payload)["claudeAiOauth"]["accessToken"] == "AT"
 

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -168,14 +168,14 @@ def rt():
 
     session = get_session(engine)
     try:
-        account = Account(email="op@example.com")
+        account = Account(username="op@example.com")
         session.add(account)
         session.flush()
         session.add(
             HarnessConnection(
                 harness="claude",
                 account_id=account.id,
-                provider_email=account.email,
+                provider_email=account.username,
                 payload={"claudeAiOauth": {"accessToken": "t"}},
             )
         )
@@ -253,9 +253,9 @@ def _account_id(engine, email: str) -> str:
 
     session = get_session(engine)
     try:
-        row = session.execute(select(Account).where(Account.email == email)).scalar_one_or_none()
+        row = session.execute(select(Account).where(Account.username == email)).scalar_one_or_none()
         if not row:
-            row = Account(email=email)
+            row = Account(username=email)
             session.add(row)
             session.commit()
         return row.id

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -349,7 +349,7 @@ def test_connect_scopes_rows_by_harness_and_account(db_session):
     assert len({claude_row.id, codex_row.id, other.id}) == 3
     assert claude_row.account_id == codex_row.account_id  # same person, one account
     assert other.account_id != claude_row.account_id
-    assert Account.get_for_email("a@example.com").id == claude_row.account_id
+    assert Account.get_for_username("a@example.com").id == claude_row.account_id
     # The first account adopted the execution fallback.
     assert UserSettings.get().fallback_account_id == claude_row.account_id
 

--- a/frontend/src/api/sse.test.tsx
+++ b/frontend/src/api/sse.test.tsx
@@ -56,7 +56,7 @@ beforeEach(() => {
   FakeEventSource.instances = []
   vi.stubGlobal('EventSource', FakeEventSource)
   // Every SSE error rechecks the session; default to a live one.
-  stubSession(JSON.stringify({ id: 'a1', email: 'me@example.com' }), 200)
+  stubSession(JSON.stringify({ id: 'a1', username: 'me@example.com' }), 200)
 })
 
 afterEach(() => {
@@ -218,7 +218,7 @@ describe('useSSE', () => {
   })
 
   it('rechecks the session on error and stays open while it is live', async () => {
-    const fetchMock = stubSession(JSON.stringify({ id: 'a1', email: 'me@example.com' }), 200)
+    const fetchMock = stubSession(JSON.stringify({ id: 'a1', username: 'me@example.com' }), 200)
     render(<Harness url="/api/x" handlers={{ 'foo.updated': vi.fn() }} />)
 
     act(() => {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -63,7 +63,7 @@ export interface AgentCallSummary {
   agent?: string | null
   label: string
   /** The account charged for this call — differs from the run's on fallback. */
-  accountEmail: string
+  accountUsername: string
   status: 'running' | 'succeeded' | 'failed' | 'abandoned'
   startedAt: string
   finishedAt?: string | null
@@ -112,7 +112,7 @@ export interface RunSummary {
   createdAt: string
   updatedAt: string
   /** Who asked; "system" when nobody did. */
-  accountEmail: string
+  accountUsername: string
   agentCalls: AgentCallSummary[]
 }
 
@@ -203,7 +203,7 @@ export interface Harness {
 
 export interface Account {
   id: string
-  email: string
+  username: string
 }
 
 export interface LoginChallenge {

--- a/frontend/src/components/AuthProvider.test.tsx
+++ b/frontend/src/components/AuthProvider.test.tsx
@@ -23,7 +23,7 @@ async function flush() {
 
 describe('AuthProvider', () => {
   it('mounts the app only once the session resolves', async () => {
-    stubFetch(200, { id: 'a1', email: 'me@example.com' })
+    stubFetch(200, { id: 'a1', username: 'me@example.com' })
     render(
       <AuthProvider>
         <div data-testid="app" />
@@ -49,7 +49,7 @@ describe('AuthProvider', () => {
   })
 
   it('a broadcast 401 unmounts the app back to the landing', async () => {
-    stubFetch(200, { id: 'a1', email: 'me@example.com' })
+    stubFetch(200, { id: 'a1', username: 'me@example.com' })
     render(
       <AuthProvider>
         <div data-testid="app" />

--- a/frontend/src/components/HarnessConnect.test.tsx
+++ b/frontend/src/components/HarnessConnect.test.tsx
@@ -53,7 +53,7 @@ describe('HarnessConnect', () => {
   it('drives the /api/auth connect flow end to end', async () => {
     const responses: Record<string, unknown> = {
       '/api/auth/harnesses/claude/login/start': { authorizeUrl: 'https://x/auth', loginId: 'L1' },
-      '/api/auth/harnesses/claude/login/complete': { id: 'a1', email: 'me@example.com' },
+      '/api/auth/harnesses/claude/login/complete': { id: 'a1', username: 'me@example.com' },
     }
     const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
       async (url) => {

--- a/frontend/src/extensions/build/WorkItemPage.tsx
+++ b/frontend/src/extensions/build/WorkItemPage.tsx
@@ -390,7 +390,7 @@ function RunRow({
           <div className="wic-op-row1">
             <span className="wic-op-kind">{run.label}</span>
             <span className="wic-op-owner" title="Who requested this run.">
-              {run.accountEmail}
+              {run.accountUsername}
             </span>
           </div>
           <span className={`wic-op-sub wic-sub-${run.state}`}>
@@ -409,7 +409,7 @@ function RunRow({
           <CallRow
             key={call.id}
             call={call}
-            runAccountEmail={run.accountEmail}
+            runAccountUsername={run.accountUsername}
             selected={selectedHere && selection?.call?.id === call.id}
             onSelect={() => onSelect(call.id)}
           />
@@ -420,12 +420,12 @@ function RunRow({
 
 function CallRow({
   call,
-  runAccountEmail,
+  runAccountUsername,
   selected,
   onSelect,
 }: {
   call: AgentCallSummary
-  runAccountEmail: string
+  runAccountUsername: string
   selected: boolean
   onSelect: () => void
 }) {
@@ -436,8 +436,8 @@ function CallRow({
         {CALL_GLYPH[call.status] ?? '·'}
       </span>
       <span className="wic-call-label">{call.label}</span>
-      {call.accountEmail !== runAccountEmail && (
-        <span className="wic-call-fallback" title={`Charged to ${call.accountEmail}.`}>
+      {call.accountUsername !== runAccountUsername && (
+        <span className="wic-call-fallback" title={`Charged to ${call.accountUsername}.`}>
           fallback
         </span>
       )}


### PR DESCRIPTION
Renames the account identity from "email" to "username" through the full stack — the ticket's larger option. The value was never only an email: the system account holds `system`, and future identity providers may hand usernames.

- **Column**: `accounts.email` (citext) → `username`, via new migration `e8f9a0b1c2d3` — pure rename plus `accounts_email_key` → `accounts_username_key` constraint rename, so a migrated database and a fresh `create_all` converge on one name. Honest downgrade (reverse renames).
- **Model**: `Account.username`, `get_for_email` → `get_for_username`, `get_or_create(username)`; the system-account seed and both build-workflow assignee lookups follow.
- **Wire**: `account_email` → `account_username` on `RunResponse`/`AgentCallResponse` (serializes as `accountUsername` via the camelizing `BaseResponse`); `AccountResponse.email` → `username`.
- **FE**: `accountEmail` → `accountUsername` in `types.ts` and `WorkItemPage` (owner span, fallback chip); the session `Account` type and auth test stubs follow.
- **Untouched by design**: `provider_email`/`providerEmail` (a real provider email), tracker assignee emails, `jira_email`, `DRUKS_DASHBOARD_EMAIL`, and harness profile responses — all still email, because they are.

## Acceptance criteria → verification

- **Mechanical sweep, nothing left behind** — `grep -rn "account_email\|accountEmail\|get_for_email"` across backend + frontend is empty; codex independently confirmed no stale references and no over-renamed provider/tracker fields.
- **Migration correctness** — single alembic head; earlier chain revisions that write `email` raw SQL (`a8060465d9ed`, `c6d7e8f9a0b1`) run before the rename; `test_accounts_migration.py` drives `upgrade head` across the rename and now asserts `username` on the far side.
- **Read-side coverage** — `test_attribution.py` asserts `account_username` for both the real-account and system paths; `test_auth.py` asserts the session wire field `username`.
- **Gates** — backend: ruff + format clean, 865 tests collect; frontend: `npm run build`, `npm run lint`, `npm test` (33/33) all pass locally. Backend pytest gates on this PR's CI.

## Codex adversarial review

`gpt-5.6-sol`, effort high, read-only: **no refutations found.** Confirmed reference completeness, protected email fields, migration ordering/constraint-name convergence (PG names the fresh unnamed unique `accounts_username_key`), wire/FE coherence, ruff, eslint, tsc, and a no-write vite build.

## Overlaps with other batch PRs

None — no other open batch PR touches these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
