### PR TITLE
Consolidate the record_event + set_status pairing into set_status (ENG-677)

### DIFF
--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -7,6 +7,7 @@ from sqlalchemy import ForeignKey, Index, func, select, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from druks.build.enums import HandoffStatus
 from druks.db import Base, db_session
 from druks.durable.reads import get_subject_status
 from druks.durable.schemas import SubjectStatus
@@ -378,6 +379,16 @@ class WorkItem(Base):
             return None
         calls = AgentCall.list_for_subject("work_item", str(item.id))
         return calls[-1].sandbox_host_id if calls else None
+
+    def mark(self, status: HandoffStatus, *, event_payload: dict[str, Any] | None = None) -> None:
+        """One handoff transition: the build event whose ``type`` is the status,
+        then the lane — the pairing lives here, not open-coded at call sites.
+        ``set_status`` stays beneath it: the ``None`` clear emits no event."""
+        # cycle: the extension imports this module at file scope.
+        from druks.build.extension import Build
+
+        Build.record_event(type=status, subject=self.subject_for(self.id), payload=event_payload)
+        self.set_status(status)
 
     def set_status(self, status: str | None) -> None:
         self.status = status

--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -380,17 +380,19 @@ class WorkItem(Base):
         calls = AgentCall.list_for_subject("work_item", str(item.id))
         return calls[-1].sandbox_host_id if calls else None
 
-    def mark(self, status: HandoffStatus, *, event_payload: dict[str, Any] | None = None) -> None:
-        """One handoff transition: the build event whose ``type`` is the status,
-        then the lane — the pairing lives here, not open-coded at call sites.
-        ``set_status`` stays beneath it: the ``None`` clear emits no event."""
-        # cycle: the extension imports this module at file scope.
-        from druks.build.extension import Build
+    def set_status(
+        self, status: HandoffStatus | None, *, event_payload: dict[str, Any] | None = None
+    ) -> None:
+        """The handoff-lane write. A non-None status is a milestone, so the
+        matching build event records first — the pairing is structural, not a
+        call-site convention. None clears the lane on (re)dispatch: no event."""
+        if status:
+            # cycle: the extension imports this module at file scope.
+            from druks.build.extension import Build
 
-        Build.record_event(type=status, subject=self.subject_for(self.id), payload=event_payload)
-        self.set_status(status)
-
-    def set_status(self, status: str | None) -> None:
+            Build.record_event(
+                type=status, subject=self.subject_for(self.id), payload=event_payload
+            )
         self.status = status
         self.updated_at = Base.utc_now()
         db_session().flush()

--- a/backend/druks/build/subscribers.py
+++ b/backend/druks/build/subscribers.py
@@ -32,7 +32,7 @@ async def work_item_back_on_board(*, subject: dict, **_: object) -> None:
 
 @subscribe("run.finished", kind=Scope.kind, subject__type="work_item", result__status="ready")
 async def scope_outcome_settles_lane(*, subject: dict, **_: object) -> None:
-    WorkItem.get(subject["id"]).mark(HandoffStatus.SCOPED, event_payload={})
+    WorkItem.get(subject["id"]).set_status(HandoffStatus.SCOPED, event_payload={})
 
 
 @subscribe("repo.pushed", to_default_branch=True)
@@ -117,7 +117,7 @@ async def observe_pr_closed(*, repo: str, pr_number: int, payload: dict) -> None
 async def _ship(*, repo: str, pr_number: int, work_item: WorkItem | None) -> None:
     if not work_item:
         return
-    work_item.mark(HandoffStatus.SHIPPED)
+    work_item.set_status(HandoffStatus.SHIPPED)
     # An operator merge over a waiting gate strands the parked run — cancel it.
     # A RUNNING run converges on its own (its merge step sees the closed PR), so
     # it is left to finish; that includes druks's own merge wrapping up.
@@ -131,7 +131,7 @@ async def _ship(*, repo: str, pr_number: int, work_item: WorkItem | None) -> Non
 async def _observe_external_close(*, repo: str, pr_number: int, work_item: WorkItem | None) -> None:
     if not work_item:
         return
