### PR TITLE
Remove the scoper's split-recommendation machinery

### DIFF
--- a/backend/druks/build/extension.py
+++ b/backend/druks/build/extension.py
@@ -150,7 +150,6 @@ class Build(Extension):
         "run.cancelled": "cancelled",
         "run.pending_input": "waiting on you",
         "needs_answers": "needs answers",
-        "split_recommended": "split recommended",
     }
 
     @classmethod

--- a/backend/druks/build/scoping/contracts.py
+++ b/backend/druks/build/scoping/contracts.py
@@ -2,29 +2,14 @@ from typing import Literal
 
 from druks.agents import AgentOutput
 
-from .exceptions import ScoperError
-
 
 class RelatedRepoOutput(AgentOutput):
     full_name: str
     purpose: str
 
 
-class SplitTicketOutput(AgentOutput):
-    title: str
-    problem: str
-    scope: str
-    acceptance_criteria: list[str]
-    blocked_by: list[int]
-
-
-class SplitProposalOutput(AgentOutput):
-    rationale: str
-    tickets: list[SplitTicketOutput]
-
-
 class ScopeBriefOutput(AgentOutput):
-    status: Literal["ready", "needs_answers", "split_recommended"]
+    status: Literal["ready", "needs_answers"]
     problem: str
     scope: str
     acceptance_criteria: list[str]
@@ -35,18 +20,3 @@ class ScopeBriefOutput(AgentOutput):
     # uncompressed escape hatch the compressed brief loses by design.
     decisions: list[str]
     open_questions: list[str]
-    # Always present; non-empty tickets only meaningful when status is
-    # split_recommended (empty for the other statuses keeps Codex output flat).
-    split_recommendation: SplitProposalOutput
-
-    def to_result(self) -> "ScopeBriefOutput":
-        if self.status == "split_recommended" and not self.split_recommendation.tickets:
-            raise ScoperError("split_recommended status requires at least one proposed ticket")
-        # A child wired to a non-existent sibling (or itself) would silently
-        # break dependency rendering later.
-        tickets = self.split_recommendation.tickets
-        for index, ticket in enumerate(tickets):
-            for dep in ticket.blocked_by:
-                if dep == index or dep not in range(len(tickets)):
-                    raise ScoperError(f"split ticket #{index} has invalid blocked_by index {dep}")
-        return self

--- a/backend/druks/build/scoping/exceptions.py
+++ b/backend/druks/build/scoping/exceptions.py
@@ -1,2 +1,0 @@
-class ScoperError(Exception):
-    pass

--- a/backend/druks/build/scoping/workflows.py
+++ b/backend/druks/build/scoping/workflows.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 # answered on the ticket (external), so the ask is just the dashboard's one-liner.
 _PARKED_ASK = {
     "needs_answers": {"presentation": "external", "label": "Answer scope questions"},
-    "split_recommended": {"presentation": "external", "label": "Decide on proposed split"},
 }
 
 

--- a/backend/templates/prompts/build/scope/scope_brief.md
+++ b/backend/templates/prompts/build/scope/scope_brief.md
@@ -31,8 +31,9 @@ loops that could have been avoided here for the cost of one careful read.
   version?", "Which component file?" are questions for the planner — they read the code.
 - Do not invent requirements beyond what the ticket and comments imply.
 - Do not split a coherent vertical slice (one endpoint + its UI consumer making the smallest
-  useful feature chunk) — that is the right PR size, not a split candidate. Split only when
-  independent surfaces could each ship and deliver value without the other.
+  useful feature chunk) — that is the right PR size, not a split candidate. When work genuinely
+  bundles independent surfaces that could each ship on their own, don't scope it silently as one:
+  raise the split as an open question (instruction 5) and let the operator decide.
 
 Produce a structured scope brief for the ticket below so the implementation agent
 (and humans) know exactly what to do — and leave the brief on the ticket yourself.
@@ -69,26 +70,19 @@ The Linear project this issue lives in maps to the following repositories in you
 
 4. If the issue is genuinely ambiguous about scope, set `status` to `"needs_answers"` and put precise questions in `open_questions`. Each question should be answerable in one or two short comments. Leave the other brief fields as best-effort placeholders (empty arrays / empty strings are fine).
 
