### PR TITLE
Collapse the wire→domain twins in build's contracts

### DIFF
--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -8,27 +8,6 @@ from druks.build.enums import (
     HumanFeedbackAction,
     ReviewDecision,
 )
-from druks.workflows import FatalError
-
-
-class QuestionOption(BaseModel):
-    id: str
-    label: str
-
-
-class Question(BaseModel):
-    id: str
-    status: Literal["open", "answered"] = "open"
-    prompt: str
-    options: list[QuestionOption] = Field(default_factory=list)
-    answer: str | None = None
-    comment_id: int | None = None
-
-
-class AcceptanceCriterion(BaseModel):
-    id: str
-    description: str
-    verification: str = ""
 
 
 class HumanFeedback(BaseModel):
@@ -39,28 +18,6 @@ class HumanFeedback(BaseModel):
     triage_body: str = ""
     question: str = ""
     implementation_instructions: str = ""
-
-
-class PlanData(BaseModel):
-    plan_markdown: str = ""
-    questions: list[Question] = Field(default_factory=list)
-    acceptance_criteria: list[AcceptanceCriterion] = Field(default_factory=list)
-
-    def get_answered(self, picks: dict[str, str]) -> list[dict[str, str]]:
-        # Each question the operator answered, paired with its answer — what the
-        # re-plan agent reads to resolve it. A pick matching an offered option maps
-        # to that option's label; anything else is the operator's own words, kept
-        # verbatim.
-        pairs = []
-        for question in self.questions:
-            chosen = picks.get(question.id)
-            if not chosen:
-                continue
-            label = next(
-                (option.label for option in question.options if option.id == chosen), chosen
-            )
-            pairs.append({"question": question.prompt, "answer": label})
-        return pairs
 
 
 class RepoProfilerOutput(AgentOutput):
@@ -109,11 +66,30 @@ class AcceptanceCriterionOutput(AgentOutput):
     verification: str
 
 
-def _criteria(items: list[AcceptanceCriterionOutput]) -> list[AcceptanceCriterion]:
-    return [
-        AcceptanceCriterion(id=c.id, description=c.description, verification=c.verification)
-        for c in items
-    ]
+class PlanData(BaseModel):
+    # The workflow's current plan, normalized from either producer — the
+    # generate_plan agent (questions and all) or a contract revision (questions
+    # resolved). It carries the agents' own output shapes; a re-plan reads the
+    # questions and acceptance criteria straight off them.
+    plan_markdown: str = ""
+    questions: list[QuestionOutput] = Field(default_factory=list)
+    acceptance_criteria: list[AcceptanceCriterionOutput] = Field(default_factory=list)
+
+    def get_answered(self, picks: dict[str, str]) -> list[dict[str, str]]:
+        # Each question the operator answered, paired with its answer — what the
+        # re-plan agent reads to resolve it. A pick matching an offered option maps
+        # to that option's label; anything else is the operator's own words, kept
+        # verbatim.
+        pairs = []
+        for question in self.questions:
+            chosen = picks.get(question.id)
+            if not chosen:
+                continue
+            label = next(
+                (option.label for option in question.options if option.id == chosen), chosen
+            )
+            pairs.append({"question": question.prompt, "answer": label})
+        return pairs
 
 
 class PlanOutput(AgentOutput):
@@ -127,15 +103,8 @@ class PlanOutput(AgentOutput):
     def to_result(self) -> PlanData:
         return PlanData(
             plan_markdown=self.plan_markdown,
-            acceptance_criteria=_criteria(self.acceptance_criteria),
-            questions=[
-                Question(
-                    id=q.id,
-                    prompt=q.prompt,
-                    options=[QuestionOption(id=o.id, label=o.label) for o in q.options],
-                )
-                for q in self.questions
-            ],
+            acceptance_criteria=self.acceptance_criteria,
+            questions=self.questions,
         )
 
 