-    work_item.mark(HandoffStatus.CANCELLED, event_payload={"external": True})
+    work_item.set_status(HandoffStatus.CANCELLED, event_payload={"external": True})
     await work_item.cancel_active_build(failure="pr closed without merge")
     snapshot_policy = work_item.extension_config_snapshot.get("policy") or {}
     if RepoPolicy.model_validate(snapshot_policy).delete_branch:
@@ -183,7 +183,7 @@ async def ticket_close_cancels_parked_scope(*, payload: dict) -> None:
     parked = Scope.parked_for(item.id)
     if not parked:
         return
-    item.mark(HandoffStatus.CANCELLED, event_payload={"external": True})
+    item.set_status(HandoffStatus.CANCELLED, event_payload={"external": True})
     await parked.cancel(failure="ticket closed while scope parked")
 
 

--- a/backend/druks/build/subscribers.py
+++ b/backend/druks/build/subscribers.py
@@ -32,8 +32,7 @@ async def work_item_back_on_board(*, subject: dict, **_: object) -> None:
 
 @subscribe("run.finished", kind=Scope.kind, subject__type="work_item", result__status="ready")
 async def scope_outcome_settles_lane(*, subject: dict, **_: object) -> None:
-    Build.record_event(type="scoped", subject=subject, payload={})
-    WorkItem.get(subject["id"]).set_status(HandoffStatus.SCOPED)
+    WorkItem.get(subject["id"]).mark(HandoffStatus.SCOPED, event_payload={})
 
 
 @subscribe("repo.pushed", to_default_branch=True)
@@ -118,8 +117,7 @@ async def observe_pr_closed(*, repo: str, pr_number: int, payload: dict) -> None
 async def _ship(*, repo: str, pr_number: int, work_item: WorkItem | None) -> None:
     if not work_item:
         return
-    Build.record_event(type="shipped", subject=WorkItem.subject_for(work_item.id))
-    work_item.set_status(HandoffStatus.SHIPPED)
+    work_item.mark(HandoffStatus.SHIPPED)
     # An operator merge over a waiting gate strands the parked run — cancel it.
     # A RUNNING run converges on its own (its merge step sees the closed PR), so
     # it is left to finish; that includes druks's own merge wrapping up.
@@ -133,12 +131,7 @@ async def _ship(*, repo: str, pr_number: int, work_item: WorkItem | None) -> Non
 async def _observe_external_close(*, repo: str, pr_number: int, work_item: WorkItem | None) -> None:
     if not work_item:
         return
-    Build.record_event(
-        type="cancelled",
-        subject=WorkItem.subject_for(work_item.id),
-        payload={"external": True},
-    )
-    work_item.set_status(HandoffStatus.CANCELLED)
+    work_item.mark(HandoffStatus.CANCELLED, event_payload={"external": True})
     await work_item.cancel_active_build(failure="pr closed without merge")
     snapshot_policy = work_item.extension_config_snapshot.get("policy") or {}
     if RepoPolicy.model_validate(snapshot_policy).delete_branch:
@@ -190,10 +183,7 @@ async def ticket_close_cancels_parked_scope(*, payload: dict) -> None:
     parked = Scope.parked_for(item.id)
     if not parked:
         return
-    Build.record_event(
-        type="cancelled", subject=WorkItem.subject_for(item.id), payload={"external": True}
-    )
-    item.set_status(HandoffStatus.CANCELLED)
+    item.mark(HandoffStatus.CANCELLED, event_payload={"external": True})
     await parked.cancel(failure="ticket closed while scope parked")
 
 

--- a/backend/tests/test_api_work_items.py
+++ b/backend/tests/test_api_work_items.py
@@ -39,17 +39,14 @@ def _seed_scope_run(db_session, item, *, state="finished", status=None):
         subject={"type": "work_item", "id": item.id},
     )
     seed_call(db_session, run, "scope", status="failed" if state == "failed" else "succeeded")
-    if status is not None:
-        from druks.events.models import Event
-
-        Event.emit(
-            type="scoped" if status == "ready" else status,
-            subject=WorkItem.subject_for(item.id),
-        )
-        db_session.flush()
     handoff = {"ready": "scoped", "skipped": "skipped"}.get(status)
     if handoff is not None:
         item.set_status(handoff)
+    elif status is not None:
+        from druks.events.models import Event
+
+        Event.emit(type=status, subject=WorkItem.subject_for(item.id))
+        db_session.flush()
     return run
 
 