-5. **Before settling on `"ready"`, check whether the work should be split into multiple sub-tickets.** A too-large ticket is the most common cause of wasted review loops and oversized PRs — catching it here, before any planning happens, is cheap. Split when *any* of these are true:
+5. **Before settling on `"ready"`, check whether the work is too large to ship as one reviewable PR.** A too-large ticket is the most common cause of wasted review loops and oversized PRs — catching it here, before any planning happens, is cheap. Treat it as a scope ambiguity: if the work genuinely bundles independent surfaces that could each ship on their own, set `status` to `"needs_answers"` and ask the operator — as an entry in `open_questions` — whether to split it, naming the seam you would carve along ("This bundles a new `/api/x` endpoint and its dashboard consumer, which could ship separately — split into two tickets, or scope as one?"). You name the seam in one line; the operator decides. Do not model the sub-tickets yourself.
+
+   Raise the split question when *any* of these are true:
    - The work crosses independent surfaces that each have their own value and could ship separately with mocks for the other (e.g. new backend endpoint + new UI consumer; data model + admin tool that uses it; migration + the feature that depends on it).
    - It bundles a refactor or migration with a feature — the refactor should land first on its own so the feature PR is a small, reviewable diff on top.
    - The acceptance criteria fall into two or more independent groups where one group could ship and be useful without the other.
-   - The work has a clear A → B → C ordering where each step is itself a meaningful PR-sized chunk (not just "implement, then write tests" — those are one PR).
 
-   **Do NOT split** when the ticket is:
+   **Do NOT** raise it when the ticket is:
    - A single feature that touches many files inside one module or one boundary (frontend-only, backend-only).
    - A pure refactor, pure bugfix, or pure docs change.
    - Vertically thin: one endpoint + one UI consumer that together make the smallest useful slice of a new feature. Vertical slices are the *right* size, even when they cross layers.
 
-   When in doubt, prefer `"ready"`. False splits are expensive — they fragment a coherent change into a chain of tiny PRs the operator has to babysit. Splits should be the exception, reserved for tickets that would clearly produce a sprawling PR otherwise.
-
-   When you decide to split, set `status` to `"split_recommended"` and populate `split_recommendation`:
-   - `rationale`: one paragraph — name the seams you're carving along and why each child can stand on its own. The operator reads this first to decide whether to accept the split.
-   - `tickets`: ordered list. Earliest-shippable first. For each entry:
-     - `title`: concise, Linear-style ("Add user model" not "Implementing the user model class").
-     - `problem`, `scope`, `acceptance_criteria`: same shape as the parent brief but scoped to this child only.
-     - `blocked_by`: list of integer indices into this `tickets` array — which other proposed sub-tickets must ship before this one. Use `[]` for independent children. The first proposed ticket always has `blocked_by: []`.
-   Leave the parent brief fields (`problem`, `scope`, `acceptance_criteria`, `stack_hints`, `related_repos`, `out_of_scope`, `open_questions`) as empty arrays / empty strings — the parent will be re-scoped (or closed as an epic) once the operator accepts the split.
+   When in doubt, prefer a single `"ready"` brief. False splits are expensive — they fragment a coherent change into a chain of tiny PRs the operator has to babysit. A split question should be the exception, reserved for tickets that would clearly produce a sprawling PR otherwise.
 
 6. Otherwise set `status` to `"ready"` and fill in every brief field. The brief is a fast-scan summary — the original Linear source stays available below it for detail. **Aim for ≤ 600 tokens across the *summary* fields** (`problem`, `scope`, `acceptance_criteria`). The cap does **not** apply to `decisions` (see below) — that section preserves operator-stated contracts uncompressed.
    - `problem`: at most three sentences stating the user-facing problem. Use the source's own framing where it provides one. You may add a single clause of inferred motivation when it helps an implementer understand "why now", but do not invent requirements that aren't implied by the source.
