### PR TITLE
Add personal access tokens with bearer-first account resolution

### DIFF
--- a/backend/druks/accounts/constants.py
+++ b/backend/druks/accounts/constants.py
@@ -1,6 +1,23 @@
+import string
+from datetime import timedelta
+
 # Owns every run nobody asked for: crons, background work. Seeded at first
 # start; no provider email ever collides with it.
 SYSTEM_ACCOUNT_ID = "system"
 
 # A signed-in session in Redis: token -> account_id.
 SESSION_PREFIX = "druks:session:"
+
+# A personal access token serializes as druks_pat_<prefix>_<secret>. The prefix
+# is the row's lookup key and the only part that may appear in errors, logs, or
+# lists; the secret exists only inside the copy-once plaintext.
+PAT_TOKEN_TAG = "druks_pat"
+PAT_NAME_LENGTH = 80
+PAT_PREFIX_LENGTH = 12
+# No separator characters, so the serialized token splits unambiguously on "_".
+PAT_PREFIX_ALPHABET = string.ascii_letters + string.digits
+PAT_SECRET_BYTES = 32  # 43 base64url characters
+PAT_LIFETIME = timedelta(days=365)
+# last_used_at advances at most this often — a busy token must not write a row
+# per request.
+PAT_LAST_USED_RESOLUTION = timedelta(hours=1)

--- a/backend/druks/accounts/dependencies.py
+++ b/backend/druks/accounts/dependencies.py
@@ -1,7 +1,10 @@
 from fastapi import HTTPException, Request
 
 from druks.accounts import sessions
-from druks.accounts.models import Account
+from druks.accounts.exceptions import InvalidPatError
+from druks.accounts.models import Account, PersonalAccessToken
+
+_BEARER_CHALLENGE = 'Bearer realm="druks"'
 
 
 async def resolve_session_account(request: Request) -> Account | None:
@@ -20,10 +23,37 @@ async def resolve_session_account(request: Request) -> Account | None:
     return account
 
 
-async def current_account(request: Request) -> Account:
-    """The signed-in account, else 401."""
+async def current_session_account(request: Request) -> Account:
+    """The signed-in session's account, else 401 — the only door for PAT
+    management, so a token can never manage tokens."""
     account = await resolve_session_account(request)
     if account:
         sessions.current_account_id.set(account.id)
         return account
     raise HTTPException(status_code=401, detail="Sign in to use this API.")
+
+
+async def current_account(request: Request) -> Account:
+    """The calling account: the Bearer personal access token when an
+    Authorization header is present — never falling back to the cookie —
+    else the signed-in session."""
+    header = request.headers.get("Authorization")
+    if header:
+        scheme, _, credential = header.partition(" ")
+        if scheme == "Bearer" and credential and " " not in credential:
+            try:
+                pat = PersonalAccessToken.authenticate(credential)
+            except InvalidPatError as error:
+                raise HTTPException(
+                    status_code=401,
+                    detail=str(error),
+                    headers={"WWW-Authenticate": f'{_BEARER_CHALLENGE}, error="invalid_token"'},
+                ) from error
+            sessions.current_account_id.set(pat.account_id)
+            return pat.account
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization must be exactly: Bearer <token>.",
+            headers={"WWW-Authenticate": _BEARER_CHALLENGE},
+        )
+    return await current_session_account(request)

