### PR TITLE
Delete the dead extension_config_snapshot concept

### DIFF
--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -199,11 +199,6 @@ class WorkItem(Base):
         ForeignKey("durable_runs.id", ondelete="SET NULL"), default=None
     )
     status: Mapped[str | None] = mapped_column(default=None)
-    # Intake-time snapshot of the resolved ``.druks/build`` config; the
-    # workflow reads it for the item's lifespan so a mid-flight config
-    # push can't flip policy under a running build. Empty only until
-    # intake fills it in (the workflow then resolves live).
-    extension_config_snapshot: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict)
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
@@ -376,12 +371,9 @@ class WorkItem(Base):
         branch: str | None = None,
         build_run_id: str | None = None,
         project_id: int | None = None,
-        extension_config_snapshot: dict[str, Any] | None = None,
     ) -> None:
         if title is not None:
             self.title = title
-        if extension_config_snapshot is not None:
-            self.extension_config_snapshot = extension_config_snapshot
         if remote_url is not None:
             self.remote_url = remote_url
         if pr_number is not None:

--- a/backend/druks/build/subscribers.py
+++ b/backend/druks/build/subscribers.py
@@ -133,9 +133,13 @@ async def _observe_external_close(*, repo: str, pr_number: int, work_item: WorkI
         return
     work_item.set_status(HandoffStatus.CANCELLED, event_payload={"external": True})
     await work_item.cancel_active_build(failure="pr closed without merge")
-    snapshot_policy = work_item.extension_config_snapshot.get("policy") or {}
-    if RepoPolicy.model_validate(snapshot_policy).delete_branch:
-        await _delete_branch(repo, work_item.branch)
+    # Branch cleanup is best-effort: resolving policy is live IO now, and a fetch
+    # failure must not strand the ticket — its reset below still runs.
+    try:
+        if (await RepoPolicy.resolve(repo)).delete_branch:
+            await _delete_branch(repo, work_item.branch)
+    except Exception:  # noqa: BLE001 — cleanup only, like _delete_branch itself
+        logger.warning("Skipped branch cleanup for %s#%s.", repo, pr_number, exc_info=True)
     # The attempt was abandoned, not the ticket: send it back to the
     # provider's resting pool rather than stranding it in In Progress.
     await work_item.set_remote_status(SemanticStatus.READY_FOR_AGENT)

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -182,14 +182,12 @@ class BuildWorkflow(Workflow):
         task_owner_email: str | None = None,
         task_owner_name: str | None = None,
     ) -> None:
-        work_item_id = self.subject["id"] if self.subject else None
-        self._work_item_id = work_item_id
         # Resolve the repo's policy + profile and the operator settings inside
         # steps so their reads are memoized — the body itself does no IO, and
         # replay reuses the values.
-        snapshot = await self._load_policy_and_profile()
-        self._policy = RepoPolicy.model_validate(snapshot["policy"])
-        self._profile = snapshot["profile"]
+        resolved = await self._load_policy_and_profile()
+        self._policy = RepoPolicy.model_validate(resolved["policy"])
+        self._profile = resolved["profile"]
         self._settings = await self._load_settings()
 
         if not await self._plan_phase():
@@ -275,11 +273,7 @@ class BuildWorkflow(Workflow):
 
     @step
     async def _load_policy_and_profile(self) -> dict[str, Any]:
-        # One memoized read: the work item's dispatch-time snapshot when present,
-        # else the live policy + the repo's profiled facts.
-        item = WorkItem.get(self._work_item_id) if self._work_item_id else None
-        if item and item.extension_config_snapshot:
-            return item.extension_config_snapshot
+        # One memoized read: the live policy + the repo's profiled facts.
         policy = await RepoPolicy.resolve(self.input.repo)
         # A build dispatches against a work item whose repo is registered.
         target = ProjectRepo.get_for_repo(self.input.repo)