@@ -107,11 +101,10 @@ The Linear project this issue lives in maps to the following repositories in you
      Empty list is fine when the operator only restated the original description without adding refinement detail. But if the operator's comments contain any of the shapes above, the corresponding text MUST appear in `decisions` near-verbatim — paraphrasing loses the precision that made the operator write it down in the first place. **When in doubt, copy more.** The brief gets longer; the implementer gets the contract right; nobody loses.
    - `stack_hints`: lowercase ecosystem-level labels — frameworks, libraries, languages, datastores, runtimes (e.g. `frontend`, `nextjs`, `django`, `postgres`, `pytest`). **Never file paths, module names, app directories, project locations, or feature names.** A label that contains a slash, points to a directory, or names a specific module is wrong — use the framework or technology behind it instead. Do not include backend/database/server labels just because the selected app repo contains them when the issue is clearly frontend-only, design-only, or documentation-only.
 
-     **stack_hints MUST be non-empty when status is `ready`.** An empty array is never correct for a finalised brief — every implementation ticket touches at least one language/framework/runtime, and this is the fast-scan context the implementer reads before touching the code. If the technologies are obvious from the source ticket or the `related_repos` descriptions above, write them down — being explicit is cheap, omission costs revision rounds. The empty-array path is only legal when `status` is `"needs_answers"` or `"split_recommended"`.
+     **stack_hints MUST be non-empty when status is `ready`.** An empty array is never correct for a finalised brief — every implementation ticket touches at least one language/framework/runtime, and this is the fast-scan context the implementer reads before touching the code. If the technologies are obvious from the source ticket or the `related_repos` descriptions above, write them down — being explicit is cheap, omission costs revision rounds. The empty-array path is only legal when `status` is `"needs_answers"`.
    - `related_repos`: each entry is `{ "full_name": "org/repo", "purpose": "design reference" }`. Use only repos from the directory above. **The implementation target itself MUST NOT appear here.** `related_repos` is a list of *additional* read-only references the implementer should consult (design refs, sibling services, shared schemas) — it must not echo the primary repo the ticket is assigned to. Including the target repo causes the implementer harness to grant itself a redundant read permission against its own working directory, which has triggered concrete tool-routing failures downstream.
    - `out_of_scope`: explicit non-goals so the agent doesn't drift. **Preserve the source's out-of-scope items verbatim or near-verbatim when present.** These are firewall statements; paraphrasing loses precision.
    - `open_questions`: empty list when status is `"ready"`.
-   - `split_recommendation`: empty proposal (`{"rationale": "", "tickets": []}`) when status is `"ready"`.
 
 # Leave your outcome on the ticket
 
@@ -147,22 +140,7 @@ emitting the JSON, matching your `status`:
 >
 > - <each open question as a bullet>
 
-**`split_recommended`** — post ONE comment on the ticket:
-
-> **Druks scoping — split recommended for {{ remote_key }}**
->
-> <rationale paragraph>
->
-> Proposed sub-tickets:
->
-> ### 1. <title>
-> <problem>
-> **Scope.** <scope>
-> **Acceptance:** <bullets>
-> _Blocked by: <1-indexed ticket numbers, when any>_
-> (…one section per proposed ticket)
-
-Post the comment for a parked status even if a near-identical comment from a previous
+Post the comment for a needs_answers park even if a near-identical comment from a previous
 round exists — each round's questions supersede the last.
 
 7. Return ONLY the JSON object matching the schema. No prose, no preamble.

