### PR TITLE
Confirming the planner's own recommendation costs no second plan

### DIFF
--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -73,6 +73,9 @@ class QuestionOutput(AgentOutput):
     prompt: str = Field(max_length=2048)
     options: list[QuestionOptionOutput] = Field(max_length=16)
 
+    def recommends(self, pick: str | None) -> bool:
+        return any(option.recommended and option.id == pick for option in self.options)
+
 
 class AcceptanceCriterionOutput(AgentOutput):
     id: str
@@ -92,14 +95,7 @@ class PlanData(BaseModel):
     assignee_github_login: str | None = None
 
     def uses_recommended_answers(self, picks: dict[str, str]) -> bool:
-        # Unanswered questions and questions without a recommendation cannot confirm intent.
-        return all(
-            any(
-                option.recommended and picks.get(question.id) == option.id
-                for option in question.options
-            )
-            for question in self.questions
-        )
+        return all(question.recommends(picks.get(question.id)) for question in self.questions)
 
     def get_answered(self, picks: dict[str, str]) -> list[dict[str, str]]:
         # Each question the operator answered, paired with its answer — what the

--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -91,7 +91,7 @@ class PlanData(BaseModel):
     # Resolved by the planner; a revision carries None.
     assignee_github_login: str | None = None
 
-    def confirms_recommendations(self, picks: dict[str, str]) -> bool:
+    def is_answered_as_recommended(self, picks: dict[str, str]) -> bool:
         # Unanswered questions and questions without a recommendation cannot confirm intent.
         return all(
             any(

--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -65,6 +65,7 @@ class QuestionOptionOutput(AgentOutput):
     # an oversized answer fails parse loudly instead of being clipped later.
     id: str = Field(max_length=64)
     label: str = Field(max_length=256)
+    recommended: bool
 
 
 class QuestionOutput(AgentOutput):
@@ -89,6 +90,16 @@ class PlanData(BaseModel):
     acceptance_criteria: list[AcceptanceCriterionOutput] = Field(default_factory=list)
     # Resolved by the planner; a revision carries None.
     assignee_github_login: str | None = None
+
+    def confirms_recommendations(self, picks: dict[str, str]) -> bool:
+        # Unanswered questions and questions without a recommendation cannot confirm intent.
+        return all(
+            any(
+                option.recommended and picks.get(question.id) == option.id
+                for option in question.options
+            )
+            for question in self.questions
+        )
 
     def get_answered(self, picks: dict[str, str]) -> list[dict[str, str]]:
         # Each question the operator answered, paired with its answer — what the

--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -91,7 +91,7 @@ class PlanData(BaseModel):
     # Resolved by the planner; a revision carries None.
     assignee_github_login: str | None = None
 
-    def is_answered_as_recommended(self, picks: dict[str, str]) -> bool:
+    def uses_recommended_answers(self, picks: dict[str, str]) -> bool:
         # Unanswered questions and questions without a recommendation cannot confirm intent.
         return all(
             any(

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -277,8 +277,8 @@ class BuildWorkflow(Workflow):
             reply = await self.review(questions=plan.questions, context=critique)
             if (
                 reply.action == "approve"
-                and not reply.note.strip()
-                and plan.confirms_recommendations(reply.answers)
+                and not reply.note
+                and plan.is_answered_as_recommended(reply.answers)
             ):
                 return True
             answered = plan.get_answered(reply.answers)

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -278,7 +278,7 @@ class BuildWorkflow(Workflow):
             if (
                 reply.action == "approve"
                 and not reply.note
-                and plan.is_answered_as_recommended(reply.answers)
+                and plan.uses_recommended_answers(reply.answers)
             ):
                 return True
             answered = plan.get_answered(reply.answers)

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -275,7 +275,11 @@ class BuildWorkflow(Workflow):
                 redrafted = True
                 reviewer_notes = grade.body
             reply = await self.review(questions=plan.questions, context=critique)
-            if reply.action == "approve" and not plan.questions:
+            if (
+                reply.action == "approve"
+                and not reply.note.strip()
+                and plan.confirms_recommendations(reply.answers)
+            ):
                 return True
             answered = plan.get_answered(reply.answers)
             note = reply.note

--- a/backend/templates/prompts/build/build_workflow/generate_plan.md
+++ b/backend/templates/prompts/build/build_workflow/generate_plan.md
@@ -15,8 +15,8 @@ your acceptance criteria. Wrong shape here compounds into every step that follow
   external services. If you cannot express it as a machine-checkable assertion — diff exists,
   test passes, column present in migration, function has this signature — it is not an AC yet.
 - **Open questions are cheap now, expensive later.** A question surfaced in the plan costs a
-  paragraph. The same question surfaced during implementation costs three revision rounds and
-  forces either a bad guess or a full loop.
+  paragraph. A confident answer is a decision, not a question: make it, plan with it, and note
+  it in the plan. Ask only when no confident decision can make the plan complete.
 - **One PR, one coherent change.** If you would want to merge half of this and revisit the
   rest, the scope should be split into two plans.
 
@@ -61,7 +61,7 @@ The plan reviewer rejected your previous draft with the critique below. Fold eve
 > {{ reviewer_notes | replace("\n", "\n> ") }}
 
 {% endif %}
-Generate the initial implementation plan. Include open questions only when the plan cannot be made decision-complete from the issue and repository build. Return specific acceptance criteria describing what must be true for this PR to pass. When the work changes a protocol or wire contract, include exact request/response examples in the plan or acceptance criteria. Do not add standalone lint, test, or type-check acceptance criteria from the verification profile. A test explicitly requested by the issue remains a valid AC. A behavioral AC may include a `Verification:` note describing how the evaluator confirms that specific criterion.
+Generate the initial implementation plan. If the issue and repository support a confident answer, make that decision, plan with it, and note it instead of asking. Include open questions only when the plan cannot be made decision-complete from the issue and repository build. For each unavoidable question, set `recommended: true` on exactly one option. Return specific acceptance criteria describing what must be true for this PR to pass. When the work changes a protocol or wire contract, include exact request/response examples in the plan or acceptance criteria. Do not add standalone lint, test, or type-check acceptance criteria from the verification profile. A test explicitly requested by the issue remains a valid AC. A behavioral AC may include a `Verification:` note describing how the evaluator confirms that specific criterion.
 
 ACCEPTANCE CRITERIA MUST BE CODE-VERIFIABLE. Druks's evaluator inspects the diff and reads tests. It runs the configured verification profile as its own check set, separate from the binding acceptance criteria the implementer must satisfy. It cannot drive a browser, click through a UI, eyeball rendered output, exercise a real third-party API, or otherwise perform a runtime/visual smoke. Any criterion phrased as "manually smoke X", "load the app locally", "verify visually", "click through Y", "confirm in production", or "exercise the live N integration" is unfulfillable in this pipeline and will lock the PR in revision loops forever.
 

--- a/backend/tests/test_build_plan_phase.py
+++ b/backend/tests/test_build_plan_phase.py
@@ -62,7 +62,7 @@ async def test_gate_mode_parks_every_plan_and_never_calls_the_reviewer(monkeypat
                 QuestionOutput(
                     id="q1",
                     prompt="Which cache?",
-                    options=[QuestionOptionOutput(id="a", label="Redis")],
+                    options=[QuestionOptionOutput(id="a", label="Redis", recommended=False)],
                 )
             ],
         ),
@@ -98,6 +98,113 @@ async def test_gate_mode_parks_every_plan_and_never_calls_the_reviewer(monkeypat
         },
         {"answered_questions": [], "operator_note": "add a rollback section", "reviewer_notes": ""},
     ]
+
+
+async def test_approve_confirming_recommendations_proceeds_without_redraft(monkeypatch):
+    """Approving every recommended option proceeds after one plan."""
+    flow = _flow()
+    passes = _fake_plans(
+        monkeypatch,
+        PlanData(
+            plan_markdown="v1",
+            questions=[
+                QuestionOutput(
+                    id="q1",
+                    prompt="Which cache?",
+                    options=[
+                        QuestionOptionOutput(id="a", label="Redis", recommended=True),
+                        QuestionOptionOutput(id="b", label="Memcache", recommended=False),
+                    ],
+                )
+            ],
+        ),
+    )
+    _no_review_agent(monkeypatch)
+
+    async def fake_review(*, questions=None, context=""):
+        return OperatorReply(action="approve", answers={"q1": "a"})
+
+    flow.review = fake_review
+
+    assert await flow._plan_phase() is True
+    assert len(passes) == 1
+
+
+async def test_approve_diverging_from_recommendation_redrafts(monkeypatch):
+    """Approving a different option folds that answer into a second plan."""
+    flow = _flow()
+    passes = _fake_plans(
+        monkeypatch,
+        PlanData(
+            plan_markdown="v1",
+            questions=[
+                QuestionOutput(
+                    id="q1",
+                    prompt="Which cache?",
+                    options=[
+                        QuestionOptionOutput(id="a", label="Redis", recommended=True),
+                        QuestionOptionOutput(id="b", label="Memcache", recommended=False),
+                    ],
+                )
+            ],
+        ),
+        PlanData(plan_markdown="v2"),
+    )
+    _no_review_agent(monkeypatch)
+    replies = iter(
+        [
+            OperatorReply(action="approve", answers={"q1": "b"}),
+            OperatorReply(action="approve"),
+        ]
+    )
+
+    async def fake_review(*, questions=None, context=""):
+        return next(replies)
+
+    flow.review = fake_review
+
+    assert await flow._plan_phase() is True
+    assert len(passes) == 2
+    assert passes[1]["answered_questions"] == [{"question": "Which cache?", "answer": "Memcache"}]
+
+
+async def test_approve_with_note_redrafts(monkeypatch):
+    """An approve note is change guidance and triggers a second plan."""
+    flow = _flow()
+    passes = _fake_plans(
+        monkeypatch,
+        PlanData(
+            plan_markdown="v1",
+            questions=[
+                QuestionOutput(
+                    id="q1",
+                    prompt="Which cache?",
+                    options=[QuestionOptionOutput(id="a", label="Redis", recommended=True)],
+                )
+            ],
+        ),
+        PlanData(plan_markdown="v2"),
+    )
+    _no_review_agent(monkeypatch)
+    replies = iter(
+        [
+            OperatorReply(
+                action="approve",
+                answers={"q1": "a"},
+                note="include the rollback command",
+            ),
+            OperatorReply(action="approve"),
+        ]
+    )
+
+    async def fake_review(*, questions=None, context=""):
+        return next(replies)
+
+    flow.review = fake_review
+
+    assert await flow._plan_phase() is True
+    assert len(passes) == 2
+    assert passes[1]["operator_note"] == "include the rollback command"
 
 
 async def test_auto_mode_folds_the_critique_into_one_redraft(monkeypatch):

--- a/backend/tests/test_contracts.py
+++ b/backend/tests/test_contracts.py
@@ -115,7 +115,7 @@ def test_get_answered_maps_picks_to_labels_and_keeps_free_text_verbatim():
     ]
 
 
-def test_confirming_recommendations_requires_an_answer_and_recommendation_per_question():
+def test_agreement_needs_every_question_picked_as_recommended():
     confirmed = O.PlanData(
         questions=[
             O.QuestionOutput(
@@ -140,10 +140,10 @@ def test_confirming_recommendations_requires_an_answer_and_recommendation_per_qu
         ]
     )
 
-    assert confirmed.confirms_recommendations({"q1": "a", "q2": "b"})
-    assert not confirmed.confirms_recommendations({"q1": "a"})
-    assert not without_recommendation.confirms_recommendations({"q1": "a"})
-    assert O.PlanData().confirms_recommendations({})
+    assert confirmed.is_answered_as_recommended({"q1": "a", "q2": "b"})
+    assert not confirmed.is_answered_as_recommended({"q1": "a"})
+    assert not without_recommendation.is_answered_as_recommended({"q1": "a"})
+    assert O.PlanData().is_answered_as_recommended({})
 
 
 def test_ask_contracts_cap_identity_and_cardinality():

--- a/backend/tests/test_contracts.py
+++ b/backend/tests/test_contracts.py
@@ -4,6 +4,7 @@
 # real schema, so this guards it directly.
 import pytest
 from druks.build import contracts as O
+from druks.build.enums import ReviewDecision
 from pydantic import ValidationError
 
 MODELS = [
@@ -98,12 +99,12 @@ def test_get_answered_maps_picks_to_labels_and_keeps_free_text_verbatim():
             O.QuestionOutput(
                 id="q1",
                 prompt="Which cache?",
-                options=[O.QuestionOptionOutput(id="a", label="Redis")],
+                options=[O.QuestionOptionOutput(id="a", label="Redis", recommended=False)],
             ),
             O.QuestionOutput(
                 id="q2",
                 prompt="Which queue?",
-                options=[O.QuestionOptionOutput(id="a", label="SQS")],
+                options=[O.QuestionOptionOutput(id="a", label="SQS", recommended=False)],
             ),
             O.QuestionOutput(id="q3", prompt="Feature flag?", options=[]),
         ]
@@ -114,12 +115,43 @@ def test_get_answered_maps_picks_to_labels_and_keeps_free_text_verbatim():
     ]
 
 
+def test_confirming_recommendations_requires_an_answer_and_recommendation_per_question():
+    confirmed = O.PlanData(
+        questions=[
+            O.QuestionOutput(
+                id="q1",
+                prompt="Which cache?",
+                options=[O.QuestionOptionOutput(id="a", label="Redis", recommended=True)],
+            ),
+            O.QuestionOutput(
+                id="q2",
+                prompt="Which queue?",
+                options=[O.QuestionOptionOutput(id="b", label="SQS", recommended=True)],
+            ),
+        ]
+    )
+    without_recommendation = O.PlanData(
+        questions=[
+            O.QuestionOutput(
+                id="q1",
+                prompt="Which cache?",
+                options=[O.QuestionOptionOutput(id="a", label="Redis", recommended=False)],
+            )
+        ]
+    )
+
+    assert confirmed.confirms_recommendations({"q1": "a", "q2": "b"})
+    assert not confirmed.confirms_recommendations({"q1": "a"})
+    assert not without_recommendation.confirms_recommendations({"q1": "a"})
+    assert O.PlanData().confirms_recommendations({})
+
+
 def test_ask_contracts_cap_identity_and_cardinality():
     # The gate view is bounded by construction: identity and list sizes are
     # hard caps at the agent boundary, never clipped downstream.
-    option = O.QuestionOptionOutput(id="a", label="Redis")
+    option = O.QuestionOptionOutput(id="a", label="Redis", recommended=False)
     with pytest.raises(ValidationError):
-        O.QuestionOptionOutput(id="a" * 65, label="Redis")
+        O.QuestionOptionOutput(id="a" * 65, label="Redis", recommended=False)
     with pytest.raises(ValidationError):
         O.QuestionOutput(id="q", prompt="p" * 2049, options=[])
     with pytest.raises(ValidationError):
@@ -135,7 +167,5 @@ def test_ask_contracts_cap_identity_and_cardinality():
 
 def test_review_output_records_no_artifact():
     # An artifact would displace the plan as the parked ask's document.
-    from druks.build.enums import ReviewDecision
-
     grade = O.ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="name the wire schema")
     assert grade.get_artifact() == {}

