### PR TITLE
Add Run.is_parked and document the replay-rebuilt state idiom

### DIFF
--- a/backend/druks/build/scoping/workflows.py
+++ b/backend/druks/build/scoping/workflows.py
@@ -5,7 +5,7 @@ from druks.build.extension import Build
 from druks.build.models import Project, ProjectRepo, WorkItem
 from druks.build.scoping.contracts import ScopeBriefOutput
 from druks.ticketing.datastructures import Ticket
-from druks.workflows import Gate, Run, RunState, Workflow
+from druks.workflows import Gate, Run, Workflow
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class Scope(Workflow):
     @classmethod
     def parked_for(cls, work_item_id: int) -> Run | None:
         runs = Run.list_for_subject("work_item", str(work_item_id), kind=cls.kind)
-        return next((run for run in runs if run.state == RunState.PENDING_INPUT.value), None)
+        return next((run for run in runs if run.is_parked), None)
 
     async def get_prompt_context(self, **context: object) -> dict[str, object]:
         # Everything the agent needs beyond the ticket it fetches itself: where

--- a/backend/druks/build/subscribers.py
+++ b/backend/druks/build/subscribers.py
@@ -16,7 +16,7 @@ from druks.signals import subscribe
 from druks.ticketing.enums import SemanticStatus
 from druks.ticketing.exceptions import TrackerNotConfigured
 from druks.ticketing.helpers import get_tracker
-from druks.workflows import Run, RunState
+from druks.workflows import Run
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ async def _ship(*, repo: str, pr_number: int, work_item: WorkItem | None) -> Non
     # A RUNNING run converges on its own (its merge step sees the closed PR), so
     # it is left to finish; that includes druks's own merge wrapping up.
     run = work_item.get_build_run()
-    if run and run.state == RunState.PENDING_INPUT.value:
+    if run and run.is_parked:
         await run.cancel(failure="pr merged while parked")
     await work_item.set_remote_status(SemanticStatus.DONE)
     logger.info("Merge observed for %s#%s.", repo, pr_number)

--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -14,13 +14,11 @@ from druks.accounts.models import Account
 from druks.core.models import Uuid7Pk
 from druks.database import db_session, get_session
 from druks.durable.dbos_state import state_expression, subject_filter, updated_at_expression
-from druks.durable.enums import ACTIVE_STATES
+from druks.durable.enums import ACTIVE_STATES, AgentCallStatus, RunState
 from druks.harnesses.artifacts import normalize_token_usage
 from druks.models import Base
 from druks.notifications.models import Notification
 from druks.settings import load_settings
-
-from .enums import AgentCallStatus
 
 if TYPE_CHECKING:
     from druks.sandbox.datastructures import AgentResult
@@ -71,6 +69,10 @@ class Run(Base):
     @property
     def is_active(self) -> bool:
         return self.state in {s.value for s in ACTIVE_STATES}
+
+    @property
+    def is_parked(self) -> bool:
+        return self.state == RunState.PENDING_INPUT.value
 
     @classmethod
     def create_row(cls, engine, *, workflow_id: str, kind: str, account_id: str | None) -> None:

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -146,6 +146,37 @@ visible by comparison. Runs with no account anywhere (crons, background work)
 run as the system account. Resuming a parked run keeps its original attribution;
 the person clicking Resume never becomes the payer.
 
+### Replay-rebuilt workflow state
+
+A `run_multistep()` body often accumulates working state across its calls — the
+drafts produced so far, the reviews of the current draft, the last delivery.
+Hold that state in plain instance attributes and mutate them only from
+orchestration-body code, right after the memoized call that produced the value:
+
+```python
+class Sweep(Workflow):
+    def __init__(self) -> None:
+        super().__init__()
+        self._findings: list[str] = []
+
+    async def run_multistep(self, repo: str) -> None:
+        self._findings.extend(await self.scan(repo))
+```
+
+This is durable by determinism: recovery re-runs the body from the top with
+every `@step`, agent call, and gate reply memoized, so the attributes rebuild
+to exactly what the live pass held. It is the standard durable-execution idiom —
+Temporal workflows hold state the same way.
+
+The one trap: never mutate these attributes inside a `@step` or `run()`. A
+completed step is skipped on replay — its body never runs again — so a write
+made there silently vanishes from the rebuilt state. A step returns values;
+the replayed body records them.
+
+`BuildJournal` (`backend/druks/build/journal.py`) is the reference shape: one
+typed object owning the run's working memory, with this contract stated on the
+class.
+
 ### Schedules and settings
 
 Set `every` to declare a cron:


### PR DESCRIPTION
Extensions were interpreting Run's state machine because the platform never named the predicate: build string-compared `run.state == RunState.PENDING_INPUT.value` to ask "is this run parked at a gate".

- `Run.is_parked` lands next to `is_active`. Verbs (`run.cancel()`, `run.resume()`) plus predicates are the extension surface; raw-state compares were the leak.
- Both build call sites switch: `_ship` in subscribers.py and `Scope.parked_for` (the audit turned up the second, identical predicate). `RunState` drops out of both files' imports.
- New `### Replay-rebuilt workflow state` section in `docs/writing-an-extension.md`: the contract (mutate instance attrs only from orchestration-body code after a memoized call), why it's safe (determinism), the one trap (writes inside `@step` are skipped on replay and silently vanish), and `BuildJournal` as the reference shape. That file pointer goes live when ENG-726 merges.

Audit decisions on the remaining raw reads in build, recorded here rather than refactored:

- `run.input_gate` in `route_pr_review` (subscribers.py): stays. It pre-flights the exact fact `resume()` consumes — the resume channel's own presence check, not state interpretation. A named accessor would alias the field it guards.
- `run.state != RunState.RUNNING.value` in `subject_activity` (extension.py): a different question ("is it actually working right now"), one caller. Naming `is_running` for a single call site is a one-caller abstraction; left raw until a second asker appears.
- `ProjectRepoSummary.from_repo` (schemas.py): maps profiler run states onto a UI status — a read-side projection across several states, not a boolean predicate.

ENG-727