### PR TITLE
Remove dead code from the build extension

### DIFF
--- a/backend/druks/build/enums.py
+++ b/backend/druks/build/enums.py
@@ -24,7 +24,6 @@ class HumanFeedbackAction(StrEnum):
 
 class Outcome(StrEnum):
     FINISHED = "finished"
-    FAILED = "failed"
     CANCELLED = "cancelled"
     SCOPED = "scoped"
 
@@ -32,5 +31,4 @@ class Outcome(StrEnum):
 class HandoffStatus(StrEnum):
     SCOPED = "scoped"
     SHIPPED = "shipped"
-    SKIPPED = "skipped"
     CANCELLED = "cancelled"

--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -15,7 +15,7 @@ from druks.ticketing.datastructures import Ticket
 from druks.ticketing.enums import SemanticStatus
 from druks.ticketing.exceptions import TrackerNotConfigured
 from druks.ticketing.helpers import get_tracker, is_tracker_source
-from druks.workflows import AgentCall, Run
+from druks.workflows import Run
 
 logger = logging.getLogger(__name__)
 
@@ -333,25 +333,6 @@ class WorkItem(Base):
         return db_session().scalars(stmt).first()
 
     @classmethod
-    def by_remote_key(
-        cls,
-        *,
-        source: str,
-        remote_keys: set[str],
-    ) -> dict[str, "WorkItem"]:
-        """Bulk variant of ``get_for_remote_key`` keyed by remote_key.
-
-        Returns a dict mapping each found key to its WorkItem; missing
-        keys are simply absent from the returned dict."""
-        if not remote_keys:
-            return {}
-        stmt = select(cls).where(
-            cls.source == source,
-            cls.remote_key.in_(remote_keys),
-        )
-        return {wi.remote_key: wi for wi in db_session().scalars(stmt) if wi.remote_key}
-
-    @classmethod
     def list_recent(cls, *, limit: int = 50, offset: int = 0) -> list["WorkItem"]:
         stmt = select(cls).order_by(cls.updated_at.desc()).limit(limit).offset(offset)
         return list(db_session().scalars(stmt))
@@ -363,22 +344,6 @@ class WorkItem(Base):
             select(cls).where(cls.status.is_not(None)).order_by(cls.updated_at.desc()).limit(limit)
         )
         return list(db_session().scalars(stmt))
-
-    @classmethod
-    def sandbox_host_id_for(cls, repo: str, pr_number: int) -> str | None:
-        """The host_id of the most recent agent run for this work item. None
-        when nothing has run for this PR yet.
-
-        Callers MUST tolerate stale ids — the host may already be gone on the
-        provider side. ``sandbox_client.attach`` translates a 404 into
-        :class:`HostGone`, and the for_pr / token-rotation paths catch that and
-        re-acquire or skip.
-        """
-        item = cls.get_for_pr(repo=repo, pr_number=pr_number)
-        if not item:
-            return None
-        calls = AgentCall.list_for_subject("work_item", str(item.id))
-        return calls[-1].sandbox_host_id if calls else None
 
     def set_status(
         self, status: HandoffStatus | None, *, event_payload: dict[str, Any] | None = None

--- a/backend/druks/build/schemas.py
+++ b/backend/druks/build/schemas.py
@@ -20,8 +20,6 @@ def _outcome_from_status(status: str) -> tuple[str, Outcome]:
         return "Complete", Outcome.FINISHED
     if status == HandoffStatus.CANCELLED:
         return "Cancelled", Outcome.CANCELLED
-    if status == HandoffStatus.SKIPPED:
-        return "Skipped", Outcome.CANCELLED
     return "Scoped", Outcome.SCOPED
 
 

--- a/backend/tests/test_api_work_items.py
+++ b/backend/tests/test_api_work_items.py
@@ -39,7 +39,7 @@ def _seed_scope_run(db_session, item, *, state="finished", status=None):
         subject={"type": "work_item", "id": item.id},
     )
     seed_call(db_session, run, "scope", status="failed" if state == "failed" else "succeeded")
-    handoff = {"ready": "scoped", "skipped": "skipped"}.get(status)
+    handoff = {"ready": "scoped"}.get(status)
     if handoff is not None:
         item.set_status(handoff)
     elif status is not None:

--- a/frontend/src/extensions/build/HistoryPage.tsx
+++ b/frontend/src/extensions/build/HistoryPage.tsx
@@ -19,7 +19,6 @@ type OutcomeFilter = 'all' | Outcome
 
 const LANDING_VERB: Record<Outcome, string> = {
   finished: 'shipped',
-  failed: 'stopped',
   cancelled: 'cancelled',
   scoped: 'scoped',
 }
