### PR TITLE
Land operator cancel as cancelled, not failed

### DIFF
--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -25,7 +25,7 @@ from druks.settings import load_settings
 from druks.skills.models import Skill
 from druks.ticketing.datastructures import Ticket
 from druks.ticketing.enums import SemanticStatus
-from druks.workflows import FatalError, Gate, Run, Workflow, step
+from druks.workflows import FatalError, Gate, OperatorCancelled, Run, Workflow, step
 
 from .extension import Build
 from .journal import BuildJournal
@@ -269,7 +269,7 @@ class BuildWorkflow(Workflow):
                 reviewer_notes = grade.body
             reply = await self.review(questions=plan.questions, context=critique)
             if reply.action == "cancel":
-                raise FatalError("cancelled at plan review")
+                raise OperatorCancelled("cancelled at plan review")
             if reply.action == "approve" and not plan.questions:
                 return True
             answered = plan.get_answered(reply.answers)
@@ -310,7 +310,7 @@ class BuildWorkflow(Workflow):
             return False
         if decision.action == "cancel":
             await self._push_ticket_status(SemanticStatus.CANCELED)
-            raise FatalError("cancelled at work review")
+            raise OperatorCancelled("cancelled at work review")
         return False
 
     async def _approved_work(self) -> bool:

--- a/backend/druks/durable/exceptions.py
+++ b/backend/druks/durable/exceptions.py
@@ -11,6 +11,12 @@ class FatalError(Exception):
     code: ClassVar[str] = ""
 
 
+class OperatorCancelled(Exception):
+    """End the run as cancelled on the operator's say-so: the message becomes the
+    run's recorded reason and the run finalizes as CANCELLED, not FAILED — a
+    deliberate stop the board reads as done, not as still needing you."""
+
+
 class WorkflowError(Exception):
     pass
 

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -23,7 +23,13 @@ from druks.accounts.context import current_account_id
 from druks.durable.activity import get_run_phase, set_run_phase
 from druks.durable.engine import _step_engine, register_schedule, run_queue, step_session
 from druks.durable.enums import AgentCallStatus, RunState
-from druks.durable.exceptions import FatalError, GateTimeout, SubjectlessGate, WorkflowError
+from druks.durable.exceptions import (
+    FatalError,
+    GateTimeout,
+    OperatorCancelled,
+    SubjectlessGate,
+    WorkflowError,
+)
 from druks.durable.models import AgentCall, Run
 from druks.durable.schemas import AgentCallResponse, SubjectActivity, SubjectSummary
 from druks.events.models import Event
