### PR TITLE
Stop a stale PR-close from cancelling the wrong build

### DIFF
--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -18,6 +18,10 @@ from druks.workflows import Run
 
 logger = logging.getLogger(__name__)
 
+# WorkItem.update() sentinel: a field left at _KEEP is untouched, while passing
+# None clears the (nullable) column — the two an intent flag has to tell apart.
+_KEEP: Any = object()
+
 
 class Project(Base):
     __tablename__ = "projects"
@@ -365,24 +369,24 @@ class WorkItem(Base):
     def update(
         self,
         *,
-        title: str | None = None,
-        remote_url: str | None = None,
-        pr_number: int | None = None,
-        branch: str | None = None,
-        build_run_id: str | None = None,
-        project_id: int | None = None,
+        title: str = _KEEP,
+        remote_url: str | None = _KEEP,
+        pr_number: int | None = _KEEP,
+        branch: str | None = _KEEP,
+        build_run_id: str | None = _KEEP,
+        project_id: int = _KEEP,
     ) -> None:
-        if title is not None:
+        if title is not _KEEP:
             self.title = title
-        if remote_url is not None:
+        if remote_url is not _KEEP:
             self.remote_url = remote_url
-        if pr_number is not None:
+        if pr_number is not _KEEP:
             self.pr_number = pr_number
-        if branch is not None:
+        if branch is not _KEEP:
             self.branch = branch
-        if build_run_id is not None:
+        if build_run_id is not _KEEP:
             self.build_run_id = build_run_id
-        if project_id is not None:
+        if project_id is not _KEEP:
             self.project_id = project_id
         self.updated_at = Base.utc_now()
         db_session().flush()

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -160,7 +160,13 @@ class BuildWorkflow(Workflow):
             task_owner_email=assignee_email,
             task_owner_name=assignee_name,
         )
-        item.update(build_run_id=run_id)
+        # start() hands back the live run's id on a duplicate dispatch; only a
+        # genuinely new run is a fresh attempt. Point the item at it and drop the
+        # prior attempt's branch/PR so a late close for the old PR can't resolve
+        # this item onto the new run and cancel it — a duplicate keeps the live
+        # run's routing untouched.
+        if item.build_run_id != run_id:
+            item.update(build_run_id=run_id, branch=None, pr_number=None)
         # Back onto the active board: a scoped item re-enters flight when its
         # build starts. History is for items at rest in a handoff lane.
         item.set_status(None)

