### PR TITLE
A parked run reads as the gate it waits on, not "Working…"

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -193,8 +193,8 @@ class Agent:
         # Registered for provisioning through execution — this connection's
         # rotation defers around it.
         async with sandbox_gate.use(connection_id, call_id):
-            host_id = await workflow._ensure_host()
             await set_run_phase("provisioning_vm")
+            host_id = await workflow._ensure_host()
 
             # Record the call RUNNING once it has a host to run on (its id names
             # the on-disk transcript dir) so the live step shows while the agent

--- a/backend/druks/durable/reads.py
+++ b/backend/druks/durable/reads.py
@@ -74,7 +74,14 @@ def get_subject_response(
 def _timeline(runs: list[Run], calls_by_run: dict[str, list[AgentCall]]) -> list[RunResponse]:
     # by_run keys every run id, so the lookup is total.
     ordered = sorted(runs, key=lambda run: (run.created_at, run.id))
-    return [RunResponse.from_run(run, calls_by_run[run.id]) for run in ordered]
+    return [
+        RunResponse.from_run(
+            run,
+            calls_by_run[run.id],
+            input_request=run.get_ask() if run.input_request else None,
+        )
+        for run in ordered
+    ]
 
 
 def _running_calls(active_run: Run | None) -> list[AgentCall]:

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -129,6 +129,7 @@ class RunResponse(BaseResponse):
     label: str
     state: Literal["scheduled", "running", "pending_input", "finished", "failed", "cancelled"]
     failure: str | None = None
+    gate: str | None = None
     # The structured ask the parked run declared at ``Gate.wait(input_request=…)`` —
     # set while the run is PENDING_INPUT, cleared on resume. Presence = "needs you".
     input_request: dict[str, Any] | None = None
@@ -139,14 +140,21 @@ class RunResponse(BaseResponse):
     agent_calls: list[AgentCallResponse] = Field(default_factory=list)
 
     @classmethod
-    def from_run(cls, run: Run, calls: list[AgentCall]) -> "RunResponse":
+    def from_run(
+        cls,
+        run: Run,
+        calls: list[AgentCall],
+        *,
+        input_request: dict[str, Any] | None,
+    ) -> "RunResponse":
         return cls(
             id=run.id,
             kind=run.kind,
             label=get_display_label(run.kind),
             state=run.state,  # type: ignore[arg-type]
             failure=run.failure,
-            input_request=run.get_ask() if run.input_request else None,
+            gate=run.input_gate,
+            input_request=input_request,
             created_at=run.created_at,
             updated_at=run.updated_at,
             account_username=run.account.username,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -498,11 +498,11 @@ def seed_agent_run(
     return call
 
 
-def seed_run(session, run_id, *, kind="build.build_workflow", account_id="system"):
+def seed_run(session, run_id, *, kind="build.build_workflow", account_id="system", input_gate=None):
     # A bare durable_runs row so an AgentCall / Artifact FK to it resolves.
     from druks.durable import Run
 
-    run = Run(id=run_id, kind=kind, account_id=account_id)
+    run = Run(id=run_id, kind=kind, account_id=account_id, input_gate=input_gate)
     session.add(run)
     session.flush()
     return run

--- a/backend/tests/test_artifacts.py
+++ b/backend/tests/test_artifacts.py
@@ -1,8 +1,12 @@
 import pytest
+from conftest import seed_run
 from druks.api.artifacts import get_artifact
+from druks.durable.enums import RunState
 from druks.durable.models import AgentCall, Artifact, Run
+from druks.durable.schemas import RunResponse
 from fastapi import HTTPException
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 
 def _seed_call(db_session) -> AgentCall:
@@ -74,9 +78,6 @@ def test_get_latest_for_run_returns_the_newest_calls_artifact(db_session, tmp_pa
 def test_get_ask_resolves_the_review_artifact(db_session, tmp_path):
     # An in-app ask stores no label/artifact — the read side derives both from
     # the run's latest artifact. A declared ask passes through untouched.
-    from druks.durable.enums import RunState
-    from druks.durable.schemas import RunResponse
-
     run = Run(
         id="run-1",
         kind="build",
@@ -88,7 +89,7 @@ def test_get_ask_resolves_the_review_artifact(db_session, tmp_path):
     db_session.flush()
     Artifact.record(call_dir=tmp_path, call_id="call-1", kind="markdown", title="Plan", content="x")
 
-    ask = RunResponse.from_run(run, []).input_request
+    ask = RunResponse.from_run(run, [], input_request=run.get_ask()).input_request
     assert ask == {
         "presentation": "in_app",
         "controls": ["approve"],
@@ -104,10 +105,18 @@ def test_get_ask_resolves_the_review_artifact(db_session, tmp_path):
     )
     db_session.add(external)
     db_session.flush()
-    assert RunResponse.from_run(external, []).input_request == {
+    response = RunResponse.from_run(external, [], input_request=external.get_ask())
+    assert response.input_request == {
         "presentation": "external",
         "label": "Review implementation",
     }
+
+
+def test_run_response_projects_the_parked_gate(db_session):
+    run = seed_run(db_session, "run-gate", input_gate="review")
+
+    response = RunResponse.from_run(run, [], input_request=None)
+    assert response.gate == "review"
 
 
 async def test_get_artifact_returns_recorded_content(db_session, tmp_path, monkeypatch):
@@ -145,8 +154,6 @@ async def test_get_artifact_404_when_content_gone(db_session, tmp_path, monkeypa
     db_session.add(Run(id="run-1", kind="build"))
     db_session.add(AgentCall(id="call-1", run_id="run-1", sandbox_host_id="host-1"))
     db_session.flush()
-    from sqlalchemy.dialects.postgresql import insert as pg_insert
-
     db_session.execute(
         pg_insert(Artifact).values(
             id="art-1", agent_call_id="call-1", kind="markdown", title="P", path="artifact.md"

--- a/backend/tests/test_attribution.py
+++ b/backend/tests/test_attribution.py
@@ -11,7 +11,8 @@ def test_run_projects_its_account(db_session):
 
     run = db_session.get(Run, "run-attr-1")
     assert run.account_id == account.id
-    assert RunResponse.from_run(run, []).account_username == "dev@example.com"
+    response = RunResponse.from_run(run, [], input_request=None)
+    assert response.account_username == "dev@example.com"
 
 
 def test_an_unowned_run_belongs_to_system(db_session):
@@ -20,4 +21,5 @@ def test_an_unowned_run_belongs_to_system(db_session):
 
     run = db_session.get(Run, "run-attr-2")
     assert run.account_id == "system"
-    assert RunResponse.from_run(run, []).account_username == "system"
+    response = RunResponse.from_run(run, [], input_request=None)
+    assert response.account_username == "system"

--- a/backend/tests/test_build_plan_phase.py
+++ b/backend/tests/test_build_plan_phase.py
@@ -1,11 +1,17 @@
 from types import SimpleNamespace
 
 import pytest
-from druks.build.contracts import PlanData, QuestionOptionOutput, QuestionOutput, ReviewOutput
+from druks.build.contracts import (
+    PlanData,
+    QuestionOptionOutput,
+    QuestionOutput,
+    ReviewOutput,
+    ReviewWork,
+)
 from druks.build.enums import ReviewDecision
 from druks.build.policy import RepoPolicy
 from druks.build.workflows import Build, BuildWorkflow
-from druks.workflows import FatalError, OperatorReply
+from druks.workflows import FatalError, OperatorReply, Run
 
 
 def _flow(*, auto_dispatch: bool = False) -> BuildWorkflow:
@@ -170,6 +176,26 @@ async def test_questions_park_in_auto_mode_too(monkeypatch):
     flow.review = fake_review
 
     assert await flow._plan_phase() is True
+
+
+async def test_review_work_ask_renders_a_notification_body(monkeypatch):
+    workflow = _flow()
+    input_requests: list[dict] = []
+
+    async def fake_wait(*, input_request):
+        input_requests.append(input_request)
+        return ReviewWork(action="approve")
+
+    async def fake_approved_work():
+        return True
+
+    monkeypatch.setattr(ReviewWork, "wait", fake_wait)
+    monkeypatch.setattr(workflow, "_approved_work", fake_approved_work)
+
+    await workflow._work_gate()
+
+    run = Run(input_request=input_requests[0])
+    assert run.get_rendered_ask()["body"]
 
 
 async def test_needs_clarification_delivery_stops_the_run(monkeypatch):

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -93,7 +93,6 @@ export interface AskQuestion {
 // artifact right here; "external" points at the PR/ticket.
 export interface InputRequest {
   presentation: 'in_app' | 'external'
-  label?: string
   controls?: string[]
   questions?: AskQuestion[]
   artifact_id?: string | null
@@ -116,6 +115,7 @@ export interface RunSummary {
   label: string
   state: RunState
   failure?: string | null
+  gate: string | null
   // The structured ask while this run is parked on the operator. Presence means
   // "needs you".
   inputRequest?: InputRequest | null

--- a/frontend/src/extensions/build/WorkItemPage.tsx
+++ b/frontend/src/extensions/build/WorkItemPage.tsx
@@ -20,7 +20,7 @@ import { Page } from '../../components/Page'
 import { queryGate } from '../../components/QueryGate'
 import { RunTranscript } from '../../components/RunTranscript'
 import { computeElapsed, dur, formatTokenCount, relTime, secondsSince } from '../../lib/format'
-import { statusLine } from './statusLine'
+import { parkedLine, statusLine } from './statusLine'
 import { agentCallPath, workItemPath } from './slug'
 import { useCanonicalPath } from '../../lib/useCanonicalPath'
 import { useTicker } from '../../lib/useTicker'
@@ -369,12 +369,12 @@ function RunRow({
   // fold it into the parent instead of showing both.
   const collapseCalls = run.agentCalls.length <= 1
   // A running run shows the live phase ("Building sandbox VM…", "Working…") as
-  // its sub-line; a parked one shows its ask; a failed one its reason.
+  // its sub-line; a parked one shows its gate; a failed one its reason.
   const sub =
     run.state === 'failed' && run.failure
       ? (run.failure.split('—')[0] ?? run.failure).trim()
       : run.state === 'pending_input'
-        ? (run.inputRequest?.label ?? STATE_LABEL.pending_input)
+        ? (parkedLine(run.gate) ?? STATE_LABEL.pending_input)
         : isRunning(run) && activity
           ? activity.label
           : (STATE_LABEL[run.state] ?? run.state)
@@ -653,7 +653,7 @@ function RunNeedsInput({ run, prUrl }: { run: RunSummary; prUrl?: string | null 
         <span>◆</span> needs you
       </div>
       <div className="ins-needs-body">
-        {ask.label ?? 'This run is waiting on you.'}
+        {parkedLine(run.gate) ?? 'This run is waiting on you.'}
         {prUrl && (
           <>
             {' '}

--- a/frontend/src/extensions/build/statusLine.test.ts
+++ b/frontend/src/extensions/build/statusLine.test.ts
@@ -23,10 +23,13 @@ describe('statusLine', () => {
     expect(statusLine(status({ state: 'pending_input', gate: 'review_work' }))).toBe(
       'Review implementation',
     )
+    expect(statusLine(status({ state: 'pending_input', gate: 'review' }))).toBe(
+      'Review the plan',
+    )
   })
 
   it('an unmapped gate reads as a generic park', () => {
-    expect(statusLine(status({ state: 'pending_input', gate: 'review' }))).toBe('Waiting on you')
+    expect(statusLine(status({ state: 'pending_input', gate: 'unknown' }))).toBe('Waiting on you')
   })
 
   it('parked without a gate falls back', () => {

--- a/frontend/src/extensions/build/statusLine.ts
+++ b/frontend/src/extensions/build/statusLine.ts
@@ -7,7 +7,12 @@ import type { SubjectStatus } from '../../api/types'
 // ticket reply, whatever the ask; unmapped gates read as a generic park.
 const PARKED_LINES: Record<string, string> = {
   scope: 'Reply on the ticket',
+  review: 'Review the plan',
   review_work: 'Review implementation',
+}
+
+export function parkedLine(gate: string | null): string | null {
+  return gate ? (PARKED_LINES[gate] ?? null) : null
 }
 
 function kindLabel(kind: string): string {
@@ -18,7 +23,7 @@ function kindLabel(kind: string): string {
 
 export function statusLine(status: SubjectStatus): string {
   if (status.state === 'pending_input') {
-    return (status.gate && PARKED_LINES[status.gate]) || 'Waiting on you'
+    return parkedLine(status.gate) ?? 'Waiting on you'
   }
   if (status.state === 'running' || status.state === 'scheduled') {
     return kindLabel(status.agent ?? status.kind ?? '')


### PR DESCRIPTION
Closes ENG-745.

An operator watching a build could not tell three different situations apart: parked on the plan-review gate, provisioning a sandbox, and the agent actually working. All three read as `Working…`, so a normal review loop looked like a stuck run.

## Provisioning names the window it covers

`set_run_phase("provisioning_vm")` fired *after* `await workflow._ensure_host()` — and `_ensure_host()` is the provisioning. The phase landed only once the minute-long spin-up had finished, so the window showed the stale previous phase and "provisioning" flashed for an instant on its way out. It is now set before the wait it describes.

## A parked run is worded from its gate identity

`Workflow.review()` parks on `OperatorReply`, whose name is `review`. Two surfaces failed to word it:

- `statusLine.ts` mapped `scope` and `review_work` but not `review`. Its test actually pinned that as *"an unmapped gate reads as a generic park"* — the test was holding the bug in place.
- `RunRow`'s parked sub-line read `run.inputRequest?.label`, which `review()` never sets, so it fell through to the generic state label.

Both now go through `parkedLine(gate)`, one vocabulary in one place. `RunResponse` carries the parked gate as an identity fact so the frontend has something to key off.

**Copy change worth a look:** the "needs you" banner now reads *"Reply on the ticket"* for the scope gate, where it previously showed the backend's *"Answer scope questions"*. That is deliberate — it is what the board already said for that gate — but it is a visible wording change, not just plumbing.

## The ask's label stays backend-side

Mid-review I had this removed as frontend copy crossing the wire, which was wrong: `get_rendered_ask()` renders `ask["label"]` as the **notification body** for every external park, so dropping it would have raised `KeyError` on every implementation-review park. It is restored, `ScopeReply` keeps its own, and there is now a test pinning that an external ask renders a body. The boundary fix is the frontend no longer *reading* it.

## Incidental

`from_run` no longer resolves the ask itself — `get_ask()` queries for the latest artifact, and a response projection should do no I/O. The caller hands it in, which is why the test call sites changed.

## Not in this PR

Attempt/round context ("plan · attempt 2") is in the ticket's fix direction but not its acceptance, so it is left out. The third acceptance point — a live signal while an agent runs — is already met: the run inspector streams the running call's transcript. No second live path was built for it.

## Verification

Frontend 51 tests, ESLint, and the TypeScript build pass; ruff check and format pass; targeted pyright is clean; 958 backend tests collect. Backend execution is CI-gated as usual — Postgres is not reachable from this sandbox, so the runtime paths here were read by hand rather than trusted to local green.
