### PR TITLE
Fix build's FE wire-type drift; a gate pins its name

### DIFF
--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 # The PR webhook resumes approve/request_changes; revise_contract and cancel
 # come from the operator's UI.
 class ReviewWork(Gate):
+    name = "review_work"
     action: Literal["approve", "request_changes", "revise_contract", "cancel"]
     reviewer: str | None = None
     body: str | None = None

--- a/backend/druks/build/subscribers.py
+++ b/backend/druks/build/subscribers.py
@@ -3,6 +3,7 @@ import re
 
 from githubkit.exception import RequestFailed, RequestTimeout
 
+from druks.build.contracts import ReviewWork
 from druks.build.enums import HandoffStatus
 from druks.build.extension import Build
 from druks.build.models import Project, ProjectRepo, WorkItem
@@ -67,9 +68,7 @@ async def build_running_reaches_the_tracker(*, subject: dict, **_: object) -> No
     await item.set_remote_status(SemanticStatus.IN_PROGRESS)
 
 
-@subscribe(
-    "run.pending_input", kind=BuildWorkflow.kind, subject__type="work_item", gate="review_work"
-)
+@subscribe("run.pending_input", kind=BuildWorkflow.kind, subject__type="work_item", gate=ReviewWork)
 async def work_review_park_reaches_the_tracker(*, subject: dict, **_: object) -> None:
     item = WorkItem.get(subject["id"])
     await item.set_remote_status(SemanticStatus.IN_REVIEW)

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -489,16 +489,8 @@ class Profile(Workflow):
         }
 
 
-# What the gate asks the operator while the run is parked, by brief status. Scope is
-# answered on the ticket (external), so the ask is just the dashboard's one-liner.
-_PARKED_ASK = {
-    "needs_answers": {"presentation": "external", "label": "Answer scope questions"},
-}
-
-
 class ScopeReply(Gate):
-    """No fields: the operator answers by commenting on the ticket — the agent
-    re-reads the thread on resume — so the reply only needs to wake the run."""
+    name = "scope"
 
 
 class Scope(Workflow):
@@ -566,4 +558,6 @@ class Scope(Workflow):
             brief = await Build.scope(remote_key=remote_key, source=source)
             if brief.status == "ready":
                 return brief
-            await ScopeReply.wait(input_request=_PARKED_ASK[brief.status])
+            await ScopeReply.wait(
+                input_request={"presentation": "external", "label": "Answer scope questions"}
+            )

--- a/backend/druks/signals.py
+++ b/backend/druks/signals.py
@@ -12,12 +12,22 @@ def subscribe(name: str, **filters: Any) -> Callable[[Subscriber], Subscriber]:
     """Register an async subscriber for the named signal.
 
     ``filters`` are equality matches against the published kwargs; ``__``
-    descends into dicts (``subject__type="work_item"``). A non-matching
-    publication skips the subscriber, so the body starts at the real work."""
+    descends into dicts (``subject__type="work_item"``); a ``Gate`` class
+    stands for its ``name``. A non-matching publication skips the
+    subscriber, so the body starts at the real work."""
 
     def register(fn: Subscriber) -> Subscriber:
+        # Lazy import: druks.workflows imports this module.
+        from druks.workflows import Gate
+
+        matches = {}
+        for lookup, expected in filters.items():
+            if isinstance(expected, type) and issubclass(expected, Gate):
+                expected = expected.name
+            matches[lookup] = expected
+
         async def receiver(_sender: Any, **kwargs: Any) -> None:
-            for lookup, expected in filters.items():
+            for lookup, expected in matches.items():
                 value: Any = kwargs
                 for part in lookup.split("__"):
                     value = value.get(part) if isinstance(value, dict) else None

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -198,17 +198,22 @@ class Journal:
 
 
 class Gate(BaseModel):
-    """A typed human-in-the-loop gate. Subclass per park point; the class name is
-    the durable recv topic, the fields are the reply's schema. `wait()` parks the
+    """A typed human-in-the-loop gate. Subclass per park point; ``name`` pins the
+    gate's durable identity — the recv channel and the parked run's ``gate`` on
+    the read side — and the fields are the reply's schema. `wait()` parks the
     running workflow until `Run.resume()` answers it (or the TTL lapses) and
     returns the validated reply — both ends of the channel hang off the class."""
 
-    topic: ClassVar[str] = ""
+    name: ClassVar[str] = ""
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
-        if not cls.__dict__.get("topic"):
-            cls.topic = _kind_from_class_name(cls.__name__)
+        if not cls.__dict__.get("name"):
+            raise WorkflowError(
+                f"{cls.__name__} must pin ``name`` — it is the gate's durable identity "
+                "(the recv channel and the parked run's gate), so it never rides the "
+                "class name."
+            )
 
     @classmethod
     async def on_wait(cls, workflow: "Workflow") -> None:
@@ -224,14 +229,14 @@ class Gate(BaseModel):
         # Suspend the running workflow until its gate is answered. A gate is a
         # run-level state — the read surfaces "needs you" straight off the parked run.
         # ``input_request`` is the plain-dict ask (at least a ``label`` and
-        # ``presentation``), stored on the run beside the gate topic and cleared on
+        # ``presentation``), stored on the run beside ``input_gate`` and cleared on
         # resume — so an extension declares the ask here, beside on_wait, not at read time.
         workflow = current_workflow.get()
         if not workflow.subject and cls.on_wait.__func__ is Gate.on_wait.__func__:
             # No subject means no feed surface; if on_wait wasn't overridden
             # either, nobody would ever see this park — fail loudly instead
             # of parking invisibly for the whole TTL.
-            raise SubjectlessGate(cls.topic)
+            raise SubjectlessGate(cls.name)
 
         async def _on_wait() -> None:
             # on_wait is real IO (it tells a human), so it gets its own checkpointed
@@ -239,8 +244,8 @@ class Gate(BaseModel):
             async with step_session():
                 await cls.on_wait(workflow)
 
-        await DBOS.run_step_async(StepOptions(name=f"{cls.topic}._on_wait"), _on_wait)
-        payload = await _park(workflow, cls.topic, input_request, ttl_seconds)
+        await DBOS.run_step_async(StepOptions(name=f"{cls.name}._on_wait"), _on_wait)
+        payload = await _park(workflow, cls.name, input_request, ttl_seconds)
         reply = cls.model_validate(payload)
         workflow.journal.add(reply)
         return reply
@@ -250,8 +255,8 @@ class OperatorReply(Gate):
     """The operator's in-app review decision. Answers and note are content for
     the next agent prompt, never control flow."""
 
-    # One topic serves every in-app review — a run parks on one gate at a time.
-    topic = "review"
+    # One gate serves every in-app review — a run parks on one at a time.
+    name = "review"
     action: _ReviewAction
     answers: dict[str, str] = Field(default_factory=dict)
     note: str = ""
@@ -259,19 +264,19 @@ class OperatorReply(Gate):
 
 async def _park(
     workflow: "Workflow",
-    topic: str,
+    gate: str,
     input_request: dict[str, Any] | None,
     ttl_seconds: float,
 ) -> dict[str, Any]:
-    # Shared park core: a park lasts days, so reap the warm VM, then suspend on the topic
-    # until Run.resume answers it.
+    # Shared park core: a park lasts days, so reap the warm VM, then suspend on the
+    # gate's channel until Run.resume answers it.
     await workflow._reap_run()
     await _emit_run_event(
         workflow.workflow_id,
         RunState.PENDING_INPUT,
         subject=workflow.subject,
         facts={
-            "input_gate": topic,
+            "input_gate": gate,
             "input_request": input_request,
             "input_requested_at": datetime.now(UTC),
         },
@@ -279,9 +284,9 @@ async def _park(
     if workflow.subject:
         # Every subjected park notifies the designated destination — no author opt-in.
         await _notify_designated_destination(workflow.workflow_id, workflow.subject)
-    payload = await DBOS.recv_async(topic, timeout_seconds=ttl_seconds)
+    payload = await DBOS.recv_async(gate, timeout_seconds=ttl_seconds)
     if payload is None:
-        raise GateTimeout(topic)
+        raise GateTimeout(gate)
     await _emit_run_event(
         workflow.workflow_id,
         RunState.RUNNING,
@@ -576,7 +581,7 @@ class Workflow:
         if not self.subject:
             # An in-app review is answered from the subject's surfaces; a
             # subjectless run has none, so nobody would ever see the ask.
-            raise SubjectlessGate(OperatorReply.topic)
+            raise SubjectlessGate(OperatorReply.name)
         request = {
             "presentation": "in_app",
             "controls": list(_REVIEW_CONTROLS),
@@ -584,7 +589,7 @@ class Workflow:
         }
         if context:
             request["context"] = context
-        payload = await _park(self, OperatorReply.topic, request, GATE_TTL_SECONDS)
+        payload = await _park(self, OperatorReply.name, request, GATE_TTL_SECONDS)
         reply = OperatorReply.model_validate(payload)
         self.journal.add(reply)
         return reply

--- a/backend/tests/test_api_work_items.py
+++ b/backend/tests/test_api_work_items.py
@@ -17,17 +17,18 @@ _RUN_STATE = {
 
 def _seed_scope_run(db_session, item, *, state="finished", status=None):
     """A scope run for ``item`` (keyed by its remote_key) with its ``scope``
-    agent call. A needs_answers status parks the run on the
-    ScopeReply gate (PENDING_INPUT + input_request) — seeded from the workflow's
-    own gate ask so the board reads exactly what the workflow stores at the park
-    point."""
-    from druks.build.workflows import _PARKED_ASK, ScopeReply
+    agent call. A needs_answers status parks the run on the ScopeReply gate
+    (PENDING_INPUT + input_request) with the same ask the workflow stores at
+    the park point."""
+    from druks.build.workflows import ScopeReply
 
-    parked = _PARKED_ASK.get(status) if status else None
+    parked = None
+    if status == "needs_answers":
+        parked = {"presentation": "external", "label": "Answer scope questions"}
     run = Run(
         id=str(uuid7()),
         kind="build.scope",
-        input_gate=ScopeReply.topic if parked else None,
+        input_gate=ScopeReply.name if parked else None,
         input_request=parked,
     )
     db_session.add(run)

--- a/backend/tests/test_durable_schemas.py
+++ b/backend/tests/test_durable_schemas.py
@@ -56,7 +56,7 @@ def test_subject_state_uses_the_latest_outcome_once_every_run_is_terminal():
 def test_status_surfaces_the_newest_active_runs_gate():
     runs = [
         _run("new", "build.build_workflow", RunState.PENDING_INPUT, "review"),
-        _run("old", "build.build_workflow", RunState.PENDING_INPUT, "scope_reply"),
+        _run("old", "build.build_workflow", RunState.PENDING_INPUT, "scope"),
     ]
     assert _status_of(runs).gate == "review"
 

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -55,6 +55,7 @@ def _build_units():
     class Approve(Gate):
         # The on_wait override is what lets the subjectless flows below park
         # here at all — without it every wait() would fail as SubjectlessGate.
+        name = "approve"
         action: str = ""
 
         @classmethod
@@ -63,6 +64,7 @@ def _build_units():
 
     class Confirm(Gate):
         # No on_wait override: only a subject run may park here.
+        name = "confirm"
         action: str = ""
 
     class SampleFlow(Workflow):

--- a/backend/tests/test_journal.py
+++ b/backend/tests/test_journal.py
@@ -71,5 +71,5 @@ def test_review_reply_validates_the_resume_wire_shape():
     assert reply.action == "request_changes"
     assert (reply.answers, reply.note) == ({"q1": "redis"}, "why q1")
     assert OperatorReply.model_validate({"action": "approve"}).answers == {}
-    # The recv topic stays the wire's "review", not the class-name derivation.
-    assert OperatorReply.topic == "review"
+    # The gate's pinned name is the wire's "review", untouched by the class name.
+    assert OperatorReply.name == "review"

--- a/backend/tests/test_lane_reactions.py
+++ b/backend/tests/test_lane_reactions.py
@@ -91,7 +91,7 @@ def _parked_scope_run(session, *, work_item_id):
     run = Run(
         id=str(uuid7()),
         kind=Scope.kind,
-        input_gate=ScopeReply.topic,
+        input_gate=ScopeReply.name,
         input_request={"presentation": "external", "label": "Answer scope questions"},
     )
     session.add(run)

--- a/backend/tests/test_notifications_durable.py
+++ b/backend/tests/test_notifications_durable.py
@@ -54,6 +54,7 @@ _REVIEW_REPLIES: list[OperatorReply] = []
 
 def _build_park_flows():
     class ParkNote(Gate):
+        name = "park_note"
         action: str = ""
 
         @classmethod

--- a/backend/tests/test_scope_durable.py
+++ b/backend/tests/test_scope_durable.py
@@ -130,7 +130,7 @@ async def test_scope_parks_then_resumes_to_ready(rt, monkeypatch):
     parked = await _wait(
         rt.engine,
         wfid,
-        lambda r: r.state == RunState.PENDING_INPUT and r.input_gate == "scope_reply",
+        lambda r: r.state == RunState.PENDING_INPUT and r.input_gate == "scope",
     )
     # The ask is declared at the gate, stored on the run — the read side renders it.
     assert parked.input_request == {

--- a/backend/tests/test_scope_reply_rescope.py
+++ b/backend/tests/test_scope_reply_rescope.py
@@ -24,7 +24,7 @@ def _scope_run(db_session, *, work_item_id, parked=True):
     run = Run(
         id=str(uuid7()),
         kind="build.scope",
-        input_gate=ScopeReply.topic if parked else None,
+        input_gate=ScopeReply.name if parked else None,
     )
     db_session.add(run)
     db_session.flush()

--- a/backend/tests/test_workflow_identity.py
+++ b/backend/tests/test_workflow_identity.py
@@ -10,7 +10,7 @@ from druks.extensions import loader as extensions_loader
 from druks.extensions.exceptions import MalformedExtension
 from druks.extensions.loader import register_workflow_package, resolve_workflow_extension
 from druks.extensions.registry import workflows
-from druks.workflows import Workflow, _log_run_event, step
+from druks.workflows import Gate, Workflow, _log_run_event, step
 
 
 @pytest.fixture(autouse=True)
@@ -29,6 +29,15 @@ def _workflow(name: str, module: str, **attrs):
     async def run(self) -> None: ...
 
     return type(name, (Workflow,), {"__module__": module, "run": run, **attrs})
+
+
+def test_a_gate_without_a_pinned_name_raises():
+    # The name is the gate's durable identity (recv channel, the parked run's
+    # gate) — it must survive a class rename, so deriving it is refused.
+    with pytest.raises(WorkflowError, match="must pin"):
+
+        class Anonymous(Gate):
+            action: str = ""
 
 
 def test_registration_is_idempotent_and_conflicts_loudly():

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -269,8 +269,9 @@ Druks sandbox contract, not `exe`, AWS, or Docker directly.
 
 ## Wait for input
 
-A gate's fields are the reply schema and its class name becomes the default
-topic:
+A gate's fields are the reply schema; `name` pins the gate's durable identity —
+the recv channel and the parked run's `gate` on the read side (declaring it is
+required — the identity must survive a class rename):
 
 ```python
 from typing import Literal
@@ -279,6 +280,7 @@ from druks.workflows import Gate, Workflow
 
 
 class ApproveReport(Gate):
+    name = "approve_report"
     action: Literal["approve", "revise", "cancel"]
     note: str | None = None
 

--- a/frontend/src/extensions/build/api.ts
+++ b/frontend/src/extensions/build/api.ts
@@ -38,9 +38,9 @@ export interface Links {
 }
 
 export interface WorkItemSummary extends SubjectSummary {
-  source: 'linear' | 'github'
+  source: 'linear' | 'github' | 'jira'
   repo: string
-  projectName?: string | null
+  projectName: string
   title: string
   remoteKey?: string | null
   remoteUrl?: string | null

--- a/frontend/src/extensions/build/statusLine.test.ts
+++ b/frontend/src/extensions/build/statusLine.test.ts
@@ -17,7 +17,7 @@ function status(overrides: Partial<SubjectStatus>): SubjectStatus {
 
 describe('statusLine', () => {
   it('parked renders build’s line for the gate identity', () => {
-    expect(statusLine(status({ state: 'pending_input', gate: 'scope_reply' }))).toBe(
+    expect(statusLine(status({ state: 'pending_input', gate: 'scope' }))).toBe(
       'Reply on the ticket',
     )
     expect(statusLine(status({ state: 'pending_input', gate: 'review_work' }))).toBe(

--- a/frontend/src/extensions/build/statusLine.ts
+++ b/frontend/src/extensions/build/statusLine.ts
@@ -6,7 +6,7 @@ import type { SubjectStatus } from '../../api/types'
 // The parked line per gate identity. Scope's gate parks for the operator's
 // ticket reply, whatever the ask; unmapped gates read as a generic park.
 const PARKED_LINES: Record<string, string> = {
-  scope_reply: 'Reply on the ticket',
+  scope: 'Reply on the ticket',
   review_work: 'Review implementation',
 }
 


### PR DESCRIPTION
ENG-738, plus the gate-identity work from the #55/#56 review discussion.

**Wire-type drift** — `WorkItemSummary.source` gains `'jira'`, `projectName` becomes required `string`; two lines in api.ts, tsc clean with zero call-site edits. The ticket's decision lands as: keep the mirror hand-written. Codegen was tried and rejected — the served openapi.json never contains extension summaries (`SerializeAsAny` on the generic subject routes), so generating meant fabricating a spec plus a script, two freshness gates, and a backend-CI carve-out for a frontend file: five moving parts against a twice-ever drift class. If codegen ever earns its keep, the seam is typed subject routes (its own platform ticket), after which the existing `types:openapi` script is the whole generator.

**A gate pins its name** — the gate's durable identity (recv channel, `Run.input_gate`, the event's `gate`, the FE's gate string) used to derive from the class name and traveled as "topic". Now every `Gate` subclass pins `name` explicitly (`__init_subclass__` refuses one that doesn't — the identity must survive a class rename), following the `Extension.name` precedent; DBOS's own `topic` kwarg at the send/recv boundary is untouched. Subscribe filters take the class itself — `gate=ReviewWork` — resolved to its name at registration. `ScopeReply` pins `name = "scope"` (wire rename for parked scope runs; rides #56's existing drain window at zero cost), `ReviewWork` keeps `review_work` (parked build runs sit on that channel; renameable whenever a drain is scheduled), `OperatorReply` always pinned `review`. `_PARKED_ASK` is gone — the ask sits inline at its park, same shape as `ReviewWork`'s.

ruff/format/pyright clean at baseline; boot probe green (pins, class filter, nameless-gate refusal); tsc, eslint, 51 FE tests.
