### PR TITLE
Real Redis in tests: drop the conftest fake, flush per test

### DIFF
--- a/.github/workflows/on-pull-request-backend.yml
+++ b/.github/workflows/on-pull-request-backend.yml
@@ -21,9 +21,10 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     # The suite talks to a real Postgres (the harness runs each test in a rolled-back
-    # transaction; the durable tests create their own databases). Defaults in
-    # backend/tests match localhost:5432 with druks/druks/druks, so this mirrors local
-    # dev (deploy/compose.dev.yaml) and needs no env wiring. Image tracks deploy/compose.yaml.
+    # transaction; the durable tests create their own databases) and a real Redis
+    # (flushed between tests). Defaults in backend/tests match localhost:5432 with
+    # druks/druks/druks and localhost:6379, so this mirrors local dev
+    # (deploy/compose.dev.yaml) and needs no env wiring. Images track deploy/compose.yaml.
     services:
       postgres:
         image: postgres:16-alpine@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
@@ -35,6 +36,15 @@ jobs:
           - 5432:5432
         options: >-
           --health-cmd "pg_isready -U druks"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:8.2-alpine@sha256:223b183cbc49f5ff48728e1fc52ccf101f05072decad2bd9867281a3c9bf75fd
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -51,82 +51,15 @@ for test_module in ("test_durable_sdk", "test_notifications_durable"):
     register_workflow_package(test_module, None)
 
 
-class FakeRedis:
-    # The subset the run lock and the MCP OAuth cache use; one instance per
-    # suite, keys per test are distinct enough (run ids, server names) that
-    # cross-test bleed can't collide.
-    def __init__(self) -> None:
-        self._data: dict[str, bytes] = {}
-        # TTLs are recorded, never enforced — enough to observe a refresh.
-        self._ttls: dict[str, int] = {}
-        self._zsets: dict[str, dict[str, float]] = {}
-
-    async def set(self, key: str, value: str, *, nx: bool = False, ex: int | None = None):
-        if nx and key in self._data:
-            return None
-        self._data[key] = value.encode()
-        if ex is not None:
-            self._ttls[key] = ex
-        return True
-
-    async def get(self, key: str) -> bytes | None:
-        return self._data.get(key)
-
-    async def exists(self, key: str) -> int:
-        return int(key in self._data)
-
-    async def getdel(self, key: str) -> bytes | None:
-        self._ttls.pop(key, None)
-        return self._data.pop(key, None)
-
-    # Sorted sets — the per-login gate's active-user registry. Stored apart
-    # from the string keys; scores kept for the range prune.
-    async def zadd(self, key: str, mapping: dict[str, float]) -> int:
-        zset = self._zsets.setdefault(key, {})
-        added = sum(1 for member in mapping if member not in zset)
-        zset.update(mapping)
-        return added
-
-    async def zrem(self, key: str, *members: str) -> int:
-        zset = self._zsets.get(key, {})
-        return sum(1 for member in members if zset.pop(member, None) is not None)
-
-    async def zcard(self, key: str) -> int:
-        return len(self._zsets.get(key, {}))
-
-    async def zremrangebyscore(self, key: str, low: object, high: float) -> int:
-        zset = self._zsets.get(key, {})
-        floor = float("-inf") if low in ("-inf", None) else float(low)  # type: ignore[arg-type]
-        doomed = [member for member, score in zset.items() if floor <= score <= float(high)]
-        for member in doomed:
-            del zset[member]
-        return len(doomed)
-
-    async def delete(self, key: str) -> None:
-        self._data.pop(key, None)
-        self._ttls.pop(key, None)
-
-    async def expire(self, key: str, seconds: int) -> bool:
-        if key not in self._data:
-            return False
-        self._ttls[key] = seconds
-        return True
-
-    async def aclose(self) -> None:
-        return
-
-
-_fake_redis = FakeRedis()
-druks.redis._client = _fake_redis  # get_client() returns it instead of connecting
-
-
-async def _keep_fake_client() -> None:
-    # The app lifespan's shutdown would null _client, and the next get_client()
-    # would dial a real Redis; the suite keeps the fake for its whole life.
-    return
-
-
-druks.redis.close_client = _keep_fake_client
+@pytest.fixture(autouse=True)
+async def _redis():
+    # Real Redis (CI runs one beside Postgres; settings default to it). Drop
+    # whatever client the previous test left — its event loop is gone, GC
+    # closes the sockets — then flush on a fresh client and close it, so every
+    # consumer dials on its own live loop (a TestClient portal, or this test's).
+    druks.redis._client = None
+    await druks.redis.get_client().flushdb()
+    await druks.redis.close_client()
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -3,7 +3,6 @@ import secrets
 from datetime import timedelta
 from pathlib import Path
 
