### PR TITLE
Make the build project/repo admin surface honest

### DIFF
--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -100,6 +100,13 @@ class ProjectRepo(Base):
     def get(cls, repo_id: int) -> "ProjectRepo | None":
         return db_session().get(cls, repo_id)
 
+    @classmethod
+    def get_in_project(cls, *, project_id: int, repo_id: int) -> "ProjectRepo | None":
+        # Scoped lookup for the nested /projects/{project_id}/repos/{repo_id} routes:
+        # a repo reached through the wrong project's URL is a miss, not a hit to reject.
+        stmt = select(cls).where(cls.id == repo_id, cls.project_id == project_id).limit(1)
+        return db_session().scalars(stmt).first()
+
     def effective_profile(self) -> dict[str, Any]:
         # {} until the repo profiler has run — an unprofiled repo is a normal state.
         return self.profile.get("effective") or {}

--- a/backend/druks/build/routes.py
+++ b/backend/druks/build/routes.py
@@ -191,9 +191,7 @@ async def update_project_repo(
     repo_id: int,
     purpose: str | None = Body(default=None, embed=True),
 ) -> ProjectRepoSummary:
-    # repo_id is the unique key; the project_id path segment is just where the
-    # repo lives, not a second thing to re-check.
-    row = ProjectRepo.get(repo_id)
+    row = ProjectRepo.get_in_project(project_id=project_id, repo_id=repo_id)
     if not row:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "repo not found")
     if purpose is not None:
@@ -208,7 +206,7 @@ async def update_project_repo(
     response_model_by_alias=True,
 )
 async def profile_project_repo(project_id: int, repo_id: int) -> ProjectRepoSummary:
-    row = ProjectRepo.get(repo_id)
+    row = ProjectRepo.get_in_project(project_id=project_id, repo_id=repo_id)
     if not row:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "repo not found")
     # Profile is subject-unique: start() returns the live run when one is already
@@ -222,7 +220,7 @@ async def profile_project_repo(project_id: int, repo_id: int) -> ProjectRepoSumm
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_project_repo(project_id: int, repo_id: int) -> None:
-    row = ProjectRepo.get(repo_id)
+    row = ProjectRepo.get_in_project(project_id=project_id, repo_id=repo_id)
     if not row:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "repo not found")
     session = db_session()

--- a/backend/tests/test_project_repo_routes.py
+++ b/backend/tests/test_project_repo_routes.py
@@ -65,3 +65,30 @@ def test_profile_endpoint_dispatches(client: TestClient, monkeypatch):
             "repo_id": repo.id,
         }
     ]
+
+
+def test_nested_repo_routes_are_scoped_to_their_project(client: TestClient, monkeypatch):
+    """PATCH / profile / DELETE reached through the wrong project's URL are 404 and
+    side-effect-free — the routes scope by (project_id, repo_id), not repo_id alone."""
+    from druks.build.models import Project, ProjectRepo
+
+    profile_calls = _stub_profile_start(monkeypatch)
+    owner = Project.create(name="Owner")
+    other = Project.create(name="Other")
+    repo_id = ProjectRepo.create(project_id=owner.id, full_name="acme/widget").id
+
+    wrong = f"/api/build/projects/{other.id}/repos/{repo_id}"
+    assert client.patch(wrong, json={"purpose": "infra"}).status_code == 404
+    assert client.post(f"{wrong}/profile").status_code == 404
+    assert client.delete(wrong).status_code == 404
+    # None of the wrong-parent calls mutated the repo or dispatched a profile run.
+    assert ProjectRepo.get(repo_id).purpose is None
+    assert profile_calls == []
+
+    # Through its own project the repo mutates and deletes as normal.
+    right = f"/api/build/projects/{owner.id}/repos/{repo_id}"
+    patched = client.patch(right, json={"purpose": "infra"})
+    assert patched.status_code == 200
+    assert patched.json()["purpose"] == "infra"
+    assert client.delete(right).status_code == 204
+    assert ProjectRepo.get(repo_id) is None

--- a/frontend/src/extensions/build/projects/ProjectsPage.tsx
+++ b/frontend/src/extensions/build/projects/ProjectsPage.tsx
@@ -215,7 +215,7 @@ function ProjectCard({ project }: { project: Project }) {
           onClick={() => {
             if (
               confirm(
-                `Delete project "${project.name}"? Repos in this project become unbound; work items keep their history.`,
+                `Delete project "${project.name}"? Move or delete its work items first — a project still referenced by work items can't be deleted.`,
               )
             ) {
               remove.mutate()


### PR DESCRIPTION
## What & why

Two confirmed FE/API contradictions on the build projects admin surface (low severity —
single-operator, no data loss), grouped as one cleanup:

**1. Project-delete copy contradicted the API.** The confirm dialog promised *"Repos in
this project become unbound; work items keep their history"*, but `delete_project`
returns **409** whenever any `WorkItem` references the project. The operator confirmed a
delete that couldn't happen. Aligned the copy with the 409: move or delete the work items
first.

**2. Nested repo routes ignored their parent.** `PATCH /projects/{project_id}/repos/{repo_id}`,
its `/profile` POST, and the DELETE resolved the repo by `repo_id` alone, so
`/projects/A/repos/B` mutated/profiled/deleted repo B even when B belongs to another
project. Scoped the lookup by `(project_id, repo_id)` — a repo reached through the wrong
project's URL is now 404 (kept the URL contract rather than flattening the routes and
churning the FE client).

## Codex adversarial review

Ran Codex as a skeptic against the diff. Verdict **APPROVE** — core fixes sound, two
non-blocking test gaps, both addressed:

- **(fixed)** The wrong-parent test proved 404 but not that the ops were side-effect-free
  (the later PATCH wrote the same value; `Workflow.start` is globally stubbed). Now it
  asserts the repo's `purpose` is untouched after the wrong PATCH and that no profile run
  was dispatched.
- **(fixed)** The correct-parent path only covered PATCH — an always-404 DELETE regression
  would have passed. Added correct-parent DELETE → 204 and the repo gone.

Codex also verified the copy matches the 409, that PATCH/profile/DELETE are the complete
nested surface (all guard before mutating/dispatching), `add_project_repo` correctly uses
the loaded `project.id`, and no other page carries the stale "unbound" promise.

## Tests

DB-backed route tests run in CI. Ruff + `ruff format` + pyright clean on the touched
package.

ENG-724
