### PR TITLE
Rename Agent access → Tokens; say what a token is for, not how it works

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -286,7 +286,7 @@ export function SettingsModal({ open, onClose }: Props) {
             <RailItem icon="harnesses" label="Harnesses" active={section === 'harnesses'} onClick={() => setSection('harnesses')} />
             <RailItem icon="skills" label="Skills" active={section === 'skills'} onClick={() => setSection('skills')} />
             <RailItem icon="mcp" label="MCP" active={section === 'mcp'} onClick={() => setSection('mcp')} />
-            <RailItem icon="agent-access" label="Agent access" active={section === 'agent-access'} onClick={() => setSection('agent-access')} />
+            <RailItem icon="agent-access" label="Tokens" active={section === 'agent-access'} onClick={() => setSection('agent-access')} />
             <div className="set-rail-label">apps</div>
             {allExtensions.map((extension) => (
               <button
@@ -1462,9 +1462,8 @@ export function AgentAccessPane() {
     <div className="set-pane">
       <div className="set-pane-head">
         <div className="set-pane-sub">
-          Mint a <b>personal access token</b> for an agent to call this druks — sent as{' '}
-          <b>Authorization: Bearer …</b>, same account and authority as your browser identity.
-          Revoking a token cuts its access immediately.
+          Give an agent, script, or CLI a token to call druks as you — same account and
+          permissions, no browser needed. Revoke it any time to cut access instantly.
         </div>
       </div>
       <div className="set-group">
@@ -1514,7 +1513,8 @@ export function AgentAccessPane() {
             </button>
           </div>
           <div className="set-field-help">
-            The only time druks shows it — a hash is stored, not the token.
+            Send it as <b>Authorization: Bearer &lt;token&gt;</b>. This is the only time druks
+            shows it — a hash is stored, not the token.
           </div>
         </div>
       )}


### PR DESCRIPTION
The Agent access settings pane described the **mechanism** instead of the **purpose**, and the nav label named a vague abstraction.

## Changes

**Nav: `Agent access` → `Tokens`.** "Agent access" is ambiguous (access for agents? to agents?). The page lists tokens — name it that. (Internal section id/icon unchanged.)

**Blurb — purpose first.** Was:
> Mint a **personal access token** for an agent to call this druks — sent as **Authorization: Bearer …**, same account and authority as your browser identity. Revoking a token cuts its access immediately.

Now:
> Give an agent, script, or CLI a token to call druks as you — same account and permissions, no browser needed. Revoke it any time to cut access instantly.

Drops the three internal terms (`personal access token`, `Authorization: Bearer`, `browser identity`) and the awkward "this druks".

**`Authorization: Bearer <token>` moves to the token reveal** — shown next to the copyable value, where someone wiring up the agent actually needs it, not in the intro.

## Verification

Pure copy (three static strings, no logic). `tsc -b` clean, `eslint` clean, `AgentAccessPane` test green (no test asserts the changed copy). Not screenshotted live — reaching the pane needs the full authed stack, disproportionate for static text the typecheck/test already cover.