-import druks.redis
 import pytest
 from conftest import configure_app_for_test, make_settings
 from druks.accounts.constants import PAT_TOKEN_TAG
@@ -15,12 +14,6 @@ from fastapi.testclient import TestClient
 
 HEADER = "X-ExeDev-Email"
 OPERATOR = {HEADER: "op@example.com"}
-
-
-@pytest.fixture(autouse=True)
-def _clear_redis():
-    druks.redis.get_client()._data.clear()
-    yield
 
 
 def _client(tmp_path: Path, **settings_overrides) -> TestClient:

--- a/backend/tests/test_gate.py
+++ b/backend/tests/test_gate.py
@@ -10,10 +10,7 @@ from druks.sandbox import gate
 
 @pytest.fixture(autouse=True)
 def _fast_poll(monkeypatch):
-    druks.redis.get_client()._data.clear()
-    druks.redis.get_client()._zsets.clear()
     monkeypatch.setattr(gate, "_POLL", 0.01)
-    yield
 
 
 async def test_use_registers_for_the_span_and_unregisters():

--- a/backend/tests/test_harness_connect.py
+++ b/backend/tests/test_harness_connect.py
@@ -11,14 +11,6 @@ from druks.harnesses.codex import CodexHarness
 from druks.harnesses.exceptions import ConnectError
 
 
-@pytest.fixture(autouse=True)
-def _clear_pending():
-    # The suite shares one in-memory fake Redis; clear the connect pending keys
-    # so one test's stash never leaks into another.
-    druks.redis.get_client()._data.clear()
-    yield
-
-
 def _jwt(claims: dict) -> str:
     header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
     payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -2,7 +2,6 @@ import base64
 import json
 from pathlib import Path
 
-import druks.redis
 import httpx
 import pytest
 from conftest import configure_app_for_test, connect_harness, make_settings
@@ -18,12 +17,6 @@ from fastapi.testclient import TestClient
 from sqlalchemy import select
 
 HEADER = "X-ExeDev-Email"
-
-
-@pytest.fixture(autouse=True)
-def _clear_redis():
-    druks.redis.get_client()._data.clear()
-    yield
 
 
 def _client(tmp_path: Path, **settings_overrides) -> TestClient:

--- a/backend/tests/test_identity_jwt.py
+++ b/backend/tests/test_identity_jwt.py
@@ -1,7 +1,6 @@
 import time
 from pathlib import Path
 
-import druks.redis
 import jwt as pyjwt
 import pytest
 from conftest import configure_app_for_test, make_settings
@@ -24,7 +23,6 @@ _JWKS = {"keys": [{**_JWK, "kid": KID}]}
 
 @pytest.fixture(autouse=True)
 def _serve_jwks(monkeypatch):
-    druks.redis.get_client()._data.clear()
     assertion._verifier.cache_clear()
 
     async def fetch_jwks(self):

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -18,7 +18,7 @@ from druks.mcp.enums import TokenSource
 from druks.mcp.exceptions import GrantRefreshError, MissingGrantError, OauthConnectError
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.mcp.models import McpOauthGrant, McpServer
-from druks.redis import get_client
+from druks.redis import close_client, get_client
 from druks.sandbox.datastructures import Workspace
 from fastapi.testclient import TestClient
 
@@ -91,17 +91,6 @@ def auth_server(monkeypatch):
         oauth, "_http", lambda: httpx.AsyncClient(transport=httpx.MockTransport(fake.handler))
     )
     return fake
-
-
-@pytest.fixture(autouse=True)
-async def _clean_oauth_redis():
-    # The suite shares one FakeRedis; OAuth keys are server-name-keyed, so a
-    # cached token from one test would satisfy the next test's mint.
-    redis = get_client()
-    for key in list(redis._data):
-        if key.startswith("mcp:oauth:"):
-            await redis.delete(key)
-    yield
 
 
 def _register_oauth_server(name: str = _NAME, enabled: bool = True) -> None:
