### PR TITLE
Drop the vestigial Project.slug column

### DIFF
--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from datetime import datetime
 from typing import Any
 
@@ -28,7 +27,6 @@ class Project(Base):
     # the natural display key — duplicate names would make the project
     # column ambiguous.
     name: Mapped[str] = mapped_column(unique=True)
-    slug: Mapped[str] = mapped_column(unique=True)
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
@@ -39,9 +37,9 @@ class Project(Base):
     )
 
     @classmethod
-    def create(cls, *, name: str, slug: str | None = None) -> "Project":
+    def create(cls, *, name: str) -> "Project":
         session = db_session()
-        project = cls(name=name, slug=slug or slugify(name))
+        project = cls(name=name)
         session.add(project)
         session.flush()
         return project
@@ -161,11 +159,6 @@ class ProjectRepo(Base):
                 if row:
                     return row
         return None
-
-
-def slugify(name: str) -> str:
-    """Lowercase, replace non-alnum runs with single hyphens, trim ends."""
-    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
 
 
 class WorkItem(Base):

--- a/backend/druks/build/routes.py
+++ b/backend/druks/build/routes.py
@@ -3,7 +3,7 @@ import logging
 from fastapi import APIRouter, Body, HTTPException, Query, Response, status
 from sqlalchemy import func, select, update
 
-from druks.build.models import Project, ProjectRepo, WorkItem, slugify
+from druks.build.models import Project, ProjectRepo, WorkItem
 from druks.build.schemas import (
     AddProjectRepoRequest,
     CreateProjectRequest,
@@ -44,7 +44,7 @@ async def create_project(body: CreateProjectRequest) -> ProjectSummary:
     name = body.name.strip()
     if not name:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "name is required")
-    project = Project.create(name=name, slug=body.slug)
+    project = Project.create(name=name)
     return ProjectSummary.from_project(project)
 
 
@@ -119,7 +119,6 @@ async def update_project(
         if not name:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "name cannot be empty")
         project.name = name
-        project.slug = slugify(name)
         db_session().flush()
     return ProjectSummary.from_project(project)
 

--- a/backend/druks/build/schemas.py
+++ b/backend/druks/build/schemas.py
@@ -60,7 +60,6 @@ class ProjectRepoSummary(BaseResponse):
 class ProjectSummary(BaseResponse):
     id: int
     name: str
-    slug: str
     created_at: datetime
     updated_at: datetime
     repos: list[ProjectRepoSummary] = Field(default_factory=list)
@@ -70,7 +69,6 @@ class ProjectSummary(BaseResponse):
         return cls(
             id=project.id,
             name=project.name,
-            slug=project.slug,
             created_at=project.created_at,
             updated_at=project.updated_at,
             repos=[ProjectRepoSummary.from_repo(repo) for repo in project.repos],
@@ -83,7 +81,6 @@ class ProjectsResponse(BaseResponse):
 
 class CreateProjectRequest(BaseModel):
     name: str
-    slug: str | None = None
 
 
 class AddProjectRepoRequest(BaseModel):

--- a/backend/migrations/versions/40cfd4c2aeee_baseline_schema.py
+++ b/backend/migrations/versions/40cfd4c2aeee_baseline_schema.py
@@ -109,12 +109,10 @@ def upgrade() -> None:
         "projects",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
-        sa.Column("slug", sa.String(), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("name"),
-        sa.UniqueConstraint("slug"),
     )
     op.create_table(
         "settings_overrides",

--- a/backend/tests/test_build_durable.py
+++ b/backend/tests/test_build_durable.py
@@ -79,8 +79,8 @@ def _seed_work_item(engine, *, repo: str) -> int:
     from sqlalchemy.orm import Session
 
     with Session(engine) as session:
-        slug = f"rt-{uuid4().hex[:8]}"
-        project = Project(name=slug, slug=slug)
+        name = f"rt-{uuid4().hex[:8]}"
+        project = Project(name=name)
         session.add(project)
         session.flush()
         item = WorkItem(project_id=project.id, repo=repo, title="rt")

--- a/frontend/src/extensions/build/projects/types.ts
+++ b/frontend/src/extensions/build/projects/types.ts
@@ -28,7 +28,6 @@ export interface ProjectRepo {
 export interface Project {
   id: number
   name: string
-  slug: string
   createdAt: string
   updatedAt: string
   repos: ProjectRepo[]
@@ -40,7 +39,6 @@ export interface ProjectsResponse {
 
 export interface CreateProjectRequest {
   name: string
-  slug?: string | null
 }
 
 export interface UpdateProjectRequest {


### PR DESCRIPTION
Item 3 (second half): drop the vestigial `Project.slug` column.

## Why

`Project.slug` was written on create/rename (`slugify(name)`), `unique`-constrained, and surfaced in the API response + FE type — but **never read**. No `/projects/<slug>` route ever existed (projects are addressed by id; there's no project detail page), and git history shows no slug lookup was ever wired. It was a natural-key handle for URLs that never got built.

## What changed

- **`models.py`** — drop the column, the `slug` param on `Project.create`, the `slugify()` helper (its only callers were here and `routes.py`), and the now-orphaned `import re`.
- **`schemas.py`** — drop `ProjectSummary.slug` (+ its `from_project` mapping) and `CreateProjectRequest.slug`.
- **`routes.py`** — `create`/`rename` stop computing a slug.
- **baseline migration** — edit the single pre-1.0 baseline (`40cfd4c2aeee`, from the #33 collapse) to drop the `projects.slug` column + its unique constraint, keeping it identical to the models. Chose editing the baseline over an incremental migration to preserve the single-baseline convention #33 just established.
- **FE** — drop `slug` from the `Project` and `CreateProjectRequest` types (never rendered by `ProjectsPage`).

## Verification
- `ruff` — clean · `pyright` — clean
- Full `build` extension load — `projects` columns are now exactly `{id, name, created_at, updated_at}`; `ProjectSummary`/`CreateProjectRequest` have no `slug`; `slugify` no longer exported
- Frontend `tsc -b` + `eslint` — clean

Net **−15 lines**.

## ⚠️ Deploy note
Test/CI DBs build the schema from the models via `create_all`, so they're correct immediately. Fresh alembic DBs get the edited baseline. But an **existing** DB that already applied the baseline keeps the `projects.slug` (NOT NULL) column — once this code stops providing `slug` on insert, `Project.create` would fail there. Pre-1.0, those DBs get recreated from the baseline; a deployed DB that isn't recreated needs the column dropped manually before this ships.
