### PR TITLE
Move build subscriber logic onto WorkItem; fold intake into dispatch

### DIFF
--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -7,9 +7,12 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from druks.build.enums import HandoffStatus
+from druks.build.policy import RepoPolicy
+from druks.core.apis.github import get_github_client
 from druks.db import Base, db_session
 from druks.durable.reads import get_subject_status
 from druks.durable.schemas import SubjectStatus
+from druks.settings import load_settings
 from druks.ticketing.datastructures import Ticket
 from druks.ticketing.enums import SemanticStatus
 from druks.ticketing.exceptions import TrackerNotConfigured
@@ -129,7 +132,7 @@ class ProjectRepo(Base):
         """
         target = (name or "").strip().lower()
         if not target:
-            return None
+            return
         # SQLite-friendly bare-name suffix match.
         stmt = select(cls).where(func.lower(cls.full_name).like(f"%/{target}")).limit(1)
         return db_session().scalars(stmt).first()
@@ -169,7 +172,7 @@ class ProjectRepo(Base):
                 row = cls.get_for_name(name)
                 if row:
                     return row
-        return None
+        return
 
 
 class WorkItem(Base):
@@ -312,6 +315,27 @@ class WorkItem(Base):
         if run and run.is_active:
             await run.cancel(failure=failure)
         db_session().flush()
+
+    async def ship(self) -> None:
+        # PR merged → settle shipped. A run still parked under an operator merge is
+        # stranded; cancel it (a RUNNING run converges on its own closed-PR merge step).
+        self.set_status(HandoffStatus.SHIPPED)
+        run = self.get_build_run()
+        if run and run.is_parked:
+            await run.cancel(failure="pr merged while parked")
+        await self.set_remote_status(SemanticStatus.DONE)
+
+    async def close_external(self) -> None:
+        # PR closed without a merge → abandon the attempt, not the ticket. Best-effort
+        # branch cleanup, then back to the provider's resting pool.
+        self.set_status(HandoffStatus.CANCELLED, event_payload={"external": True})
+        await self.cancel_active_build(failure="pr closed without merge")
+        try:
+            if (await RepoPolicy.resolve(self.repo)).delete_branch:
+                await get_github_client(load_settings()).delete_branch(self.repo, self.branch)
+        except Exception:  # noqa: BLE001 — cleanup only
+            logger.warning("Skipped branch cleanup for %s.", self.repo, exc_info=True)
+        await self.set_remote_status(SemanticStatus.READY_FOR_AGENT)
 
     @classmethod
     def get_for_remote_key(

--- a/backend/druks/build/subscribers.py
+++ b/backend/druks/build/subscribers.py
@@ -1,37 +1,49 @@
-import logging
-import re
-
-from githubkit.exception import RequestFailed, RequestTimeout
-
 from druks.build.contracts import ReviewWork
 from druks.build.enums import HandoffStatus
 from druks.build.extension import Build
-from druks.build.models import Project, ProjectRepo, WorkItem
-from druks.build.policy import RepoPolicy
+from druks.build.models import ProjectRepo, WorkItem
 from druks.build.workflows import BuildWorkflow, Profile, Scope
-from druks.core.apis.exceptions import GitHubAppNotConfiguredError, GitHubAppNotInstalledError
-from druks.core.apis.github import get_github_client
-from druks.settings import load_settings
 from druks.signals import subscribe
 from druks.ticketing.enums import SemanticStatus
 from druks.ticketing.exceptions import TrackerNotConfigured
 from druks.ticketing.helpers import get_tracker
 from druks.workflows import Run
 
-logger = logging.getLogger(__name__)
-
-_REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+# Projections
 
 
 @subscribe("run.running", subject__type="work_item")
-async def work_item_back_on_board(*, subject: dict, **_: object) -> None:
+async def run_start_returns_item_to_board(*, subject: dict, **_: object) -> None:
     # Any run starting for a work item puts it back on the active board —
     # re-scoping, a new build, a resume all mean druks has it in court again.
     WorkItem.get(subject["id"]).set_status(None)
 
 
+@subscribe("run.state", kind=BuildWorkflow.kind, subject__type="work_item")
+async def provision_mirrors_onto_item(
+    *, subject: dict, pr_number: int, branch: str, **_: object
+) -> None:
+    # The implementer's provisioned PR + branch, mirrored onto the work item —
+    # the read side (board links, webhook routing by repo+PR) keys off them.
+    WorkItem.get(subject["id"]).update(pr_number=pr_number, branch=branch)
+
+
+@subscribe("run.running", kind=BuildWorkflow.kind, subject__type="work_item")
+async def build_start_marks_ticket_in_progress(*, subject: dict, **_: object) -> None:
+    # Every (re)start and gate-resume of a build means the ticket is in progress —
+    # including the return from a rework loop that had parked it In Review.
+    item = WorkItem.get(subject["id"])
+    await item.set_remote_status(SemanticStatus.IN_PROGRESS)
+
+
+@subscribe("run.pending_input", kind=BuildWorkflow.kind, subject__type="work_item", gate=ReviewWork)
+async def review_park_marks_ticket_in_review(*, subject: dict, **_: object) -> None:
+    item = WorkItem.get(subject["id"])
+    await item.set_remote_status(SemanticStatus.IN_REVIEW)
+
+
 @subscribe("run.finished", kind=Scope.kind, subject__type="work_item", result__status="ready")
-async def scope_outcome_settles_lane(*, subject: dict, **_: object) -> None:
+async def scope_ready_settles_the_lane(*, subject: dict, **_: object) -> None:
     WorkItem.get(subject["id"]).set_status(HandoffStatus.SCOPED, event_payload={})
 
 
@@ -51,31 +63,11 @@ async def policy_push_reprofiles_the_repo(*, repo: str, paths: list, **_: object
     )
 
 
-@subscribe("run.state", kind=BuildWorkflow.kind, subject__type="work_item")
-async def provision_reaches_the_work_item(
-    *, subject: dict, pr_number: int, branch: str, **_: object
-) -> None:
-    # The implementer's provisioned PR + branch, mirrored onto the work item —
-    # the read side (board links, webhook routing by repo+PR) keys off them.
-    WorkItem.get(subject["id"]).update(pr_number=pr_number, branch=branch)
-
-
-@subscribe("run.running", kind=BuildWorkflow.kind, subject__type="work_item")
-async def build_running_reaches_the_tracker(*, subject: dict, **_: object) -> None:
-    # Every (re)start and gate-resume of a build means the ticket is in progress —
-    # including the return from a rework loop that had parked it In Review.
-    item = WorkItem.get(subject["id"])
-    await item.set_remote_status(SemanticStatus.IN_PROGRESS)
-
-
-@subscribe("run.pending_input", kind=BuildWorkflow.kind, subject__type="work_item", gate=ReviewWork)
-async def work_review_park_reaches_the_tracker(*, subject: dict, **_: object) -> None:
-    item = WorkItem.get(subject["id"])
-    await item.set_remote_status(SemanticStatus.IN_REVIEW)
+# Routers
 
 
 @subscribe("pr.review_submitted")
-async def route_pr_review(*, repo: str, pr_number: int, payload: dict) -> None:
+async def pr_review_answers_the_gate(*, repo: str, pr_number: int, payload: dict) -> None:
     if not WorkItem.is_known_druks_pr(repo=repo, pr_number=pr_number, branch=payload["branch"]):
         return
 
@@ -88,13 +80,13 @@ async def route_pr_review(*, repo: str, pr_number: int, payload: dict) -> None:
 def _active_build_run_for_pr(repo: str, pr_number: int) -> "Run | None":
     item = WorkItem.get_for_pr(repo=repo, pr_number=pr_number)
     if not item:
-        return None
+        return
     run = item.get_build_run()
     return run if run and run.is_active else None
 
 
 @subscribe("pr.closed")
-async def observe_pr_closed(*, repo: str, pr_number: int, payload: dict) -> None:
+async def pr_close_settles_the_item(*, repo: str, pr_number: int, payload: dict) -> None:
     """A PR druks owns closed on GitHub — the owner announcing the outcome.
     One path for every merge, druks's own included: GitHub says merged, druks
     ships the item. The status guards are redelivery idempotency."""
@@ -102,50 +94,18 @@ async def observe_pr_closed(*, repo: str, pr_number: int, payload: dict) -> None
         repo=repo, pr_number=pr_number, branch=payload["branch"], include_terminal=True
     ):
         return
-    work_item = WorkItem.get_for_pr(repo=repo, pr_number=pr_number)
-    status = work_item.status if work_item else None
-    if status == HandoffStatus.SHIPPED:
-        return
-    if payload["merged"]:
-        await _ship(repo=repo, pr_number=pr_number, work_item=work_item)
-    elif status != HandoffStatus.CANCELLED:
-        await _observe_external_close(repo=repo, pr_number=pr_number, work_item=work_item)
-
-
-async def _ship(*, repo: str, pr_number: int, work_item: WorkItem | None) -> None:
-    if not work_item:
-        return
-    work_item.set_status(HandoffStatus.SHIPPED)
-    # An operator merge over a waiting gate strands the parked run — cancel it.
-    # A RUNNING run converges on its own (its merge step sees the closed PR), so
-    # it is left to finish; that includes druks's own merge wrapping up.
-    run = work_item.get_build_run()
-    if run and run.is_parked:
-        await run.cancel(failure="pr merged while parked")
-    await work_item.set_remote_status(SemanticStatus.DONE)
-    logger.info("Merge observed for %s#%s.", repo, pr_number)
-
-
-async def _observe_external_close(*, repo: str, pr_number: int, work_item: WorkItem | None) -> None:
-    if not work_item:
-        return
-    work_item.set_status(HandoffStatus.CANCELLED, event_payload={"external": True})
-    await work_item.cancel_active_build(failure="pr closed without merge")
-    # Branch cleanup is best-effort: resolving policy is live IO now, and a fetch
-    # failure must not strand the ticket — its reset below still runs.
-    try:
-        if (await RepoPolicy.resolve(repo)).delete_branch:
-            await get_github_client(load_settings()).delete_branch(repo, work_item.branch)
-    except Exception:  # noqa: BLE001 — cleanup only
-        logger.warning("Skipped branch cleanup for %s#%s.", repo, pr_number, exc_info=True)
-    # The attempt was abandoned, not the ticket: send it back to the
-    # provider's resting pool rather than stranding it in In Progress.
-    await work_item.set_remote_status(SemanticStatus.READY_FOR_AGENT)
-    logger.info("External close observed for %s#%s.", repo, pr_number)
+    item = WorkItem.get_for_pr(repo=repo, pr_number=pr_number)
+    if item:
+        if item.status == HandoffStatus.SHIPPED:
+            return
+        if payload["merged"]:
+            await item.ship()
+        elif item.status != HandoffStatus.CANCELLED:
+            await item.close_external()
 
 
 @subscribe("ticket.transitioned")
-async def route_ticket_transition(*, payload: dict) -> None:
+async def ticket_transition_drives_the_funnel(*, payload: dict) -> None:
     """A tracker ticket changed state (Jira or Linear). Scope a refinement
     candidate and open a build when it hits the trigger status — build's whole
     tracker-driven funnel."""
@@ -155,11 +115,11 @@ async def route_ticket_transition(*, payload: dict) -> None:
         await _dispatch_scope(source, key)
     trigger = settings.linear_trigger_status if source == "linear" else settings.jira_trigger_status
     if trigger and status == trigger:
-        await _dispatch_intake(source, payload)
+        await BuildWorkflow.dispatch(ticket=payload)
 
 
 @subscribe("ticket.commented")
-async def route_ticket_comment(*, payload: dict) -> None:
+async def ticket_reply_resumes_parked_scope(*, payload: dict) -> None:
     """An operator's reply on a ticket with a parked scope run — resume it; the
     agent re-reads the whole thread, so which comment was answered is irrelevant."""
     if not payload["parent_id"]:
@@ -197,76 +157,3 @@ async def _dispatch_scope(source: str, key: str) -> None:
     async with tracker:
         ticket = await tracker.fetch_ticket(key)
         await Scope.dispatch(ticket=ticket)
-
-
-async def _dispatch_intake(source: str, payload: dict) -> None:
-    key = payload["identifier"]
-    item = WorkItem.get_for_remote_key(source=source, remote_key=key)
-    if item:
-        # Re-intake: refresh what the tracker may have changed since creation.
-        item.update(title=payload["title"], remote_url=payload["url"])
-    else:
-        repo, project_id = await _resolve_repo(source, payload)
-        if not repo:
-            logger.info("Ticket %s has no routable repo; skipping intake.", key)
-            return
-        item = WorkItem.create(
-            project_id=project_id,
-            source=source,
-            title=payload["title"],
-            remote_key=key,
-            remote_url=payload["url"],
-            repo=repo,
-        )
-
-    await BuildWorkflow.dispatch(
-        work_item_id=item.id,
-        assignee_email=payload["assignee_email"],
-        assignee_name=payload["assignee_name"],
-    )
-
-
-async def _resolve_repo(source: str, payload: dict) -> tuple[str | None, int | None]:
-    if source == "jira":
-        target = ProjectRepo.lookup(project_name=payload["project_name"], labels=payload["labels"])
-        return (target.full_name, target.project_id) if target else (None, None)
-    # Linear: the project name is the bare repo name; resolve the owner by
-    # probing the operator Extension's installations.
-    repo = await _accessible_repo_for_project(payload["project_name"])
-    project = Project.get_for_repo(repo) if repo else None
-    return (repo, project.id) if project else (None, None)
-
-
-async def _accessible_repo_for_project(project_name: str | None) -> str | None:
-    candidates = await _candidate_repos(project_name)
-    if len(candidates) <= 1:
-        return candidates[0] if candidates else None
-
-    # Candidates exist only when the Extension is configured, so the client is too.
-    github = get_github_client(load_settings())
-    accessible = []
-    for repo in candidates:
-        try:
-            await github.get_repository(repo)
-        except (GitHubAppNotInstalledError, RequestFailed, RequestTimeout):
-            continue  # uninstalled/404/403/network — inaccessible, keep probing
-        accessible.append(repo)
-    return accessible[0] if len(accessible) == 1 else None
-
-
-async def _candidate_repos(project_name: str | None) -> list[str]:
-    name = (project_name or "").strip()
-    if not name or not _REPO_SLUG_RE.match(name):
-        return []
-
-    try:
-        github = get_github_client(load_settings())
-    except GitHubAppNotConfiguredError:
-        return []
-
-    try:
-        owners = await github.list_installation_accounts()
-    except Exception:  # noqa: BLE001 — best-effort; no installations → no candidates
-        logger.warning("Could not list Extension installations for repo resolution.", exc_info=True)
-        return []
-    return [f"{owner}/{name}" for owner in sorted(owners, key=str.casefold)]

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -98,18 +98,28 @@ class BuildWorkflow(Workflow):
         )
 
     @classmethod
-    async def dispatch(
-        cls,
-        *,
-        work_item_id: int,
-        assignee_email: str | None = None,
-        assignee_name: str | None = None,
-    ) -> str:
-        item = WorkItem.get(work_item_id)
-        if not item:
-            raise ValueError(f"dispatching a build for unknown work item {work_item_id}")
-        # The assignee's account runs the calls; the owner fields stay input.
-        assignee = Account.get_for_username(assignee_email.strip()) if assignee_email else None
+    async def dispatch(cls, *, ticket: dict) -> str | None:
+        # The tracker funnel's entry: a ticket at the trigger status opens a build.
+        # Resolve-or-refresh the item, then start (start() dedups a live run).
+        item = WorkItem.get_for_remote_key(source=ticket["source"], remote_key=ticket["identifier"])
+        if item:
+            item.update(title=ticket["title"], remote_url=ticket["url"])
+        else:
+            repo = ProjectRepo.lookup(project_name=ticket["project_name"], labels=ticket["labels"])
+            if repo:
+                item = WorkItem.create(
+                    project_id=repo.project_id,
+                    source=ticket["source"],
+                    title=ticket["title"] or ticket["identifier"],
+                    remote_key=ticket["identifier"],
+                    remote_url=ticket["url"],
+                    repo=repo.full_name,
+                )
+            else:
+                logger.info("Ticket %s has no routable repo; skipping.", ticket["identifier"])
+                return
+        email = ticket["assignee_email"]
+        assignee = Account.get_for_username(email.strip()) if email else None
         run_id = await cls.start(
             subject=WorkItem.subject_for(item.id),
             account_id=assignee.id if assignee else None,
@@ -118,18 +128,15 @@ class BuildWorkflow(Workflow):
             ticket_ref=item.remote_key,
             remote_title=item.title,
             remote_url=item.remote_url,
-            task_owner_email=assignee_email,
-            task_owner_name=assignee_name,
+            task_owner_email=email,
+            task_owner_name=ticket["assignee_name"],
         )
-        # start() hands back the live run's id on a duplicate dispatch; only a
-        # genuinely new run is a fresh attempt. Point the item at it and drop the
-        # prior attempt's branch/PR so a late close for the old PR can't resolve
-        # this item onto the new run and cancel it — a duplicate keeps the live
-        # run's routing untouched.
+        # A duplicate dispatch gets the live run back; only a genuinely new run
+        # resets routing — drop the old branch/PR so a late close for the prior PR
+        # can't resolve this item onto the new run and cancel it.
         if item.build_run_id != run_id:
             item.update(build_run_id=run_id, branch=None, pr_number=None)
-        # Back onto the active board: a scoped item re-enters flight when its
-        # build starts. History is for items at rest in a handoff lane.
+        # (Re)dispatched → back in flight; clear the handoff lane.
         item.set_status(None)
         return run_id
 
@@ -481,14 +488,14 @@ class Scope(Workflow):
     async def dispatch(cls, *, ticket: Ticket) -> str | None:
         # The scoped label is the done marker — remove it to force a re-scope.
         if ticket.has_label(Build.settings().scoper_scoped_label):
-            return None
+            return
         item = WorkItem.get_for_remote_key(source=ticket.provider, remote_key=ticket.key)
         if not item:
             target = ProjectRepo.lookup(project_name=ticket.project_name, labels=ticket.labels)
             project = Project.get_for_repo(target.full_name) if target else None
             if not project:
                 logger.info("No project routes %s; not scoping.", ticket.key)
-                return None
+                return
             item = WorkItem.create(
                 project_id=project.id,
                 source=ticket.provider,

--- a/backend/tests/test_build_dispatch.py
+++ b/backend/tests/test_build_dispatch.py
@@ -15,7 +15,19 @@ async def test_dispatch_pulls_scoped_item_back_onto_the_board(db_session, monkey
         return "run-1"
 
     monkeypatch.setattr(BuildWorkflow, "start", classmethod(fake_start))
-    run_id = await BuildWorkflow.dispatch(work_item_id=item.id)
+    run_id = await BuildWorkflow.dispatch(
+        ticket={
+            "source": item.source,
+            "identifier": item.remote_key,
+            "status": "Ready",
+            "title": item.title,
+            "url": "https://tracker.test/ACME-1",
+            "project_name": "r",
+            "labels": [],
+            "assignee_email": None,
+            "assignee_name": None,
+        }
+    )
 
     assert run_id == "run-1"
     assert item.build_run_id == "run-1"
@@ -37,7 +49,19 @@ async def test_redispatch_to_a_new_run_clears_prior_attempt_branch_and_pr(
         return "run-new"
 
     monkeypatch.setattr(BuildWorkflow, "start", classmethod(fake_start))
-    await BuildWorkflow.dispatch(work_item_id=item.id)
+    await BuildWorkflow.dispatch(
+        ticket={
+            "source": item.source,
+            "identifier": item.remote_key,
+            "status": "Ready",
+            "title": item.title,
+            "url": "https://tracker.test/ACME-2",
+            "project_name": "r",
+            "labels": [],
+            "assignee_email": None,
+            "assignee_name": None,
+        }
+    )
 
     assert item.build_run_id == "run-new"
     assert item.pr_number is None
@@ -55,7 +79,19 @@ async def test_duplicate_dispatch_keeps_the_live_attempt_routing(db_session, mon
         return "run-live"
 
     monkeypatch.setattr(BuildWorkflow, "start", classmethod(dedup_start))
-    await BuildWorkflow.dispatch(work_item_id=item.id)
+    await BuildWorkflow.dispatch(
+        ticket={
+            "source": item.source,
+            "identifier": item.remote_key,
+            "status": "Ready",
+            "title": item.title,
+            "url": "https://tracker.test/ACME-3",
+            "project_name": "r",
+            "labels": [],
+            "assignee_email": None,
+            "assignee_name": None,
+        }
+    )
 
     assert item.build_run_id == "run-live"
     assert item.pr_number == 7

--- a/backend/tests/test_webhooks_jira.py
+++ b/backend/tests/test_webhooks_jira.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 import druks.build.subscribers as subs
 import druks.core.webhooks.jira as jira_mod
 import pytest
-from conftest import make_settings
+from conftest import make_settings, seed_run
 from druks.core.webhooks.jira import JiraEvents
 from fastapi import HTTPException
 
@@ -143,7 +143,7 @@ async def test_open_category_is_not_terminal(tmp_path, monkeypatch):
     assert events[0][1]["terminal"] is False
 
 
-# --- subscriber: scope + intake routing ------------------------------------
+# --- subscriber: scope + build routing -------------------------------------
 
 
 def _pin_settings(monkeypatch, **over):
@@ -163,33 +163,22 @@ async def test_candidate_status_dispatches_scope(tmp_path, monkeypatch):
     scope = AsyncMock()
     monkeypatch.setattr(subs.Scope, "dispatch", scope)
 
-    await subs.route_ticket_transition(payload=_jira_payload(status="Backlog"))
+    await subs.ticket_transition_drives_the_funnel(payload=_jira_payload(status="Backlog"))
 
     tracker.fetch_ticket.assert_awaited_once_with("IT-12")
     scope.assert_awaited_once_with(ticket=ticket)
 
 
-async def test_trigger_status_opens_build_on_the_scoped_work_item(tmp_path, monkeypatch):
-    """A scoped ticket already has its work item — intake refreshes it from the
-    webhook and dispatches by id."""
+async def test_trigger_status_dispatches_build_with_the_webhook_payload(tmp_path, monkeypatch):
+    """The build funnel receives the normalized ticket payload without a refetch."""
     _pin_settings(monkeypatch, jira_trigger_status="Ready")
-    refreshed = {}
-    monkeypatch.setattr(
-        subs.WorkItem,
-        "get_for_remote_key",
-        lambda *, source, remote_key: SimpleNamespace(
-            id=7, repo="acme/acme-app", update=lambda **kw: refreshed.update(kw)
-        ),
-    )
     build = AsyncMock()
     monkeypatch.setattr(subs.BuildWorkflow, "dispatch", build)
+    payload = _jira_payload(status="Ready")
 
-    await subs.route_ticket_transition(payload=_jira_payload(status="Ready"))
+    await subs.ticket_transition_drives_the_funnel(payload=payload)
 
-    build.assert_awaited_once()
-    assert build.await_args.kwargs["work_item_id"] == 7
-    assert build.await_args.kwargs["assignee_email"] == "dev@acme.co"
-    assert refreshed["title"] == "Add an endpoint"
+    build.assert_awaited_once_with(ticket=payload)
 
 
 async def test_trigger_status_routes_an_unscoped_ticket_by_label(tmp_path, db_session, monkeypatch):
@@ -200,16 +189,19 @@ async def test_trigger_status_routes_an_unscoped_ticket_by_label(tmp_path, db_se
     ProjectRepo.create(project_id=project.id, full_name="octo/alfred")
     db_session.flush()
     _pin_settings(monkeypatch, jira_trigger_status="Ready")
-    build = AsyncMock()
-    monkeypatch.setattr(subs.BuildWorkflow, "dispatch", build)
+    seed_run(db_session, "run-new")
 
-    await subs.route_ticket_transition(
+    async def fake_start(cls, **kwargs):
+        return "run-new"
+
+    monkeypatch.setattr(subs.BuildWorkflow, "start", classmethod(fake_start))
+
+    await subs.ticket_transition_drives_the_funnel(
         payload=_jira_payload(key="SHRP-1", status="Ready", project="Octo", labels=["Alfred"]),
     )
 
-    build.assert_awaited_once()
     item = WorkItem.get_for_remote_key(source="jira", remote_key="SHRP-1")
-    assert build.await_args.kwargs["work_item_id"] == item.id
+    assert item.build_run_id == "run-new"
     assert item.repo == "octo/alfred"
     assert item.project_id == project.id
 
@@ -217,14 +209,14 @@ async def test_trigger_status_routes_an_unscoped_ticket_by_label(tmp_path, db_se
 async def test_trigger_status_ignores_an_unroutable_ticket(tmp_path, db_session, monkeypatch):
     """No signal matches a registered repo → no build."""
     _pin_settings(monkeypatch, jira_trigger_status="Ready")
-    build = AsyncMock()
-    monkeypatch.setattr(subs.BuildWorkflow, "dispatch", build)
+    start = AsyncMock()
+    monkeypatch.setattr(subs.BuildWorkflow, "start", start)
 
-    await subs.route_ticket_transition(
+    await subs.ticket_transition_drives_the_funnel(
         payload=_jira_payload(key="SHRP-2", status="Ready", project="Octo"),
     )
 
-    build.assert_not_called()
+    start.assert_not_called()
 
 
 async def test_irrelevant_status_does_nothing(tmp_path, monkeypatch):
@@ -235,7 +227,7 @@ async def test_irrelevant_status_does_nothing(tmp_path, monkeypatch):
     monkeypatch.setattr(subs.Scope, "dispatch", scope)
     monkeypatch.setattr(subs.BuildWorkflow, "dispatch", build)
 
-    await subs.route_ticket_transition(payload=_jira_payload(status="In Progress"))
+    await subs.ticket_transition_drives_the_funnel(payload=_jira_payload(status="In Progress"))
 
     scope.assert_not_called()
     build.assert_not_called()

--- a/backend/tests/test_webhooks_pull_request.py
+++ b/backend/tests/test_webhooks_pull_request.py
@@ -247,7 +247,7 @@ async def test_external_merge_pushes_done(db_session, tmp_path, monkeypatch):
 async def test_external_close_honors_delete_branch_policy(db_session, tmp_path, monkeypatch):
     """delete_branch: false in the repo's live .druks/build/config.yml keeps the
     head branch on an external close."""
-    from druks.build import subscribers as webhooks_mod
+    from druks.build import models as build_models
 
     async def _fetch(*, repo, path):
         return "delete_branch: false\n"
@@ -260,7 +260,7 @@ async def test_external_close_honors_delete_branch_policy(db_session, tmp_path, 
         deleted.append((repo, branch))
 
     monkeypatch.setattr(
-        webhooks_mod, "get_github_client", lambda settings: SimpleNamespace(delete_branch=_record)
+        build_models, "get_github_client", lambda settings: SimpleNamespace(delete_branch=_record)
     )
 
     repo, pr_number, branch = "ClawHaven/acme-app", 93, "agent/eng-22"
@@ -275,7 +275,7 @@ async def test_external_close_honors_delete_branch_policy(db_session, tmp_path, 
 
 @pytest.mark.asyncio
 async def test_external_close_deletes_branch_by_default(db_session, tmp_path, monkeypatch):
-    from druks.build import subscribers as webhooks_mod
+    from druks.build import models as build_models
 
     deleted = []
 
@@ -283,7 +283,7 @@ async def test_external_close_deletes_branch_by_default(db_session, tmp_path, mo
         deleted.append((repo, branch))
 
     monkeypatch.setattr(
-        webhooks_mod, "get_github_client", lambda settings: SimpleNamespace(delete_branch=_record)
+        build_models, "get_github_client", lambda settings: SimpleNamespace(delete_branch=_record)
     )
 
     repo, pr_number, branch = "ClawHaven/acme-app", 94, "agent/eng-23"
@@ -300,7 +300,7 @@ async def test_external_close_deletes_branch_by_default(db_session, tmp_path, mo
 async def test_external_close_survives_policy_resolution_failure(db_session, tmp_path, monkeypatch):
     """Branch cleanup is best-effort: a policy-resolution failure must not strand
     the ticket — the cancel and resting-pool reset still happen."""
-    from druks.build import subscribers as webhooks_mod
+    from druks.build import models as build_models
     from druks.build.policy import RepoPolicy
     from druks.ticketing.enums import SemanticStatus
 
@@ -315,7 +315,7 @@ async def test_external_close_survives_policy_resolution_failure(db_session, tmp
         deleted.append((repo, branch))
 
     monkeypatch.setattr(
-        webhooks_mod, "get_github_client", lambda settings: SimpleNamespace(delete_branch=_delete)
+        build_models, "get_github_client", lambda settings: SimpleNamespace(delete_branch=_delete)
     )
 
     pushed = []


### PR DESCRIPTION
ENG-739 — build's reactive layer was hard to read for two reasons, both fixed here: multi-step domain logic hid in the subscriber file, and the reaction names mixed three genres. The direction (confirmed against Temporal/Restate/DBOS/Inngest/eve/Prefect/crewAI) is to keep the wiring declarative and put the logic on domain classes.

**Phase 1 — logic onto WorkItem, one naming genre.** `_ship`/`_observe_external_close` become `WorkItem.ship()` / `WorkItem.close_external()` (cycle-free imports — `policy.py` and the github client don't import `models`). All 11 reactions are renamed trigger-noun → effect-verb (`observe_pr_closed` → `pr_close_settles_the_item`, `route_ticket_transition` → `ticket_transition_drives_the_funnel`, …) and the file is ordered into two blocks — Projections (run/webhook lifecycle → item/board/tracker) then Routers (owner webhooks / tracker → runs) — so it reads as a one-page causality table. No behavior change.

**Phase 2 — fold intake into dispatch, delete the github probe.** `BuildWorkflow.dispatch` now takes the `ticket.transitioned` webhook payload directly and owns resolve-or-refresh + start, mirroring `Scope.dispatch`; the handler is one line (`await BuildWorkflow.dispatch(ticket=payload)`). The old `_dispatch_intake`/`_resolve_repo`/`_accessible_repo_for_project`/`_candidate_repos` are gone — the github "probe" only reconstructed the owner prefix Linear omits, which `ProjectRepo.lookup`/`get_for_name` already resolve from the DB (scope proves it). Build now resolves repos the same way scope does, closing the drift. Dispatch reads the payload rather than re-fetching a Ticket a webhook already delivered.

Tests: `test_build_dispatch.py` moves from `dispatch(work_item_id=…)` to `dispatch(ticket={…})` payloads that resolve the same item; the jira routing tests now exercise the *real* dispatch (stubbing only `start`) instead of asserting on a mocked id; the pull-request tests repoint the github-client monkeypatch to `models`, where `close_external` now lives. The `dispatch(work_item_id=…)` signature had no production caller (no route/MCP/dashboard re-triggers a build), so nothing of value was pinned.

While the files were open I also brought pre-existing `return None` guards in the touched files to bare `return` (house rule 1) — in `Scope.dispatch`, `ProjectRepo.get_for_name`/`lookup`, and `_active_build_run_for_pr` — and restored the load-bearing why-comment on dispatch's branch/PR reset that got trimmed in the rewrite.

Verification: ruff check + ruff format clean; pyright 100 errors on the changed tree vs 101 on the origin/main baseline (one fewer, no new errors on touched lines). DB-backed pytest is left to CI (shared test DB).

Note for a separate ticket: the Linear webhook hardcodes `"labels": []` (`core/webhooks/linear.py`), so Linear label-based routing silently does nothing today — only `project_name` resolves. Jira sends real labels. Out of scope here.
