### PR TITLE
Rework the front-door copy around durable agent apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Druks is a platform for durable agent orchestration on DBOS and Postgres. It owns
+Druks runs durable agent applications on DBOS and Postgres. It owns
 workflow execution, persisted state and events, gates, webhooks, sandbox access,
 and the shared dashboard. Apps are **extensions**: standalone Python packages
 that self-register through the `druks.extensions` entry point. `build` is the

--- a/README.md
+++ b/README.md
@@ -11,11 +11,9 @@
 > Druks is under active development. Expect breaking changes and rough edges
 > before 1.0; `main` and `latest` are edge builds, not stable releases.
 
-Druks is a platform for **durable agent orchestration**. It gives
-long-running agent applications a durable workflow engine, human gates,
-sandboxed execution, events, webhooks, settings, and an operator dashboard.
-The application supplies the domain logic as an independently packaged
-extension.
+Druks is the self-hosted **home for durable agent apps**, running on the
+Claude and Codex subscriptions you already pay for. Build ships out of the
+box: autonomous software delivery from ticket to reviewed pull request.
 
 An ordinary agent script loses its place when the process dies. A Druks
 workflow records the result of each completed durable operation in Postgres.

--- a/frontend/src/components/Landing.tsx
+++ b/frontend/src/components/Landing.tsx
@@ -30,7 +30,7 @@ export function Landing({ onSignedIn }: { onSignedIn: (account: Account) => void
         <div className="landing-word">
           druks<span>.</span>
         </div>
-        <div className="landing-tag">durable agent orchestration</div>
+        <div className="landing-tag">home for durable agent apps</div>
         <div className="landing-head">
           <h1>Connect a harness to sign in</h1>
           <p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "druks"
 version = "0.0.1"
-description = "Platform for durable agent orchestration."
+description = "Autonomous software delivery; the self-hosted home for durable agent apps."
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]


### PR DESCRIPTION
## Summary

Positioning pass on the front door: retire "durable agent orchestration" and lead with what an installation does.