@@ -152,15 +121,9 @@ class ContractRevisionOutput(AgentOutput):
         # implementation_instructions ride the prompt, not the plan artifact.
         return PlanData(
             plan_markdown=self.plan_markdown,
-            acceptance_criteria=_criteria(self.acceptance_criteria),
+            acceptance_criteria=self.acceptance_criteria,
             questions=[],
         )
-
-
-class PlanReview(BaseModel):
-    decision: ReviewDecision
-    body: str = ""
-    assignee_github_login: str | None = None
 
 
 class ReviewOutput(AgentOutput):
@@ -175,13 +138,6 @@ class ReviewOutput(AgentOutput):
     # Required but nullable: the agent always reports the field, null when it
     # resolved no assignee login convincingly.
     assignee_github_login: str | None
-
-    def to_result(self) -> PlanReview:
-        return PlanReview(
-            decision=self.decision,
-            body=self.body,
-            assignee_github_login=self.assignee_github_login,
-        )
 
 
 class TriageOutput(AgentOutput):
@@ -204,19 +160,11 @@ class CommandCheckOutput(AgentOutput):
     reason: str
 
 
-class Implementation(BaseModel):
-    # A delivery: a pushed commit on a branch with a PR. Every field required — an
-    # implementer that could not deliver raises out of to_result instead.
-    base_sha: str
-    head_sha: str
-    branch: str
-    pr_number: int
-
-
 class ImplementationOutput(AgentOutput):
     type: Literal["result"]
-    # ``needs_clarification`` = the implementer found a contradiction in the
-    # binding requirements and bailed; ``summary`` carries the reason.
+    # ``needs_clarification`` = the implementer found a contradiction in the binding
+    # requirements and bailed; ``summary`` carries the reason. The workflow turns
+    # that into a run-stopping failure.
     status: Literal["success", "needs_clarification"]
     # Nullable only for needs_clarification (bailed before delivering) — the strict
     # schema bans defaults, so optional is spelled required-but-nullable. On success
@@ -253,18 +201,6 @@ class ImplementationOutput(AgentOutput):
             )
         return self
 
-    def to_result(self) -> Implementation:
-        # A bail is a stop, not a result: the run fails with the implementer's own
-        # reason, read off the dashboard instead of dug out of the transcript.
-        if self.status == "needs_clarification":
-            raise FatalError(f"implementation needs clarification: {self.summary}")
-        return Implementation(
-            base_sha=self.base_sha,
-            head_sha=self.head_sha,
-            branch=self.branch,
-            pr_number=self.pr_number,
-        )
-
 
 class FindingOutput(AgentOutput):
     severity: Literal["high", "medium", "low"]
@@ -287,20 +223,12 @@ class AcceptanceResultOutput(AgentOutput):
     evidence: str
 
 
-class ImplementationReview(BaseModel):
-    verdict: EvaluationVerdict
-    body: str = ""
-
-
 class EvaluationOutput(AgentOutput):
     verdict: EvaluationVerdict
     body: str
     findings: list[FindingOutput]
     checks: list[EvalCheckOutput]
     acceptance_results: list[AcceptanceResultOutput]
