### PR TITLE
Drop the per-call 'fallback' account badge

### DIFF
--- a/frontend/src/extensions/build/WorkItemPage.tsx
+++ b/frontend/src/extensions/build/WorkItemPage.tsx
@@ -410,7 +410,6 @@ function RunRow({
           <CallRow
             key={call.id}
             call={call}
-            runAccountUsername={run.accountUsername}
             selected={selectedHere && selection?.call?.id === call.id}
             onSelect={() => onSelect(call.id)}
           />
@@ -421,12 +420,10 @@ function RunRow({
 
 function CallRow({
   call,
-  runAccountUsername,
   selected,
   onSelect,
 }: {
   call: AgentCallSummary
-  runAccountUsername: string
   selected: boolean
   onSelect: () => void
 }) {
@@ -437,11 +434,6 @@ function CallRow({
         {CALL_GLYPH[call.status] ?? '·'}
       </span>
       <span className="wic-call-label">{call.label}</span>
-      {call.accountUsername !== runAccountUsername && (
-        <span className="wic-call-fallback" title={`Charged to ${call.accountUsername}.`}>
-          fallback
-        </span>
-      )}
       <span className="wic-call-ledger">
         <span className="wic-op-dur">{elapsed > 0 ? dur(elapsed) : '–'}</span>
         <span className="wic-op-cost">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1936,7 +1936,6 @@ input.set-select { background-image: none; padding-right: 12px; }
 .wic-g-failed    { color: var(--wic-failed); }
 .wic-g-abandoned { color: var(--wic-cancelled); }
 .wic-call-label { font-size: 12px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.wic-call-fallback { font-family: var(--font-mono); font-size: 9.5px; color: var(--decision-request-revision); border: 1px solid color-mix(in oklch, var(--decision-request-revision) 40%, transparent); border-radius: 3px; padding: 0 5px; margin-left: 6px; white-space: nowrap; }
 .wic-call-ledger { display: flex; gap: 10px; white-space: nowrap; }
 
 /* ============================================================


### PR DESCRIPTION
The work-item timeline tagged every agent call whose charged account differed from the run's account with a `fallback` chip. On an actor-less run (`system` — webhooks, schedules, the default build workflow) that's *every* call, since those always execute on the fallback account. So the badge was permanent noise there, and "fallback" read like a failover / degraded mode rather than what it meant: "billed to the fallback account."

Removes the chip, its now-dead `runAccountUsername` prop threading, and the `.wic-call-fallback` CSS.

Leaves the run-level `system` owner label (titled "Who requested this run") in place — separate concern.

`tsc -b` + `eslint` clean.