--- a/backend/migrations/versions/b3f1a9c47d20_drop_extension_config_snapshot.py
+++ b/backend/migrations/versions/b3f1a9c47d20_drop_extension_config_snapshot.py
@@ -1,0 +1,36 @@
+"""drop work_items.extension_config_snapshot
+
+Revision ID: b3f1a9c47d20
+Revises: 0ec9db44973e
+Create Date: 2026-07-19 17:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "b3f1a9c47d20"
+down_revision: str | Sequence[str] | None = "0ec9db44973e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("work_items", "extension_config_snapshot")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "work_items",
+        sa.Column(
+            "extension_config_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+    )
+    op.alter_column("work_items", "extension_config_snapshot", server_default=None)

--- a/backend/tests/test_extension_config.py
+++ b/backend/tests/test_extension_config.py
@@ -1,5 +1,5 @@
 import pytest
-from conftest import make_settings, make_test_work_item
+from conftest import make_settings
 from druks.build.policy import RepoPolicy
 from druks.extensions.config import resolve_extension_config
 from druks.extensions.exceptions import ExtensionConfigError
@@ -124,11 +124,11 @@ class TestExtensionPromptOverridePaths:
         assert await _resolve_override("build/build_workflow/implement.md", repo=REPO) == "tuned"
 
 
-class TestWorkItemSnapshot:
-    """The build run resolves its policy + profile once: a snapshotted work item
-    holds for the item's lifespan; without a snapshot it resolves live. Pins
-    the ``_load_policy_and_profile`` decision in isolation — the @step runs
-    through a pass-through so no DBOS runtime is needed."""
+class TestLoadPolicyAndProfile:
+    """The build run resolves its policy + profile once, live — the repo's
+    config plus its profiled facts. Pins ``_load_policy_and_profile`` in
+    isolation; the @step runs through a pass-through so no DBOS runtime is
+    needed."""
 
     @pytest.fixture(autouse=True)
     def _passthrough_step(self, monkeypatch, db_engine):
@@ -143,32 +143,14 @@ class TestWorkItemSnapshot:
         yield
         configure_engine(None)
 
-    def _flow(self, *, repo, work_item_id):
+    def _flow(self, *, repo):
         from druks.build.workflows import BuildWorkflow
 
         flow = BuildWorkflow()
         flow.input = BuildWorkflow._run_input_model(repo=repo, pr_number=1, branch="agent/x")
-        flow._work_item_id = work_item_id
         return flow
 
-    async def test_run_reads_snapshot_from_work_item(self, db_session, monkeypatch):
-        async def _boom(cls, repo):
-            raise AssertionError("snapshot present — live resolution is a bug")
-
-        monkeypatch.setattr(RepoPolicy, "resolve", classmethod(_boom))
-
-        item = make_test_work_item(repo=REPO, title="t")
-        item.update(
-            extension_config_snapshot={
-                "policy": {"sandbox": {"image": "snapped"}},
-                "profile": {},
-            }
-        )
-
-        snapshot = await self._flow(repo=REPO, work_item_id=item.id)._load_policy_and_profile()
-        assert RepoPolicy.model_validate(snapshot["policy"]).sandbox.image == "snapped"
-
-    async def test_run_resolves_live_without_snapshot(self, db_session, monkeypatch):
+    async def test_resolves_live(self, db_session, monkeypatch):
         from druks.build.models import Project, ProjectRepo
 
         async def _live(cls, repo):
@@ -181,9 +163,9 @@ class TestWorkItemSnapshot:
         project = Project.create(name="Acme")
         ProjectRepo.create(project_id=project.id, full_name=REPO)
 
-        snapshot = await self._flow(repo=REPO, work_item_id=None)._load_policy_and_profile()
-        assert RepoPolicy.model_validate(snapshot["policy"]).sandbox.image == "live"
-        assert snapshot["profile"] == {}  # registered but not yet profiled
+        resolved = await self._flow(repo=REPO)._load_policy_and_profile()
+        assert RepoPolicy.model_validate(resolved["policy"]).sandbox.image == "live"
+        assert resolved["profile"] == {}  # registered but not yet profiled
 
 
 class TestPolicyKeysParsing:

--- a/backend/tests/test_webhooks_pull_request.py
+++ b/backend/tests/test_webhooks_pull_request.py
@@ -10,6 +10,16 @@ from druks.events.models import Event
 from sqlalchemy import func, select
 
 
+@pytest.fixture(autouse=True)
+def _stub_config_fetch(monkeypatch):
+    # The external-close path resolves the repo's live .druks/build/config.yml;
+    # default to "no file" (default policy) so tests don't reach GitHub.
+    async def _fetch(*, repo, path):
+        return None
+
+    monkeypatch.setattr("druks.extensions.config.fetch_file", _fetch)
+
+
 def _milestone_count(work_item_id, milestone):
     from druks.database import db_session
 
@@ -235,9 +245,14 @@ async def test_external_merge_pushes_done(db_session, tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_external_close_honors_delete_branch_policy(db_session, tmp_path, monkeypatch):
-    """delete_branch: false in the item's extension-config snapshot keeps the
+    """delete_branch: false in the repo's live .druks/build/config.yml keeps the
     head branch on an external close."""
     from druks.build import subscribers as webhooks_mod
+
+    async def _fetch(*, repo, path):
+        return "delete_branch: false\n"
+
+    monkeypatch.setattr("druks.extensions.config.fetch_file", _fetch)
 
     deleted = []
 