-
-    def to_result(self) -> ImplementationReview:
-        return ImplementationReview(verdict=self.verdict, body=self.body)
 
 
 class CodeReviewOutput(AgentOutput):

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -6,11 +6,11 @@ from pydantic import BaseModel, Field
 
 from druks.accounts.models import Account
 from druks.build.contracts import (
+    EvaluationOutput,
     HumanFeedback,
-    Implementation,
-    ImplementationReview,
+    ImplementationOutput,
     PlanData,
-    PlanReview,
+    ReviewOutput,
 )
 from druks.build.enums import (
     EvaluationVerdict,
@@ -121,12 +121,12 @@ class BuildWorkflow(Workflow):
         # run() from the top with every agent call and gate reply memoized, so
         # these rebuild to exactly what the live pass held.
         self._plans: list[PlanData] = []
-        self._plan_reviews: list[PlanReview] = []
+        self._plan_reviews: list[ReviewOutput] = []
         # Where _plan_reviews stood at the latest plan draft, so
         # reviewer_requirements only spans reviews of the current plan.
         self._reviews_at_plan = 0
-        self._implementation_reviews: list[ImplementationReview] = []
-        self._implementation_results: list[Implementation] = []
+        self._implementation_reviews: list[EvaluationOutput] = []
+        self._implementation_results: list[ImplementationOutput] = []
         self._human_feedback: list[HumanFeedback] = []
         # The questions the operator answered ({question, answer}), fed to the next plan
         # pass; empty on the first pass and after a plain re-plan.
@@ -364,7 +364,7 @@ class BuildWorkflow(Workflow):
         self._note = note
         return self._add_plan(await Build.generate_plan())
 
-    async def review_plan(self) -> PlanReview:
+    async def review_plan(self) -> ReviewOutput:
         grade = await Build.review_plan()
         self._plan_reviews.append(grade)
         return grade
@@ -372,8 +372,13 @@ class BuildWorkflow(Workflow):
     async def revise_contract(self) -> PlanData:
         return self._add_plan(await Build.revise_contract())
 
-    async def implement(self) -> Implementation:
+    async def implement(self) -> ImplementationOutput:
         delivery = await Build.implement()
+        # A bail is a stop, not a result: the implementer hit a contradiction in the
+        # binding requirements and couldn't deliver. Fail the run with its own reason,
+        # read off the dashboard instead of dug out of the transcript.
+        if delivery.status == "needs_clarification":
+            raise FatalError(f"implementation needs clarification: {delivery.summary}")
         if not self.pr_number:
             # First delivery: the implementer provisioned the branch + draft PR alongside
             # its commits; publish the pair (the run.state signal mirrors it onto the item).
@@ -381,7 +386,7 @@ class BuildWorkflow(Workflow):
         self._implementation_results.append(delivery)
         return delivery
 
-    async def evaluate(self) -> ImplementationReview:
+    async def evaluate(self) -> EvaluationOutput:
         review = await Build.evaluate_implementation()
         self._implementation_reviews.append(review)
         return review
@@ -443,11 +448,11 @@ class BuildWorkflow(Workflow):
         return self.plan.questions
 
     @property
-    def plan_reviews(self) -> list[PlanReview]:
+    def plan_reviews(self) -> list[ReviewOutput]:
         return list(self._plan_reviews)
 
     @property
-    def implementation_reviews(self) -> list[ImplementationReview]:
+    def implementation_reviews(self) -> list[EvaluationOutput]:
         return list(self._implementation_reviews)
 
     @property
@@ -462,7 +467,7 @@ class BuildWorkflow(Workflow):
         return len(self._plans)
 
     @property
-    def reviewer_requirements(self) -> list[PlanReview]:
+    def reviewer_requirements(self) -> list[ReviewOutput]:
         # Approve-with-required-changes verdicts on the current plan draft
         # only — reviews of superseded drafts don't bind the implementer.
         return [
@@ -482,7 +487,7 @@ class BuildWorkflow(Workflow):
         return list(self._human_feedback)
 
     @property
-    def _last_implement(self) -> Implementation | None:
+    def _last_implement(self) -> ImplementationOutput | None:
         return self._implementation_results[-1] if self._implementation_results else None
 
     @property

--- a/backend/tests/test_build_durable.py
+++ b/backend/tests/test_build_durable.py
@@ -143,15 +143,13 @@ def _stub(monkeypatch, rt):
     # stages (generate_plan, review_code) return their stub as the step result,
     # so those stubs are the real domain models; contract-consuming stages take
     # attribute lookalikes. Returns the invocation log (agent ids, in order).
-    from druks.build.contracts import Implementation
-
     results = {
         "generate_plan": PlanData(plan_markdown="p"),
         "review_plan": SimpleNamespace(
             decision=ReviewDecision.APPROVE, body="", assignee_github_login=None
         ),
-        "implement": Implementation(
-            base_sha="a", head_sha="b", branch="agent/acme-1", pr_number=42
+        "implement": SimpleNamespace(
+            status="success", base_sha="a", head_sha="b", branch="agent/acme-1", pr_number=42
         ),
         "evaluate_implementation": EvaluationOutput(
             verdict=EvaluationVerdict.PASS, body="", findings=[], checks=[], acceptance_results=[]

--- a/backend/tests/test_build_plan_phase.py
+++ b/backend/tests/test_build_plan_phase.py
@@ -1,7 +1,11 @@
-from druks.build.contracts import PlanData, PlanReview, Question, QuestionOption
+from types import SimpleNamespace
+
+import pytest
+from druks.build.contracts import PlanData, QuestionOptionOutput, QuestionOutput, ReviewOutput
 from druks.build.enums import ReviewDecision
 from druks.build.policy import RepoPolicy
 from druks.build.workflows import Build, BuildWorkflow
+from druks.workflows import FatalError
 
 
 async def test_plan_phase_threads_free_text_into_the_next_pass(monkeypatch):
@@ -16,10 +20,10 @@ async def test_plan_phase_threads_free_text_into_the_next_pass(monkeypatch):
             PlanData(
                 plan_markdown="v1",
                 questions=[
-                    Question(
+                    QuestionOutput(
                         id="q1",
                         prompt="Which cache?",
-                        options=[QuestionOption(id="a", label="Redis")],
+                        options=[QuestionOptionOutput(id="a", label="Redis")],
                     )
                 ],
             ),
@@ -35,7 +39,9 @@ async def test_plan_phase_threads_free_text_into_the_next_pass(monkeypatch):
         return next(plans)
 
     async def fake_review_agent():
-        return PlanReview(decision=ReviewDecision.REQUEST_CHANGES)
+        return ReviewOutput(
+            decision=ReviewDecision.REQUEST_CHANGES, body="", assignee_github_login=None
+        )
 
     monkeypatch.setattr(Build, "generate_plan", fake_plan_agent)
     monkeypatch.setattr(Build, "review_plan", fake_review_agent)
@@ -66,3 +72,19 @@ async def test_plan_phase_threads_free_text_into_the_next_pass(monkeypatch):
         },
         {"answered": [], "note": "add a rollback section"},
     ]
+
+
+async def test_needs_clarification_delivery_stops_the_run(monkeypatch):
+    """The implementer bailing (needs_clarification) fails the run with its own
+    reason — the stop is a workflow decision now, not a contract side effect."""
+    flow = BuildWorkflow()
+
+    async def bailed():
+        return SimpleNamespace(
+            status="needs_clarification",
+            summary="AC-3 requires a pure function that performs I/O",
+        )
+
+    monkeypatch.setattr(Build, "implement", bailed)
+    with pytest.raises(FatalError, match="pure function"):
+        await flow.implement()

--- a/backend/tests/test_contracts.py
+++ b/backend/tests/test_contracts.py
@@ -72,11 +72,10 @@ def test_implementation_success_requires_a_delivery():
         _implementation(branch=None, pr_number=None)
 
 
-def test_implementation_needs_clarification_fails_the_run_with_its_reason():
-    # A bail is a stop, not a result: to_result raises with the agent's why, which
-    # becomes the run's failure — read off the dashboard, not dug out of the transcript.
-    from druks.workflows import FatalError
-
+def test_needs_clarification_may_omit_the_delivery_fields():
+    # The bail path carries no commit — the validator binds a delivery only on
+    # success, so a needs_clarification output validates with the shas left null.
+    # The workflow turns that bail into a run-stopping failure (see the plan-phase tests).
     bailed = _implementation(
         status="needs_clarification",
         summary="AC-3 requires a pure function that performs I/O",
@@ -86,8 +85,8 @@ def test_implementation_needs_clarification_fails_the_run_with_its_reason():
         branch=None,
         pr_number=None,
     )
-    with pytest.raises(FatalError, match="pure function"):
-        bailed.to_result()
+    assert bailed.status == "needs_clarification"
+    assert "pure function" in bailed.summary
 
 
 def test_get_answered_maps_picks_to_labels_and_keeps_free_text_verbatim():
@@ -95,13 +94,17 @@ def test_get_answered_maps_picks_to_labels_and_keeps_free_text_verbatim():
     # words (kept verbatim); unanswered questions don't reach the re-plan agent.
     plan = O.PlanData(
         questions=[
-            O.Question(
-                id="q1", prompt="Which cache?", options=[O.QuestionOption(id="a", label="Redis")]
+            O.QuestionOutput(
+                id="q1",
+                prompt="Which cache?",
+                options=[O.QuestionOptionOutput(id="a", label="Redis")],
             ),
-            O.Question(
-                id="q2", prompt="Which queue?", options=[O.QuestionOption(id="a", label="SQS")]
+            O.QuestionOutput(
+                id="q2",
+                prompt="Which queue?",
+                options=[O.QuestionOptionOutput(id="a", label="SQS")],
             ),
-            O.Question(id="q3", prompt="Feature flag?", options=[]),
+            O.QuestionOutput(id="q3", prompt="Feature flag?", options=[]),
         ]
     )
     assert plan.get_answered({"q1": "a", "q2": "kafka — we already run it"}) == [


### PR DESCRIPTION
Item 2 of the build-extension cleanup: collapse the `*Output`/domain-twin double-modeling in `contracts.py` so each agent result flows as its `*Output` directly.

## The premise

Every agent result was modelled twice — the strict `AgentOutput` the LLM must emit, and a hand-written plain-`BaseModel` twin that `to_result()` copied it into field by field. The rationale (*"keep the contract out of durable records"*) doesn't hold: the raw contract is already persisted to the `AgentCall`'s `output.json`, and `to_result()` runs **inside** the memoized DBOS step — so the twin was a second, lossier copy, not a firewall. For the field-identical cases it was pure toll.

## What changed

Use the `*Output` types directly where the twin only mirrored them:

- **Drop `Question` / `QuestionOption` / `AcceptanceCriterion`** (field-identical, nested only inside `PlanData`) and the `_criteria()` helper. `PlanData` keeps its role — it normalizes two producers (`generate_plan` and `revise_contract`) into one "current plan" — but now holds the `*Output` nested types, so `PlanOutput.to_result` is a direct field copy. (The three dead `Question` fields — `status`/`answer`/`comment_id` — go with it.)
- **Drop `PlanReview` → use `ReviewOutput`**; **drop `ImplementationReview` → use `EvaluationOutput`** (its `findings`/`checks`/`acceptance_results`, previously thrown away, are now available to surface). Both `to_result` overrides go — the default returns `self`.
- **Drop the `Implementation` twin.** `ImplementationOutput`'s `needs_clarification` bail moves from `to_result` into `BuildWorkflow.implement()`, where every other terminal stop already lives (cancel/close raise from the body). The step returns the fact; the body decides the run stops — deterministic on replay, and consistent with the rest of the workflow.

**Kept:** `HumanFeedback` (a genuine two-source merge of `TriageOutput` + the gate reply) and `RepoProfilerOutput`'s map to its stored-JSON shape.

## Verification
- `ruff` — clean
- `pyright` — **28 = baseline** (identical to `origin/main`; zero new errors)
- Full `build` extension load via `druks.extensions.loader` — imports + wiring intact
- Collapsed contract logic (`get_answered`, the delivery validator, the moved bail) exercised directly against the branch
- Tests updated: `test_contracts.py`, `test_build_plan_phase.py` (incl. a new workflow-level bail test), `test_build_durable.py`

Net: **−44 lines**, one shape per agent result, `contracts.py` down 132 lines. `contracts.py` is now just the wire schemas + `PlanData` + `HumanFeedback` — the name finally fits.