--- a/backend/druks/accounts/dependencies.py
+++ b/backend/druks/accounts/dependencies.py
@@ -38,7 +38,9 @@ async def current_account(request: Request) -> Account:
     Authorization header is present — never falling back to the cookie —
     else the signed-in session."""
     header = request.headers.get("Authorization")
-    if header:
+    # Present-but-empty is still present: it must be challenged, never slide
+    # to the cookie.
+    if header is not None:
         scheme, _, credential = header.partition(" ")
         if scheme == "Bearer" and credential and " " not in credential:
             try:

--- a/backend/druks/accounts/exceptions.py
+++ b/backend/druks/accounts/exceptions.py
@@ -1,0 +1,3 @@
+class InvalidPatError(Exception):
+    """A presented bearer credential that resolves to no live personal access
+    token — unknown, mismatched, revoked, or expired."""

--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -1,9 +1,23 @@
+import base64
+import hashlib
+import hmac
+import secrets
 from datetime import datetime
 
-from sqlalchemy import select
+from sqlalchemy import ForeignKey, Index, LargeBinary, String, select
 from sqlalchemy.dialects.postgresql import CITEXT
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from druks.accounts.constants import (
+    PAT_LAST_USED_RESOLUTION,
+    PAT_LIFETIME,
+    PAT_NAME_LENGTH,
+    PAT_PREFIX_ALPHABET,
+    PAT_PREFIX_LENGTH,
+    PAT_SECRET_BYTES,
+    PAT_TOKEN_TAG,
+)
+from druks.accounts.exceptions import InvalidPatError
 from druks.core.models import Uuid7Pk
 from druks.database import db_session
 from druks.models import Base
@@ -40,3 +54,101 @@ class Account(Base, Uuid7Pk):
         session.add(account)
         session.flush()
         return account
+
+
+def _hash_token(token: str) -> bytes:
+    return hashlib.sha256(token.encode()).digest()
+
+
+def _new_prefix() -> str:
+    return "".join(secrets.choice(PAT_PREFIX_ALPHABET) for _ in range(PAT_PREFIX_LENGTH))
+
+
+class PersonalAccessToken(Base, Uuid7Pk):
+    __tablename__ = "personal_access_tokens"
+    __table_args__ = (
+        Index("personal_access_tokens_account_idx", "account_id", "revoked_at", "created_at"),
+    )
+
+    account_id: Mapped[str] = mapped_column(ForeignKey("accounts.id", ondelete="RESTRICT"))
+    account: Mapped[Account] = relationship(lazy="joined", innerjoin=True)
+    name: Mapped[str] = mapped_column(String(PAT_NAME_LENGTH))
+    token_prefix: Mapped[str] = mapped_column(String(PAT_PREFIX_LENGTH), unique=True, index=True)
+    # SHA-256 of the full serialized token; the plaintext is never stored.
+    token_hash: Mapped[bytes] = mapped_column(LargeBinary, unique=True)
+    created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
+    expires_at: Mapped[datetime]
+    last_used_at: Mapped[datetime | None]
+    revoked_at: Mapped[datetime | None]
+
+    @property
+    def is_revoked(self) -> bool:
+        return bool(self.revoked_at)
+
+    @property
+    def is_expired(self) -> bool:
+        return Base.utc_now() >= self.expires_at
+
+    @property
+    def is_active(self) -> bool:
+        return not self.is_revoked and not self.is_expired
+
+    @classmethod
+    def get(cls, pat_id: str) -> "PersonalAccessToken | None":
+        return db_session().get(cls, pat_id)
+
+    @classmethod
+    def get_for_prefix(cls, prefix: str) -> "PersonalAccessToken | None":
+        return db_session().scalar(select(cls).where(cls.token_prefix == prefix))
+
+    @classmethod
+    def list_for_account(cls, account_id: str) -> list["PersonalAccessToken"]:
+        stmt = select(cls).where(cls.account_id == account_id).order_by(cls.created_at.desc())
+        return list(db_session().scalars(stmt))
+
+    @classmethod
+    def create(cls, *, account_id: str, name: str) -> "tuple[PersonalAccessToken, str]":
+        """Mint ``account_id`` a token; returns (row, plaintext). The plaintext
+        is shown exactly once — only its hash lands in the row."""
+        prefix = _new_prefix()
+        while cls.get_for_prefix(prefix):
+            prefix = _new_prefix()
+        secret = base64.urlsafe_b64encode(secrets.token_bytes(PAT_SECRET_BYTES))
+        token = f"{PAT_TOKEN_TAG}_{prefix}_{secret.rstrip(b'=').decode()}"
+        row = cls(
+            account_id=account_id,
+            name=name,
+            token_prefix=prefix,
+            token_hash=_hash_token(token),
+            expires_at=Base.utc_now() + PAT_LIFETIME,
+        )
+        session = db_session()
+        session.add(row)
+        session.flush()
+        return row, token
+
+    @classmethod
+    def authenticate(cls, credential: str) -> "PersonalAccessToken":
+        """Resolve a presented bearer credential to its live row — the one
+        authentication door for both HTTP and MCP — or raise InvalidPatError.
+        Stamps last_used_at, at most hourly."""
+        prefix, _, _ = credential.removeprefix(f"{PAT_TOKEN_TAG}_").partition("_")
+        row = cls.get_for_prefix(prefix)
+        if not row:
+            raise InvalidPatError("Not a recognized personal access token.")
+        if not hmac.compare_digest(_hash_token(credential), row.token_hash):
+            raise InvalidPatError("Not a recognized personal access token.")
+        if row.revoked_at:
+            raise InvalidPatError(f"Token {row.token_prefix} was revoked.")
+        if row.is_expired:
+            raise InvalidPatError(f"Token {row.token_prefix} has expired.")
+        now = Base.utc_now()
+        if not row.last_used_at or now - row.last_used_at >= PAT_LAST_USED_RESOLUTION:
+            row.last_used_at = now
+            db_session().flush()
+        return row
+
+    def revoke(self) -> None:
+        # Keep the first revocation instant — a repeat revoke changes nothing.
+        self.revoked_at = self.revoked_at or Base.utc_now()
+        db_session().flush()

--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -115,12 +115,15 @@ class PersonalAccessToken(Base, Uuid7Pk):
             prefix = _new_prefix()
         secret = base64.urlsafe_b64encode(secrets.token_bytes(PAT_SECRET_BYTES))
         token = f"{PAT_TOKEN_TAG}_{prefix}_{secret.rstrip(b'=').decode()}"
+        # One clock read: expires_at is exactly created_at + the lifetime.
+        now = Base.utc_now()
         row = cls(
             account_id=account_id,
             name=name,
             token_prefix=prefix,
             token_hash=_hash_token(token),
-            expires_at=Base.utc_now() + PAT_LIFETIME,
+            created_at=now,
+            expires_at=now + PAT_LIFETIME,
         )
         session = db_session()
         session.add(row)

--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -82,16 +82,17 @@ class PersonalAccessToken(Base, Uuid7Pk):
     revoked_at: Mapped[datetime | None]
 
     @property
-    def is_revoked(self) -> bool:
-        return bool(self.revoked_at)
-
-    @property
     def is_expired(self) -> bool:
         return Base.utc_now() >= self.expires_at
 
     @property
-    def is_active(self) -> bool:
-        return not self.is_revoked and not self.is_expired
+    def status(self) -> str:
+        # One tri-state on the wire; revoked outranks expired outranks active.
+        if self.revoked_at:
+            return "revoked"
+        if self.is_expired:
+            return "expired"
+        return "active"
 
     @classmethod
     def get(cls, pat_id: str) -> "PersonalAccessToken | None":

--- a/backend/druks/accounts/routes.py
+++ b/backend/druks/accounts/routes.py
@@ -8,7 +8,7 @@ from druks.accounts.dependencies import (
     resolve_session_account,
 )
 from druks.accounts.models import Account, PersonalAccessToken
-from druks.accounts.schemas import AccountResponse, CreatedPatResponse, PatResponse
+from druks.accounts.schemas import AccountResponse, PatResponse
 from druks.harnesses.base import Harness
 from druks.harnesses.exceptions import LoginError
 from druks.harnesses.models import HarnessConnection
@@ -111,34 +111,33 @@ async def logout(request: Request, response: Response) -> None:
     _set_session_cookie(request, response, "")
 
 
-# PAT management rides the session gate only (current_session_account, per
-# route — this router is ungated at include time), so a token can never mint
-# or revoke tokens.
-
-
-@router.get("/pats", response_model=list[PatResponse], response_model_by_alias=True)
+@router.get("/personal-tokens", response_model=list[PatResponse], response_model_by_alias=True)
 async def list_pats(
     account: Account = Depends(current_session_account),
 ) -> list[PersonalAccessToken]:
     return PersonalAccessToken.list_for_account(account.id)
 
 
-@router.post("/pats", response_model=CreatedPatResponse, response_model_by_alias=True)
+@router.post("/personal-tokens")
 async def create_pat(
     account: Account = Depends(current_session_account),
     name: str = Body(..., embed=True),
-) -> CreatedPatResponse:
+) -> dict[str, str]:
     name = name.strip()
     if name and len(name) <= PAT_NAME_LENGTH:
-        pat, token = PersonalAccessToken.create(account_id=account.id, name=name)
-        return CreatedPatResponse(**PatResponse.model_validate(pat).model_dump(), token=token)
+        # The plaintext, handed back exactly once — only its hash is stored,
+        # and the new row surfaces through the list.
+        _, token = PersonalAccessToken.create(account_id=account.id, name=name)
+        return {"token": token}
     raise HTTPException(
         status_code=422,
         detail=f"A token needs a name of at most {PAT_NAME_LENGTH} characters.",
     )
 
 
-@router.delete("/pats/{pat_id}", response_model=PatResponse, response_model_by_alias=True)
+@router.delete(
+    "/personal-tokens/{pat_id}", response_model=PatResponse, response_model_by_alias=True
+)
 async def revoke_pat(
     pat_id: str, account: Account = Depends(current_session_account)
 ) -> PersonalAccessToken:

--- a/backend/druks/accounts/routes.py
+++ b/backend/druks/accounts/routes.py
@@ -1,9 +1,14 @@
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, Response
 
 from druks.accounts import sessions
-from druks.accounts.dependencies import current_account, resolve_session_account
-from druks.accounts.models import Account
-from druks.accounts.schemas import AccountResponse
+from druks.accounts.constants import PAT_NAME_LENGTH
+from druks.accounts.dependencies import (
+    current_account,
+    current_session_account,
+    resolve_session_account,
+)
+from druks.accounts.models import Account, PersonalAccessToken
+from druks.accounts.schemas import AccountResponse, CreatedPatResponse, PatResponse
 from druks.harnesses.base import Harness
 from druks.harnesses.exceptions import LoginError
 from druks.harnesses.models import HarnessConnection
@@ -37,8 +42,10 @@ def _set_session_cookie(request: Request, response: Response, token: str) -> Non
 async def get_session(
     request: Request, response: Response, account: Account = Depends(current_account)
 ) -> Account:
-    # Slide the cookie with the Redis TTL.
-    _set_session_cookie(request, response, request.cookies[sessions.SESSION_COOKIE])
+    # Slide the cookie with the Redis TTL; a Bearer request carries none.
+    token = request.cookies.get(sessions.SESSION_COOKIE)
+    if token:
+        _set_session_cookie(request, response, token)
     return account
 
 
@@ -102,3 +109,42 @@ async def logout(request: Request, response: Response) -> None:
     if token:
         await sessions.drop_session(token)
     _set_session_cookie(request, response, "")
+
+
+# PAT management rides the session gate only (current_session_account, per
+# route — this router is ungated at include time), so a token can never mint
+# or revoke tokens.
+
+
+@router.get("/pats", response_model=list[PatResponse], response_model_by_alias=True)
+async def list_pats(
+    account: Account = Depends(current_session_account),
+) -> list[PersonalAccessToken]:
+    return PersonalAccessToken.list_for_account(account.id)
+
+
+@router.post("/pats", response_model=CreatedPatResponse, response_model_by_alias=True)
+async def create_pat(
+    account: Account = Depends(current_session_account),
+    name: str = Body(..., embed=True),
+) -> CreatedPatResponse:
+    name = name.strip()
+    if name and len(name) <= PAT_NAME_LENGTH:
+        pat, token = PersonalAccessToken.create(account_id=account.id, name=name)
+        return CreatedPatResponse(**PatResponse.model_validate(pat).model_dump(), token=token)
+    raise HTTPException(
+        status_code=422,
+        detail=f"A token needs a name of at most {PAT_NAME_LENGTH} characters.",
+    )
+
+
+@router.delete("/pats/{pat_id}", response_model=PatResponse, response_model_by_alias=True)
+async def revoke_pat(
+    pat_id: str, account: Account = Depends(current_session_account)
+) -> PersonalAccessToken:
+    pat = PersonalAccessToken.get(pat_id)
+    if pat and pat.account_id == account.id:
+        pat.revoke()
+        return pat
+    # One shape for missing and foreign — existence stays account-scoped.
+    raise HTTPException(status_code=404, detail="No such token.")

--- a/backend/druks/accounts/schemas.py
+++ b/backend/druks/accounts/schemas.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 
 from druks.schemas import BaseResponse
 
@@ -17,7 +17,8 @@ class PatResponse(BaseResponse):
 
     id: str
     name: str
-    token_prefix: str
+    # Wire name is the spec's `prefix`; the column keeps its qualified name.
+    prefix: str = Field(validation_alias="token_prefix")
     created_at: datetime
     expires_at: datetime
     last_used_at: datetime | None

--- a/backend/druks/accounts/schemas.py
+++ b/backend/druks/accounts/schemas.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import ConfigDict
 
 from druks.schemas import BaseResponse
@@ -8,3 +10,23 @@ class AccountResponse(BaseResponse):
 
     id: str
     username: str
+
+
+class PatResponse(BaseResponse):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    name: str
+    token_prefix: str
+    created_at: datetime
+    expires_at: datetime
+    last_used_at: datetime | None
+    revoked_at: datetime | None
+    is_active: bool
+    is_expired: bool
+    is_revoked: bool
+
+
+class CreatedPatResponse(PatResponse):
+    # The plaintext, returned exactly once at create — never stored or listed.
+    token: str

--- a/backend/druks/accounts/schemas.py
+++ b/backend/druks/accounts/schemas.py
@@ -17,7 +17,9 @@ class PatResponse(BaseResponse):
 
     id: str
     name: str
-    # Wire name is the spec's `prefix`; the column keeps its qualified name.
+    # The token's visible handle — the secret is unrecoverable, so the prefix
+    # is how a row is identified in the list and how a token string found in
+    # the wild maps back to what to revoke.
     prefix: str = Field(validation_alias="token_prefix")
     created_at: datetime
     expires_at: datetime
@@ -26,8 +28,3 @@ class PatResponse(BaseResponse):
     is_active: bool
     is_expired: bool
     is_revoked: bool
-
-
-class CreatedPatResponse(PatResponse):
-    # The plaintext, returned exactly once at create — never stored or listed.
-    token: str

--- a/backend/druks/accounts/schemas.py
+++ b/backend/druks/accounts/schemas.py
@@ -25,6 +25,4 @@ class PatResponse(BaseResponse):
     expires_at: datetime
     last_used_at: datetime | None
     revoked_at: datetime | None
-    is_active: bool
-    is_expired: bool
-    is_revoked: bool
+    status: str

--- a/backend/migrations/versions/0ec9db44973e_personal_access_tokens.py
+++ b/backend/migrations/versions/0ec9db44973e_personal_access_tokens.py
@@ -1,0 +1,56 @@
+"""personal access tokens
+
+Revision ID: 0ec9db44973e
+Revises: 40cfd4c2aeee
+Create Date: 2026-07-19 10:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0ec9db44973e"
+down_revision: str | Sequence[str] | None = "40cfd4c2aeee"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "personal_access_tokens",
+        sa.Column("account_id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(length=80), nullable=False),
+        sa.Column("token_prefix", sa.String(length=12), nullable=False),
+        sa.Column("token_hash", sa.LargeBinary(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(["account_id"], ["accounts.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("token_hash"),
+    )
+    op.create_index(
+        "personal_access_tokens_account_idx",
+        "personal_access_tokens",
+        ["account_id", "revoked_at", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_personal_access_tokens_token_prefix"),
+        "personal_access_tokens",
+        ["token_prefix"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_personal_access_tokens_token_prefix"), table_name="personal_access_tokens"
+    )
+    op.drop_index("personal_access_tokens_account_idx", table_name="personal_access_tokens")
+    op.drop_table("personal_access_tokens")

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -1,5 +1,5 @@
 import pytest
-from druks.accounts.dependencies import current_account
+from druks.accounts.dependencies import current_account, current_session_account
 from druks.api.app import app
 from fastapi.routing import APIRoute, _IncludedRouter
 
@@ -10,6 +10,13 @@ EXEMPT_API_PATHS = {
     "/api/auth/harnesses/{name}/login/complete",
     "/api/auth/logout",
     "/api/{path:path}",  # the JSON-404 catch-all
+}
+
+# PAT management admits the session cookie only — never a PAT, so a token
+# cannot mint or revoke tokens.
+SESSION_ONLY_API_PATHS = {
+    "/api/auth/pats",
+    "/api/auth/pats/{pat_id}",
 }
 
 
@@ -32,8 +39,8 @@ def api_routes():
     return list(_walk(app.router.routes))
 
 
-def _session_gated(route) -> bool:
-    return any(dependency.call is current_account for dependency in route.dependant.dependencies)
+def _gated_by(route, gate) -> bool:
+    return any(dependency.call is gate for dependency in route.dependant.dependencies)
 
 
 def test_every_internal_api_route_sits_behind_the_session_gate(api_routes):
@@ -42,7 +49,8 @@ def test_every_internal_api_route_sits_behind_the_session_gate(api_routes):
         for route in api_routes
         if route.path.startswith("/api/")
         and route.path not in EXEMPT_API_PATHS
-        and not _session_gated(route)
+        and route.path not in SESSION_ONLY_API_PATHS
+        and not _gated_by(route, current_account)
     ]
     assert unguarded == []
     # The sweep only covers the stream families if they exist; pin that.
@@ -55,5 +63,17 @@ def test_the_exemptions_are_exactly_the_enumerated_ones(api_routes):
     # The other direction: nothing exempt or outside /api carries the gate.
     for route in api_routes:
         if route.path in EXEMPT_API_PATHS or not route.path.startswith("/api/"):
-            assert not _session_gated(route), route.path
+            assert not _gated_by(route, current_account), route.path
     assert any(route.path.startswith("/_external/") for route in api_routes)
+
+
+def test_pat_management_is_session_only(api_routes):
+    listed = [route for route in api_routes if route.path in SESSION_ONLY_API_PATHS]
+    assert {route.path for route in listed} == SESSION_ONLY_API_PATHS
+    for route in listed:
+        assert _gated_by(route, current_session_account), route.path
+        assert not _gated_by(route, current_account), route.path
+    # And nothing else carries the session-only gate.
+    for route in api_routes:
+        if route.path not in SESSION_ONLY_API_PATHS:
+            assert not _gated_by(route, current_session_account), route.path

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -15,8 +15,8 @@ EXEMPT_API_PATHS = {
 # PAT management admits the session cookie only — never a PAT, so a token
 # cannot mint or revoke tokens.
 SESSION_ONLY_API_PATHS = {
-    "/api/auth/pats",
-    "/api/auth/pats/{pat_id}",
+    "/api/auth/personal-tokens",
+    "/api/auth/personal-tokens/{pat_id}",
 }
 
 

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -159,35 +159,37 @@ def test_a_dead_token_401s_with_its_prefix_only(tmp_path, db_session):
 def test_a_pat_cannot_manage_pats(tmp_path, db_session):
     with _client(tmp_path) as client:
         pat, token = _mint()
-        assert client.get("/api/auth/pats", headers=_bearer(token)).status_code == 401
-        create = client.post("/api/auth/pats", json={"name": "x"}, headers=_bearer(token))
+        assert client.get("/api/auth/personal-tokens", headers=_bearer(token)).status_code == 401
+        create = client.post(
+            "/api/auth/personal-tokens", json={"name": "x"}, headers=_bearer(token)
+        )
         assert create.status_code == 401
-        revoke = client.delete(f"/api/auth/pats/{pat.id}", headers=_bearer(token))
+        revoke = client.delete(f"/api/auth/personal-tokens/{pat.id}", headers=_bearer(token))
         assert revoke.status_code == 401
 
 
 def test_the_session_manages_the_token_lifecycle(tmp_path, db_session):
     with _client(tmp_path) as client:
         _sign_in(client)
-        created = client.post("/api/auth/pats", json={"name": "ci bot"})
+        created = client.post("/api/auth/personal-tokens", json={"name": "ci bot"})
         assert created.status_code == 200
-        body = created.json()
-        assert body["token"].startswith(f"{PAT_TOKEN_TAG}_")
-        assert body["name"] == "ci bot"
-        assert body["isActive"] is True
+        # Create answers only the plaintext, exactly once; the row surfaces
+        # through the list.
+        assert list(created.json()) == ["token"]
+        token = created.json()["token"]
+        assert token.startswith(f"{PAT_TOKEN_TAG}_")
 
-        listed = client.get("/api/auth/pats").json()
+        listed = client.get("/api/auth/personal-tokens").json()
         assert [item["name"] for item in listed] == ["ci bot"]
-        assert listed[0]["prefix"] == body["prefix"]
-        assert body["token"].split("_")[2] == body["prefix"]
-        # The plaintext appears exactly once, at create.
+        assert token.split("_")[2] == listed[0]["prefix"]
         assert "token" not in listed[0]
 
-        revoked = client.delete(f"/api/auth/pats/{body['id']}").json()
+        row_id = listed[0]["id"]
+        revoked = client.delete(f"/api/auth/personal-tokens/{row_id}").json()
         assert revoked["isRevoked"] is True
         assert revoked["isActive"] is False
         # A repeat revoke answers the same state, same instant.
-        again = client.delete(f"/api/auth/pats/{body['id']}").json()
+        again = client.delete(f"/api/auth/personal-tokens/{row_id}").json()
         assert again["revokedAt"] == revoked["revokedAt"]
 
 
@@ -195,14 +197,14 @@ def test_the_list_is_scoped_to_the_signed_in_account(tmp_path, db_session):
     with _client(tmp_path) as client:
         _mint("other@example.com")
         _sign_in(client)
-        assert client.get("/api/auth/pats").json() == []
+        assert client.get("/api/auth/personal-tokens").json() == []
 
 
 def test_revoking_anothers_token_is_a_404(tmp_path, db_session):
     with _client(tmp_path) as client:
         pat, _ = _mint("other@example.com")
         _sign_in(client)
-        assert client.delete(f"/api/auth/pats/{pat.id}").status_code == 404
+        assert client.delete(f"/api/auth/personal-tokens/{pat.id}").status_code == 404
         session_registry().expire_all()
         assert not pat.revoked_at
 
@@ -210,5 +212,5 @@ def test_revoking_anothers_token_is_a_404(tmp_path, db_session):
 def test_a_token_needs_a_name_that_fits(tmp_path, db_session):
     with _client(tmp_path) as client:
         _sign_in(client)
-        assert client.post("/api/auth/pats", json={"name": "   "}).status_code == 422
-        assert client.post("/api/auth/pats", json={"name": "x" * 81}).status_code == 422
+        assert client.post("/api/auth/personal-tokens", json={"name": "   "}).status_code == 422
+        assert client.post("/api/auth/personal-tokens", json={"name": "x" * 81}).status_code == 422

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -1,0 +1,206 @@
+import hashlib
+import secrets
+from datetime import timedelta
+from pathlib import Path
+
+import druks.redis
+import pytest
+from conftest import configure_app_for_test, make_settings
+from druks.accounts.constants import PAT_TOKEN_TAG, SESSION_PREFIX
+from druks.accounts.exceptions import InvalidPatError
+from druks.accounts.models import Account, PersonalAccessToken
+from druks.accounts.sessions import SESSION_COOKIE
+from druks.database import db_session as session_registry
+from druks.models import Base
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _clear_redis():
+    druks.redis.get_client()._data.clear()
+    yield
+
+
+def _client(tmp_path: Path) -> TestClient:
+    app = configure_app_for_test(settings=make_settings(tmp_path), authenticated=False)
+    return TestClient(app)
+
+
+def _sign_in(client: TestClient, username: str = "op@example.com") -> Account:
+    account = Account.get_or_create(username)
+    token = f"session-{username}"
+    druks.redis.get_client()._data[f"{SESSION_PREFIX}{token}"] = account.id.encode()
+    client.cookies.set(SESSION_COOKIE, token)
+    return account
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _mint(username: str = "agent@example.com") -> tuple[PersonalAccessToken, str]:
+    account = Account.get_or_create(username)
+    return PersonalAccessToken.create(account_id=account.id, name="agent")
+
+
+def test_the_minted_token_shape_and_hash_are_pinned(db_session):
+    pat, token = _mint()
+    prefix, _, secret = token.removeprefix(f"{PAT_TOKEN_TAG}_").partition("_")
+    assert token.startswith(f"{PAT_TOKEN_TAG}_")
+    assert len(prefix) == 12
+    assert len(secret) == 43
+    assert pat.token_prefix == prefix
+    # The stored hash is SHA-256 of the full serialized token: exactly 32 bytes.
+    assert len(pat.token_hash) == 32
+    assert pat.token_hash == hashlib.sha256(token.encode()).digest()
+    assert pat.expires_at == pat.created_at + timedelta(days=365)
+    assert not pat.last_used_at
+    assert pat.is_active
+
+
+def test_a_prefix_collision_regenerates(db_session, monkeypatch):
+    first, _ = _mint()
+    replay = iter(first.token_prefix)
+    random_choice = secrets.choice
+
+    def collide_once(alphabet):
+        # Feed the taken prefix back once, then return to real randomness.
+        try:
+            return next(replay)
+        except StopIteration:
+            return random_choice(alphabet)
+
+    monkeypatch.setattr(secrets, "choice", collide_once)
+    second, _ = PersonalAccessToken.create(account_id=first.account_id, name="two")
+    assert second.token_prefix != first.token_prefix
+
+
+def test_authenticate_rejects_everything_but_the_live_token(db_session):
+    pat, token = _mint()
+    assert PersonalAccessToken.authenticate(token).id == pat.id
+    with pytest.raises(InvalidPatError):
+        PersonalAccessToken.authenticate("not-even-shaped-right")
+    with pytest.raises(InvalidPatError):
+        PersonalAccessToken.authenticate(f"{PAT_TOKEN_TAG}_{pat.token_prefix}_wrongsecret")
+
+    pat.expires_at = Base.utc_now() - timedelta(days=1)
+    with pytest.raises(InvalidPatError, match=f"{pat.token_prefix} has expired"):
+        PersonalAccessToken.authenticate(token)
+
+    pat.expires_at = Base.utc_now() + timedelta(days=1)
+    pat.revoke()
+    with pytest.raises(InvalidPatError, match=f"{pat.token_prefix} was revoked"):
+        PersonalAccessToken.authenticate(token)
+
+
+def test_last_used_advances_at_most_hourly(db_session):
+    pat, token = _mint()
+    PersonalAccessToken.authenticate(token)
+    first_use = pat.last_used_at
+    assert first_use
+    PersonalAccessToken.authenticate(token)
+    assert pat.last_used_at == first_use
+    pat.last_used_at = first_use - timedelta(hours=2)
+    PersonalAccessToken.authenticate(token)
+    assert pat.last_used_at > first_use - timedelta(hours=2)
+
+
+def test_a_bearer_pat_authenticates_gated_routes(tmp_path, db_session):
+    with _client(tmp_path) as client:
+        _, token = _mint()
+        response = client.get("/api/auth/session", headers=_bearer(token))
+        assert response.status_code == 200
+        assert response.json()["username"] == "agent@example.com"
+        # No cookie to slide on a Bearer request.
+        assert "set-cookie" not in response.headers
+        assert client.get("/api/settings", headers=_bearer(token)).status_code == 200
+
+
+def test_an_authorization_header_never_falls_back_to_the_cookie(tmp_path, db_session):
+    with _client(tmp_path) as client:
+        _sign_in(client)
+        assert client.get("/api/auth/session").status_code == 200
+        response = client.get(
+            "/api/auth/session", headers=_bearer(f"{PAT_TOKEN_TAG}_unknownpref1_nosecret")
+        )
+        assert response.status_code == 401
+        assert response.headers["WWW-Authenticate"] == 'Bearer realm="druks", error="invalid_token"'
+
+
+@pytest.mark.parametrize(
+    "header", ["Token abc", "Bearer", "Bearer ", "Bearer a b", "bearer lowercased"]
+)
+def test_a_malformed_authorization_header_is_challenged(tmp_path, db_session, header):
+    with _client(tmp_path) as client:
+        response = client.get("/api/auth/session", headers={"Authorization": header})
+        assert response.status_code == 401
+        assert response.headers["WWW-Authenticate"] == 'Bearer realm="druks"'
+
+
+def test_a_dead_token_401s_with_its_prefix_only(tmp_path, db_session):
+    with _client(tmp_path) as client:
+        pat, token = _mint()
+        pat.revoke()
+        response = client.get("/api/auth/session", headers=_bearer(token))
+        assert response.status_code == 401
+        assert response.headers["WWW-Authenticate"] == 'Bearer realm="druks", error="invalid_token"'
+        assert pat.token_prefix in response.json()["detail"]
+        _, _, secret = token.removeprefix(f"{PAT_TOKEN_TAG}_").partition("_")
+        assert secret not in response.text
+
+
+def test_a_pat_cannot_manage_pats(tmp_path, db_session):
+    with _client(tmp_path) as client:
+        pat, token = _mint()
+        assert client.get("/api/auth/pats", headers=_bearer(token)).status_code == 401
+        create = client.post("/api/auth/pats", json={"name": "x"}, headers=_bearer(token))
+        assert create.status_code == 401
+        revoke = client.delete(f"/api/auth/pats/{pat.id}", headers=_bearer(token))
+        assert revoke.status_code == 401
+
+
+def test_the_session_manages_the_token_lifecycle(tmp_path, db_session):
+    with _client(tmp_path) as client:
+        _sign_in(client)
+        created = client.post("/api/auth/pats", json={"name": "ci bot"})
+        assert created.status_code == 200
+        body = created.json()
+        assert body["token"].startswith(f"{PAT_TOKEN_TAG}_")
+        assert body["name"] == "ci bot"
+        assert body["isActive"] is True
+
+        listed = client.get("/api/auth/pats").json()
+        assert [item["name"] for item in listed] == ["ci bot"]
+        assert listed[0]["tokenPrefix"] == body["tokenPrefix"]
+        # The plaintext appears exactly once, at create.
+        assert "token" not in listed[0]
+
+        revoked = client.delete(f"/api/auth/pats/{body['id']}").json()
+        assert revoked["isRevoked"] is True
+        assert revoked["isActive"] is False
+        # A repeat revoke answers the same state, same instant.
+        again = client.delete(f"/api/auth/pats/{body['id']}").json()
+        assert again["revokedAt"] == revoked["revokedAt"]
+
+
+def test_the_list_is_scoped_to_the_signed_in_account(tmp_path, db_session):
+    with _client(tmp_path) as client:
+        _mint("other@example.com")
+        _sign_in(client)
+        assert client.get("/api/auth/pats").json() == []
+
+
+def test_revoking_anothers_token_is_a_404(tmp_path, db_session):
+    with _client(tmp_path) as client:
+        pat, _ = _mint("other@example.com")
+        _sign_in(client)
+        assert client.delete(f"/api/auth/pats/{pat.id}").status_code == 404
+        session_registry().expire_all()
+        assert not pat.revoked_at
+
+
+def test_a_token_needs_a_name_that_fits(tmp_path, db_session):
+    with _client(tmp_path) as client:
+        _sign_in(client)
+        assert client.post("/api/auth/pats", json={"name": "   "}).status_code == 422
+        assert client.post("/api/auth/pats", json={"name": "x" * 81}).status_code == 422

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -128,13 +128,20 @@ def test_an_authorization_header_never_falls_back_to_the_cookie(tmp_path, db_ses
 
 
 @pytest.mark.parametrize(
-    "header", ["Token abc", "Bearer", "Bearer ", "Bearer a b", "bearer lowercased"]
+    "header", ["", "Token abc", "Bearer", "Bearer ", "Bearer a b", "bearer lowercased"]
 )
 def test_a_malformed_authorization_header_is_challenged(tmp_path, db_session, header):
     with _client(tmp_path) as client:
         response = client.get("/api/auth/session", headers={"Authorization": header})
         assert response.status_code == 401
         assert response.headers["WWW-Authenticate"] == 'Bearer realm="druks"'
+
+
+def test_an_empty_authorization_header_never_slides_to_the_cookie(tmp_path, db_session):
+    with _client(tmp_path) as client:
+        _sign_in(client)
+        response = client.get("/api/auth/session", headers={"Authorization": ""})
+        assert response.status_code == 401
 
 
 def test_a_dead_token_401s_with_its_prefix_only(tmp_path, db_session):
@@ -171,7 +178,8 @@ def test_the_session_manages_the_token_lifecycle(tmp_path, db_session):
 
         listed = client.get("/api/auth/pats").json()
         assert [item["name"] for item in listed] == ["ci bot"]
-        assert listed[0]["tokenPrefix"] == body["tokenPrefix"]
+        assert listed[0]["prefix"] == body["prefix"]
+        assert body["token"].split("_")[2] == body["prefix"]
         # The plaintext appears exactly once, at create.
         assert "token" not in listed[0]
 

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -55,7 +55,7 @@ def test_the_minted_token_shape_and_hash_are_pinned(db_session):
     assert pat.token_hash == hashlib.sha256(token.encode()).digest()
     assert pat.expires_at == pat.created_at + timedelta(days=365)
     assert not pat.last_used_at
-    assert pat.is_active
+    assert pat.status == "active"
 
 
 def test_a_prefix_collision_regenerates(db_session, monkeypatch):
@@ -186,8 +186,7 @@ def test_the_session_manages_the_token_lifecycle(tmp_path, db_session):
 
         row_id = listed[0]["id"]
         revoked = client.delete(f"/api/auth/personal-tokens/{row_id}").json()
-        assert revoked["isRevoked"] is True
-        assert revoked["isActive"] is False
+        assert revoked["status"] == "revoked"
         # A repeat revoke answers the same state, same instant.
         again = client.delete(f"/api/auth/personal-tokens/{row_id}").json()
         assert again["revokedAt"] == revoked["revokedAt"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,21 @@ the identity proxy to strip every client-supplied copy of
 TLS and set HSTS at that public proxy; the shipped Caddy listener is loopback
 HTTP behind the TLS edge.
 
+## Personal access tokens
+
+Agents and other non-browser clients authenticate the same internal API with
+personal access tokens minted in Settings → Agent access, sent as
+`Authorization: Bearer <token>`. A token serializes as
+`druks_pat_<prefix>_<secret>`; Druks stores only the SHA-256 of the full
+token, shows the plaintext exactly once at mint, and expires it 365 days
+after creation. When the header is present it must authenticate — a bad
+token is a 401, never a fall back to the session cookie — and token
+management itself accepts the dashboard session only, so a leaked token
+cannot mint or revoke tokens. On compromise, revoke the token in Settings →
+Agent access (immediate; the list shows each token's prefix and last use,
+tracked hourly, to identify it) and mint a replacement — rotation is mint
+first, revoke second.
+
 ## GitHub Apps
 
 The bundled `build` extension requires two GitHub Apps. These are application

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -32,14 +32,14 @@ describe('personal access tokens', () => {
 
     await api.createPat('ci bot')
     const createCall = fetchMock.mock.calls[0]
-    expect(createCall?.[0]).toBe('/api/auth/pats')
+    expect(createCall?.[0]).toBe('/api/auth/personal-tokens')
     expect(createCall?.[1]?.method).toBe('POST')
     expect(JSON.parse(String(createCall?.[1]?.body))).toEqual({ name: 'ci bot' })
 
     // Revoke answers the updated row, so the client parses the DELETE body.
     const revoked = await api.revokePat('p1')
     const revokeCall = fetchMock.mock.calls[1]
-    expect(revokeCall?.[0]).toBe('/api/auth/pats/p1')
+    expect(revokeCall?.[0]).toBe('/api/auth/personal-tokens/p1')
     expect(revokeCall?.[1]?.method).toBe('DELETE')
     expect(revoked.isRevoked).toBe(true)
   })

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -26,7 +26,7 @@ describe('API error messages', () => {
 describe('personal access tokens', () => {
   it('mints with the embedded name and parses the revoke response', async () => {
     const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
-      async () => new Response(JSON.stringify({ id: 'p1', isRevoked: true }), { status: 200 }),
+      async () => new Response(JSON.stringify({ id: 'p1', status: 'revoked' }), { status: 200 }),
     )
     vi.stubGlobal('fetch', fetchMock)
 
@@ -41,7 +41,7 @@ describe('personal access tokens', () => {
     const revokeCall = fetchMock.mock.calls[1]
     expect(revokeCall?.[0]).toBe('/api/auth/personal-tokens/p1')
     expect(revokeCall?.[1]?.method).toBe('DELETE')
-    expect(revoked.isRevoked).toBe(true)
+    expect(revoked.status).toBe('revoked')
   })
 })
 

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { AUTH_EXPIRED_EVENT, UnauthorizedError, authApi, getJSON, postJSON } from './client'
+import { AUTH_EXPIRED_EVENT, UnauthorizedError, api, authApi, getJSON, postJSON } from './client'
 
 function failWith(status: number, statusText: string, body: string) {
   vi.stubGlobal(
@@ -20,6 +20,28 @@ describe('API error messages', () => {
   it('falls back to the status line when the body is not JSON detail', async () => {
     failWith(502, 'Bad Gateway', '<html>proxy error</html>')
     await expect(postJSON('/api/x', {})).rejects.toThrow('502 Bad Gateway: <html>proxy error</html>')
+  })
+})
+
+describe('personal access tokens', () => {
+  it('mints with the embedded name and parses the revoke response', async () => {
+    const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async () => new Response(JSON.stringify({ id: 'p1', isRevoked: true }), { status: 200 }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await api.createPat('ci bot')
+    const createCall = fetchMock.mock.calls[0]
+    expect(createCall?.[0]).toBe('/api/auth/pats')
+    expect(createCall?.[1]?.method).toBe('POST')
+    expect(JSON.parse(String(createCall?.[1]?.body))).toEqual({ name: 'ci bot' })
+
+    // Revoke answers the updated row, so the client parses the DELETE body.
+    const revoked = await api.revokePat('p1')
+    const revokeCall = fetchMock.mock.calls[1]
+    expect(revokeCall?.[0]).toBe('/api/auth/pats/p1')
+    expect(revokeCall?.[1]?.method).toBe('DELETE')
+    expect(revoked.isRevoked).toBe(true)
   })
 })
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,7 +2,6 @@ import type {
   Account,
   AgentCallFiles,
   ArtifactContent,
-  CreatedPat,
   DashboardHealth,
   FeedResponse,
   ExtensionsSettingsResponse,
@@ -204,12 +203,13 @@ export const api = {
       { enabled },
     ),
 
-  // Personal access tokens — the agent door to this same API. The secret comes
-  // back once, on mint; list rows carry the prefix only. Management is
+  // Personal access tokens — the agent door to this same API. The plaintext
+  // comes back once, on mint; list rows carry the prefix only. Management is
   // session-only, so these calls always ride the cookie.
-  pats: () => getJSON<Pat[]>('/api/auth/pats'),
-  createPat: (name: string) => postJSON<CreatedPat>('/api/auth/pats', { name }),
-  revokePat: (id: string) => deleteJSON<Pat>(`/api/auth/pats/${encodeURIComponent(id)}`),
+  pats: () => getJSON<Pat[]>('/api/auth/personal-tokens'),
+  createPat: (name: string) => postJSON<{ token: string }>('/api/auth/personal-tokens', { name }),
+  revokePat: (id: string) =>
+    deleteJSON<Pat>(`/api/auth/personal-tokens/${encodeURIComponent(id)}`),
 
   // MCP servers — a backend-owned registry, delivered into every agent VM. The
   // token is write-only: sent on create, redacted in every response. Keyed by

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,11 +2,13 @@ import type {
   Account,
   AgentCallFiles,
   ArtifactContent,
+  CreatedPat,
   DashboardHealth,
   FeedResponse,
   ExtensionsSettingsResponse,
   Harness,
   LoginChallenge,
+  Pat,
   SubjectResponse,
   SubjectSummary,
   UpdateHarnessRequest,
@@ -201,6 +203,13 @@ export const api = {
       `/api/skills/${encodeURIComponent(collectionId)}/skills/${encodeURIComponent(name)}`,
       { enabled },
     ),
+
+  // Personal access tokens — the agent door to this same API. The secret comes
+  // back once, on mint; list rows carry the prefix only. Management is
+  // session-only, so these calls always ride the cookie.
+  pats: () => getJSON<Pat[]>('/api/auth/pats'),
+  createPat: (name: string) => postJSON<CreatedPat>('/api/auth/pats', { name }),
+  revokePat: (id: string) => deleteJSON<Pat>(`/api/auth/pats/${encodeURIComponent(id)}`),
 
   // MCP servers — a backend-owned registry, delivered into every agent VM. The
   // token is write-only: sent on create, redacted in every response. Keyed by

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -433,6 +433,27 @@ export interface McpRegistryCandidate {
   headers: RegistryHeader[]
 }
 
+// A personal access token an agent presents as `Authorization: Bearer …` to
+// call this same API. Only the prefix ever appears here; the secret is
+// returned once, at mint, as CreatedPat.token.
+export interface Pat {
+  id: string
+  name: string
+  tokenPrefix: string
+  createdAt: string
+  expiresAt: string
+  lastUsedAt: string | null
+  revokedAt: string | null
+  isActive: boolean
+  isExpired: boolean
+  isRevoked: boolean
+}
+
+export interface CreatedPat extends Pat {
+  /** The full plaintext, shown exactly once — druks stores only a hash. */
+  token: string
+}
+
 export interface McpServer {
   name: string
   url: string

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -439,7 +439,7 @@ export interface McpRegistryCandidate {
 export interface Pat {
   id: string
   name: string
-  tokenPrefix: string
+  prefix: string
   createdAt: string
   expiresAt: string
   lastUsedAt: string | null

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -444,9 +444,7 @@ export interface Pat {
   expiresAt: string
   lastUsedAt: string | null
   revokedAt: string | null
-  isActive: boolean
-  isExpired: boolean
-  isRevoked: boolean
+  status: 'active' | 'expired' | 'revoked'
 }
 
 export interface McpServer {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -434,8 +434,8 @@ export interface McpRegistryCandidate {
 }
 
 // A personal access token an agent presents as `Authorization: Bearer …` to
-// call this same API. Only the prefix ever appears here; the secret is
-// returned once, at mint, as CreatedPat.token.
+// call this same API. Only the prefix ever appears here; the plaintext is
+// returned once, at mint, and nowhere else.
 export interface Pat {
   id: string
   name: string
@@ -447,11 +447,6 @@ export interface Pat {
   isActive: boolean
   isExpired: boolean
   isRevoked: boolean
-}
-
-export interface CreatedPat extends Pat {
-  /** The full plaintext, shown exactly once — druks stores only a hash. */
-  token: string
 }
 
 export interface McpServer {

--- a/frontend/src/components/AgentAccessPane.test.tsx
+++ b/frontend/src/components/AgentAccessPane.test.tsx
@@ -14,9 +14,7 @@ function pat(overrides: Partial<Pat> = {}): Pat {
     expiresAt: '2027-07-19T10:00:00Z',
     lastUsedAt: null,
     revokedAt: null,
-    isActive: true,
-    isExpired: false,
-    isRevoked: false,
+    status: 'active',
     ...overrides,
   }
 }
@@ -72,8 +70,7 @@ describe('AgentAccessPane', () => {
           id: 'p3',
           name: 'old',
           prefix: 'Zz9876543210',
-          isActive: false,
-          isRevoked: true,
+          status: 'revoked',
           revokedAt: '2026-07-01T00:00:00Z',
         }),
       ],
@@ -114,7 +111,7 @@ describe('AgentAccessPane', () => {
   it('revokes only after the operator confirms', async () => {
     const fetchMock = stubFetch({
       list: () => [pat()],
-      revoked: pat({ isActive: false, isRevoked: true, revokedAt: '2026-07-19T11:00:00Z' }),
+      revoked: pat({ status: 'revoked', revokedAt: '2026-07-19T11:00:00Z' }),
     })
     const confirm = vi.fn(() => false)
     vi.stubGlobal('confirm', confirm)

--- a/frontend/src/components/AgentAccessPane.test.tsx
+++ b/frontend/src/components/AgentAccessPane.test.tsx
@@ -1,0 +1,134 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { CreatedPat, Pat } from '../api/types'
+import { AgentAccessPane } from './SettingsModal'
+
+function pat(overrides: Partial<Pat> = {}): Pat {
+  return {
+    id: 'p1',
+    name: 'ci bot',
+    tokenPrefix: 'AbCdEf123456',
+    createdAt: '2026-07-19T10:00:00Z',
+    expiresAt: '2027-07-19T10:00:00Z',
+    lastUsedAt: null,
+    revokedAt: null,
+    isActive: true,
+    isExpired: false,
+    isRevoked: false,
+    ...overrides,
+  }
+}
+
+const MINTED: CreatedPat = { ...pat({ id: 'p2', name: 'laptop' }), token: 'druks_pat_AbCdEf123456_secret' }
+
+function stubFetch(routes: { list: () => Pat[]; created?: CreatedPat; revoked?: Pat }) {
+  const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+    async (url, init) => {
+      const method = init?.method ?? 'GET'
+      if (url === '/api/auth/pats' && method === 'GET') {
+        return new Response(JSON.stringify(routes.list()), { status: 200 })
+      }
+      if (url === '/api/auth/pats' && method === 'POST') {
+        return new Response(JSON.stringify(routes.created), { status: 200 })
+      }
+      if (method === 'DELETE') {
+        return new Response(JSON.stringify(routes.revoked), { status: 200 })
+      }
+      return new Response('{}', { status: 404 })
+    },
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function renderPane() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentAccessPane />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe('AgentAccessPane', () => {
+  it('lists tokens with prefix and status', async () => {
+    stubFetch({
+      list: () => [
+        pat(),
+        pat({
+          id: 'p3',
+          name: 'old',
+          tokenPrefix: 'Zz9876543210',
+          isActive: false,
+          isRevoked: true,
+          revokedAt: '2026-07-01T00:00:00Z',
+        }),
+      ],
+    })
+    renderPane()
+    expect(await screen.findByText('ci bot')).toBeTruthy()
+    expect(screen.getByText(/AbCdEf123456…/)).toBeTruthy()
+    expect(screen.getByText('active')).toBeTruthy()
+    expect(screen.getByText('revoked')).toBeTruthy()
+    // A revoked token offers nothing to revoke.
+    expect(screen.getAllByText('✕ revoke')).toHaveLength(1)
+  })
+
+  it('mints and keeps the copy-once secret visible across the list refetch', async () => {
+    const rows: Pat[] = []
+    const fetchMock = stubFetch({ list: () => rows, created: MINTED })
+    renderPane()
+    await flush()
+
+    fireEvent.change(screen.getByPlaceholderText(/What will hold it/), {
+      target: { value: 'laptop' },
+    })
+    // The refetch after mint returns the new row; the banner must survive it.
+    rows.push(pat({ id: 'p2', name: 'laptop' }))
+    fireEvent.click(screen.getByText('mint'))
+    await flush()
+
+    const createCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'POST')
+    expect(JSON.parse(String(createCall?.[1]?.body))).toEqual({ name: 'laptop' })
+    const secretBox = screen.getByLabelText('personal access token') as HTMLInputElement
+    expect(secretBox.value).toBe(MINTED.token)
+
+    // Dismissing is the only thing that clears it.
+    fireEvent.click(screen.getByText('done'))
+    expect(screen.queryByLabelText('personal access token')).toBeNull()
+  })
+
+  it('revokes only after the operator confirms', async () => {
+    const fetchMock = stubFetch({
+      list: () => [pat()],
+      revoked: pat({ isActive: false, isRevoked: true, revokedAt: '2026-07-19T11:00:00Z' }),
+    })
+    const confirm = vi.fn(() => false)
+    vi.stubGlobal('confirm', confirm)
+    renderPane()
+
+    fireEvent.click(await screen.findByText('✕ revoke'))
+    await flush()
+    expect(confirm).toHaveBeenCalledWith('Revoke ci bot? Agents using it lose access immediately.')
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(false)
+
+    confirm.mockReturnValue(true)
+    fireEvent.click(screen.getByText('✕ revoke'))
+    await flush()
+    const revokeCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'DELETE')
+    expect(revokeCall?.[0]).toBe('/api/auth/pats/p1')
+  })
+})

--- a/frontend/src/components/AgentAccessPane.test.tsx
+++ b/frontend/src/components/AgentAccessPane.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { CreatedPat, Pat } from '../api/types'
+import type { Pat } from '../api/types'
 import { AgentAccessPane } from './SettingsModal'
 
 function pat(overrides: Partial<Pat> = {}): Pat {
@@ -21,16 +21,16 @@ function pat(overrides: Partial<Pat> = {}): Pat {
   }
 }
 
-const MINTED: CreatedPat = { ...pat({ id: 'p2', name: 'laptop' }), token: 'druks_pat_AbCdEf123456_secret' }
+const MINTED = { token: 'druks_pat_AbCdEf123456_secret' }
 
-function stubFetch(routes: { list: () => Pat[]; created?: CreatedPat; revoked?: Pat }) {
+function stubFetch(routes: { list: () => Pat[]; created?: { token: string }; revoked?: Pat }) {
   const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
     async (url, init) => {
       const method = init?.method ?? 'GET'
-      if (url === '/api/auth/pats' && method === 'GET') {
+      if (url === '/api/auth/personal-tokens' && method === 'GET') {
         return new Response(JSON.stringify(routes.list()), { status: 200 })
       }
-      if (url === '/api/auth/pats' && method === 'POST') {
+      if (url === '/api/auth/personal-tokens' && method === 'POST') {
         return new Response(JSON.stringify(routes.created), { status: 200 })
       }
       if (method === 'DELETE') {
@@ -129,6 +129,6 @@ describe('AgentAccessPane', () => {
     fireEvent.click(screen.getByText('✕ revoke'))
     await flush()
     const revokeCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'DELETE')
-    expect(revokeCall?.[0]).toBe('/api/auth/pats/p1')
+    expect(revokeCall?.[0]).toBe('/api/auth/personal-tokens/p1')
   })
 })

--- a/frontend/src/components/AgentAccessPane.test.tsx
+++ b/frontend/src/components/AgentAccessPane.test.tsx
@@ -9,7 +9,7 @@ function pat(overrides: Partial<Pat> = {}): Pat {
   return {
     id: 'p1',
     name: 'ci bot',
-    tokenPrefix: 'AbCdEf123456',
+    prefix: 'AbCdEf123456',
     createdAt: '2026-07-19T10:00:00Z',
     expiresAt: '2027-07-19T10:00:00Z',
     lastUsedAt: null,
@@ -71,7 +71,7 @@ describe('AgentAccessPane', () => {
         pat({
           id: 'p3',
           name: 'old',
-          tokenPrefix: 'Zz9876543210',
+          prefix: 'Zz9876543210',
           isActive: false,
           isRevoked: true,
           revokedAt: '2026-07-01T00:00:00Z',

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -5,10 +5,12 @@ import { api } from '../api/client'
 import { ExtensionGlyph } from './ExtensionGlyph'
 import { LoginSteps, useHarnessLogin } from './HarnessLogin'
 import {
+  type CreatedPat,
   type Harness,
   type ExtensionSettings,
   type McpRegistryCandidate,
   type McpServer,
+  type Pat,
   type SkillCollection,
   type UpdateHarnessRequest,
   type UpdateExtensionsSettingsRequest,
@@ -110,7 +112,7 @@ export function SettingsModal({ open, onClose }: Props) {
   // Pending per-harness edits (name -> sparse UpdateHarnessRequest), flushed by
   // submit() — same dirty/save flow as the extension and general settings.
   const [harnessEdits, setHarnessEdits] = useState<Record<string, UpdateHarnessRequest>>({})
-  // 'general' | 'harnesses' | 'skills' | 'mcp' | <extension name>
+  // 'general' | 'harnesses' | 'skills' | 'mcp' | 'agent-access' | <extension name>
   const [section, setSection] = useState<string>('general')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -285,6 +287,7 @@ export function SettingsModal({ open, onClose }: Props) {
             <RailItem icon="harnesses" label="Harnesses" active={section === 'harnesses'} onClick={() => setSection('harnesses')} />
             <RailItem icon="skills" label="Skills" active={section === 'skills'} onClick={() => setSection('skills')} />
             <RailItem icon="mcp" label="MCP" active={section === 'mcp'} onClick={() => setSection('mcp')} />
+            <RailItem icon="agent-access" label="Agent access" active={section === 'agent-access'} onClick={() => setSection('agent-access')} />
             <div className="set-rail-label">apps</div>
             {allExtensions.map((extension) => (
               <button
@@ -328,6 +331,7 @@ export function SettingsModal({ open, onClose }: Props) {
               ))}
             {section === 'skills' && <SkillsPane />}
             {section === 'mcp' && <McpServersPane />}
+            {section === 'agent-access' && <AgentAccessPane />}
             {extensionSection && (
               <ExtensionPane
                 extension={extensionSection}
@@ -415,6 +419,12 @@ function RailGlyph({ name }: { name: string }) {
         <rect x="2.5" y="2.5" width="4" height="4" rx="1" />
         <rect x="9.5" y="9.5" width="4" height="4" rx="1" />
         <path d="M6.5 4.5H10a1.5 1.5 0 0 1 1.5 1.5v3.5" />
+      </>
+    ),
+    'agent-access': (
+      <>
+        <circle cx="5.2" cy="5.2" r="2.7" />
+        <path d="M7.1 7.1 13.5 13.5M10.7 10.7l2-2" />
       </>
     ),
     extension: (
@@ -1378,6 +1388,182 @@ function McpServerRow({
           title="remove server"
         >
           ✕ remove
+        </button>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Agent access — personal access tokens agents present to call this same API.
+// The minted secret lives only in component state between mint and dismiss:
+// never in the query cache, storage, or a URL — and a list refetch can't
+// clear it, only the operator can.
+// ---------------------------------------------------------------------------
+
+export function AgentAccessPane() {
+  const queryClient = useQueryClient()
+  const patsQuery = useQuery({ queryKey: ['pats'], queryFn: () => api.pats() })
+  const [name, setName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [minted, setMinted] = useState<CreatedPat | null>(null)
+  const [copied, setCopied] = useState(false)
+  const pats = patsQuery.data ?? []
+
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ['pats'] })
+
+  async function mint() {
+    const value = name.trim()
+    if (!value) return
+    setBusy(true)
+    setError(null)
+    try {
+      const created = await api.createPat(value)
+      setMinted(created)
+      setCopied(false)
+      setName('')
+      await refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function revoke(pat: Pat) {
+    if (!window.confirm(`Revoke ${pat.name}? Agents using it lose access immediately.`)) return
+    setBusy(true)
+    setError(null)
+    try {
+      await api.revokePat(pat.id)
+      await refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function copy() {
+    if (!minted) return
+    try {
+      await navigator.clipboard.writeText(minted.token)
+      setCopied(true)
+    } catch {
+      // Clipboard denied — the token stays on screen to copy by hand.
+    }
+  }
+
+  return (
+    <div className="set-pane">
+      <div className="set-pane-head">
+        <div className="set-pane-sub">
+          Mint a <b>personal access token</b> for an agent to call this druks — sent as{' '}
+          <b>Authorization: Bearer …</b>, same account and authority as your session. Revoking a
+          token cuts its access immediately.
+        </div>
+      </div>
+      <div className="set-group">
+        <div className="set-group-label">mint token</div>
+        <div className="skill-add">
+          <input
+            className="skill-add-input"
+            placeholder="What will hold it?  e.g. claude on my laptop"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void mint()
+            }}
+            autoComplete="off"
+            data-1p-ignore=""
+            data-lpignore="true"
+            disabled={busy}
+          />
+          <button className="set-btn primary" disabled={busy || !name.trim()} onClick={() => void mint()}>
+            {busy ? 'minting…' : 'mint'}
+          </button>
+        </div>
+        {error && <div className="set-skill-error">{error}</div>}
+      </div>
+      {minted && (
+        <div className="set-group">
+          <div className="set-group-label">{minted.name} — copy it now</div>
+          <div className="skill-add">
+            <input
+              className="skill-add-input"
+              readOnly
+              value={minted.token}
+              onFocus={(e) => e.currentTarget.select()}
+              aria-label="personal access token"
+              data-1p-ignore=""
+              data-lpignore="true"
+            />
+            <button className="set-btn primary" onClick={() => void copy()}>
+              {copied ? 'copied' : 'copy'}
+            </button>
+            <button className="set-btn ghost" onClick={() => setMinted(null)}>
+              done
+            </button>
+          </div>
+          <div className="set-field-help">
+            The only time druks shows it — a hash is stored, not the token.
+          </div>
+        </div>
+      )}
+      {pats.length > 0 && (
+        <div className="set-group">
+          <div className="set-group-label">
+            tokens<span className="gl-count">{pats.length}</span>
+          </div>
+          <div className="mcp-servers">
+            {pats.map((pat) => (
+              <PatRow key={pat.id} pat={pat} busy={busy} onRevoke={revoke} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function patStatusLabel(pat: Pat): string {
+  if (pat.isRevoked) return 'revoked'
+  if (pat.isExpired) return 'expired'
+  return 'active'
+}
+
+function PatRow({
+  pat,
+  busy,
+  onRevoke,
+}: {
+  pat: Pat
+  busy: boolean
+  onRevoke: (pat: Pat) => Promise<void>
+}) {
+  return (
+    <div className={'mcp-row' + (pat.isActive ? '' : ' is-off')}>
+      <div className="mcp-id">
+        <span className="mcp-name">{pat.name}</span>
+        <span className="mcp-url">
+          {pat.tokenPrefix}… · expires {new Date(pat.expiresAt).toLocaleDateString()}
+        </span>
+      </div>
+      <span className="mcp-tok">
+        last used {pat.lastUsedAt ? new Date(pat.lastUsedAt).toLocaleString() : 'never'}
+      </span>
+      <span className={'hr-chip ' + (pat.isActive ? 'hr-chip-on' : 'hr-chip-off')}>
+        {patStatusLabel(pat)}
+      </span>
+      {!pat.isRevoked && (
+        <button
+          className="sc-remove"
+          onClick={() => void onRevoke(pat)}
+          disabled={busy}
+          title="revoke token"
+        >
+          ✕ revoke
         </button>
       )}
     </div>

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1533,12 +1533,6 @@ export function AgentAccessPane() {
   )
 }
 
-function patStatusLabel(pat: Pat): string {
-  if (pat.isRevoked) return 'revoked'
-  if (pat.isExpired) return 'expired'
-  return 'active'
-}
-
 function PatRow({
   pat,
   busy,
@@ -1548,8 +1542,9 @@ function PatRow({
   busy: boolean
   onRevoke: (pat: Pat) => Promise<void>
 }) {
+  const active = pat.status === 'active'
   return (
-    <div className={'mcp-row' + (pat.isActive ? '' : ' is-off')}>
+    <div className={'mcp-row' + (active ? '' : ' is-off')}>
       <div className="mcp-id">
         <span className="mcp-name">{pat.name}</span>
         <span className="mcp-url">
@@ -1559,10 +1554,8 @@ function PatRow({
       <span className="mcp-tok">
         last used {pat.lastUsedAt ? new Date(pat.lastUsedAt).toLocaleString() : 'never'}
       </span>
-      <span className={'hr-chip ' + (pat.isActive ? 'hr-chip-on' : 'hr-chip-off')}>
-        {patStatusLabel(pat)}
-      </span>
-      {!pat.isRevoked && (
+      <span className={'hr-chip ' + (active ? 'hr-chip-on' : 'hr-chip-off')}>{pat.status}</span>
+      {pat.status !== 'revoked' && (
         <button
           className="sc-remove"
           onClick={() => void onRevoke(pat)}

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -5,7 +5,6 @@ import { api } from '../api/client'
 import { ExtensionGlyph } from './ExtensionGlyph'
 import { LoginSteps, useHarnessLogin } from './HarnessLogin'
 import {
-  type CreatedPat,
   type Harness,
   type ExtensionSettings,
   type McpRegistryCandidate,
@@ -1407,7 +1406,9 @@ export function AgentAccessPane() {
   const [name, setName] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [minted, setMinted] = useState<CreatedPat | null>(null)
+  // The mint answers only the plaintext; the name is the one the operator just
+  // typed, held here alongside it for the copy-once banner.
+  const [minted, setMinted] = useState<{ name: string; token: string } | null>(null)
   const [copied, setCopied] = useState(false)
   const pats = patsQuery.data ?? []
 
@@ -1421,7 +1422,7 @@ export function AgentAccessPane() {
     setError(null)
     try {
       const created = await api.createPat(value)
-      setMinted(created)
+      setMinted({ name: value, token: created.token })
       setCopied(false)
       setName('')
       await refresh()

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1415,7 +1415,8 @@ export function AgentAccessPane() {
 
   async function mint() {
     const value = name.trim()
-    if (!value) return
+    // No second mint while a secret is on screen — "done" acknowledges it first.
+    if (!value || minted) return
     setBusy(true)
     setError(null)
     try {
@@ -1480,7 +1481,11 @@ export function AgentAccessPane() {
             data-lpignore="true"
             disabled={busy}
           />
-          <button className="set-btn primary" disabled={busy || !name.trim()} onClick={() => void mint()}>
+          <button
+            className="set-btn primary"
+            disabled={busy || !!minted || !name.trim()}
+            onClick={() => void mint()}
+          >
             {busy ? 'minting…' : 'mint'}
           </button>
         </div>
@@ -1547,7 +1552,7 @@ function PatRow({
       <div className="mcp-id">
         <span className="mcp-name">{pat.name}</span>
         <span className="mcp-url">
-          {pat.tokenPrefix}… · expires {new Date(pat.expiresAt).toLocaleDateString()}
+          {pat.prefix}… · expires {new Date(pat.expiresAt).toLocaleDateString()}
         </span>
       </div>
       <span className="mcp-tok">


### PR DESCRIPTION
T1 of the MCP arc (spec: tmp/mcp-arc-tickets.md). Adds `personal_access_tokens` under accounts (prefix-indexed, SHA-256 hash of the full serialized token, 365d expiry, hourly `last_used_at`, revocation), a shared `PersonalAccessToken.authenticate()` door (constant-time hash compare, prefix-only in errors, no prefix-existence oracle), and bearer-first `current_account`: an Authorization header must be exactly `Bearer <token>` and must authenticate — 401 with `WWW-Authenticate` on any failure, never a cookie fallback. PAT management (`GET/POST/DELETE /api/auth/pats`) rides a new session-only dependency so a token can never mint or revoke tokens; `test_auth_boundary.py` pins the enumeration both directions in the same commit that adds the routes. Frontend: **Agent access** settings pane (McpServersPane pattern) with the copy-once secret held in component state only — never query cache, storage, or URL — surviving the post-mint refetch until dismissed. Docs: PAT lifecycle + compromise/rotation in configuration.md.

Test evidence: new `test_auth_pats.py` (12 tests: mint shape, auth happy path, wrong/unknown/revoked/expired 401s, exact-Bearer parsing, hash pinned to 32 bytes, session-only management, cross-account 404); boundary enumeration extended; frontend vitest 45/45, lint + build clean; ruff clean; pyright = main baseline. Backend suite runs in CI.

Open question for review: `last_used_at` stamps inside the request transaction — a PAT-authenticated SSE stream would hold that row lock for the stream's life (concurrent same-token stampers block until it closes). MCP v1 is polling-only and dashboard SSE rides cookies, so this ships the simple spec-faithful version; flagging in case you want a separate-transaction stamp now rather than when streams arrive.