--- a/backend/tests/test_contracts.py
+++ b/backend/tests/test_contracts.py
@@ -140,10 +140,10 @@ def test_agreement_needs_every_question_picked_as_recommended():
         ]
     )
 
-    assert confirmed.is_answered_as_recommended({"q1": "a", "q2": "b"})
-    assert not confirmed.is_answered_as_recommended({"q1": "a"})
-    assert not without_recommendation.is_answered_as_recommended({"q1": "a"})
-    assert O.PlanData().is_answered_as_recommended({})
+    assert confirmed.uses_recommended_answers({"q1": "a", "q2": "b"})
+    assert not confirmed.uses_recommended_answers({"q1": "a"})
+    assert not without_recommendation.uses_recommended_answers({"q1": "a"})
+    assert O.PlanData().uses_recommended_answers({})
 
 
 def test_ask_contracts_cap_identity_and_cardinality():

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -80,12 +80,11 @@ export interface AgentCallSummary {
   tokens?: TokenUsage | null
 }
 
-// A question the ask surfaces for the operator to answer with one of its options
-// or in their own words.
+// A question the ask surfaces for the operator to answer with one offered option.
 export interface AskQuestion {
   id: string
   prompt: string
-  options: { id: string; label: string }[]
+  options: { id: string; label: string; recommended: boolean }[]
 }
 
 // The ask a parked run declares (input_request, snake_case keys). presentation