@@ -94,11 +91,8 @@ def _seed_op(db_session, work_item_id, *, kind="implement", state, input_gate=No
 def _ship(repo, pr_number):
     """Merge a work item's PR — the 'shipped' log event that lands it in
     History, mirroring the merge handler."""
-    from druks.events.models import Event
-
     item = WorkItem.get_for_pr(repo=repo, pr_number=pr_number)
     if item:
-        Event.emit(type="shipped", subject=WorkItem.subject_for(item.id))
         item.set_status("shipped")
 
 

--- a/backend/tests/test_webhooks_pull_request.py
+++ b/backend/tests/test_webhooks_pull_request.py
@@ -160,7 +160,6 @@ async def test_remerge_after_retrigger_records_a_fresh_shipped(db_session, tmp_p
     repo, pr_number, branch = "ClawHaven/acme-app", 77, "agent/eng-9"
     work_item_id, _ = _park_work_item(repo=repo, pr_number=pr_number, branch=branch)
     # Round 1: shipped.
-    Event.emit(type="shipped", subject=WorkItem.subject_for(work_item_id))
     WorkItem.get(work_item_id).set_status("shipped")
     # Re-trigger: a newer RUNNING build run; dispatch cleared the handoff status.
     new_run = seed_build_run(ds(), work_item_id=work_item_id, state="running")
@@ -179,7 +178,6 @@ async def test_merge_echo_with_no_newer_activity_still_dedups(db_session, tmp_pa
     webhook arrives with nothing newer — still dropped."""
     repo, pr_number, branch = "ClawHaven/acme-app", 78, "agent/eng-10"
     work_item_id, _ = _park_work_item(repo=repo, pr_number=pr_number, branch=branch)
-    Event.emit(type="shipped", subject=WorkItem.subject_for(work_item_id))
     WorkItem.get(work_item_id).set_status("shipped")
 
     await _fire_closed(repo=repo, pr_number=pr_number, branch=branch, tmp_path=tmp_path)


### PR DESCRIPTION
The event/status pairing moves into `WorkItem.set_status` itself: a non-`None` status is a handoff milestone, so the setter records the matching build event (subject = `subject_for(self.id)`, `type` = the status) before writing the lane; `None` clears the lane on (re)dispatch and emits nothing. The four open-coded `Build.record_event` + `set_status` pairs in the build subscribers collapse onto plain `set_status` calls with their payloads preserved exactly (`scoped` → `{}`, `shipped` → none, both `cancelled` → `{"external": True}`).

This is one step past the ticket's original `mark`/`set_status` split, per review: the ticket's own complaint was that the invariant is "enforced only by convention", and a separate `mark` keeps a public event-skipping setter around — the invariant stays conventional. Folding emission into `set_status` makes it structural: there is no way to put an item in a lane without the fact being recorded.

The tests were quietly proving the point — `test_webhooks_pull_request` and `test_api_work_items` hand-rolled the same `Event.emit` + `set_status` pairs to arrange state. Those collapse too; the `test_api_work_items` seed helper now routes lane statuses through `set_status` and only bare non-lane statuses through `Event.emit`, emitting the same event types as before for every parametrization.

## Acceptance criteria → verification

- **Four sites, no open-coded pair** — subscribers contain only the `None`-clear and four `set_status` calls.
- **`None` still emits nothing** — the emission sits under `if status:`; both production `None`-clears unchanged.
- **Behavior identical at the four sites** — same event type/subject/payload/ordering; codex verified, including `shipped`'s omitted payload normalizing to `{}` in `Event.emit` as before, and the redelivery dedup guards in `observe_pr_closed` still preventing double-emission.
- **Suite green, no count change** — 865 tests collect (unchanged); milestone-count assertions in `test_webhooks_pull_request` / `test_lane_reactions` hold on this PR's CI.

## Codex adversarial review

Two passes, `gpt-5.6-sol`, effort high, read-only, both **no refutations found**: the first on the `mark` design, the second on this collapsed design — auditing every test-side `set_status` arrangement against every event-count assertion, the seed-helper restructure, StrEnum/str equivalence, and the cycle-safe deferred import.

## Overlaps with other batch PRs

None — ENG-692, the other ticket in this batch, closed with no PR (already implemented on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