@@ -51,6 +57,7 @@ __all__ = [
     "FatalError",
     "Gate",
     "Journal",
+    "OperatorCancelled",
     "OperatorReply",
     "Run",
     "RunState",
@@ -426,15 +433,29 @@ async def _execute_run(
     body: Callable,
 ) -> Any:
     # Ensure the row (idempotent, so a scheduled run with no start() makes it
-    # here), then run the body between its running and finished/failed events.
-    # Every failure re-raises so DBOS records the terminal ERROR derived state
-    # reads; an operator cancel already carries its own reason and terminal
-    # status, so it passes through untouched.
+    # here), then run the body between its running event and a terminal one. A
+    # crash or FatalError re-raises so DBOS records the terminal ERROR that
+    # derived state reads as failed.
     Run.create_row(_step_engine(), workflow_id=workflow_id, kind=kind, account_id=account_id)
     await _emit_run_event(workflow_id, RunState.RUNNING, subject=subject)
     try:
         result = await body()
     except (DBOSAwaitedWorkflowCancelledError, DBOSWorkflowCancelledError):
+        # An external cancel (Run.cancel) already wrote the reason and the
+        # CANCELLED status, so let it pass through untouched.
+        raise
+    except OperatorCancelled as cancelled:
+        # The operator ended the run at a review gate. Derived state reads the DBOS
+        # status, so end it CANCELLED, not the ERROR a raise records: emit the
+        # terminal event while the run is still live, then set the status. The
+        # re-raise can't overwrite a terminal CANCELLED, so the run stands cancelled.
+        await _emit_run_event(
+            workflow_id,
+            RunState.CANCELLED,
+            subject=subject,
+            facts={**_GATE_CLEARED, "failure": str(cancelled)},
+        )
+        await DBOS.cancel_workflow_async(workflow_id)
         raise
     except Exception as exc:
         await _emit_run_event(

--- a/backend/tests/test_build_plan_phase.py
+++ b/backend/tests/test_build_plan_phase.py
@@ -5,7 +5,7 @@ from druks.build.contracts import PlanData, QuestionOptionOutput, QuestionOutput
 from druks.build.enums import ReviewDecision
 from druks.build.policy import RepoPolicy
 from druks.build.workflows import Build, BuildWorkflow
-from druks.workflows import FatalError, OperatorReply
+from druks.workflows import FatalError, OperatorCancelled, OperatorReply
 
 
 def _flow(*, auto_dispatch: bool = False) -> BuildWorkflow:
@@ -182,7 +182,7 @@ async def test_cancel_at_the_plan_park_stops_the_run(monkeypatch):
 
     flow.review = fake_review
 
-    with pytest.raises(FatalError, match="cancelled at plan review"):
+    with pytest.raises(OperatorCancelled, match="cancelled at plan review"):
         await flow._plan_phase()
 
 

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -12,7 +12,7 @@ from druks.durable import FatalError, Run, RunState
 from druks.durable.dbos_state import workflow_status
 from druks.durable.engine import configure_engine, init_dbos, launch, shutdown
 from druks.extensions.registry import agents, workflows
-from druks.workflows import Gate, Workflow, step
+from druks.workflows import Gate, OperatorCancelled, Workflow, step
 from pydantic import BaseModel
 from sqlalchemy import create_engine, select
 
@@ -77,6 +77,8 @@ def _build_units():
             decision = await Approve.wait()
             if decision.action == "close":
                 raise FatalError("closed at review")
+            if decision.action == "cancel":
+                raise OperatorCancelled("cancelled at review")
 
     class AgentFlow(Workflow):
         DECIDER = Agent(id="decider", contract=Decision, model="claude", prompt="t")
@@ -413,6 +415,26 @@ async def test_fail_branch(rt):
             {"id": wfid},
         ).scalar_one()
     assert status == "ERROR"
+
+
+async def test_cancel_branch(rt):
+    from sqlalchemy import text
+
+    wfid = await rt.SampleFlow.start(subject=None, repo="owner/app")
+    parked = await _wait_for(rt.engine, wfid, lambda r: r.input_gate == "approve")
+
+    await parked.resume(action="cancel")
+    cancelled = await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.CANCELLED)
+    assert cancelled.failure == "cancelled at review"
+    assert cancelled.input_gate is None
+    # CANCELLED derives from DBOS's own record: the body self-cancelled, so DBOS
+    # holds terminal CANCELLED — a deliberate stop, not the ERROR a raise leaves.
+    with rt.engine.connect() as conn:
+        status = conn.execute(
+            text("SELECT status FROM dbos.workflow_status WHERE workflow_uuid = :id"),
+            {"id": wfid},
+        ).scalar_one()
+    assert status == "CANCELLED"
 
 
 async def test_subjectless_gate_fails_loudly(rt):


### PR DESCRIPTION
## Problem

Cancelling a run at an in-app review gate (plan or work review) raised `FatalError`. DBOS records a raised exception as `ERROR`, and derived state maps `ERROR → failed` (`dbos_state.state_expression`). So a **deliberate operator cancel** landed in the board's `needs-you` lane looking identical to a crash (`failed → "retry or cancel"`), with nothing left for the operator to do.

Seen live on ENG-699 (work item 6): DBOS status `ERROR`, `failure = "cancelled at plan review"`, permanently flagged "attention needed."

## Fix

Raise a typed `OperatorCancelled` at the two review-gate cancel points instead of `FatalError`. `_execute_run` catches it, emits the terminal `run.cancelled` event **while the run is still live**, then flips the DBOS status to `CANCELLED` — the one state derived reads. The re-raise reaches DBOS, which refuses to overwrite a terminal `CANCELLED` (`update_workflow_outcome` guards on `status != CANCELLED`), so the run stands cancelled and drops off the active board (the board polls derived status every 2s; `cancelled` is neither `pending_input` nor `failed`).

This also lights up the `run.cancelled` feed label that `build/extension.py` already declared but nothing produced. External cancel (`Run.cancel` via MCP) is unchanged — it already writes `CANCELLED` before the workflow unwinds.

## Tests

- `test_durable_sdk.py::test_cancel_branch` — end-to-end through real DBOS: an `OperatorCancelled` at a gate finalizes the run `CANCELLED` (DBOS status + derived state + recorded reason), mirroring the existing `test_fail_branch`.
- `test_build_plan_phase.py` — cancel at the plan park now raises `OperatorCancelled`.

Verified locally against the dev DBOS Postgres (`test_durable_sdk` + `test_build_plan_phase` + `test_run_cancel`, 38 passed); ruff clean.

## Already-stuck row

The pre-existing ENG-699 run was flipped `ERROR → CANCELLED` directly on the host to clear it off the board now (its `failure` column already read "cancelled at plan review").
