### PR TITLE
Don't destroy the session when the account lookup returns None

### DIFF
--- a/backend/druks/accounts/dependencies.py
+++ b/backend/druks/accounts/dependencies.py
@@ -8,16 +8,12 @@ _BEARER_CHALLENGE = 'Bearer realm="druks"'
 
 
 async def resolve_session_account(request: Request) -> Account | None:
-    """The account behind the session cookie, or None."""
     token = request.cookies.get(sessions.SESSION_COOKIE)
     if not token:
         return
     account_id = await sessions.resolve_session(token)
     if not account_id:
         return
-    # Never drop the session on a missing account: nothing deletes accounts
-    # (the FKs forbid it), so a None here is a transient read, not a real
-    # deletion — dropping would turn a blip into a forced re-login.
     return Account.get(account_id)
 
 

--- a/backend/druks/accounts/dependencies.py
+++ b/backend/druks/accounts/dependencies.py
@@ -8,19 +8,17 @@ _BEARER_CHALLENGE = 'Bearer realm="druks"'
 
 
 async def resolve_session_account(request: Request) -> Account | None:
-    """The session cookie's account, or None; drops a session whose account
-    is gone."""
+    """The account behind the session cookie, or None."""
     token = request.cookies.get(sessions.SESSION_COOKIE)
     if not token:
         return
     account_id = await sessions.resolve_session(token)
     if not account_id:
         return
-    account = Account.get(account_id)
-    if not account:
-        await sessions.drop_session(token)
-        return
-    return account
+    # Never drop the session on a missing account: nothing deletes accounts
+    # (the FKs forbid it), so a None here is a transient read, not a real
+    # deletion — dropping would turn a blip into a forced re-login.
+    return Account.get(account_id)
 
 
 async def current_session_account(request: Request) -> Account:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 from conftest import configure_app_for_test, connect_harness, make_settings
 from druks import database
+from druks.accounts.constants import SESSION_PREFIX
 from druks.accounts.models import Account
 from druks.accounts.sessions import SESSION_COOKIE
 from druks.harnesses import base as hbase
@@ -126,6 +127,18 @@ def test_redis_eviction_signs_out_but_keeps_credentials(tmp_path, monkeypatch, d
     assert HarnessConnection.get_for_account(
         "claude", Account.get_for_username("me@example.com").id
     )
+
+
+def test_missing_account_does_not_drop_the_session(tmp_path, monkeypatch, db_session):
+    # A None from Account.get is a transient/anomalous read (nothing deletes
+    # accounts), so it 401s the request but must never destroy the session —
+    # else a blip becomes a forced re-login.
+    with _client(tmp_path) as client:
+        _login(client, monkeypatch)
+        key = f"{SESSION_PREFIX}{client.cookies[SESSION_COOKIE]}"
+        druks.redis.get_client()._data[key] = b"no-such-account"
+        assert client.get("/api/auth/session").status_code == 401
+        assert key in druks.redis.get_client()._data
 
 
 def test_session_keeps_its_account_across_reconnects(tmp_path, monkeypatch, db_session):


### PR DESCRIPTION
## Why

`resolve_session_account` dropped the session whenever `Account.get(account_id)` returned `None` — added in ENG-703 (#15) as cleanup for a "deleted account":

```python
account = Account.get(account_id)
if not account:
    await sessions.drop_session(token)   # ← permanent logout
    return
```

But **nothing deletes accounts** — there's no code path, and every account FK is `ON DELETE RESTRICT`, so an account with any login/run/usage can't be removed. The "account is gone" case the guard defends can't happen legitimately.

So the guard only ever fires on an **anomaly** — a transient/ambiguous lookup miss — and in exactly that case, destroying the session is the wrong response: it turns a momentary blip into a forced re-login. This bit prod (2026-07-20): a session's account lookup transiently returned `None`, the session was dropped, and the operator was logged out despite the account being perfectly present.

## Change

Remove the drop. A `None` still `401`s that one request (`current_session_account` raises), but the session survives — so a transient miss self-heals on the next request instead of forcing a re-login. New regression test asserts a missing-account lookup leaves the session key intact.

## Verification

- `ruff` / `ruff format` / `pyright` clean.
- `test_auth.py` full suite green (12 passed), including the new `test_missing_account_does_not_drop_the_session`.
- Complements the existing `test_redis_eviction_signs_out_but_keeps_credentials` (real session-key loss → 401 is still correct; that path is untouched).

Related: the transient-`None` *trigger* itself (why `Account.get` returned `None` under a concurrent request burst) is a separate open thread that needs request-level logging to pin — this PR removes the destructive amplifier, not that root.