@@ -247,12 +262,7 @@ async def test_external_close_honors_delete_branch_policy(db_session, tmp_path, 
     monkeypatch.setattr(webhooks_mod, "_delete_branch", _record)
 
     repo, pr_number, branch = "ClawHaven/acme-app", 93, "agent/eng-22"
-    work_item_id, _ = _park_work_item(repo=repo, pr_number=pr_number, branch=branch)
-    from druks.build.models import WorkItem
-
-    WorkItem.get(work_item_id).update(
-        extension_config_snapshot={"policy": {"delete_branch": False}}
-    )
+    _park_work_item(repo=repo, pr_number=pr_number, branch=branch)
 
     await _fire_closed(
         repo=repo, pr_number=pr_number, branch=branch, tmp_path=tmp_path, merged=False
@@ -280,3 +290,42 @@ async def test_external_close_deletes_branch_by_default(db_session, tmp_path, mo
     )
 
     assert deleted == [(repo, branch)]
+
+
+@pytest.mark.asyncio
+async def test_external_close_survives_policy_resolution_failure(db_session, tmp_path, monkeypatch):
+    """Branch cleanup is best-effort: a policy-resolution failure must not strand
+    the ticket — the cancel and resting-pool reset still happen."""
+    from druks.build import subscribers as webhooks_mod
+    from druks.build.policy import RepoPolicy
+    from druks.ticketing.enums import SemanticStatus
+
+    async def _boom(cls, repo):
+        raise RuntimeError("github down")
+
+    monkeypatch.setattr(RepoPolicy, "resolve", classmethod(_boom))
+
+    deleted = []
+
+    async def _delete(repo, branch):
+        deleted.append((repo, branch))
+
+    monkeypatch.setattr(webhooks_mod, "_delete_branch", _delete)
+
+    pushed = []
+
+    async def _record(self, status):
+        pushed.append(status)
+
+    monkeypatch.setattr(WorkItem, "set_remote_status", _record)
+
+    repo, pr_number, branch = "ClawHaven/acme-app", 95, "agent/eng-24"
+    work_item_id, _ = _park_work_item(repo=repo, pr_number=pr_number, branch=branch)
+
+    await _fire_closed(
+        repo=repo, pr_number=pr_number, branch=branch, tmp_path=tmp_path, merged=False
+    )
+
+    assert deleted == []  # cleanup skipped when policy can't be resolved
+    assert pushed == [SemanticStatus.READY_FOR_AGENT]  # ticket still reset
+    assert _milestone_count(work_item_id, "cancelled") == 1


### PR DESCRIPTION
## What & why

`_observe_external_close` decided whether to delete a closed PR's branch by reading
`WorkItem.extension_config_snapshot`, but **nothing in production ever populated that
column** — it stayed `{}`, so `RepoPolicy.model_validate({}).delete_branch` fell to its
default `True`. An operator's `.druks/build/config.yml` `delete_branch: false` was
silently ignored on the external-close path, even though the merge path resolved policy
live and honored it.

Rather than implement the never-built "freeze policy for a run's lifespan" idea, this
deletes the dead concept:

- Drop the `extension_config_snapshot` column (+ migration `b3f1a9c47d20`) and the
  `update()` param.
- `_load_policy_and_profile` always resolves live (drops the snapshot branch).
- `_observe_external_close` resolves `RepoPolicy` live for the repo.
- Retarget the two snapshot-manufacturing tests onto the real close path — a repo with
  `delete_branch: false` keeps its branch on external close.

## Codex adversarial review

Ran Codex as a skeptic against the diff. Two findings:

1. **(fixed)** Resolving policy live in `_observe_external_close` adds IO that can raise
   (GitHub/config fetch, invalid YAML) between the build-cancel and the ticket-reset;
   a failed GitHub webhook delivery isn't retried, which would strand the ticket In
   Progress. Made branch cleanup best-effort (matching `_delete_branch`'s own error
   swallowing) so a resolution failure logs and skips cleanup but still resets the
   ticket. Added `test_external_close_survives_policy_resolution_failure`.
2. **(dismissed — out of scope)** `fetch_file` has a 24h disk cache, so "live" is served
   from cache. This is pre-existing, and the **merge path resolves through the same
   cache** — this change gives external-close parity with merge, and is strictly better
   than the old always-`{}` snapshot (which never honored `delete_branch: false`). Cache
   invalidation on config-push is a separate systemic gap, not an ENG-722 regression.

## Tests

DB-backed tests run in CI (the local test DB is shared). Ruff + `ruff format` + pyright
clean on the touched packages (pyright at the repo's pre-existing baseline; no new
errors).

ENG-722
