### PR TITLE
Caddyfile: forward the dashboard, don't gate it

### DIFF
--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -42,28 +42,9 @@ http://:8000 {
 		}
 	}
 
-	# The edge authenticates; this proxy forwards its identity assertion and
-	# the backend maps the asserted email to an account (DRUKS_AUTH_MODE=header
-	# reads the same DRUKS_AUTH_HEADER). The upstream proxy must strip any
-	# client-supplied copy of the header before inserting its authenticated
-	# value. DRUKS_AUTH_HEADER has no default — name your edge's header in the
-	# .env (exe.dev: X-ExeDev-Email, Teleport: X-Forwarded-Email, Cloudflare
-	# Access: Cf-Access-Authenticated-User-Email, …); swapping the identity
-	# edge is a config change, never a code change.
-	# The backend serves everything behind the gate — the API, the SPA at /,
-	# extension frontends at /app/<name>. Cache policy for the served
-	# frontends lives with their server (api/app.py), not at the edge.
-	@dashboard_user header {$DRUKS_AUTH_HEADER} *
-	handle @dashboard_user {
-		reverse_proxy {$DRUKS_UPSTREAM}
-	}
-
-	# No identity header at all. exe.dev passes unauthenticated traffic
-	# through and relies on this redirect to its SSO; proxies like Teleport
-	# intercept upstream and never reach here, so this stays exe-shaped.
-	handle {
-		redir https://{host}/__exe.dev/login?redirect={uri} 302
-	}
+	# Identity is the edge's job (auth_mode header/jwt) or moot (mode=none serves
+	# the single operator); the app re-asserts it per request, so Caddy forwards.
+	reverse_proxy {$DRUKS_UPSTREAM}
 }
 
 # Public integrations ingress — set DRUKS_WEBHOOK_HOST to a hostname with an

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -127,12 +127,6 @@ services:
     restart: unless-stopped
     environment:
       DRUKS_UPSTREAM: ${DRUKS_UPSTREAM:-127.0.0.1:8001}
-      # Both Caddy and druks read DRUKS_AUTH_HEADER (web gets it from env_file):
-      # Caddy requires the edge's assertion, druks maps it to an account. No
-      # default anywhere — the backend refuses header mode without it.
-      DRUKS_AUTH_HEADER: ${DRUKS_AUTH_HEADER:-}
-      # ``:-`` so an empty .env value still collapses to the inert loopback
-      # default — Caddy treats set-but-empty as a real (broken) site address.
       DRUKS_WEBHOOK_HOST: ${DRUKS_WEBHOOK_HOST:-http://127.0.0.1:8081}
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro


### PR DESCRIPTION
## The bug

Deploying to the prod host (`DRUKS_AUTH_MODE=none`) crash-looped caddy:

```
Error: adapting config using caddyfile: malformed header matcher: expected both field and value, at Caddyfile:56
```

The dashboard block was written only for the edge-identity shape — `@dashboard_user header {$DRUKS_AUTH_HEADER} *` — plus an exe.dev SSO redirect for header-less requests. With `DRUKS_AUTH_HEADER` unset the matcher rendered `header  *` (malformed → won't boot). caddy only re-reads its file on recreate, so it stayed latent until a deploy recreated the container.

## Change

The gate doesn't belong in the bundled proxy at all. Identity is:

- **`auth_mode=none`** → the app serves the single operator account; the header is ignored.
- **`header` / `jwt`** → the external edge asserts identity; the app maps it **per request**.
- **PAT** → `/mcp`, handled separately.

There are no sessions — [`current_session_account`](backend/druks/accounts/dependencies.py) re-asserts identity every request (`no session state`). So there's no unauthenticated-browser-needs-login case that druks owns; the SSO redirect was pure exe.dev-ism, and the edge (exe.dev/Teleport/Cloudflare) owns that.

So the dashboard block collapses to a plain forward:

```
reverse_proxy {$DRUKS_UPSTREAM}
```

and caddy stops referencing `DRUKS_AUTH_HEADER` (the app still reads it from `env_file` for header mode). No matcher, no redirect, no new knobs.

## Verification

`caddy validate` clean. Applied to prod: caddy boots, serves `200`, stack healthy. Host `compose.yaml` + `Caddyfile` match this template.

Net: **3 insertions, 28 deletions.**