--- a/backend/tests/test_build_dispatch.py
+++ b/backend/tests/test_build_dispatch.py
@@ -20,3 +20,55 @@ async def test_dispatch_pulls_scoped_item_back_onto_the_board(db_session, monkey
     assert run_id == "run-1"
     assert item.build_run_id == "run-1"
     assert item.status is None
+
+
+async def test_redispatch_to_a_new_run_clears_prior_attempt_branch_and_pr(
+    db_session, monkeypatch
+) -> None:
+    """A genuinely new run is a fresh attempt: dispatch points the item at it and
+    drops the prior attempt's branch/PR, so a late close for the old PR can't
+    resolve this item onto the new run."""
+    seed_run(db_session, "run-old")
+    seed_run(db_session, "run-new")
+    item = make_test_work_item(repo="o/r", title="t", remote_key="ACME-2")
+    item.update(build_run_id="run-old", pr_number=7, branch="agent/old")
+
+    async def fake_start(cls, **kwargs):
+        return "run-new"
+
+    monkeypatch.setattr(BuildWorkflow, "start", classmethod(fake_start))
+    await BuildWorkflow.dispatch(work_item_id=item.id)
+
+    assert item.build_run_id == "run-new"
+    assert item.pr_number is None
+    assert item.branch is None
+
+
+async def test_duplicate_dispatch_keeps_the_live_attempt_routing(db_session, monkeypatch) -> None:
+    """A duplicate dispatch dedups to the live run — start() hands back its id —
+    so the item's branch/PR must survive, or PR routing and board links break."""
+    seed_run(db_session, "run-live")
+    item = make_test_work_item(repo="o/r", title="t", remote_key="ACME-3")
+    item.update(build_run_id="run-live", pr_number=7, branch="agent/live")
+
+    async def dedup_start(cls, **kwargs):
+        return "run-live"
+
+    monkeypatch.setattr(BuildWorkflow, "start", classmethod(dedup_start))
+    await BuildWorkflow.dispatch(work_item_id=item.id)
+
+    assert item.build_run_id == "run-live"
+    assert item.pr_number == 7
+    assert item.branch == "agent/live"
+
+
+def test_update_clears_nullable_with_none_and_skips_omitted(db_session) -> None:
+    """update() tells a clear from a skip: pr_number=None clears the column,
+    while leaving branch out preserves it."""
+    item = make_test_work_item(repo="o/r", title="t", remote_key="ACME-4")
+    item.update(pr_number=9, branch="agent/keep")
+
+    item.update(pr_number=None)
+
+    assert item.pr_number is None
+    assert item.branch == "agent/keep"

--- a/backend/tests/test_webhooks_pull_request.py
+++ b/backend/tests/test_webhooks_pull_request.py
@@ -329,3 +329,23 @@ async def test_external_close_survives_policy_resolution_failure(db_session, tmp
     assert deleted == []  # cleanup skipped when policy can't be resolved
     assert pushed == [SemanticStatus.READY_FOR_AGENT]  # ticket still reset
     assert _milestone_count(work_item_id, "cancelled") == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_close_after_redispatch_spares_the_new_run(db_session, tmp_path):
+    """A delayed pr.closed for a superseded attempt's PR must not touch the new
+    run: re-dispatch cleared the item's branch/PR, so the stale close no longer
+    resolves the item."""
+    from druks.database import db_session as ds
+
+    repo, pr_a, branch_a = "ClawHaven/acme-app", 61, "agent/eng-old"
+    item = make_test_work_item(repo=repo, title="Re-dispatched")
+    item.update(pr_number=pr_a, branch=branch_a)
+    # Re-dispatch: a new run takes over and the prior attempt's branch/PR clear.
+    new_run = seed_build_run(ds(), work_item_id=item.id, state="running")
+    item.update(branch=None, pr_number=None)
+
+    await _fire_closed(repo=repo, pr_number=pr_a, branch=branch_a, tmp_path=tmp_path, merged=False)
+
+    assert _fresh_run(new_run.id).state == "running"  # the live attempt is untouched
+    assert _milestone_count(item.id, "cancelled") == 0


### PR DESCRIPTION
## What & why

Attempt-scoped truth (`branch`, `pr_number`, `build_run_id`) lives on the `WorkItem`.
On re-dispatch, `dispatch` swapped `build_run_id` to the new run but left the old
branch/PR in place, and `WorkItem.update()` couldn't clear a nullable field (`None`
meant "skip"). A delayed `pr.closed` for the *old* attempt's PR still resolved the item
by `(repo, pr_number)` and called `cancel_active_build()`, cancelling whatever
`build_run_id` now pointed at — the **new** run.

This is the agreed down-payment (not the deeper redesign):

- `WorkItem.update()` gets a `_KEEP` sentinel, so `None` clears a nullable column
  instead of being a skip. Params are typed to each column's nullability, so only the
  nullable columns can be cleared.
- `dispatch` drops the prior attempt's branch/PR **only when the run actually changes** —
  `start()` hands back the live run's id on a duplicate dispatch, and a duplicate must
  keep the live run's routing.
- `_observe_external_close` guards the cancel: it acts only on a PR the item's current
  attempt owns.

The deeper fix — PR events resolve *the run that owns the PR*, so the `WorkItem` stops
being the attempt authority — is deferred, as the ticket notes.

## Codex adversarial review

Ran Codex as a skeptic against the diff. Findings and resolutions:

1. **(fixed — was a real regression I introduced)** Clearing branch/PR unconditionally on
   dispatch wiped a **live** run's routing, because `start()` returns the existing run's
   id on DBOS dedup (a repeated ticket trigger). Now the clear is gated on
   `item.build_run_id != run_id`. Added `test_duplicate_dispatch_keeps_the_live_attempt_routing`
   alongside the new-run case, both routed through the real `dispatch`.
2. **(deferred — the noted follow-up)** A delayed *old-attempt* `run.state` mirror can
   restore the stale PR after the new attempt took over (the `run.state` signal carries
   no originating run id), re-opening the wrong-cancel window. Closing this needs PR
   events / the provision mirror to be run-scoped — exactly the "PR events resolve the
   run that owns the PR" redesign this ticket defers. Documented as the residual.
3. **(acknowledged)** The `_observe_external_close` guard is tautological on today's
   production path (`observe_pr_closed` resolves the work item via `get_for_pr(pr_number)`,
   so `work_item.pr_number == pr_number` is guaranteed). It's the invariant the ticket
   asked for, load-bearing once resolution moves to the run in the deferred redesign; kept
   as a cheap defensive assertion with a contract test.
4. **(fixed)** Strengthened the dispatch tests to run through `BuildWorkflow.dispatch`
   (not hand-rebound rows), covering both new-attempt-clears and duplicate-preserves.
5. **(fixed)** The `_KEEP` sentinel with `str | None` params broke `is not _KEEP`
   narrowing for the non-null columns (`title`, `project_id`, `extension_config_snapshot`),
   which CI's pyright flags. Typed each param to its column's nullability.

## Tests

DB-backed tests run in CI (the local test DB is shared). Ruff + `ruff format` + pyright
clean on the touched packages (no new errors vs the repo baseline).

ENG-723