--- a/frontend/src/extensions/build/WorkItemPage.tsx
+++ b/frontend/src/extensions/build/WorkItemPage.tsx
@@ -667,11 +667,10 @@ function RunNeedsInput({ run, prUrl }: { run: RunSummary; prUrl?: string | null 
   )
 }
 
-// The in-app review: the artifact (the plan) rendered, the LLM's questions as
-// options (plus an "other…" box for the operator's own words), and the workflow's
-// controls as buttons. A click resumes the run with {control, answers, note};
-// the operator's choice maps to a stored action server-side — free text is content
-// for the next plan pass, never a control.
+// The in-app review: the artifact (the plan), structured question options, one
+// note, and the workflow's controls. A click resumes the run with
+// {control, answers, note}; free text is content for the next plan pass, never a
+// control.
 function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }) {
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [note, setNote] = useState('')
@@ -688,13 +687,9 @@ function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }) {
     setPending(control)
     setError(null)
     try {
-      // Only answers with content travel — a cleared "other…" box means unanswered.
-      const given = Object.fromEntries(
-        Object.entries(answers).filter(([, answer]) => answer.trim() !== ''),
-      )
       // The run un-parks; the subject's SSE stream re-emits the snapshot and this
       // banner clears itself.
-      await api.resumeRun(runId, { control, answers: given, note: note.trim() })
+      await api.resumeRun(runId, { control, answers, note: note.trim() })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'could not submit')
       setPending(null)
@@ -716,10 +711,7 @@ function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }) {
         </div>
       )}
       {ask.questions?.map((question) => {
-        // One answer per question — an offered option or the operator's own words;
-        // picking clears the typed text, typing clears the pick.
         const picked = answers[question.id] ?? ''
-        const isOption = question.options.some((option) => option.id === picked)
         return (
           <fieldset key={question.id} className="review-question">
             <legend>{question.prompt}</legend>
@@ -734,16 +726,11 @@ function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }) {
                   }
                 />
                 {option.label}
+                {option.recommended && (
+                  <span className="review-recommended">recommended</span>
+                )}
               </label>
             ))}
