### PR TITLE
Cancel is a run action, not a review verdict (ENG-700)

### DIFF
--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -14,11 +14,11 @@ if TYPE_CHECKING:
     from druks.build.workflows import BuildWorkflow
 
 
-# The PR webhook resumes approve/request_changes; revise_contract and cancel
-# come from the operator's UI.
+# The PR webhook resumes approve/request_changes; revise_contract comes from the
+# operator's UI. Ending the run is a run-level action (cancel), not a review verdict.
 class ReviewWork(Gate):
     name = "review_work"
-    action: Literal["approve", "request_changes", "revise_contract", "cancel"]
+    action: Literal["approve", "request_changes", "revise_contract"]
     reviewer: str | None = None
     body: str | None = None
 

--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -14,9 +14,10 @@ if TYPE_CHECKING:
     from druks.build.workflows import BuildWorkflow
 
 
-# The PR webhook resumes approve/request_changes; revise_contract comes from the
-# operator's UI. Ending the run is a run-level action (cancel), not a review verdict.
 class ReviewWork(Gate):
+    """The verdict on the built work: approve/request_changes (PR webhook) or
+    revise_contract (UI)."""
+
     name = "review_work"
     action: Literal["approve", "request_changes", "revise_contract"]
     reviewer: str | None = None

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -24,7 +24,6 @@ from druks.sandbox.layout import (
 from druks.settings import load_settings
 from druks.skills.models import Skill
 from druks.ticketing.datastructures import Ticket
-from druks.ticketing.enums import SemanticStatus
 from druks.workflows import FatalError, Gate, Run, Workflow, step
 
 from .extension import Build
@@ -244,7 +243,7 @@ class BuildWorkflow(Workflow):
 
     async def _plan_phase(self) -> bool:
         """Gate mode: plan → park. Auto mode: machine review with one bounded
-        redraft. True → implement; cancel raises."""
+        redraft. True → implement."""
         gate = self._policy.plan_approval_gate(self._settings.auto_dispatch_on_plan_approval)
         answered: list[dict[str, str]] = []
         note = ""
@@ -268,8 +267,6 @@ class BuildWorkflow(Workflow):
                 redrafted = True
                 reviewer_notes = grade.body
             reply = await self.review(questions=plan.questions, context=critique)
-            if reply.action == "cancel":
-                raise FatalError("cancelled at plan review")
             if reply.action == "approve" and not plan.questions:
                 return True
             answered = plan.get_answered(reply.answers)
@@ -307,10 +304,6 @@ class BuildWorkflow(Workflow):
             return await self._triage()
         if decision.action == "revise_contract":
             await Build.revise_contract()
-            return False
-        if decision.action == "cancel":
-            await self._push_ticket_status(SemanticStatus.CANCELED)
-            raise FatalError("cancelled at work review")
         return False
 
     async def _approved_work(self) -> bool:
@@ -391,15 +384,6 @@ class BuildWorkflow(Workflow):
     @step
     async def _clear_draft(self) -> None:
         await self.set_pr_draft(draft=False)
-
-    @step
-    async def _push_ticket_status(self, status: SemanticStatus) -> None:
-        work_item = WorkItem.get_for_pr(
-            repo=self.input.repo,
-            pr_number=self.pr_number,
-        )
-        if work_item:
-            await work_item.set_remote_status(status)
 
     async def request_assignee_review(self) -> None:
         login = self.journal.assignee_github_login

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -72,7 +72,7 @@ GATE_TTL_SECONDS = 14 * 24 * 60 * 60
 # The decision verbs an in-app review offers. Framework-owned: an extension's
 # agent supplies the plan and questions (content), but the verbs are ours — so a
 # resume can only carry an action we defined, the line the resume endpoint checks.
-_ReviewAction = Literal["approve", "request_changes", "cancel"]
+_ReviewAction = Literal["approve", "request_changes"]
 _REVIEW_CONTROLS = get_args(_ReviewAction)
 
 T = TypeVar("T")

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -19,7 +19,7 @@ from fastapi.testclient import TestClient
 
 _IN_APP_ASK = {
     "presentation": "in_app",
-    "controls": ["approve", "request_changes", "cancel"],
+    "controls": ["approve", "request_changes"],
     "questions": [],
 }
 

--- a/backend/tests/test_agent_services.py
+++ b/backend/tests/test_agent_services.py
@@ -37,7 +37,7 @@ def resume_spy(monkeypatch):
 def _in_app_ask(questions=()):
     return {
         "presentation": "in_app",
-        "controls": ["approve", "request_changes", "cancel"],
+        "controls": ["approve", "request_changes"],
         "questions": list(questions),
     }
 
@@ -104,7 +104,7 @@ def test_get_gate_returns_the_ask_and_parked_at(db_session):
     assert view.run_id == run.id
     assert view.gate == "review"
     assert view.parked_at == run.input_requested_at
-    assert view.ask["controls"] == ["approve", "request_changes", "cancel"]
+    assert view.ask["controls"] == ["approve", "request_changes"]
     assert view.ask["questions"][0]["prompt"] == "Which db?"
 
 

--- a/backend/tests/test_build_durable.py
+++ b/backend/tests/test_build_durable.py
@@ -121,7 +121,6 @@ def _stub(monkeypatch, rt, *, plan_approval="human", auto_dispatch=False):
         return None
 
     for name in (
-        "_push_ticket_status",
         "set_pr_draft",
         "request_assignee_review",
         "_clear_draft",

--- a/backend/tests/test_build_plan_phase.py
+++ b/backend/tests/test_build_plan_phase.py
@@ -172,20 +172,6 @@ async def test_questions_park_in_auto_mode_too(monkeypatch):
     assert await flow._plan_phase() is True
 
 
-async def test_cancel_at_the_plan_park_stops_the_run(monkeypatch):
-    flow = _flow()
-    _fake_plans(monkeypatch, PlanData(plan_markdown="v1"))
-    _no_review_agent(monkeypatch)
-
-    async def fake_review(*, questions=None, context=""):
-        return OperatorReply(action="cancel")
-
-    flow.review = fake_review
-
-    with pytest.raises(FatalError, match="cancelled at plan review"):
-        await flow._plan_phase()
-
-
 async def test_needs_clarification_delivery_stops_the_run(monkeypatch):
     """The implementer bailing (needs_clarification) fails the run with its own
     reason — the stop is a workflow decision now, not a contract side effect."""

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -23,7 +23,7 @@ from fastmcp.client.transports import StreamableHttpTransport
 
 _IN_APP_ASK = {
     "presentation": "in_app",
-    "controls": ["approve", "request_changes", "cancel"],
+    "controls": ["approve", "request_changes"],
     "questions": [],
 }
 
@@ -219,7 +219,7 @@ async def test_gate_cycle_reads_answers_and_reports_stale_rounds(
     async with live(app), _client(app, pat_token) as client:
         gate = (await client.call_tool("get_gate", {"run_id": run.id})).structured_content
         assert gate["runId"] == run.id
-        assert gate["ask"]["controls"] == ["approve", "request_changes", "cancel"]
+        assert gate["ask"]["controls"] == ["approve", "request_changes"]
 
         stale = await _call_error(
             client,

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -150,7 +150,7 @@ def test_deleting_designated_destination_unsets_the_pointer(tmp_path, db_session
 
 _IN_APP_ASK = {
     "presentation": "in_app",
-    "controls": ["approve", "request_changes", "cancel"],
+    "controls": ["approve", "request_changes"],
     "questions": [{"id": "q1", "prompt": "which?", "options": [{"id": "a", "label": "A"}]}],
 }
 

--- a/backend/tests/test_notifications_durable.py
+++ b/backend/tests/test_notifications_durable.py
@@ -411,7 +411,6 @@ async def test_in_app_park_notifies_with_actions(rt, deliver_spy):
     assert notification.actions == [
         {"id": "approve", "label": "Approve"},
         {"id": "request_changes", "label": "Request changes"},
-        {"id": "cancel", "label": "Cancel"},
         {"id": "postgres", "label": "Postgres"},
     ]
     assert notification.deep_link is None

--- a/backend/tests/test_resume.py
+++ b/backend/tests/test_resume.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException
 # answer service echoes.
 _ASK = {
     "presentation": "in_app",
-    "controls": ["approve", "request_changes", "cancel"],
+    "controls": ["approve", "request_changes"],
     "questions": [{"id": "q1", "prompt": "which?", "options": [{"id": "a", "label": "A"}]}],
 }
 

--- a/backend/tests/test_webhooks_slack.py
+++ b/backend/tests/test_webhooks_slack.py
@@ -22,7 +22,7 @@ _WEBHOOK_URL = "https://hooks.slack.com/services/T000/B000/slackrail"
 
 _IN_APP_ASK = {
     "presentation": "in_app",
-    "controls": ["approve", "request_changes", "cancel"],
+    "controls": ["approve", "request_changes"],
     "questions": [],
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -173,6 +173,9 @@ export const api = {
     runId: string,
     body: { control: string; answers: Record<string, string>; note: string },
   ) => postNoContent(`/api/runs/${runId}/resume`, body),
+  // Cancel is a run-level action, not a review verdict — it ends any active run.
+  cancelRun: (runId: string, reason: string) =>
+    postJSON<{ runId: string; result: string }>(`/api/runs/${runId}/cancel`, { reason }),
   listEvents: (params: { limit?: number; before?: string; extension?: string } = {}) => {
     const query = new URLSearchParams()
     if (params.limit !== undefined) query.set('limit', String(params.limit))

--- a/frontend/src/extensions/build/WorkItemPage.tsx
+++ b/frontend/src/extensions/build/WorkItemPage.tsx
@@ -104,6 +104,8 @@ const CALL_GLYPH: Record<string, string> = {
   abandoned: '⊘',
 }
 const isRunning = (run: RunSummary) => run.state === 'running'
+const isActiveRun = (run: RunSummary) =>
+  run.state === 'running' || run.state === 'pending_input' || run.state === 'scheduled'
 
 interface Metrics {
   elapsed: number
@@ -549,16 +551,73 @@ function RunHeader({
           <span className="ins-sh-k">tokens</span> {fmtTok(m.tokens)}
         </span>
       </span>
-      {call && (
-        <button
-          type="button"
-          className="ins-run-link"
-          onClick={() => navigate(agentCallPath(wi.id, wi.remoteKey, wi.title, call.id))}
-        >
-          open full run ↗
-        </button>
-      )}
+      <span className="ins-sh-actions">
+        {isActiveRun(run) && <CancelRun runId={run.id} />}
+        {call && (
+          <button
+            type="button"
+            className="ins-run-link"
+            onClick={() => navigate(agentCallPath(wi.id, wi.remoteKey, wi.title, call.id))}
+          >
+            open full run ↗
+          </button>
+        )}
+      </span>
     </div>
+  )
+}
+
+// Cancel is a run-level action: end any active run, parked or running. A destructive
+// stop, so it confirms first and takes an optional reason (the recorded cancel note).
+// The detail stream re-emits the snapshot on the state flip, so this control unmounts
+// itself — no local success handling.
+function CancelRun({ runId }: { runId: string }) {
+  const [confirming, setConfirming] = useState(false)
+  const [reason, setReason] = useState('')
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function cancel() {
+    setPending(true)
+    setError(null)
+    try {
+      await api.cancelRun(runId, reason.trim() || 'cancelled by operator')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'could not cancel')
+      setPending(false)
+    }
+  }
+
+  if (!confirming) {
+    return (
+      <button type="button" className="ins-run-link ins-cancel" onClick={() => setConfirming(true)}>
+        cancel run
+      </button>
+    )
+  }
+  return (
+    <span className="ins-cancel-confirm">
+      <input
+        type="text"
+        className="ins-cancel-reason mono"
+        placeholder="reason (optional)"
+        maxLength={500}
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+      />
+      <button type="button" className="ins-run-link ins-cancel" disabled={pending} onClick={cancel}>
+        confirm cancel
+      </button>
+      <button
+        type="button"
+        className="ins-run-link"
+        disabled={pending}
+        onClick={() => setConfirming(false)}
+      >
+        back
+      </button>
+      {error && <span className="review-error">{error}</span>}
+    </span>
   )
 }
 
@@ -580,7 +639,6 @@ const CONTROL_LABEL: Record<string, string> = {
   approve: 'Approve',
   request_changes: 'Request changes',
   revise_contract: 'Revise contract',
-  cancel: 'Cancel',
 }
 
 // A run parked on an external ask (PR review, ticket comment): a one-line

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2203,8 +2203,11 @@ input.set-select { background-image: none; padding-right: 12px; }
 .ins-xscript-bar .ins-stream-meta { margin-bottom: 0; }
 .ins-run-link { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); white-space: nowrap; cursor: pointer; }
 .ins-run-link:hover { color: var(--text); }
-/* In the sticky step header the run link sits flush right of the metrics. */
-.ins-step-head .ins-run-link { margin-left: auto; }
+/* In the sticky step header the run actions sit flush right of the metrics. */
+.ins-step-head .ins-sh-actions { margin-left: auto; display: inline-flex; align-items: center; gap: 16px; }
+.ins-run-link.ins-cancel { color: var(--outcome-abandoned); }
+.ins-cancel-confirm { display: inline-flex; align-items: center; gap: 10px; }
+.ins-cancel-reason { font-family: var(--font-mono); font-size: 11px; padding: 3px 8px; width: 190px; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text); }
 .ins-live-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--bucket-run); box-shadow: 0 0 6px var(--bucket-run); animation: pulse 1.4s ease-in-out infinite; }
 
 /* provisioning notice */


### PR DESCRIPTION
Fixes ENG-700.

## Problem

Cancelling a build at a review gate raised `FatalError`, which DBOS records as `ERROR` and derived state reads as `failed` — so a deliberate operator cancel sat in the **needs-you** lane looking identical to a crash, with nothing left to do.

The root cause is a conflation: **cancel-the-run was smuggled into the review verdict vocabulary** (`_REVIEW_CONTROLS = approve | request_changes | cancel`). A review verdict is a decision about the *artifact* (the plan); cancelling is a lifecycle action on the *run*. Different axes, one button.

## Fix — split the two axes

- The plan/work review offers only **verdicts**: `approve`, `request_changes` (dropped `cancel` from `_ReviewAction` and `ReviewWork.action`).
- **Cancel is a run-level action that already exists**: `POST /api/runs/{id}/cancel` (the gateway `cancel_run` → `Run.cancel` → DBOS `CANCELLED` → derived `RunState.CANCELLED`). No new endpoint — I briefly added a duplicate and reverted it.
- build's two `raise FatalError("cancelled at …")` arms are deleted; build stops owning a decision that was never its to own.
- Frontend: a standalone **cancel run** control on any active run (parked *or* running — strictly more than before, which only let you cancel a parked review). It confirms first and takes an optional reason. The review Cancel button is gone with the vocabulary.

## Deliberately not done (supersedes ENG-700 as written)

ENG-700 kept `cancel` as a review control and moved the ticket-status push to a `run.cancelled` subscriber. Today's decision supersedes both:

- **No tracker write on cancel** — druks reacts, never stamps; the tracker owns its own status.
- **No `run.cancelled` event** — nothing consumes one. The board drops a cancelled run from derived state; History shows it cancelled off the run's own state (same as MCP cancel today).

## Tests

- `75 passed` across every affected suite (resume, plan-phase, run-cancel, mcp-endpoint, agent-routes/services, notifications, slack, journal); ruff clean; frontend `tsc -b` + eslint clean.
- Deleted the cancel-at-plan-review test (behavior gone) and cleaned the stale `[…, "cancel"]` review-ask fixtures across 5 test files so nothing claims cancel is a review control.

Not visually verified — seeing the frontend control live needs the full stack plus a seeded active run; it's a small component reusing existing `ins-run-link` styling.

Supersedes #68 (the scrapped `OperatorCancelled` approach, which kept build inventing the outcome).
