### PR TITLE
Fail clearly when a build's repo is no longer registered

### DIFF
--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -14,7 +14,7 @@ from druks.ticketing.datastructures import Ticket
 from druks.ticketing.enums import SemanticStatus
 from druks.ticketing.exceptions import TrackerNotConfigured
 from druks.ticketing.helpers import get_tracker, is_tracker_source
-from druks.workflows import Run
+from druks.workflows import FatalError, Run
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +138,19 @@ class ProjectRepo(Base):
     def get_for_repo(cls, full_name: str) -> "ProjectRepo | None":
         stmt = select(cls).where(func.lower(cls.full_name) == full_name.lower()).limit(1)
         return db_session().scalars(stmt).first()
+
+    @classmethod
+    def require_for_repo(cls, full_name: str) -> "ProjectRepo":
+        # A run's stored repo name can outlive its registration — a rename or a
+        # GitHub transfer leaves the old full_name behind, and the lookup matches
+        # the literal string. Fail with the reason, not an opaque NoneType.
+        repo = cls.get_for_repo(full_name)
+        if not repo:
+            raise FatalError(
+                f"{full_name!r} is not a registered project repo — it may have been "
+                "renamed or transferred; re-register it under its current name"
+            )
+        return repo
 
     @classmethod
     def lookup(

--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -135,17 +135,15 @@ class ProjectRepo(Base):
         return db_session().scalars(stmt).first()
 
     @classmethod
-    def get_for_repo(cls, full_name: str) -> "ProjectRepo | None":
+    def get_for_repo(
+        cls, full_name: str, *, raise_on_missing: bool = False
+    ) -> "ProjectRepo | None":
         stmt = select(cls).where(func.lower(cls.full_name) == full_name.lower()).limit(1)
-        return db_session().scalars(stmt).first()
-
-    @classmethod
-    def require_for_repo(cls, full_name: str) -> "ProjectRepo":
-        # A run's stored repo name can outlive its registration — a rename or a
-        # GitHub transfer leaves the old full_name behind, and the lookup matches
-        # the literal string. Fail with the reason, not an opaque NoneType.
-        repo = cls.get_for_repo(full_name)
-        if not repo:
+        repo = db_session().scalars(stmt).first()
+        if raise_on_missing and not repo:
+            # A run's stored repo name can outlive its registration — a rename or
+            # a GitHub transfer leaves the old full_name behind, and this matches
+            # the literal string. Fail with the reason, not an opaque NoneType.
             raise FatalError(
                 f"{full_name!r} is not a registered project repo — it may have been "
                 "renamed or transferred; re-register it under its current name"

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -46,6 +46,19 @@ GITHUB_MCP_NAME = "github"
 GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
 
 
+def _registered_target(full_name: str) -> ProjectRepo:
+    # A run's stored repo name can outlive its registration — a rename or a
+    # GitHub transfer leaves the old full_name behind, and lookups match the
+    # literal string. Fail with the reason instead of an opaque NoneType.
+    target = ProjectRepo.get_for_repo(full_name)
+    if not target:
+        raise FatalError(
+            f"{full_name!r} is not a registered project repo — it may have been "
+            "renamed or transferred; re-register it under its current name"
+        )
+    return target
+
+
 @dataclass(frozen=True, kw_only=True)
 class BuildWorkspace(RepoWorkspace):
     # The base RepoWorkspace brings the cloned repo + token; a build run adds the
@@ -231,8 +244,7 @@ class BuildWorkflow(Workflow):
     async def _load_policy_and_profile(self) -> dict[str, Any]:
         # One memoized read: the live policy + the repo's profiled facts.
         policy = await RepoPolicy.resolve(self.input.repo)
-        # A build dispatches against a work item whose repo is registered.
-        target = ProjectRepo.get_for_repo(self.input.repo)
+        target = _registered_target(self.input.repo)
         return {
             "policy": policy.model_dump(mode="json"),
             "profile": target.effective_profile(),
@@ -540,8 +552,7 @@ class Scope(Workflow):
             for r in item.project.repos
             if r.full_name != item.repo
         ]
-        # The ticket routed through this repo to exist, so it's registered.
-        target = ProjectRepo.get_for_repo(item.repo)
+        target = _registered_target(item.repo)
         settings = Build.settings()
         return {
             "target_repo": item.repo,

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -46,19 +46,6 @@ GITHUB_MCP_NAME = "github"
 GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
 
 
-def _registered_target(full_name: str) -> ProjectRepo:
-    # A run's stored repo name can outlive its registration — a rename or a
-    # GitHub transfer leaves the old full_name behind, and lookups match the
-    # literal string. Fail with the reason instead of an opaque NoneType.
-    target = ProjectRepo.get_for_repo(full_name)
-    if not target:
-        raise FatalError(
-            f"{full_name!r} is not a registered project repo — it may have been "
-            "renamed or transferred; re-register it under its current name"
-        )
-    return target
-
-
 @dataclass(frozen=True, kw_only=True)
 class BuildWorkspace(RepoWorkspace):
     # The base RepoWorkspace brings the cloned repo + token; a build run adds the
@@ -244,7 +231,7 @@ class BuildWorkflow(Workflow):
     async def _load_policy_and_profile(self) -> dict[str, Any]:
         # One memoized read: the live policy + the repo's profiled facts.
         policy = await RepoPolicy.resolve(self.input.repo)
-        target = _registered_target(self.input.repo)
+        target = ProjectRepo.require_for_repo(self.input.repo)
         return {
             "policy": policy.model_dump(mode="json"),
             "profile": target.effective_profile(),
@@ -552,7 +539,7 @@ class Scope(Workflow):
             for r in item.project.repos
             if r.full_name != item.repo
         ]
-        target = _registered_target(item.repo)
+        target = ProjectRepo.require_for_repo(item.repo)
         settings = Build.settings()
         return {
             "target_repo": item.repo,

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -231,7 +231,7 @@ class BuildWorkflow(Workflow):
     async def _load_policy_and_profile(self) -> dict[str, Any]:
         # One memoized read: the live policy + the repo's profiled facts.
         policy = await RepoPolicy.resolve(self.input.repo)
-        target = ProjectRepo.require_for_repo(self.input.repo)
+        target = ProjectRepo.get_for_repo(self.input.repo, raise_on_missing=True)
         return {
             "policy": policy.model_dump(mode="json"),
             "profile": target.effective_profile(),
@@ -539,7 +539,7 @@ class Scope(Workflow):
             for r in item.project.repos
             if r.full_name != item.repo
         ]
-        target = ProjectRepo.require_for_repo(item.repo)
+        target = ProjectRepo.get_for_repo(item.repo, raise_on_missing=True)
         settings = Build.settings()
         return {
             "target_repo": item.repo,

--- a/backend/tests/test_build_prompts.py
+++ b/backend/tests/test_build_prompts.py
@@ -5,8 +5,10 @@ from types import SimpleNamespace
 import pytest
 from druks.build import workflows as build_workflows
 from druks.build.journal import BuildJournal
+from druks.build.models import Project, ProjectRepo
 from druks.build.prompt_context import BuildPromptContext
 from druks.prompts import render_prompt
+from druks.workflows import FatalError
 
 _OP_TEMPLATES = [
     "generate_plan.md",
@@ -178,3 +180,18 @@ def test_build_prompt_context_covers_template_attrs():
     fields = set(BuildPromptContext.__dataclass_fields__)
     missing = sorted(a for a in attrs if a not in fields)
     assert not missing, f"BuildPromptContext missing template attrs: {missing}"
+
+
+def test_registered_target_returns_the_repo(db_session):
+    project = Project.create(name="acme/widget")
+    ProjectRepo.create(project_id=project.id, full_name="acme/widget")
+    assert build_workflows._registered_target("acme/widget").full_name == "acme/widget"
+
+
+def test_registered_target_fails_clearly_when_the_repo_was_transferred(db_session):
+    # Registered under the new name; a run still holding the old name must fail
+    # with the reason, not an opaque NoneType crash.
+    project = Project.create(name="czpython/druks")
+    ProjectRepo.create(project_id=project.id, full_name="czpython/druks")
+    with pytest.raises(FatalError, match="renamed or transferred"):
+        build_workflows._registered_target("clawhaven/druks")

--- a/backend/tests/test_build_prompts.py
+++ b/backend/tests/test_build_prompts.py
@@ -182,16 +182,16 @@ def test_build_prompt_context_covers_template_attrs():
     assert not missing, f"BuildPromptContext missing template attrs: {missing}"
 
 
-def test_registered_target_returns_the_repo(db_session):
+def test_require_for_repo_returns_the_repo(db_session):
     project = Project.create(name="acme/widget")
     ProjectRepo.create(project_id=project.id, full_name="acme/widget")
-    assert build_workflows._registered_target("acme/widget").full_name == "acme/widget"
+    assert ProjectRepo.require_for_repo("acme/widget").full_name == "acme/widget"
 
 
-def test_registered_target_fails_clearly_when_the_repo_was_transferred(db_session):
+def test_require_for_repo_fails_clearly_when_the_repo_was_transferred(db_session):
     # Registered under the new name; a run still holding the old name must fail
     # with the reason, not an opaque NoneType crash.
     project = Project.create(name="czpython/druks")
     ProjectRepo.create(project_id=project.id, full_name="czpython/druks")
     with pytest.raises(FatalError, match="renamed or transferred"):
-        build_workflows._registered_target("clawhaven/druks")
+        ProjectRepo.require_for_repo("clawhaven/druks")

--- a/backend/tests/test_build_prompts.py
+++ b/backend/tests/test_build_prompts.py
@@ -182,16 +182,16 @@ def test_build_prompt_context_covers_template_attrs():
     assert not missing, f"BuildPromptContext missing template attrs: {missing}"
 
 
-def test_require_for_repo_returns_the_repo(db_session):
+def test_get_for_repo_returns_the_repo(db_session):
     project = Project.create(name="acme/widget")
     ProjectRepo.create(project_id=project.id, full_name="acme/widget")
-    assert ProjectRepo.require_for_repo("acme/widget").full_name == "acme/widget"
+    assert ProjectRepo.get_for_repo("acme/widget").full_name == "acme/widget"
 
 
-def test_require_for_repo_fails_clearly_when_the_repo_was_transferred(db_session):
+def test_get_for_repo_raises_when_the_repo_was_transferred(db_session):
     # Registered under the new name; a run still holding the old name must fail
     # with the reason, not an opaque NoneType crash.
     project = Project.create(name="czpython/druks")
     ProjectRepo.create(project_id=project.id, full_name="czpython/druks")
     with pytest.raises(FatalError, match="renamed or transferred"):
-        ProjectRepo.require_for_repo("clawhaven/druks")
+        ProjectRepo.get_for_repo("clawhaven/druks", raise_on_missing=True)


### PR DESCRIPTION
## The bug

A build crashed with `'NoneType' object has no attribute 'effective_profile'`. The `druks` repo was transferred `clawhaven/druks` → `czpython/druks`, but the work item still carries the old `repo = clawhaven/druks`. `ProjectRepo.get_for_repo` matches the literal `full_name`, so it returns `None`, and the build/scope workflows called `.effective_profile()` / `.purpose` on it. (GitHub keeps the old name alive as a 301 redirect, but druks stores/looks up the raw string.)

## Change

`get_for_repo(full_name, *, raise_on_missing=True)` — one param, not a new method. The default stays `Optional` (the `repo.pushed` subscriber legitimately skips unregistered repos); the two build/scope sites pass `raise_on_missing=True` to fail with a `FatalError` that names the repo and cause — "renamed or transferred; re-register it" — instead of the opaque `NoneType`.

## Scope

Guard only — it makes the failure diagnosable. It does **not** yet follow a transfer (map an old `full_name` to the current one); that's a separate durable ticket. The data fix for the escalated item is operator-side.

## Verification

New tests (registered → returns the repo; transferred → raises the clear `FatalError`); 22 pass; `ruff`/format clean.