-            <textarea
-              className="review-other"
-              placeholder="other — answer in your own words…"
-              value={isOption ? '' : picked}
-              onChange={(e) =>
-                setAnswers((prev) => ({ ...prev, [question.id]: e.target.value }))
-              }
-            />
           </fieldset>
         )
       })}
@@ -761,7 +748,7 @@ function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }) {
           const needsGuidance =
             control === 'request_changes' &&
             note.trim() === '' &&
-            !Object.values(answers).some((answer) => answer.trim() !== '')
+            Object.keys(answers).length === 0
           return (
             <button
               key={control}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2238,11 +2238,10 @@ input.set-select { background-image: none; padding-right: 12px; }
 .review-question legend { font-size: 13px; color: var(--text-mid); margin-bottom: 6px; padding: 0; }
 .review-option { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--text-mid); padding: 3px 0; cursor: pointer; }
 .review-option input { accent-color: var(--bucket-human); }
-.review-other, .review-note { display: block; width: 100%; border: 1px solid var(--border); border-radius: 5px; background: var(--surface-2); color: var(--text-mid); font-family: inherit; font-size: 13px; line-height: 1.45; padding: 6px 10px; resize: vertical; }
-.review-other:focus, .review-note:focus { outline: none; border-color: color-mix(in oklch, var(--bucket-human) 50%, transparent); }
-.review-other::placeholder, .review-note::placeholder { color: var(--text-faint); }
-.review-other { margin-top: 6px; min-height: 30px; }
-.review-note { margin-top: 12px; min-height: 44px; }
+.review-recommended { color: var(--bucket-human); font-size: 11px; font-weight: 600; }
+.review-note { display: block; width: 100%; min-height: 44px; margin-top: 12px; border: 1px solid var(--border); border-radius: 5px; background: var(--surface-2); color: var(--text-mid); font-family: inherit; font-size: 13px; line-height: 1.45; padding: 6px 10px; resize: vertical; }
+.review-note:focus { outline: none; border-color: color-mix(in oklch, var(--bucket-human) 50%, transparent); }
+.review-note::placeholder { color: var(--text-faint); }
 .review-controls { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
 .review-btn { border: 1px solid var(--border); border-radius: 5px; background: var(--surface-2); color: var(--text-mid); font-size: 12px; padding: 6px 14px; }
 .review-btn:hover:not(:disabled) { border-color: var(--text-dim); }


### PR DESCRIPTION
Closes ENG-746.

Answering a plan-review gate always cost a second full opus plan (~$2, fresh sandbox), even when the operator picked exactly what the planner recommended.

## Approve now short-circuits on agreement, not on absence of questions

`_plan_phase` returned early only when the plan carried **no** questions:

```python
if reply.action == "approve" and not plan.questions:
    return True
```

One question was enough to send every answer — including each one matching the planner's own suggestion, with no note — back through a full `generate_plan`. There was no way to say "your defaults are right, go".

The blocker was that the recommendation lived in the option's label prose, so nothing downstream could tell agreement from divergence. `QuestionOptionOutput` now carries a structured `recommended` boolean, and `PlanData.confirms_recommendations()` decides.

**The judgement calls, spelled out** — each of these re-plans, because none of them is the operator confirming a default:

- an answer that diverges from the recommendation
- a question the planner marked no recommendation on
- a question left unanswered
- any note (a note is change guidance)

A plan with no questions still short-circuits exactly as before — `all([])` is `True`.

## The planner decides instead of blocking

`generate_plan.md` already said to ask only when the plan cannot be made decision-complete, and was not obeying it — the run this came from raised a question *and* recommended an answer to it. The core truth now says a confident answer is a decision, not a question, and the instruction pins exactly one option per unavoidable question as `recommended: true`.

## One free-text on the gate

The gate had two free-text inputs — a per-question "other, in your own words" and a global note — for the same job. The per-question box is gone; the options answer the questions and the note is the single free-text, matching every other review surface. The backend's verbatim fallback in `get_answered` is untouched, so the API still accepts free-text answers from other clients; only the second box goes.

## The recommendation is visible

Worth a look, because it is the part that is easy to get wrong: with the recommendation now structural, the planner no longer has to write "(recommended)" into the label — which is how the operator on the original run knew which option to pick. So the marker renders beside the option it belongs to. Without it the operator cannot see which default they are confirming, and the whole feature is invisible magic.

## Contract note

`recommended` is a plain required field, not a defaulted one: `AgentOutput` goes to a strict structured-output validator where a field with a default 400s at runtime, and the house pattern for "must appear in `required`" is already established one class down (`assignee_github_login` is required-but-nullable). An earlier draft shimmed a default in with a `mode="before"` validator; that softened the contract — an agent omitting the field would silently get `False` instead of failing to parse — so it is gone and the 13 test constructors pass the field explicitly.

## Verification

Frontend 51 tests, ESLint, and the TypeScript build pass; ruff check and format pass; pyright on the changed contract is clean; 960 backend tests collect. Backend execution is CI-gated as usual — Postgres is not reachable from this sandbox.