@@ -371,14 +360,13 @@ def test_connect_route_returns_the_consent_url(tmp_path, registry_state, auth_se
         assert response.json()["authorizationUrl"].startswith(f"{_AUTH_BASE}/authorize?")
 
 
-async def test_callback_route_completes_the_connect(
-    tmp_path, registry_state, auth_server, db_session
-):
+def test_callback_route_completes_the_connect(tmp_path, registry_state, auth_server, db_session):
     _register_oauth_server(enabled=False)
-    url = await oauth.begin_connect(_NAME, _SERVER_URL, _ENDPOINT)
-    state = dict(parse_qsl(urlparse(url).query))["state"]
+    settings = make_settings(tmp_path, endpoint=_ENDPOINT)
 
-    with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
+    with TestClient(configure_app_for_test(settings=settings)) as client:
+        url = client.post(f"/api/mcp-servers/{_NAME}/connect").json()["authorizationUrl"]
+        state = dict(parse_qsl(urlparse(url).query))["state"]
         page = client.get("/api/mcp-servers/oauth/callback", params={"state": state, "code": "c"})
         assert page.status_code == 200
         assert "Connected" in page.text
@@ -411,6 +399,9 @@ async def test_disconnect_route_drops_grant_and_cache(
     _register_oauth_server()
     _store_grant()
     await oauth.mint_access_token(_NAME)
+    # The mint's Redis client is bound to this test's loop; close it so the
+    # route dials its own — the cached token lives in Redis either way.
+    await close_client()
 
     with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
         assert client.delete(f"/api/mcp-servers/{_NAME}/grant").status_code == 204

--- a/backend/tests/test_mcp_registry.py
+++ b/backend/tests/test_mcp_registry.py
@@ -4,11 +4,9 @@ import httpx
 import pytest
 from conftest import configure_app_for_test, make_settings
 from druks.mcp import registry
-from druks.mcp.constants import REGISTRY_SEARCH_CACHE_PREFIX
 from druks.mcp.exceptions import RegistryUnavailableError
 from druks.mcp.models import McpOauthGrant, McpServer
 from druks.mcp.registry import derive_server_name, resolve_candidates, search_registry
-from druks.redis import get_client
 from druks.settings import PACKAGED_MCP_TRUSTED
 from fastapi.testclient import TestClient
 
@@ -192,18 +190,6 @@ def test_derive_server_name_strips_noise_and_stays_identifier_safe():
 
 
 # --- the client: one GET, cached in Redis, loud on failure ------------------
-
-
-@pytest.fixture(autouse=True)
-def _fresh_search_cache():
-    # The suite's FakeRedis lives for the whole session; drop this module's
-    # keys so every test sees a cold cache.
-    redis = get_client()
-    redis._data = {
-        key: value
-        for key, value in redis._data.items()
-        if not key.startswith(REGISTRY_SEARCH_CACHE_PREFIX)
-    }
 
 
 def _client_returning(handler):

--- a/backend/tests/test_system_health.py
+++ b/backend/tests/test_system_health.py
@@ -1,20 +1,7 @@
 from pathlib import Path
 
-import pytest
 from conftest import configure_app_for_test, make_settings
 from fastapi.testclient import TestClient
-
-MODULE = "druks.api.health_status"
-
-
-@pytest.fixture(autouse=True)
-def _no_redis_freshness(monkeypatch):
-    """Webhook freshness lives in Redis; tests have none running."""
-
-    async def none(provider):
-        return None
-
-    monkeypatch.setattr(f"{MODULE}.last_delivery_at", none)
 
 
 def _client(tmp_path: Path) -> TestClient:

--- a/backend/tests/test_webhooks_framework.py
+++ b/backend/tests/test_webhooks_framework.py
@@ -1,3 +1,6 @@
+import hashlib
+import hmac
+
 import pytest
 from druks.extensions.registry import webhooks
 from druks.settings import Settings
@@ -7,30 +10,6 @@ from druks.webhooks.router import router as webhooks_router
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse, Response
 from fastapi.testclient import TestClient
-
-MODULE = "druks.webhooks.base"
-
-
-@pytest.fixture(autouse=True)
-def _fake_deliveries(monkeypatch):
-    """Delivery dedup lives in Redis; substitute a per-test set."""
-    seen: set[str] = set()
-
-    async def mark(provider, key):
-        if key is None:
-            return True
-        dedup = f"{provider}:{key}"
-        if dedup in seen:
-            return False
-        seen.add(dedup)
-        return True
-
-    async def release(provider, key):
-        if key is not None:
-            seen.discard(f"{provider}:{key}")
-
-    monkeypatch.setattr(f"{MODULE}.mark_delivery", mark)
-    monkeypatch.setattr(f"{MODULE}.release_delivery", release)
 
 
 @pytest.fixture(autouse=True)
@@ -193,6 +172,8 @@ def _client_for(*hook_classes: type[Webhook], settings: Settings) -> TestClient:
 
     The hook classes are passed in for clarity (they self-register on
     definition; this just documents which hooks the test exercises).
+    Use as a context manager: delivery marking talks to Redis, and only the
+    ``with`` form gives every request one shared event loop for that client.
     """
     app = FastAPI()
     app.state.settings = settings
@@ -214,8 +195,8 @@ def test_dispatch_calls_matching_on_action_method(settings):
         async def on_ping(self):
             return JSONResponse({"pong": self.data.get("seq")})
 
-    client = _client_for(Hook, settings=settings)
-    response = client.post("/_external/dispatch/events/", json={"seq": 7})
+    with _client_for(Hook, settings=settings) as client:
+        response = client.post("/_external/dispatch/events/", json={"seq": 7})
     assert response.status_code == 200
     assert response.json() == {"pong": 7}
 
@@ -237,8 +218,8 @@ def test_dispatch_unhandled_action_falls_through_to_on_unhandled(settings):
             seen.append(action)
             return JSONResponse({"unhandled": action}, status_code=202)
 
-    client = _client_for(Hook, settings=settings)
-    response = client.post("/_external/fallback/events/", json={})
+    with _client_for(Hook, settings=settings) as client:
+        response = client.post("/_external/fallback/events/", json={})
     assert response.status_code == 202
     assert response.json() == {"unhandled": "no_method_for_this"}
     assert seen == ["no_method_for_this"]
@@ -255,8 +236,8 @@ def test_dispatch_request_is_authentic_false_raises_401(settings):
         def get_action(self):
             return "ping"
 
-    client = _client_for(Hook, settings=settings)
-    response = client.post("/_external/auth/events/", json={})
+    with _client_for(Hook, settings=settings) as client:
+        response = client.post("/_external/auth/events/", json={})
     assert response.status_code == 401
 
 
@@ -271,14 +252,14 @@ def test_dispatch_request_is_authentic_may_raise_http_exception(settings):
         def get_action(self):
             return "ping"
 
-    client = _client_for(Hook, settings=settings)
-    response = client.post("/_external/rich/events/", json={})
+    with _client_for(Hook, settings=settings) as client:
+        response = client.post("/_external/rich/events/", json={})
     assert response.status_code == 403
 
 
 def test_unknown_path_returns_404(settings):
-    client = _client_for(settings=settings)
-    response = client.post("/_external/nothing/here/", json={})
+    with _client_for(settings=settings) as client:
+        response = client.post("/_external/nothing/here/", json={})
     assert response.status_code == 404
 
 
@@ -296,8 +277,8 @@ def test_trailing_slash_is_optional_on_request_url(settings):
         async def on_ping(self):
             return JSONResponse({"ok": True})
 
-    client = _client_for(Hook, settings=settings)
-    response = client.post("/_external/loose/events", json={})
+    with _client_for(Hook, settings=settings) as client:
+        response = client.post("/_external/loose/events", json={})
     assert response.status_code == 200
 
 
@@ -324,14 +305,14 @@ def test_dedup_first_call_dispatches_second_call_short_circuits(settings):
             seen_pings.append(self.data["seq"])
             return JSONResponse({"ok": True})
 
-    client = _client_for(Hook, settings=settings)
-    r1 = client.post("/_external/dedup/events/", json={"key": "K", "seq": 1})
-    assert r1.status_code == 200
-    assert r1.json() == {"ok": True}
+    with _client_for(Hook, settings=settings) as client:
+        r1 = client.post("/_external/dedup/events/", json={"key": "K", "seq": 1})
+        assert r1.status_code == 200
+        assert r1.json() == {"ok": True}
 
-    r2 = client.post("/_external/dedup/events/", json={"key": "K", "seq": 2})
-    assert r2.status_code == 200
-    assert r2.json() == {"accepted": False, "duplicate": True}
+        r2 = client.post("/_external/dedup/events/", json={"key": "K", "seq": 2})
+        assert r2.status_code == 200
+        assert r2.json() == {"accepted": False, "duplicate": True}
 
     assert seen_pings == [1]
 
@@ -360,13 +341,13 @@ def test_failed_handler_releases_claim_so_retry_reprocesses(settings):
                 raise RuntimeError("transient handler failure")
             return JSONResponse({"ok": True})
 
-    client = _client_for(Hook, settings=settings)
-    r1 = client.post("/_external/flaky/events/", json={"key": "K", "seq": 1})
-    assert r1.status_code == 500  # handler raised; claim released
+    with _client_for(Hook, settings=settings) as client:
+        r1 = client.post("/_external/flaky/events/", json={"key": "K", "seq": 1})
+        assert r1.status_code == 500  # handler raised; claim released
 
-    r2 = client.post("/_external/flaky/events/", json={"key": "K", "seq": 2})
-    assert r2.status_code == 200
-    assert r2.json() == {"ok": True}
+        r2 = client.post("/_external/flaky/events/", json={"key": "K", "seq": 2})
+        assert r2.status_code == 200
+        assert r2.json() == {"ok": True}
     assert attempts == [1, 2]  # reprocessed, not swallowed as a duplicate
 
 
@@ -374,12 +355,9 @@ def test_failed_handler_releases_claim_so_retry_reprocesses(settings):
 
 
 def test_verify_hmac_sha256_accepts_correct_signature():
-    import hashlib
-    import hmac as _hmac
-
     body = b'{"hello":"world"}'
     secret = "supersecret"
-    sig = "sha256=" + _hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
     # Should not raise.
     verify_hmac_sha256(body, sig, secret)

--- a/backend/tests/test_webhooks_slack.py
+++ b/backend/tests/test_webhooks_slack.py
@@ -119,24 +119,23 @@ def test_signature_verifier_against_a_known_answer(monkeypatch):
 async def test_unsigned_or_stale_requests_401_and_never_resume(tmp_path, db_session, resume_spy):
     run, notification = _parked_notification(db_session)
     body = _interactivity_body(encode_button(notification.correlation_token, "approve"))
-    client = _client(tmp_path)
+    with _client(tmp_path) as client:
+        no_headers = client.post("/_external/slack/interactivity/", content=body)
+        assert no_headers.status_code == 401
 
-    no_headers = client.post("/_external/slack/interactivity/", content=body)
-    assert no_headers.status_code == 401
+        wrong_secret = client.post(
+            "/_external/slack/interactivity/",
+            content=body,
+            headers=_signed_headers(body, secret="wrong-secret"),
+        )
+        assert wrong_secret.status_code == 401
 
-    wrong_secret = client.post(
-        "/_external/slack/interactivity/",
-        content=body,
-        headers=_signed_headers(body, secret="wrong-secret"),
-    )
-    assert wrong_secret.status_code == 401
-
-    replayed = client.post(
-        "/_external/slack/interactivity/",
-        content=body,
-        headers=_signed_headers(body, timestamp=str(int(time.time()) - 3600)),
-    )
-    assert replayed.status_code == 401
+        replayed = client.post(
+            "/_external/slack/interactivity/",
+            content=body,
+            headers=_signed_headers(body, timestamp=str(int(time.time()) - 3600)),
+        )
+        assert replayed.status_code == 401
 
     assert resume_spy == []
     assert Notification.get(notification.id).state == "pending"
@@ -148,11 +147,10 @@ async def test_unsigned_or_stale_requests_401_and_never_resume(tmp_path, db_sess
 async def test_signed_click_routes_through_respond(tmp_path, db_session, resume_spy):
     run, notification = _parked_notification(db_session)
     body = _interactivity_body(encode_button(notification.correlation_token, "approve"))
-    client = _client(tmp_path)
-
-    response = client.post(
-        "/_external/slack/interactivity/", content=body, headers=_signed_headers(body)
-    )
+    with _client(tmp_path) as client:
+        response = client.post(
+            "/_external/slack/interactivity/", content=body, headers=_signed_headers(body)
+        )
 
     assert response.status_code == 200
     assert response.json() == {"accepted": True}
@@ -168,20 +166,19 @@ async def test_signed_click_routes_through_respond(tmp_path, db_session, resume_
 async def test_dead_round_click_is_acknowledged_without_resume(tmp_path, db_session, resume_spy):
     run, notification = _parked_notification(db_session)
     notification.mark_acknowledged()
-    client = _client(tmp_path)
+    with _client(tmp_path) as client:
+        body = _interactivity_body(encode_button(notification.correlation_token, "approve"))
+        acknowledged = client.post(
+            "/_external/slack/interactivity/", content=body, headers=_signed_headers(body)
+        )
+        assert acknowledged.status_code == 200
+        assert acknowledged.json() == {"accepted": False}
 
-    body = _interactivity_body(encode_button(notification.correlation_token, "approve"))
-    acknowledged = client.post(
-        "/_external/slack/interactivity/", content=body, headers=_signed_headers(body)
-    )
-    assert acknowledged.status_code == 200
-    assert acknowledged.json() == {"accepted": False}
-
-    ghost = _interactivity_body(encode_button("ghost-token", "approve"))
-    unknown = client.post(
-        "/_external/slack/interactivity/", content=ghost, headers=_signed_headers(ghost)
-    )
-    assert unknown.status_code == 200
+        ghost = _interactivity_body(encode_button("ghost-token", "approve"))
+        unknown = client.post(
+            "/_external/slack/interactivity/", content=ghost, headers=_signed_headers(ghost)
+        )
+        assert unknown.status_code == 200
     assert unknown.json() == {"accepted": False}
     assert "ghost-token" not in unknown.text
 
@@ -190,7 +187,6 @@ async def test_dead_round_click_is_acknowledged_without_resume(tmp_path, db_sess
 
 async def test_malformed_payloads_400_never_500_never_resume(tmp_path, db_session, resume_spy):
     run, notification = _parked_notification(db_session)
-    client = _client(tmp_path)
     malformed = [
         b"not-a-form",
         urlencode({"payload": "not json"}).encode(),
@@ -200,11 +196,12 @@ async def test_malformed_payloads_400_never_500_never_resume(tmp_path, db_sessio
         _interactivity_body("not-an-encoded-button!!"),
     ]
 
-    for body in malformed:
-        response = client.post(
-            "/_external/slack/interactivity/", content=body, headers=_signed_headers(body)
-        )
-        assert response.status_code == 400
+    with _client(tmp_path) as client:
+        for body in malformed:
+            response = client.post(
+                "/_external/slack/interactivity/", content=body, headers=_signed_headers(body)
+            )
+            assert response.status_code == 400
 
     assert resume_spy == []
     assert Notification.get(notification.id).state == "pending"
@@ -214,12 +211,12 @@ async def test_unknown_interactivity_type_is_acknowledged_unhandled(
     tmp_path, db_session, resume_spy
 ):
     _parked_notification(db_session)
-    client = _client(tmp_path)
     body = urlencode({"payload": json.dumps({"type": "view_submission"})}).encode()
 
-    response = client.post(
-        "/_external/slack/interactivity/", content=body, headers=_signed_headers(body)
-    )
+    with _client(tmp_path) as client:
+        response = client.post(
+            "/_external/slack/interactivity/", content=body, headers=_signed_headers(body)
+        )
 
     assert response.status_code == 200
     assert response.json() == {"accepted": True, "handled": False}


### PR DESCRIPTION
Phase 0 of the test-suite repair: Redis is now required for tests — real Redis, no mocks.

- CI stands a `redis:8.2-alpine` service beside Postgres (digest-pinned, tracking deploy/compose.yaml, healthchecked on 6379).
- conftest loses FakeRedis, the `_client` patch, and the `close_client` neuter. One autouse fixture replaces them: abandon the previous test's loop-bound client, FLUSHDB on a fresh one, close — every consumer dials on its own live loop, and the app lifespan's real `close_client()` runs again at TestClient exit.
- Seven files lose their "scrub the shared fake's keys" fixtures (gate, identity, identity_jwt, auth_pats, harness_connect, mcp_oauth, mcp_registry); FLUSHDB-per-test covers them.
- test_system_health reads the real `last_delivery_at`; test_webhooks_framework exercises the real `mark_delivery`/`release_delivery` dedup path.
- Webhook framework + slack TestClients enter their context: a non-`with` client spins a portal loop per request, and a real loop-bound client can't hop loops the way the dict fake could.
- test_mcp_oauth: the callback test now drives connect → callback fully through the wire on one portal; the disconnect test closes the mint's client before entering TestClient.

+104/−249 (net −145), conftest 621 → 554. No tests deleted; 146 tests in touched files still collect. Notes: used redis 8.2 (deploy's version) over the planned 7; test_agents.py had no redis fakery to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)