@@ -44,7 +43,6 @@ export function HistoryPage() {
   const items = historyQuery.data!.items
   const counts: Record<Outcome, number> = {
     finished: items.filter((i) => i.outcome === 'finished').length,
-    failed: items.filter((i) => i.outcome === 'failed').length,
     cancelled: items.filter((i) => i.outcome === 'cancelled').length,
     scoped: items.filter((i) => i.outcome === 'scoped').length,
   }
@@ -72,10 +70,6 @@ export function HistoryPage() {
           <span>·</span>
           <span>
             <span className="outcome-tag outcome-scoped">◇</span> {counts.scoped} scoped
-          </span>
-          <span>·</span>
-          <span>
-            <span className="outcome-tag outcome-failed">✕</span> {counts.failed} stopped
           </span>
           <span>·</span>
           <span>
@@ -110,12 +104,6 @@ export function HistoryPage() {
             current={outcomeFilter}
             onSelect={setOutcomeFilter}
             label={`scoped (${counts.scoped})`}
-          />
-          <FilterChip<OutcomeFilter>
-            value="failed"
-            current={outcomeFilter}
-            onSelect={setOutcomeFilter}
-            label={`stopped (${counts.failed})`}
           />
           <FilterChip<OutcomeFilter>
             value="cancelled"

--- a/frontend/src/extensions/build/OutcomeTag.tsx
+++ b/frontend/src/extensions/build/OutcomeTag.tsx
@@ -2,7 +2,6 @@ import type { Outcome } from './api'
 
 const GLYPH: Record<Outcome, string> = {
   finished: '✓',
-  failed: '✕',
   cancelled: '◯',
   scoped: '◇',
 }

--- a/frontend/src/extensions/build/api.ts
+++ b/frontend/src/extensions/build/api.ts
@@ -28,19 +28,7 @@ export const buildApi = {
   },
 }
 
-export type PendingReason =
-  | 'plan_questions_open'
-  | 'plan_waiting_review'
-  | 'impl_waiting_review'
-  | 'eval_blocked'
-  | 'stuck_past_threshold'
-  | 'dead_letter'
-  | 'scope_questions_open'
-  | 'scope_dead'
-  | 'research_needs_approval'
-  | 'research_needs_clarification'
-
-export type Outcome = 'finished' | 'failed' | 'cancelled' | 'scoped'
+export type Outcome = 'finished' | 'cancelled' | 'scoped'
 
 export interface Links {
   repo: string
@@ -61,55 +49,6 @@ export interface WorkItemSummary extends SubjectSummary {
   updatedAt: string
   links: Links
 }
-
-export interface JobSummary {
-  id: number
-  kind: string
-  status: 'queued' | 'running' | 'succeeded' | 'failed' | 'dead'
-  repo?: string | null
-  prNumber?: number | null
-  branch?: string | null
-  attempts: number
-  maxAttempts: number
-  runAfter: string
-  lastError?: string | null
-  createdAt: string
-  updatedAt: string
-}
-
-export type PendingItem =
-  | {
-      type: 'human_review'
-      workItem: WorkItemSummary
-      reason: PendingReason
-      reasonLabel: string
-    }
-  | {
-      type: 'dead_job'
-      workItem?: WorkItemSummary | null
-      job: JobSummary
-      lastError: string
-      reason: 'dead_letter'
-    }
-  | {
-      type: 'stuck_effort'
-      workItem: WorkItemSummary
-      thresholdSeconds: number
-      reason: 'stuck_past_threshold'
-    }
-  | {
-      type: 'scope_questions'
-      item: DashboardItem
-      reason: 'scope_questions_open'
-      reasonLabel: string
-    }
-  | {
-      type: 'scope_dead'
-      item: DashboardItem
-      reason: 'scope_dead'
-      reasonLabel: string
-      lastError?: string | null
-    }
 
 export interface DashboardItem {
   /** Stable id like "code:37" — used for React keys and SSE diffs. */


### PR DESCRIPTION
First pass of the build-extension cleanup: a pure-deletion sweep of definitions with no consumers, surfaced by a fresh-eyes read of the reference extension. **No behaviour change** — every removed path was already unreachable.

## Backend
- **`Outcome.FAILED`** — never emitted. `_outcome_from_status` only produces `FINISHED` / `CANCELLED` / `SCOPED`.
- **`HandoffStatus.SKIPPED`** — `set_status(SKIPPED)` is never called; its `_outcome_from_status` branch was unreachable.
- **`WorkItem.by_remote_key` / `WorkItem.sandbox_host_id_for`** — zero callers. The now-unused `AgentCall` import goes with them.

## Frontend
- **`api.ts`: `PendingReason` / `JobSummary` / `PendingItem`** — a pre-DBOS job/research vocabulary (`dead_letter`, `attempts`/`maxAttempts`, `research_needs_*`) with no importers anywhere.
- **`HistoryPage` "stopped" lane** (landing verb, count, header stat, filter chip) and the **`OutcomeTag`** glyph — all keyed off the removed `Outcome.FAILED`, so they rendered a permanent `stopped (0)`.

## Verification
- `ruff check backend/druks/build` — clean
- `py_compile` on the edited modules — ok
- `tsc -b` (frontend typecheck) — clean
- `eslint` on the three changed files — clean

Net: **+2 / −115** across 6 files.

Follow-ups from the same review (separate PRs): collapse the `*Output`/domain-twin double-modeling in `contracts.py`; decide the intent of `ScopeBriefOutput`'s unused rich structure and the vestigial `Project.slug` column.