--- a/backend/tests/test_api_work_items.py
+++ b/backend/tests/test_api_work_items.py
@@ -17,7 +17,7 @@ _RUN_STATE = {
 
 def _seed_scope_run(db_session, item, *, state="finished", status=None):
     """A scope run for ``item`` (keyed by its remote_key) with its ``scope``
-    agent call. A needs_answers / split_recommended status parks the run on the
+    agent call. A needs_answers status parks the run on the
     ScopeReply gate (PENDING_INPUT + input_request) — seeded from the workflow's
     own gate ask so the board reads exactly what the workflow stores at the park
     point."""

--- a/backend/tests/test_scope_brief_prompt.py
+++ b/backend/tests/test_scope_brief_prompt.py
@@ -43,7 +43,6 @@ async def test_prompt_owns_the_tracker_writes():
     assert "Write the brief into the ticket description" in output
     assert "druks-scoped" in output
     assert "open questions for ACME-1" in output
-    assert "split recommended for ACME-1" in output
 
 
 async def test_prompt_carries_the_recommended_skills():

--- a/backend/tests/test_scope_brief_prompt.py
+++ b/backend/tests/test_scope_brief_prompt.py
@@ -67,15 +67,16 @@ async def test_prompt_tells_scoper_to_focus_stack_hints_on_task_surface():
     assert "Do not include backend/database/server labels" in output
 
 
-async def test_prompt_teaches_scoper_when_to_recommend_a_split():
-    # The split branch is the operator's main upstream defence against
-    # oversized PRs and wasted review loops. If this guidance ever drops
-    # out of the prompt, scoping silently regresses to always-ready and
-    # we won't notice until tickets get too big again.
+async def test_prompt_teaches_scoper_to_raise_oversized_work_as_a_question():
+    # Oversized-ticket detection is the scoper's main upstream defence against
+    # wasted review loops. It routes through needs_answers now (ask the operator
+    # whether to split) rather than a structured proposal — if this guidance ever
+    # drops out, scoping silently regresses to always-ready and we won't notice
+    # until tickets get too big again.
     output = await _render()
-    assert "split_recommended" in output
-    assert "Do NOT split" in output
-    assert "Vertical slices" in output
+    assert "too large to ship as one reviewable PR" in output
+    assert "whether to split" in output
+    assert "Vertical slices are the" in output
 
 
 async def test_jira_prompt_carries_connector_routing_hint():

--- a/backend/tests/test_scope_durable.py
+++ b/backend/tests/test_scope_durable.py
@@ -81,7 +81,7 @@ async def _wait(engine, wfid, predicate, timeout=20.0):
 
 
 def _brief(status, *, questions=()):
-    from druks.build.scoping.contracts import ScopeBriefOutput, SplitProposalOutput
+    from druks.build.scoping.contracts import ScopeBriefOutput
 
     return ScopeBriefOutput(
         status=status,
@@ -93,7 +93,6 @@ def _brief(status, *, questions=()):
         out_of_scope=[],
         decisions=[],
         open_questions=list(questions),
-        split_recommendation=SplitProposalOutput(rationale="", tickets=[]),
     )
 
 


### PR DESCRIPTION
Item 3 (first half): remove the scoper's **split-recommendation** machinery. `Project.slug` — the other half of the original item 3 — is left for a follow-up (it needs a migration).

## Why

The scoper could return `status="split_recommended"` with a fully-structured proposal — `SplitProposalOutput` / `SplitTicketOutput[]` with a `blocked_by` dependency graph, validated in `to_result`. But **nothing ever consumed that structure**: the agent posts a prose comment for the operator, the human splits manually, and druks validated the graph then threw it away (`blocked_by` / `SplitTicketOutput` appeared only in `scoping/contracts.py`). A validated-but-unread graph reads as load-bearing when it isn't.

Rather than leave a degraded stub, remove it whole and reintroduce splits as a **real feature** later — agent proposes → operator accepts at the gate → druks *materializes* the child work items with the dependency graph, wired end to end.

## What changed

- **`ScopeBriefOutput`**: drop `SplitTicketOutput` / `SplitProposalOutput` / the `split_recommendation` field / the `to_result` graph guard; narrow `status` to `Literal["ready", "needs_answers"]`.
- **`scoping/exceptions.py` deleted** — `ScoperError` existed only to police the split graph.
- Drop the `split_recommended` entries from `_PARKED_ASK` (scope gate) and the feed's `_LABEL`.

## The behavior isn't lost — it folds into `needs_answers`

Oversized-ticket detection is the scoper's main upstream defence against wasted review loops, so we keep it. The scope prompt now has the scoper raise *"this bundles independent surfaces that could each ship — split into two tickets, or scope as one?"* as an **open question** the operator answers, instead of a one-way structured proposal parked in a murky state. All the when-to-split / when-not-to-split heuristics stay; only the structured apparatus and the separate status go.

## Verification
- `ruff` — clean · `pyright` — **10 = baseline** (no new errors)
- Full `build` extension load via the loader
- Narrowed contract exercised — `ScopeBriefOutput` now rejects `split_recommended`, accepts `ready`/`needs_answers`
- Scope prompt re-rendered: valid Jinja, no `split_recommended`, new split-as-question guidance present
- Tests updated: `test_scope_durable.py`, `test_scope_brief_prompt.py` (repointed at the new guidance), `test_api_work_items.py`

Net **−56 lines**, no migration, no frontend change (the FE never modelled split).
