### PR TITLE
Run.is_running; human_feedback pairs by adjacency; ReviewWork calls public workflow methods

### DIFF
--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -24,8 +24,8 @@ class ReviewWork(Gate):
     @classmethod
     async def on_wait(cls, workflow: Workflow) -> None:
         build = cast("BuildWorkflow", workflow)
-        await build._set_pr_draft(draft=False)
-        await build._request_assignee_review()
+        await build.set_pr_draft(draft=False)
+        await build.request_assignee_review()
 
 
 class RepoProfilerOutput(AgentOutput):

--- a/backend/druks/build/extension.py
+++ b/backend/druks/build/extension.py
@@ -18,7 +18,7 @@ from druks.build.scoping.contracts import ScopeBriefOutput
 from druks.db import db_session
 from druks.events import Event, FeedItem
 from druks.extensions import Extension
-from druks.workflows import Run, RunState, SubjectActivity, get_run_phase
+from druks.workflows import Run, SubjectActivity, get_run_phase
 
 if TYPE_CHECKING:
     from druks.build.schemas import WorkItemSummary
@@ -185,7 +185,7 @@ class Build(Extension):
     def _work_item_id(event: Event) -> int | None:
         if event.subject_type == "work_item" and event.subject_id:
             return int(event.subject_id)
-        return None
+        return
 
     @classmethod
     def subject_summary(cls, subject_id: str) -> "WorkItemSummary | None":
@@ -213,13 +213,13 @@ class Build(Extension):
         from druks.build.scoping.workflows import Scope
 
         item = WorkItem.get(int(subject_id))
-        assert item is not None  # the read-side resolves the summary before the activity
-        run = item.get_build_run()
-        if not run:
-            scope_runs = Run.list_for_subject("work_item", str(item.id), kind=Scope.kind)
-            run = scope_runs[0] if scope_runs else None
-        # Only while a run is actually RUNNING — a run parked on a gate isn't working.
-        if not run or run.state != RunState.RUNNING.value:
-            return None
-        phase = await get_run_phase(run.id)
-        return _PHASE_META.get(phase or "")
+        if item:
+            run = item.get_build_run()
+            if not run:
+                scope_runs = Run.list_for_subject("work_item", str(item.id), kind=Scope.kind)
+                run = scope_runs[0] if scope_runs else None
+            # Only while a run is actually RUNNING — a run parked on a gate isn't working.
+            if run and run.is_running:
+                phase = await get_run_phase(run.id)
+                return _PHASE_META.get(phase or "")
+        return

--- a/backend/druks/build/journal.py
+++ b/backend/druks/build/journal.py
@@ -46,15 +46,19 @@ class BuildJournal(Journal):
 
     @property
     def human_feedback(self) -> list[dict[str, str]]:
-        # zip strict=False: the newest reply is still undigested while its own
-        # triage agent renders this very projection.
-        replies = self.filter(ReviewWork, action="request_changes")
-        return [
-            {
-                "reviewer": reply.reviewer or "(triage)",
-                "body": triage.body,
-                "question": triage.question,
-                "implementation_instructions": triage.implementation_instructions,
-            }
-            for reply, triage in zip(replies, self.filter(TriageOutput), strict=False)
-        ]
+        # A triage digests the request_changes reply recorded just before it; the
+        # newest reply has no triage yet while its own triage agent renders this
+        # very projection, so it contributes no pair.
+        pairs = []
+        for reply in self.filter(ReviewWork, action="request_changes"):
+            if triages := self.filter(TriageOutput, after=reply):
+                triage = triages[0]
+                pairs.append(
+                    {
+                        "reviewer": reply.reviewer or "(triage)",
+                        "body": triage.body,
+                        "question": triage.question,
+                        "implementation_instructions": triage.implementation_instructions,
+                    }
+                )
+        return pairs

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -390,7 +390,7 @@ class BuildWorkflow(Workflow):
 
     @step
     async def _clear_draft(self) -> None:
-        await self._set_pr_draft(draft=False)
+        await self.set_pr_draft(draft=False)
 
     @step
     async def _push_ticket_status(self, status: SemanticStatus) -> None:
@@ -401,7 +401,7 @@ class BuildWorkflow(Workflow):
         if work_item:
             await work_item.set_remote_status(status)
 
-    async def _request_assignee_review(self) -> None:
+    async def request_assignee_review(self) -> None:
         login = self.journal.assignee_github_login
         if login and self.input.repo and self.pr_number:
             try:
@@ -416,7 +416,7 @@ class BuildWorkflow(Workflow):
                     self.pr_number,
                 )
 
