### PR TITLE
Repo profiler lists only enforced-green CI gates as verification

### DIFF
--- a/backend/templates/prompts/build/profile/repo_profiler.md
+++ b/backend/templates/prompts/build/profile/repo_profiler.md
@@ -19,12 +19,14 @@ its name or a language's usual defaults.
 
 2. **Determine the verification commands that gate a PR.** Derive tests, lint, and
    typecheck commands from enforced CI checks that are currently green on the default branch:
-   required checks and commands the repo's CI or docs treat as must-pass. Report the exact
-   configured command; never invent one. Leave a category empty when no command qualifies —
-   empty test, lint, and typecheck categories are correct and common. Put editor-only or
-   advisory tools, optional linters, and known-red or flaky suites in `stack_summary` as
-   context, never in verification. Do not list a command that `stack_summary` describes as
-   not a CI gate, red, or flaky.
+   required checks and commands the repo's CI or docs treat as must-pass. Confirm each
+   candidate is actually passing on the default branch — check its latest run or commit
+   status with `gh` (authenticated here); never assume a configured or required check is
+   green. Report the exact configured command; never invent one. Leave a category empty when
+   no command qualifies — empty test, lint, and typecheck categories are correct and common.
+   Put editor-only or advisory tools, optional linters, and known-red or flaky suites in
+   `stack_summary` as context, never in verification. Do not list a command that
+   `stack_summary` describes as not a CI gate, red, or flaky.
 
 3. **Recommend the skills an implementer will need to build here.** Pick from the catalog
    below — do not invent skill names. A skill belongs in `recommended_skills` only when its

--- a/backend/templates/prompts/build/profile/repo_profiler.md
+++ b/backend/templates/prompts/build/profile/repo_profiler.md
@@ -17,11 +17,14 @@ its name or a language's usual defaults.
    framework actually in use — not every file extension present, the ones the project is
    built on.
 
-2. **Determine the real verification commands.** Look for how tests, lint, typecheck, and
-   format actually run in this repo — package scripts, CI workflow steps, a Makefile, a
-   README's "running tests" section. Report the exact command a human would type. Leave a
-   command empty (not invented) when the repo genuinely has none — a fabricated command
-   fails every future build's verification step.
+2. **Determine the verification commands that gate a PR.** Derive tests, lint, and
+   typecheck commands from enforced CI checks that are currently green on the default branch:
+   required checks and commands the repo's CI or docs treat as must-pass. Report the exact
+   configured command; never invent one. Leave a category empty when no command qualifies —
+   empty test, lint, and typecheck categories are correct and common. Put editor-only or
+   advisory tools, optional linters, and known-red or flaky suites in `stack_summary` as
+   context, never in verification. Do not list a command that `stack_summary` describes as
+   not a CI gate, red, or flaky.
 
 3. **Recommend the skills an implementer will need to build here.** Pick from the catalog
    below — do not invent skill names. A skill belongs in `recommended_skills` only when its


### PR DESCRIPTION
## What

`build/profile/repo_profiler.md` step 2 asked the profiler for *"the exact command a human would type,"* guarding only against *fabricated* commands. So it put `uv run pyright` and the full `uv run pytest backend/` suite into druks's own verification profile as binding gates — pyright is editor-only (its own `stack_summary` said *"not currently a CI gate"* and it listed it anyway), and the full suite includes a flaky/hanging DBOS recovery test. Both are red in a build sandbox, so every self-build's verification was red before the diff was even considered.

## Change (prompt-only)

Step 2 now lists a command only when it is an **enforced CI gate that is currently green on the default branch** (a required / must-pass check). Editor-only or advisory tools, optional linters, and known-red/flaky suites go in `stack_summary` as context, never in `verification`. Added the reconcile rule: a command the summary itself calls "not a CI gate, red, or flaky" must not appear in the verification profile.

Also drops the orphan "format" (the stored contract has only `test_commands` / `lint_commands` / `typecheck_commands`).

Single file, 8/−5 lines. Steps 1/3/4/5 unchanged. No code, schema, or test touched — nothing pins the prompt text; operators can still override per repo via `.druks/build/config.yml`.

## Acceptance (ENG-741)

- Re-profiling druks lists neither `uv run pyright` nor the flaky full test suite under `verification`. ✓
- A command the profiler notes as "not a CI gate" never appears in the emitted profile. ✓

Fixes ENG-741. Companion to ENG-742 (verification commands becoming implementer-binding ACs), which must land for the evaluator's baseline/green-CI handling to backstop a red gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