-    async def _set_pr_draft(self, *, draft: bool) -> None:
+    async def set_pr_draft(self, *, draft: bool) -> None:
         if self.input.repo and self.pr_number:
             try:
                 await get_github_client(load_settings()).set_pull_request_draft_state(

--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -74,6 +74,10 @@ class Run(Base):
     def is_parked(self) -> bool:
         return self.state == RunState.PENDING_INPUT.value
 
+    @property
+    def is_running(self) -> bool:
+        return self.state == RunState.RUNNING.value
+
     @classmethod
     def create_row(cls, engine, *, workflow_id: str, kind: str, account_id: str | None) -> None:
         # Own committed transaction (not the caller's request txn) so the row

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -176,10 +176,17 @@ class Journal:
     def add(self, entry: Any) -> None:
         self._entries.append(entry)
 
-    def filter(self, contract: type[T], **filters: Any) -> list[T]:
+    def filter(self, contract: type[T], *, after: Any = None, **filters: Any) -> list[T]:
+        # ``after`` anchors by identity: only entries recorded after that exact entry.
+        entries = self._entries
+        if after:
+            if positions := [i for i, entry in enumerate(entries) if entry is after]:
+                entries = entries[positions[0] + 1 :]
+            else:
+                raise WorkflowError("after= must be an entry of this journal")
         return [
             entry
-            for entry in self._entries
+            for entry in entries
             if isinstance(entry, contract)
             and all(getattr(entry, name) == expected for name, expected in filters.items())
         ]

--- a/backend/tests/test_build_durable.py
+++ b/backend/tests/test_build_durable.py
@@ -122,8 +122,8 @@ def _stub(monkeypatch, rt, *, plan_approval="human", auto_dispatch=False):
 
     for name in (
         "_push_ticket_status",
-        "_set_pr_draft",
-        "_request_assignee_review",
+        "set_pr_draft",
+        "request_assignee_review",
         "_clear_draft",
     ):
         monkeypatch.setattr(flow, name, _noop)

--- a/backend/tests/test_journal.py
+++ b/backend/tests/test_journal.py
@@ -1,4 +1,5 @@
 import pytest
+from druks.durable.exceptions import WorkflowError
 from druks.workflows import Journal, OperatorReply
 from pydantic import BaseModel
 
@@ -45,6 +46,20 @@ def test_filters_are_flat_anded_equality():
 def test_a_filter_typo_raises_when_entries_scan():
     with pytest.raises(AttributeError):
         _journal().filter(Finding, verdict="success")
+
+
+def test_filter_after_anchors_by_identity_not_equality():
+    journal = Journal()
+    first = Finding(status="success")  # structurally equal twins — the anchor
+    second = Finding(status="success")  # must resolve by identity
+    journal.add(first)
+    journal.add(Grade(decision="approve"))
+    journal.add(second)
+    anchored = journal.filter(Finding, after=first)
+    assert len(anchored) == 1 and anchored[0] is second
+    assert journal.filter(Grade, after=second) == []
+    with pytest.raises(WorkflowError):
+        journal.filter(Finding, after=Finding(status="success"))
 
 
 def test_review_reply_validates_the_resume_wire_shape():


### PR DESCRIPTION
ENG-737 — the three legibility items from the 2026-07-23 pass.

**Run.is_running** — the last raw `run.state != RunState.RUNNING.value` compare (build's `subject_activity`) becomes a predicate next to `is_active`/`is_parked`, same move ENG-727 made for parked. `RunState` drops out of extension.py's imports. While in there: the guard reads positively, and a missing work item now resolves to no activity the same quiet way `subject_summary` resolves it to no summary — no assert.

**human_feedback pairs by adjacency** — the projection stops zipping two independently filtered streams by position: each request_changes reply pairs with the first `TriageOutput` recorded after it, and the newest, still-undigested reply contributes no pair. The mechanism is a new SDK anchor — `Journal.filter(contract, after=entry)` restricts a typed projection to what landed after a prior entry (identity-matched, so structurally equal twins can't alias; anchoring on an entry the journal never recorded raises `WorkflowError`) — so the pairing reads declaratively through the journal's typed door, with no type-switching in extension code. Projection-side only — no record shape changes, nothing for replay or deploy to care about. The existing pairing test (interleaved replies, approve never paired, the `(triage)` fallback) passes unchanged; the SDK test covers the identity anchor and the misuse error.

**ReviewWork stops calling privates** — `_set_pr_draft`/`_request_assignee_review` were always the gate's API; they're public `set_pr_draft`/`request_assignee_review` now. Grep-everywhere mechanical: the gate's `on_wait`, `_clear_draft`, and the durable test's monkeypatch list.

Codex adversarial pass: approve, zero blocking findings — checked the pairing edge cases (zero triages, newest reply un-triaged while its own triage renders the projection, replay reconstruction order, interleaved approve/cancel replies), stale-name sweep, and the guard flip. It confirmed nearest-pending-reply binding is equivalent to strict adjacency under the live invariant.

ruff + format + pyright clean (pyright baseline unchanged at 116 pre-existing).
