### PR TITLE
Extensions speak subject rows; the identity dict stays in storage

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -176,7 +176,7 @@ class Agent:
             # The visible nudge: this call charged the fallback account.
             Event.emit(
                 type="credential.fallback",
-                subject=workflow.subject,
+                subject=workflow._subject,
                 payload={"run_id": workflow_id, "harness": harness.name},
                 extension=type(workflow).extension,
             )

--- a/backend/druks/build/extension.py
+++ b/backend/druks/build/extension.py
@@ -27,7 +27,7 @@ _PHASE_META: dict[str, SubjectActivity] = {
 
 class Build(Extension):
     name = "build"
-    subject_type = "work_item"
+    subject = WorkItem
     # build's tables (projects, work_items, ...) are already unprefixed in core's
     # migration history, so they must stay that way.
     prefix_tables = False
@@ -184,9 +184,8 @@ class Build(Extension):
         return
 
     @classmethod
-    def subject_summary(cls, subject_id: str) -> WorkItemSummary | None:
-        item = WorkItem.get(int(subject_id))
-        return WorkItemSummary.from_work_item(item) if item else None
+    def subject_summary(cls, subject: WorkItem) -> WorkItemSummary:
+        return WorkItemSummary.from_work_item(subject)
 
     @classmethod
     def list_subjects(cls) -> list[WorkItemSummary]:
@@ -199,9 +198,6 @@ class Build(Extension):
         ]
 
     @classmethod
-    async def subject_activity(cls, subject_id: str) -> SubjectActivity | None:
-        item = WorkItem.get(int(subject_id))
-        if item:
-            phase = await get_subject_phase("work_item", str(item.id))
-            return _PHASE_META.get(phase or "")
-        return
+    async def subject_activity(cls, subject: WorkItem) -> SubjectActivity | None:
+        phase = await get_subject_phase(subject.subject_type, str(subject.id))
+        return _PHASE_META.get(phase or "")

--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -289,7 +289,7 @@ class WorkItem(Subject):
         self.set_status(HandoffStatus.SHIPPED)
         build = get_subject_status(self.subject_type, str(self.id), kind=BuildWorkflow.kind)
         if build.is_parked:
-            await BuildWorkflow.cancel(self.subject, failure="pr merged while parked")
+            await BuildWorkflow.cancel(self, failure="pr merged while parked")
         await self.set_remote_status(SemanticStatus.DONE)
 
     async def close_external(self) -> None:
@@ -299,7 +299,7 @@ class WorkItem(Subject):
         from druks.build.workflows import BuildWorkflow
 
         self.set_status(HandoffStatus.CANCELLED, event_payload={"external": True})
-        await BuildWorkflow.cancel(self.subject, failure="pr closed without merge")
+        await BuildWorkflow.cancel(self, failure="pr closed without merge")
         db_session().flush()
         try:
             if (await RepoPolicy.resolve(self.repo)).delete_branch:
@@ -345,9 +345,7 @@ class WorkItem(Subject):
             # cycle: the extension imports this module at file scope.
             import druks.build.extension as build_extension
 
-            build_extension.Build.record_event(
-                type=status, subject=self.subject, payload=event_payload
-            )
+            build_extension.Build.record_event(type=status, subject=self, payload=event_payload)
         self.status = status
         self.updated_at = Base.utc_now()
         db_session().flush()

--- a/backend/druks/build/subscribers.py
+++ b/backend/druks/build/subscribers.py
@@ -12,39 +12,37 @@ from druks.workflows import get_subject_status
 # Projections
 
 
-@subscribe("run.running", subject__type="work_item")
-async def run_start_returns_item_to_board(*, subject: dict, **_: object) -> None:
+@subscribe("run.running", subject=WorkItem)
+async def run_start_returns_item_to_board(*, subject: WorkItem, **_: object) -> None:
     # Any run starting for a work item puts it back on the active board —
     # re-scoping, a new build, a resume all mean druks has it in court again.
-    WorkItem.get(subject["id"]).set_status(None)
+    subject.set_status(None)
 
 
-@subscribe("run.state", kind=BuildWorkflow.kind, subject__type="work_item")
+@subscribe("run.state", kind=BuildWorkflow.kind, subject=WorkItem)
 async def provision_mirrors_onto_item(
-    *, subject: dict, pr_number: int, branch: str, **_: object
+    *, subject: WorkItem, pr_number: int, branch: str, **_: object
 ) -> None:
     # The implementer's provisioned PR + branch, mirrored onto the work item —
     # the read side (board links, webhook routing by repo+PR) keys off them.
-    WorkItem.get(subject["id"]).update(pr_number=pr_number, branch=branch)
+    subject.update(pr_number=pr_number, branch=branch)
 
 
-@subscribe("run.running", kind=BuildWorkflow.kind, subject__type="work_item")
-async def build_start_marks_ticket_in_progress(*, subject: dict, **_: object) -> None:
+@subscribe("run.running", kind=BuildWorkflow.kind, subject=WorkItem)
+async def build_start_marks_ticket_in_progress(*, subject: WorkItem, **_: object) -> None:
     # Every (re)start and gate-resume of a build means the ticket is in progress —
     # including the return from a rework loop that had parked it In Review.
-    item = WorkItem.get(subject["id"])
-    await item.set_remote_status(SemanticStatus.IN_PROGRESS)
+    await subject.set_remote_status(SemanticStatus.IN_PROGRESS)
 
 
-@subscribe("run.pending_input", kind=BuildWorkflow.kind, subject__type="work_item", gate=ReviewWork)
-async def review_park_marks_ticket_in_review(*, subject: dict, **_: object) -> None:
-    item = WorkItem.get(subject["id"])
-    await item.set_remote_status(SemanticStatus.IN_REVIEW)
+@subscribe("run.pending_input", kind=BuildWorkflow.kind, gate=ReviewWork, subject=WorkItem)
+async def review_park_marks_ticket_in_review(*, subject: WorkItem, **_: object) -> None:
+    await subject.set_remote_status(SemanticStatus.IN_REVIEW)
 
 
-@subscribe("run.finished", kind=Scope.kind, subject__type="work_item", result__status="ready")
-async def scope_ready_settles_the_lane(*, subject: dict, **_: object) -> None:
-    WorkItem.get(subject["id"]).set_status(HandoffStatus.SCOPED, event_payload={})
+@subscribe("run.finished", kind=Scope.kind, result__status="ready", subject=WorkItem)
+async def scope_ready_settles_the_lane(*, subject: WorkItem, **_: object) -> None:
+    subject.set_status(HandoffStatus.SCOPED, event_payload={})
 
 
 @subscribe("repo.pushed", to_default_branch=True)
@@ -69,7 +67,7 @@ async def pr_review_answers_the_gate(*, repo: str, pr_number: int, payload: dict
     status = get_subject_status(item.subject_type, str(item.id), kind=BuildWorkflow.kind)
     if status.is_parked and status.gate == ReviewWork.name:
         await ReviewWork.answer(
-            item.subject,
+            item,
             action=payload["action"],
             reviewer=payload["reviewer"],
             body=payload["body"],
@@ -116,7 +114,7 @@ async def ticket_reply_resumes_parked_scope(*, payload: dict) -> None:
         if item:
             status = get_subject_status(item.subject_type, str(item.id), kind=Scope.kind)
             if status.is_parked and status.gate == ScopeReply.name:
-                await ScopeReply.answer(item.subject)
+                await ScopeReply.answer(item)
 
 
 @subscribe("ticket.transitioned", payload__terminal=True)
@@ -129,7 +127,7 @@ async def ticket_close_cancels_parked_scope(*, payload: dict) -> None:
         status = get_subject_status(item.subject_type, str(item.id), kind=Scope.kind)
         if status.is_parked and status.gate == ScopeReply.name:
             item.set_status(HandoffStatus.CANCELLED, event_payload={"external": True})
-            await Scope.cancel(item.subject, failure="ticket closed while scope parked")
+            await Scope.cancel(item, failure="ticket closed while scope parked")
 
 
 async def _dispatch_scope(source: str, key: str) -> None:

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -115,7 +115,7 @@ class BuildWorkflow(Workflow):
         email = ticket["assignee_email"]
         assignee = Account.get_for_username(email.strip()) if email else None
         run_id = await cls.start(
-            subject=item.subject,
+            subject=item,
             account_id=assignee.id if assignee else None,
             repo=item.repo,
             source=item.source,
@@ -419,7 +419,7 @@ class Profile(Workflow):
     @classmethod
     async def dispatch(cls, repo: ProjectRepo, *, refresh_only: bool = False) -> str:
         return await cls.start(
-            subject=repo.subject,
+            subject=repo,
             repo_id=repo.id,
             refresh_only=refresh_only,
         )
@@ -504,7 +504,7 @@ class Scope(Workflow):
         if ticket.assignee_email:
             assignee = Account.get_for_username(ticket.assignee_email.strip())
         return await cls.start(
-            subject=item.subject,
+            subject=item,
             account_id=assignee.id if assignee else None,
             remote_key=ticket.key,
             source=ticket.provider,
@@ -515,7 +515,7 @@ class Scope(Workflow):
         # the work lands (the subject's repo + siblings), the marks it must leave
         # on the tracker, and the target repo's recommended skills for the brief's
         # Skills section.
-        item = WorkItem.get(self.subject["id"])
+        item = self.subject
         target = ProjectRepo.get_for_repo(item.repo, raise_on_missing=True)
         siblings = [
             {"full_name": repo.full_name, "purpose": repo.purpose or ""}

--- a/backend/druks/extensions/base.py
+++ b/backend/druks/extensions/base.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from druks.events.feed import generic_entry
 from druks.events.models import Event
+from druks.models import Subject
 from druks.user_settings.models import SettingsOverride
 
 from .registry import agents as agent_registry
@@ -85,11 +86,9 @@ class Extension:
     # belong to the extension itself rather than one of its workflows. Mirrors a
     # workflow's ``Settings``.
     settings_model: ClassVar[type[BaseModel] | None] = None
-    # The kind of subject this extension's runs are about (e.g. "work_item"). Set it to
-    # get the generic subject read-side mounted at ``/api/<name>/<subject_type>`` — the
-    # platform serves status + timeline + live stream, and the extension supplies only
-    # the domain summary. None = the extension has no subject read-side.
-    subject_type: ClassVar[str | None] = None
+    # The row this extension's runs are about. Declaring it mounts the generic
+    # subject read-side; None means the extension has no subject read-side.
+    subject: ClassVar[type[Subject] | None] = None
     # The checks this extension contributes to ``druks doctor`` — one per precondition
     # it owns (its API key set, its webhook secret present, its provider reachable).
     # ``druks doctor`` runs each through the same ``CheckResult`` report as its core
@@ -243,7 +242,7 @@ class Extension:
         its ``routes`` modules, plus the generic read-side it gets for free —
         ``/transcripts`` always, and the subject read-side
         (``/<subject_type>`` → status + timeline + live stream) when it declares a
-        ``subject_type``. Override to add a router built outside a ``routes`` module."""
+        ``subject``. Override to add a router built outside a ``routes`` module."""
         # Local, not module-top: keeps FastAPI off the import graph so the loader
         # stays importable app-lessly; enumerating routers is where it's really needed.
         from fastapi import APIRouter
@@ -258,7 +257,7 @@ class Extension:
                     seen.add(id(value))
                     declared.append(value)
         routers = [*declared, cls._get_transcript_routes()]
-        if cls.subject_type:
+        if cls.subject:
             routers.append(cls._get_subject_routes())
         return routers
 
@@ -352,18 +351,19 @@ class Extension:
     def _get_subject_routes(cls) -> "APIRouter":
         """The board and one subject (header + status + timeline + activity), each with a
         point-in-time read and a ``/stream`` that pushes the whole snapshot on change.
-        Mounted at ``/api/<name>/<subject_type>`` once the extension sets ``subject_type``."""
+        Mounted at ``/api/<name>/<subject_type>`` once the extension declares ``subject``."""
         from fastapi import APIRouter, HTTPException, status
         from fastapi.responses import StreamingResponse
 
         from druks.api.dependencies import EngineDep
-        from druks.database import session_scope
+        from druks.database import db_session, session_scope
         from druks.durable import reads
         from druks.durable.live import SSE_HEADERS, stream
         from druks.durable.schemas import SubjectList, SubjectResponse, SubjectRow
 
-        kind = cls.subject_type
-        assert kind is not None
+        subject_model = cls.subject
+        assert subject_model
+        kind = subject_model.subject_type
 
         router = APIRouter(prefix=f"/{kind}", tags=[f"{cls.name}:{kind}"])
 
@@ -375,11 +375,16 @@ class Extension:
                 ]
             )
 
-        async def subject(subject_id: str) -> SubjectResponse | None:
-            summary = cls.subject_summary(subject_id)
+        async def subject_response(subject_id: str) -> SubjectResponse | None:
+            if not subject_id.isdigit():
+                return
+            subject = db_session().get(subject_model, int(subject_id))
+            if not subject:
+                return
+            summary = cls.subject_summary(subject)
             if not summary:
-                return None
-            activity = await cls.subject_activity(subject_id)
+                return
+            activity = await cls.subject_activity(subject)
             return reads.get_subject_response(kind, subject_id, summary=summary, activity=activity)
 
         @router.get("", response_model=SubjectList, response_model_by_alias=True)
@@ -398,8 +403,8 @@ class Extension:
             )
 
         @router.get("/{subject_id}", response_model=SubjectResponse, response_model_by_alias=True)
-        async def get_subject(subject_id: str) -> SubjectResponse:
-            response = await subject(subject_id)
+        async def read_subject(subject_id: str) -> SubjectResponse:
+            response = await subject_response(subject_id)
             if not response:
                 raise HTTPException(status.HTTP_404_NOT_FOUND, f"No {kind} {subject_id!r}.")
             return response
@@ -408,7 +413,7 @@ class Extension:
         async def stream_subject(subject_id: str, engine: EngineDep) -> StreamingResponse:
             async def snapshot() -> SubjectResponse | None:
                 with session_scope(engine):
-                    return await subject(subject_id)
+                    return await subject_response(subject_id)
 
             return StreamingResponse(
                 stream(snapshot), media_type="text/event-stream", headers=SSE_HEADERS
@@ -428,13 +433,18 @@ class Extension:
         cls,
         *,
         type: str,
-        subject: dict[str, Any] | None = None,
+        subject: Subject | None = None,
         payload: dict[str, Any] | None = None,
     ) -> None:
         """Record one of this extension's domain events to the log, stamped with the
         extension automatically. Apps record through here so the ``Event`` model
         stays a platform internal — the write-side twin of ``format_event``."""
-        Event.emit(type=type, subject=subject, payload=payload, extension=cls.name)
+        Event.emit(
+            type=type,
+            subject=subject.identity if subject else None,
+            payload=payload,
+            extension=cls.name,
+        )
 
     @classmethod
     def format_event(cls, event: Event) -> "FeedItem":
@@ -445,23 +455,21 @@ class Extension:
         return generic_entry(event)
 
     @classmethod
-    def subject_summary(cls, subject_id: str) -> "SubjectSummary | None":
+    def subject_summary(cls, subject: Any) -> "SubjectSummary | None":
         """This extension's domain header for one subject — its own fields only; the
-        read-side composes it with the platform's generic status + timeline. None when
-        the id isn't one of its subjects. Required once ``subject_type`` is set."""
-        raise NotImplementedError(
-            f"extension {cls.name!r} sets subject_type but no subject_summary"
-        )
+        read-side composes it with the platform's generic status + timeline. Required
+        once ``subject`` is set."""
+        raise NotImplementedError(f"extension {cls.name!r} sets subject but no subject_summary")
 
     @classmethod
     def list_subjects(cls) -> "Sequence[SubjectSummary]":
         """This extension's subjects, newest-movement first, each as its domain summary.
         Returns a covariant ``Sequence`` so an extension can return ``list`` of its own
-        ``SubjectSummary`` subclass. Required once ``subject_type`` is set."""
-        raise NotImplementedError(f"extension {cls.name!r} sets subject_type but no list_subjects")
+        ``SubjectSummary`` subclass. Required once ``subject`` is set."""
+        raise NotImplementedError(f"extension {cls.name!r} sets subject but no list_subjects")
 
     @classmethod
-    async def subject_activity(cls, subject_id: str) -> "SubjectActivity | None":
+    async def subject_activity(cls, subject: Any) -> "SubjectActivity | None":
         """The subject's live sub-phase, if any (e.g. "Building sandbox VM…"). Optional —
         override to surface a transient signal the running run pushes."""
-        return None
+        return

--- a/backend/druks/extensions/loader.py
+++ b/backend/druks/extensions/loader.py
@@ -174,6 +174,18 @@ def _load_entry(entry: "EntryPoint") -> type[Extension]:
     return extension
 
 
+def _tables_declared_in(package: str) -> set[str]:
+    # A table belongs to whoever declared its model, not to whoever happened to import
+    # it first: an extension entry module pulls its own models in, and a sibling's.
+    from druks.models import Base
+
+    return {
+        mapper.local_table.name
+        for mapper in Base.registry.mappers
+        if mapper.class_.__module__.startswith(f"{package}.") and mapper.local_table is not None
+    }
+
+
 def import_extension_models(only: type[Extension] | None = None) -> None:
     """Import extensions' ``<package>.models`` so their tables register on the shared
     metadata before ``create_all`` or autogenerate. Defaults to every installed
@@ -185,23 +197,17 @@ def import_extension_models(only: type[Extension] | None = None) -> None:
     import importlib
     import importlib.util
 
-    # Core/framework tables must be registered first, so an extension's transitive pull
-    # of them isn't read as the extension's own (and flagged for missing the prefix).
-    import druks.durable.models  # noqa: F401
-    import druks.skills.models  # noqa: F401
-    import druks.user_settings.models  # noqa: F401
-    from druks.models import Base
-
     extensions = [only] if only else iter_extensions()
-    seen = set(Base.metadata.tables)
     for extension in extensions:
         name = f"{extension.package}.models"
         if not importlib.util.find_spec(name):
             continue
         importlib.import_module(name)
-        owned = set(Base.metadata.tables) - seen
-        seen |= owned
-        misnamed = sorted(t for t in owned if not t.startswith(extension.table_prefix))
+        misnamed = sorted(
+            table
+            for table in _tables_declared_in(extension.package)
+            if not table.startswith(extension.table_prefix)
+        )
         if misnamed and extension.prefix_tables and not extension.builtin:
             raise ValueError(
                 f"extension {extension.name!r} tables must start with "

--- a/backend/druks/models.py
+++ b/backend/druks/models.py
@@ -37,8 +37,8 @@ class Base(DeclarativeBase):
 
 class Subject(Base):
     """A row an extension's runs are about — a work item, a repo, a document.
-    Subclass it instead of ``Base``: the class name is the subject type, so a
-    subject never spells its identity twice."""
+    Subclass it instead of ``Base``: the class name is the subject type, so
+    ``WorkItem`` is ``work_item``."""
 
     __abstract__ = True
 
@@ -51,5 +51,9 @@ class Subject(Base):
         super().__init_subclass__(**kwargs)
 
     @property
-    def subject(self) -> dict[str, Any]:
-        return {"type": self.subject_type, "id": self.id}
+    def identity(self) -> dict[str, Any]:
+        """What a run or an event records in place of the row, which can be gone by
+        the time either is read."""
+        if self.id:
+            return {"type": self.subject_type, "id": self.id}
+        raise ValueError(f"unsaved {type(self).__name__} has no identity — flush it first")

--- a/backend/druks/scaffolding/extension_template/package/models.py-tpl
+++ b/backend/druks/scaffolding/extension_template/package/models.py-tpl
@@ -1,6 +1,9 @@
-from druks.db import Base
+from druks.db import Base, Subject
 
 # SQLAlchemy models for this extension — subclass ``Base``. Every table name must
 # start with "{{ name }}_": the platform scopes this extension's migrations to that
 # prefix (its own history in ``alembic_version_{{ name }}``) and enforces it at boot.
+# One of these models is usually the thing your runs work on — a note, a repo, a
+# ticket. Subclass ``Subject`` for that one, and set ``subject = ThatModel`` on the
+# Extension so druks can show it a board and a page.
 # After adding a model: ``druks makemigrations {{ name }} -m "..." && druks init-db``.

--- a/backend/druks/scaffolding/extension_template/package/subscribers.py-tpl
+++ b/backend/druks/scaffolding/extension_template/package/subscribers.py-tpl
@@ -4,5 +4,5 @@ from druks.signals import subscribe  # noqa: F401
 # kwargs; ``__`` descends into dicts). Defining a handler registers it — no body guards.
 #
 # @subscribe("run.finished", subject__type="{{ name }}")
-# async def on_finished(*, subject: dict, **_: object) -> None:
+# async def on_finished(*, subject: YourSubject, **_: object) -> None:
 #     ...

--- a/backend/druks/scaffolding/extension_template/package/workflows.py-tpl
+++ b/backend/druks/scaffolding/extension_template/package/workflows.py-tpl
@@ -7,6 +7,6 @@ from druks.workflows import FatalError, Gate, Workflow, step  # noqa: F401
 # Set ``every = "<cron>"`` to schedule one; raise ``FatalError`` for a clean domain
 # stop; a ``Gate`` subclass parks the run for human input.
 #
-# Callers launch with ``cls.start(subject=<{"type", "id"} dict or None>, **input)``.
+# Callers launch with ``cls.start(subject=<Subject row or None>, **input)``.
 # Only if a workflow grows launch policy (dedupe, routing, subject lookup) wrap
 # start() in a ``dispatch()`` classmethod and point callers there instead.

--- a/backend/druks/signals.py
+++ b/backend/druks/signals.py
@@ -3,6 +3,8 @@ from typing import Any
 
 from blinker import signal
 
+from druks.database import db_session
+
 __all__ = ["subscribe"]
 
 Subscriber = Callable[..., Awaitable[None]]
@@ -12,14 +14,18 @@ def subscribe(name: str, **filters: Any) -> Callable[[Subscriber], Subscriber]:
     """Register an async subscriber for the named signal.
 
     ``filters`` are equality matches against the published kwargs; ``__``
-    descends into dicts (``subject__type="work_item"``); a ``Gate`` class
-    stands for its ``name``. A non-matching publication skips the
-    subscriber, so the body starts at the real work."""
+    descends into dicts (``payload__terminal=True``); a ``Gate`` class stands for
+    its ``name``. ``subject=WorkItem`` narrows to that subject and hands the body
+    its row. A non-matching publication skips the subscriber, so the body starts
+    at the real work."""
 
     def register(fn: Subscriber) -> Subscriber:
         # Lazy import: druks.workflows imports this module.
         from druks.workflows import Gate
 
+        subject_class = filters.pop("subject", None)
+        if subject_class:
+            filters["subject__type"] = subject_class.subject_type
         matches = {}
         for lookup, expected in filters.items():
             if isinstance(expected, type) and issubclass(expected, Gate):
@@ -33,6 +39,11 @@ def subscribe(name: str, **filters: Any) -> Callable[[Subscriber], Subscriber]:
                     value = value.get(part) if isinstance(value, dict) else None
                 if value != expected:
                     return
+            if subject_class:
+                row = db_session().get(subject_class, int(kwargs["subject"]["id"]))
+                if not row:
+                    return
+                kwargs["subject"] = row
             await fn(**kwargs)
 
         # weak=False: ``receiver`` is a local closure nothing else references, so a

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -15,10 +15,11 @@ from dbos._error import (
     DBOSQueueDeduplicatedError,
     DBOSWorkflowCancelledError,
 )
-from pydantic import BaseModel, ConfigDict, Field, create_model
+from pydantic import BaseModel, Field, create_model
 from uuid_utils import uuid7
 
 from druks.accounts.context import current_account_id
+from druks.database import db_session
 from druks.durable.activity import set_run_phase
 from druks.durable.engine import _step_engine, register_schedule, run_queue, step_session
 from druks.durable.enums import AgentCallStatus, RunState
@@ -34,7 +35,7 @@ from druks.extensions.settings import (
     validate_setting_override,
     validate_settings_declaration,
 )
-from druks.models import snake_name
+from druks.models import Base, Subject, snake_name
 from druks.notifications.outbox import notifications_queue, send_notification
 from druks.sandbox.client import sandbox_client
 from druks.sandbox.constants import SANDBOX_HOST_ROTATE_BEFORE_SECONDS
@@ -90,14 +91,6 @@ _in_step: ContextVar[bool] = ContextVar("_in_step", default=False)
 # Reserved so _entry's arity and old checkpoints stay untouched; a body
 # parameter may not claim it.
 _ACCOUNT_INPUT_KEY = "__account_id__"
-
-
-class _Subject(BaseModel):
-    # What a run is about — the opaque {type, id} the platform keys events to.
-    # Modelled so start() validates the shape declaratively instead of by hand.
-    model_config = ConfigDict(extra="forbid")
-    type: str = Field(min_length=1)
-    id: int | str
 
 
 def _resolve_body_method(cls: type["Workflow"]) -> str:
@@ -218,15 +211,14 @@ class Gate(BaseModel):
         return
 
     @classmethod
-    async def answer(cls, subject: dict[str, Any], **reply: Any) -> None:
-        subject_key = _Subject.model_validate(subject)
-        runs = Run.list_for_subject(subject_key.type, str(subject_key.id))
+    async def answer(cls, subject: Subject, **reply: Any) -> None:
+        runs = Run.list_for_subject(subject.subject_type, str(subject.id))
         parked = next((run for run in runs if run.is_parked and run.input_gate == cls.name), None)
         if parked:
             await parked.resume(**reply)
             return
         raise WorkflowError(
-            f"subject {subject_key.type}:{subject_key.id} is not parked on gate {cls.name!r}"
+            f"subject {subject.subject_type}:{subject.id} is not parked on gate {cls.name!r}"
         )
 
     @classmethod
@@ -239,7 +231,7 @@ class Gate(BaseModel):
         # ``presentation``), stored on the run beside ``input_gate`` and cleared on
         # resume — so an extension declares the ask here, beside on_wait, not at read time.
         workflow = current_workflow.get()
-        if not workflow.subject and cls.on_wait.__func__ is Gate.on_wait.__func__:
+        if not workflow._subject and cls.on_wait.__func__ is Gate.on_wait.__func__:
             # No subject means no feed surface; if on_wait wasn't overridden
             # either, nobody would ever see this park — fail loudly instead
             # of parking invisibly for the whole TTL.
@@ -281,23 +273,23 @@ async def _park(
     await _emit_run_event(
         workflow.workflow_id,
         RunState.PENDING_INPUT,
-        subject=workflow.subject,
+        subject=workflow._subject,
         facts={
             "input_gate": gate,
             "input_request": input_request,
             "input_requested_at": datetime.now(UTC),
         },
     )
-    if workflow.subject:
+    if workflow._subject:
         # Every subjected park notifies the designated destination — no author opt-in.
-        await _notify_designated_destination(workflow.workflow_id, workflow.subject)
+        await _notify_designated_destination(workflow.workflow_id, workflow._subject)
     payload = await DBOS.recv_async(gate, timeout_seconds=ttl_seconds)
     if payload is None:
         raise GateTimeout(gate)
     await _emit_run_event(
         workflow.workflow_id,
         RunState.RUNNING,
-        subject=workflow.subject,
+        subject=workflow._subject,
         facts={**_GATE_CLEARED, "answer_parked_at": Run.input_requested_at},
     )
     return payload
@@ -529,9 +521,8 @@ class Workflow:
     def __init__(self) -> None:
         self._workflow_id: str = ""
         # What the run is about ({"type", "id"}), set from the dispatch arguments
-        # before run(); None for a subjectless framework run. Dispatch-only —
-        # read, don't write.
-        self.subject: dict[str, Any] | None = None
+        # before run(); None for a subjectless framework run.
+        self._subject: dict[str, Any] | None = None
         # run()'s validated input bundle (the model synthesized from its signature),
         # set before run() — for templates and derived properties. None = no input.
         self.input: BaseModel | None = None
@@ -545,6 +536,17 @@ class Workflow:
         # The run's warm VM, provisioned lazily and reaped at segment boundaries;
         # its lease expiry decides when it must rotate.
         self._host: Sandbox | None = None
+
+    @property
+    def subject(self) -> Any:
+        if not self._subject:
+            return
+        subject_type, subject_id = self._subject["type"], self._subject["id"]
+        for mapper in Base.registry.mappers:
+            model = mapper.class_
+            if issubclass(model, Subject) and model.subject_type == subject_type:
+                return db_session().get(model, int(subject_id))
+        raise LookupError(f"no subject class is named {subject_type!r}")
 
     @property
     def state(self) -> Any:
@@ -571,7 +573,12 @@ class Workflow:
 
         async def _fan_out() -> None:
             async with step_session():
-                await publish("run.state", subject=self.subject, kind=self.kind, **facts)
+                await publish(
+                    "run.state",
+                    subject=self._subject,
+                    kind=self.kind,
+                    **facts,
+                )
 
         await DBOS.run_step_async(StepOptions(name="run.state", **_IO_RETRIES), _fan_out)
 
@@ -585,7 +592,7 @@ class Workflow:
         # a Gate. The artifact the reviewer judges isn't named here — a parked
         # run can't produce new ones, so the read side resolves the latest on
         # demand.
-        if not self.subject:
+        if not self._subject:
             # An in-app review is answered from the subject's surfaces; a
             # subjectless run has none, so nobody would ever see the ask.
             raise SubjectlessGate(OperatorReply.name)
@@ -687,9 +694,8 @@ class Workflow:
         SettingsOverride.set_workflow_setting(cls.kind, field, value)
 
     @classmethod
-    async def cancel(cls, subject: dict[str, Any], *, failure: str | None = None) -> None:
-        subject_key = _Subject.model_validate(subject)
-        runs = Run.list_for_subject(subject_key.type, str(subject_key.id), kind=cls.kind)
+    async def cancel(cls, subject: Subject, *, failure: str | None = None) -> None:
+        runs = Run.list_for_subject(subject.subject_type, str(subject.id), kind=cls.kind)
         run = next((run for run in runs if run.is_active), None)
         if run:
             await run.cancel(failure=failure)
@@ -698,7 +704,7 @@ class Workflow:
     async def start(
         cls,
         *,
-        subject: dict[str, Any] | None,
+        subject: Subject | None,
         account_id: str | None = None,
         **input: Any,
     ) -> str:
@@ -716,8 +722,6 @@ class Workflow:
             # Browser-origin starts inherit the request's authenticated account;
             # dispatchers that know better pass account_id explicitly.
             account_id = current_account_id.get()
-        if subject is not None:
-            _Subject.model_validate(subject)  # raises on a bad shape (wrong/extra keys, types)
         wire: dict[str, Any] = {}
         if cls._run_input_model:
             wire = cls._run_input_model.model_validate(input).model_dump(mode="json")
@@ -733,7 +737,7 @@ class Workflow:
         # when DBOS gives up on a dead workflow. A duplicate start() hands back
         # the live run's id. Subjectless runs are unbounded.
         enqueue_options = (
-            SetEnqueueOptions(deduplication_id=f"{cls.kind}:{subject['type']}:{subject['id']}")
+            SetEnqueueOptions(deduplication_id=f"{cls.kind}:{subject.subject_type}:{subject.id}")
             if subject
             else nullcontext()
         )
@@ -742,14 +746,18 @@ class Workflow:
         # subject id is stamped as a string — the one shape every reader compares.
         attributes = None
         if subject:
-            attributes = {"subject_type": subject["type"], "subject_id": str(subject["id"])}
+            attributes = {
+                "subject_type": subject.subject_type,
+                "subject_id": str(subject.id),
+            }
+        subject_record = subject.identity if subject else None
         try:
             with (
                 SetWorkflowID(workflow_id),
                 SetWorkflowAttributes(attributes),
                 enqueue_options,
             ):
-                await run_queue.enqueue_async(cls._entry, subject, wire)
+                await run_queue.enqueue_async(cls._entry, subject_record, wire)
         except DBOSQueueDeduplicatedError as duplicate:
             holder = _get_dbos_instance()._sys_db.get_deduplicated_workflow(
                 run_queue.name, duplicate.deduplication_id
@@ -800,7 +808,7 @@ async def _run_instance(
 ) -> Any:
     instance = cls()
     instance._workflow_id = DBOS.workflow_id  # type: ignore[assignment]
-    instance.subject = subject
+    instance._subject = subject
     # Platform routing comes off before body validation; an old checkpoint
     # without the key replays account-less.
     input = dict(input or {})

--- a/backend/tests/druks-field_notes/druks_field_notes/extension.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/extension.py
@@ -8,11 +8,11 @@ from druks.extensions import Extension
 from pydantic import BaseModel, Field, SecretStr, field_validator
 
 from druks_field_notes.contracts import NoteSummary
+from druks_field_notes.models import Note
+from druks_field_notes.schemas import NoteView
 
 if TYPE_CHECKING:
     from druks.settings import Settings
-
-    from druks_field_notes.schemas import NoteView
 
 # The env var field_notes would read its summarizer credential from. Unset in a
 # bare install, so the check below reports it missing — the "extension owns a check
@@ -35,7 +35,7 @@ def check_summary_api_key(settings: "Settings") -> CheckResult:
 
 class FieldNotes(Extension):
     name = "field_notes"
-    subject_type = "note"
+    subject = Note
     icon = "notebook"
     description = "Turns a jotted observation into a one-line summary with an agent."
 
@@ -97,21 +97,11 @@ class FieldNotes(Extension):
         )
 
     @classmethod
-    def subject_summary(cls, subject_id: str) -> "NoteView | None":
-        # models imported lazily: the entry point loads this module before the loader
-        # snapshots the table metadata, so a module-top model import would register
-        # field_notes_notes early and slip past the prefix check.
-        from druks_field_notes.models import Note
-        from druks_field_notes.schemas import NoteView
-
-        note = Note.get(int(subject_id))
-        return NoteView.from_note(note) if note is not None else None
+    def subject_summary(cls, subject: Note) -> NoteView:
+        return NoteView.from_note(subject)
 
     @classmethod
-    def list_subjects(cls) -> "list[NoteView]":
-        from druks_field_notes.models import Note
-        from druks_field_notes.schemas import NoteView
-
+    def list_subjects(cls) -> list[NoteView]:
         notes = Note.list_recent(limit=cls.settings().board_size)
         return [NoteView.from_note(note) for note in notes]
 

--- a/backend/tests/druks-field_notes/druks_field_notes/models.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/models.py
@@ -1,21 +1,20 @@
 from datetime import datetime
 
-from druks.db import Base, db_session
+from druks.db import Subject, db_session
 from sqlalchemy import select
 from sqlalchemy.orm import Mapped, mapped_column
 
 
-class Note(Base):
+class Note(Subject):
     __tablename__ = "field_notes_notes"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
     # What the note is about — the raw observation an operator jotted down. A run's
     # agent reads this and writes back a one-line summary.
     body: Mapped[str]
     # The agent's summary of ``body``, written when a Summarize run finishes. None
     # until then.
     summary: Mapped[str | None]
-    created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
+    created_at: Mapped[datetime] = mapped_column(default=Subject.utc_now)
 
     @classmethod
     def create(cls, *, body: str) -> "Note":

--- a/backend/tests/druks-field_notes/druks_field_notes/routes.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/routes.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, status
-from pydantic import BaseModel
+from typing import Annotated
+
+from fastapi import APIRouter, Body, status
 
 from druks_field_notes.models import Note
 from druks_field_notes.schemas import NoteView
@@ -9,17 +10,13 @@ from druks_field_notes.workflows import Summarize
 router = APIRouter(prefix="/notes", tags=["field_notes"])
 
 
-class WriteNote(BaseModel):
-    body: str
-
-
 @router.get("", response_model=list[NoteView], response_model_by_alias=True)
 async def list_notes() -> list[NoteView]:
     return [NoteView.from_note(note) for note in Note.list_recent()]
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)
-async def write_note(request: WriteNote) -> dict[str, int]:
-    note = Note.create(body=request.body)
-    await Summarize.dispatch(note_id=note.id)
+async def write_note(body: Annotated[str, Body(embed=True)]) -> dict[str, int]:
+    note = Note.create(body=body)
+    await Summarize.dispatch(note=note)
     return {"id": note.id}

--- a/backend/tests/druks-field_notes/druks_field_notes/subscribers.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/subscribers.py
@@ -1,11 +1,12 @@
 from druks.signals import subscribe
 
 from druks_field_notes.extension import FieldNotes
+from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
 
 
-@subscribe("run.finished", kind=Summarize.kind, subject__type="note")
-async def note_summarized(*, subject: dict, **_: object) -> None:
+@subscribe("run.finished", kind=Summarize.kind, subject=Note)
+async def note_summarized(*, subject: Note, **_: object) -> None:
     # A finished summarize run is a milestone worth its own feed row — record it so
     # format_event can render it. The run lifecycle is the trigger; the extension
     # only reacts.

--- a/backend/tests/druks-field_notes/druks_field_notes/workflows.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/workflows.py
@@ -8,19 +8,15 @@ class Summarize(Workflow):
     """Reads one note and writes its summary — a single durable operation: the
     agent produces the summary prose, and the run stores it on the note."""
 
-    async def run(self, note_id: int) -> None:
-        note = Note.get(note_id)
-        assert note is not None  # dispatched against a note the route just created
+    async def run(self) -> None:
+        note = self.subject
         # The note body is the agent's prompt context; the summary it returns is the
         # extension's own domain result, saved onto the note.
         result = await FieldNotes.summarize(note_body=note.body)
         note.save_summary(result.summary)
 
     @classmethod
-    async def dispatch(cls, *, note_id: int) -> str:
+    async def dispatch(cls, *, note: Note) -> str:
         # Launch policy for a note: one run per note, keyed by its subject; the
         # signed-in requester attributes it ambiently.
-        return await cls.start(
-            subject={"type": FieldNotes.subject_type, "id": note_id},
-            note_id=note_id,
-        )
+        return await cls.start(subject=note)

--- a/backend/tests/test_api_work_items.py
+++ b/backend/tests/test_api_work_items.py
@@ -46,7 +46,7 @@ def _seed_scope_run(db_session, item, *, state="finished", status=None):
     elif status is not None:
         from druks.events.models import Event
 
-        Event.emit(type=status, subject=item.subject)
+        Event.emit(type=status, subject=item.identity)
         db_session.flush()
     return run
 
@@ -97,7 +97,7 @@ def _ship(repo, pr_number):
         item.set_status("shipped")
 
 
-# The generic subject read-side — Build declares subject_type="work_item", so the
+# The generic subject read-side — Build declares subject=WorkItem, so the
 # platform mounts /api/build/work_item (list) and /{id} (detail). Build supplies
 # only the domain summary; status (RunState-aggregated) and the timeline are the
 # platform's. See test_generic_subjects.py for the platform-side contract.
@@ -311,7 +311,7 @@ async def test_subject_activity_surfaces_running_phase(db_session, monkeypatch):
         return "provisioning_vm"
 
     monkeypatch.setattr(build_extension, "get_subject_phase", phase)
-    activity = await build_extension.Build.subject_activity(str(item.id))
+    activity = await build_extension.Build.subject_activity(item)
     assert activity is not None
     assert activity.label == "Building sandbox VM…"
     assert activity.kind == "infra"
@@ -326,4 +326,4 @@ async def test_subject_activity_none_when_not_running(db_session):
         db_session, work_item_id=item.id, state="pending_input", input_gate="review_plan"
     )
 
-    assert await build_extension.Build.subject_activity(str(item.id)) is None
+    assert await build_extension.Build.subject_activity(item) is None

--- a/backend/tests/test_build_durable.py
+++ b/backend/tests/test_build_durable.py
@@ -70,7 +70,7 @@ def rt():
             os.environ["DRUKS_DATABASE_URL"] = db_url_snap
 
 
-def _seed_work_item(engine, *, repo: str) -> int:
+def _seed_work_item(engine, *, repo: str):
     # The run.* subscribers dereference the subject row (a subscriber failure
     # now fails the lifecycle step), so the item must exist, not just its id.
     from uuid import uuid4
@@ -86,7 +86,9 @@ def _seed_work_item(engine, *, repo: str) -> int:
         item = WorkItem(project_id=project.id, repo=repo, title="rt")
         session.add(item)
         session.commit()
-        return item.id
+        session.refresh(item)
+        session.expunge(item)
+        return item
 
 
 async def _wait(engine, wfid, predicate, timeout=20.0):
@@ -201,10 +203,10 @@ async def _dict(d):
 async def test_happy_path_to_merge(rt, monkeypatch):
     _stub(monkeypatch, rt)
 
-    item_id = _seed_work_item(rt.engine, repo="acme/widget")
+    item = _seed_work_item(rt.engine, repo="acme/widget")
     wfid = await rt.flow.start(
         repo="acme/widget",
-        subject={"type": "work_item", "id": item_id},
+        subject=item,
     )
 
     parked = await _wait(
@@ -232,7 +234,7 @@ async def test_happy_path_to_merge(rt, monkeypatch):
     session = get_session(rt.engine)
     try:
         events = (
-            session.query(Event).filter(Event.subject_id == str(item_id)).order_by(Event.id).all()
+            session.query(Event).filter(Event.subject_id == str(item.id)).order_by(Event.id).all()
         )
     finally:
         session.close()
@@ -245,10 +247,10 @@ async def test_auto_mode_machine_review_replaces_the_plan_gate(rt, monkeypatch):
     once, where it substitutes for the operator."""
     invoked = _stub(monkeypatch, rt, plan_approval=None, auto_dispatch=True)
 
-    item_id = _seed_work_item(rt.engine, repo="acme/gizmo")
+    item = _seed_work_item(rt.engine, repo="acme/gizmo")
     wfid = await rt.flow.start(
         repo="acme/gizmo",
-        subject={"type": "work_item", "id": item_id},
+        subject=item,
     )
 
     parked = await _wait(

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -12,6 +12,7 @@ from druks.durable import FatalError, Run, RunState
 from druks.durable.dbos_state import workflow_status
 from druks.durable.engine import configure_engine, init_dbos, launch, shutdown
 from druks.extensions.registry import agents, workflows
+from druks.models import Subject
 from druks.workflows import Gate, Workflow, step
 from pydantic import BaseModel
 from sqlalchemy import create_engine, select
@@ -48,6 +49,10 @@ class RepoCfg(BaseModel):
 
 
 SINK: list[str] = []
+
+
+class Widget(Subject):
+    __tablename__ = "test_widgets"
 
 
 # run_multistep() below for fixtures using @step/a gate; run() for the rest.
@@ -116,7 +121,7 @@ def _build_units():
         # Records the subject the platform threaded in, and returns a BaseModel
         # so the result rides its run.finished event.
         async def run(self) -> Decision:
-            SINK.append(f"subj-id:{self.subject['id']}")  # type: ignore[index]
+            SINK.append(f"subj-id:{self.subject.id}")
             return Decision(action="ok")
 
     class DoubleGateFlow(Workflow):
@@ -187,6 +192,10 @@ def rt():
         account = Account(username="op@example.com")
         session.add(account)
         session.flush()
+        session.add_all(
+            Widget(id=subject_id)
+            for subject_id in (7, 4242, 636363, 424242, 515151, 878787, 909090)
+        )
         session.add(
             HarnessConnection(
                 harness="claude",
@@ -289,9 +298,7 @@ async def test_attribution_rides_the_run_and_survives_resume(rt):
 
     SINK.clear()
     account_id = _account_id(rt.engine, "op@example.com")
-    wfid = await rt.AttributedFlow.start(
-        subject={"type": "widget", "id": 878787}, account_id=account_id
-    )
+    wfid = await rt.AttributedFlow.start(subject=Widget(id=878787), account_id=account_id)
     parked = await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.PENDING_INPUT)
     with rt.engine.connect() as conn:
         attributes = conn.execute(
@@ -326,7 +333,7 @@ async def test_duplicate_start_shares_the_run_across_accounts(rt):
     # subject share the one active run.
     first = _account_id(rt.engine, "op@example.com")
     second = _account_id(rt.engine, "peer@example.com")
-    subject = {"type": "widget", "id": 909090}
+    subject = Widget(id=909090)
     wfid = await rt.SampleFlow.start(subject=subject, account_id=first, repo="owner/app")
     parked = await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.PENDING_INPUT)
 
@@ -429,7 +436,7 @@ async def test_subjectless_gate_fails_loudly(rt):
 async def test_subject_gate_parks_unchanged(rt):
     """The same no-on_wait gate still parks and resumes for a subject run — the
     subject's watchers are the ones who'd see it, feed-side."""
-    wfid = await rt.ConfirmFlow.start(subject={"type": "widget", "id": 636363})
+    wfid = await rt.ConfirmFlow.start(subject=Widget(id=636363))
     parked = await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.PENDING_INPUT)
     assert parked.input_gate == "confirm"
     # start() stamped the subject as workflow attributes — the keying every
@@ -691,22 +698,19 @@ async def test_user_settings_get_recreates_the_singleton(rt):
         assert UserSettings.get().id == UserSettings.SINGLETON_ID
 
 
-async def test_subject_shape_validation(rt):
-    # start() validates the {type, id} subject shape before enqueuing, so a
-    # malformed subject is rejected up front rather than inside the run.
-    from pydantic import ValidationError
+async def test_a_run_hydrates_the_subject_row_it_was_started_for(rt):
+    from druks.database import db_session, session_scope
 
-    for bad in (
-        {"type": "x"},  # missing id
-        {"id": 1},  # missing type
-        {},
-        {"type": "x", "id": 1, "extra": 1},  # extra key
-        {"type": "", "id": 1},  # empty type
-        {"type": "x", "id": None},  # id wrong type
-        ["type", "id"],  # not a dict
-    ):
-        with pytest.raises(ValidationError):
-            await rt.SubjectFlow.start(subject=bad)
+    with session_scope(rt.engine):
+        widget = Widget()
+        db_session().add(widget)
+        db_session().flush()
+        assert widget.identity == {"type": "widget", "id": widget.id}
+
+        run = Workflow()
+        run._subject = widget.identity
+
+        assert run.subject is widget
 
 
 async def test_input_is_validated_at_start(rt):
@@ -782,7 +786,7 @@ async def test_step_on_run_or_run_multistep_is_rejected(rt):
 async def test_subject_reaches_body_and_result_rides_finished_event(rt):
     from druks.events.models import Event
 
-    wfid = await rt.SubjectFlow.start(subject={"type": "widget", "id": 7})
+    wfid = await rt.SubjectFlow.start(subject=Widget(id=7))
     await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.FINISHED)
 
     assert "subj-id:7" in SINK  # the platform threaded subject into self.subject
@@ -816,9 +820,7 @@ async def test_run_events_carry_subject(rt):
     # run-state transition emits a run-level event keyed to it.
     from druks.events.models import Event
 
-    wfid = await rt.RecordFeedback.start(
-        subject={"type": "widget", "id": 4242}, repo="owner/evented"
-    )
+    wfid = await rt.RecordFeedback.start(subject=Widget(id=4242), repo="owner/evented")
     await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.FINISHED)
 
     session = get_session(rt.engine)
@@ -837,7 +839,7 @@ async def test_duplicate_start_returns_the_live_run(rt):
     # held while the run is enqueued, running, or parked — a duplicate start()
     # hands back the live run's id. The slot frees at the terminal outcome, so
     # the subject can run again.
-    subject = {"type": "widget", "id": 515151}
+    subject = Widget(id=515151)
     wfid = await rt.SampleFlow.start(subject=subject, repo="owner/app")
     parked = await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.PENDING_INPUT)
 
@@ -859,7 +861,7 @@ async def test_duplicate_start_returns_the_live_run(rt):
 async def test_failed_enqueue_claims_no_slot(rt, monkeypatch):
     # A failure at enqueue claims nothing — the next start() proceeds instead of
     # being handed a phantom "live" run DBOS never received.
-    subject = {"type": "widget", "id": 424242}
+    subject = Widget(id=424242)
 
     async def _boom(*args, **kwargs):
         raise RuntimeError("queue down")

--- a/backend/tests/test_events_feed.py
+++ b/backend/tests/test_events_feed.py
@@ -8,11 +8,11 @@ def test_feed_reads_run_and_milestone_events(db_session):
     item = make_test_work_item(repo="acme/extension", remote_key="ACME-9", title="t")
     Event.emit(
         type="run.running",
-        subject=item.subject,
+        subject=item.identity,
         extension="build",
         payload={"kind": "build.build_workflow", "run": "wf1"},
     )
-    Event.emit(type="shipped", subject=item.subject, extension="build")
+    Event.emit(type="shipped", subject=item.identity, extension="build")
     db_session.flush()
 
     page, _ = build_feed()

--- a/backend/tests/test_extension_appless_load.py
+++ b/backend/tests/test_extension_appless_load.py
@@ -26,16 +26,18 @@ _FILES = {
         from druks.extensions import Extension
         from pydantic import BaseModel, Field
 
+        from .models import ProbeItem
+
 
         class Probe(Extension):
             name = "probe"
-            subject_type = "widget"
+            subject = ProbeItem
 
             class Settings(BaseModel):
                 budget: int = Field(default=3, ge=1)
 
             @classmethod
-            def subject_summary(cls, subject_id):
+            def subject_summary(cls, subject):
                 return None
 
             @classmethod
@@ -43,14 +45,11 @@ _FILES = {
                 return []
     """,
     "models.py": """
-        from druks.db import Base
-        from sqlalchemy.orm import Mapped, mapped_column
+        from druks.db import Subject
 
 
-        class ProbeItem(Base):
+        class ProbeItem(Subject):
             __tablename__ = "probe_items"
-
-            id: Mapped[str] = mapped_column(primary_key=True)
     """,
     "routes.py": """
         from fastapi import APIRouter
@@ -65,9 +64,11 @@ _FILES = {
     "subscribers.py": """
         from druks.signals import subscribe
 
+        from .models import ProbeItem
 
-        @subscribe("run.finished", subject__type="widget")
-        async def on_widget_done(**_: object) -> None:
+
+        @subscribe("run.finished", subject__type="probe_item")
+        async def on_probe_item_done(*, subject: ProbeItem, **_: object) -> None:
             ...
     """,
     "workflows.py": """

--- a/backend/tests/test_gate_receipt.py
+++ b/backend/tests/test_gate_receipt.py
@@ -10,12 +10,12 @@ _ASK = {"presentation": "in_app", "controls": ["approve"], "questions": []}
 
 
 class _ParkedWorkflow:
-    # The slice of Workflow that _park touches. subject=None keeps the emit to
+    # The slice of Workflow that _park touches. A subjectless run keeps the emit to
     # its facts write (no feed event, no notification) — the receipt path under
     # test is exactly that write.
     def __init__(self, workflow_id: str) -> None:
         self.workflow_id = workflow_id
-        self.subject = None
+        self._subject = None
 
     async def _reap_run(self) -> None:
         return

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -5,9 +5,14 @@ from conftest import seed_dbos_status
 from druks.durable import AgentCall, Run
 from druks.durable.schemas import SubjectSummary
 from druks.extensions.base import Extension
+from druks.models import Subject
 from fastapi import APIRouter
 from fastapi.testclient import TestClient
 from uuid_utils import uuid7
+
+
+class Thing(Subject):
+    __tablename__ = "faketest_things"
 
 
 class _ThingSummary(SubjectSummary):
@@ -16,18 +21,20 @@ class _ThingSummary(SubjectSummary):
 
 class _ThingExtension(Extension):
     name = "faketest"
-    subject_type = "thing"
+    subject = Thing
 
-    _THINGS = {"1": "First", "2": "Second"}
+    _THINGS = {1: "First", 2: "Second"}
 
     @classmethod
-    def subject_summary(cls, subject_id: str) -> _ThingSummary | None:
-        title = cls._THINGS.get(subject_id)
-        return _ThingSummary(id=subject_id, title=title) if title is not None else None
+    def subject_summary(cls, subject: Thing) -> _ThingSummary:
+        return _ThingSummary(id=str(subject.id), title=cls._THINGS[subject.id])
 
     @classmethod
     def list_subjects(cls) -> list[_ThingSummary]:
-        return [_ThingSummary(id=sid, title=title) for sid, title in cls._THINGS.items()]
+        return [
+            _ThingSummary(id=str(subject_id), title=title)
+            for subject_id, title in cls._THINGS.items()
+        ]
 
 
 def _seed_run(
@@ -70,6 +77,9 @@ def client(tmp_path: Path, db_session, monkeypatch):
     from conftest import configure_app_for_test, make_settings
 
     monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
+    for subject_id in _ThingExtension._THINGS:
+        db_session.merge(Thing(id=subject_id))
+    db_session.flush()
     app = configure_app_for_test(settings=make_settings(tmp_path))
 
     holder = APIRouter()

--- a/backend/tests/test_lane_reactions.py
+++ b/backend/tests/test_lane_reactions.py
@@ -22,7 +22,7 @@ async def test_run_running_puts_item_back_on_board(db_session):
     item = make_test_work_item(repo="acme/widget", title="t", source="linear", remote_key="ACME-1")
     item.set_status(HandoffStatus.SCOPED)
 
-    await publish("run.running", subject=item.subject, kind="build.scope")
+    await publish("run.running", subject=item.identity, kind="build.scope")
 
     assert WorkItem.get(item.id).status is None
 
@@ -32,7 +32,7 @@ async def test_scope_finish_settles_the_lane(db_session):
 
     await publish(
         "run.finished",
-        subject=item.subject,
+        subject=item.identity,
         kind=Scope.kind,
         result={"status": "ready"},
     )
@@ -45,7 +45,7 @@ async def test_parked_statuses_leave_the_item_active(db_session):
 
     await publish(
         "run.finished",
-        subject=item.subject,
+        subject=item.identity,
         kind=Scope.kind,
         result={"status": "needs_answers"},
     )
@@ -59,7 +59,7 @@ async def test_other_kinds_are_ignored(db_session):
 
     await publish(
         "run.finished",
-        subject=item.subject,
+        subject=item.identity,
         kind="build.build_workflow",
         result={"status": "ready"},
     )
@@ -75,7 +75,7 @@ async def test_build_lifecycle_reaches_the_tracker(db_session, monkeypatch):
 
     monkeypatch.setattr(WorkItem, "set_remote_status", _push)
     item = make_test_work_item(repo="acme/widget", title="t", source="linear", remote_key="ACME-7")
-    subject = item.subject
+    subject = item.identity
 
     await publish("run.running", subject=subject, kind=BuildWorkflow.kind)
     await publish("run.pending_input", subject=subject, kind=BuildWorkflow.kind, gate="review_work")
@@ -101,7 +101,7 @@ async def test_pr_review_answers_through_the_review_gate(db_session, monkeypatch
         db_session,
         run.id,
         "pending_input",
-        subject=item.subject,
+        subject=item.identity,
     )
     item.update(build_run_id=run.id)
     answers = []
@@ -125,7 +125,7 @@ async def test_pr_review_answers_through_the_review_gate(db_session, monkeypatch
 
     assert answers == [
         (
-            item.subject,
+            item,
             {
                 "action": "request_changes",
                 "reviewer": "alice",
@@ -227,7 +227,7 @@ async def test_provision_state_reaches_the_work_item(db_session):
 
     await publish(
         "run.state",
-        subject=item.subject,
+        subject=item.identity,
         kind=BuildWorkflow.kind,
         pr_number=12,
         branch="agent/eng-8",

--- a/backend/tests/test_notifications_durable.py
+++ b/backend/tests/test_notifications_durable.py
@@ -10,6 +10,7 @@ from druks.database import configure_session, db_session, get_session
 from druks.durable.engine import configure_engine, init_dbos, launch, shutdown
 from druks.durable.enums import RunState
 from druks.extensions.registry import workflows
+from druks.models import Subject
 from druks.notifications import outbox
 from druks.notifications.exceptions import DeliveryError, NotificationError
 from druks.notifications.models import Destination, Notification
@@ -45,6 +46,10 @@ class _Question(BaseModel):
     id: str
     prompt: str
     options: list[dict] = Field(default_factory=list)
+
+
+class NotificationProbe(Subject):
+    __tablename__ = "test_notification_probes"
 
 
 # What the in-app reviews resumed with — the respond round-trip asserts the
@@ -112,6 +117,15 @@ def rt():
     init_db(engine)
     configure_engine(engine)
     configure_session(engine)
+    session = get_session(engine)
+    try:
+        session.add_all(
+            NotificationProbe(id=subject_id)
+            for subject_id in (9001, 9002, 9003, 9004, 9005, 9006, 9007, 9008, 9009, 9010, 9014)
+        )
+        session.commit()
+    finally:
+        session.close()
     in_app_flow, external_flow, external_url_flow, double_park_flow = _build_park_flows()
     os.environ["DRUKS_DATABASE_URL"] = URL
     # The outbox module was imported above — its queue + workflow register
@@ -400,7 +414,7 @@ async def test_in_app_park_notifies_with_actions(rt, deliver_spy):
     )
     _set_gate_park_pointer(rt, destination.id)
 
-    workflow_id = await rt.InAppFlow.start(subject={"type": "notification_probe", "id": 9001})
+    workflow_id = await rt.InAppFlow.start(subject=NotificationProbe(id=9001))
     parked = await _wait_run(rt, workflow_id, lambda run: run.state == RunState.PENDING_INPUT)
 
     notification = await _wait_notification(rt, workflow_id, "delivered")
@@ -429,7 +443,7 @@ async def test_external_park_notifies_without_actions(rt, deliver_spy):
     )
     _set_gate_park_pointer(rt, destination.id)
 
-    workflow_id = await rt.ExternalFlow.start(subject={"type": "notification_probe", "id": 9002})
+    workflow_id = await rt.ExternalFlow.start(subject=NotificationProbe(id=9002))
     await _wait_run(rt, workflow_id, lambda run: run.state == RunState.PENDING_INPUT)
 
     notification = await _wait_notification(rt, workflow_id, "delivered")
@@ -446,7 +460,7 @@ async def test_external_park_with_declared_url_sets_deep_link(rt, deliver_spy):
     )
     _set_gate_park_pointer(rt, destination.id)
 
-    workflow_id = await rt.ExternalUrlFlow.start(subject={"type": "notification_probe", "id": 9003})
+    workflow_id = await rt.ExternalUrlFlow.start(subject=NotificationProbe(id=9003))
     await _wait_run(rt, workflow_id, lambda run: run.state == RunState.PENDING_INPUT)
 
     notification = await _wait_notification(rt, workflow_id, "delivered")
@@ -457,8 +471,8 @@ async def test_external_park_with_declared_url_sets_deep_link(rt, deliver_spy):
 async def test_no_designated_destination_notifies_nothing(rt, deliver_spy):
     _set_gate_park_pointer(rt, None)
 
-    in_app_id = await rt.InAppFlow.start(subject={"type": "notification_probe", "id": 9004})
-    external_id = await rt.ExternalFlow.start(subject={"type": "notification_probe", "id": 9014})
+    in_app_id = await rt.InAppFlow.start(subject=NotificationProbe(id=9004))
+    external_id = await rt.ExternalFlow.start(subject=NotificationProbe(id=9014))
     await _wait_run(rt, in_app_id, lambda run: run.state == RunState.PENDING_INPUT)
     await _wait_run(rt, external_id, lambda run: run.state == RunState.PENDING_INPUT)
 
@@ -476,7 +490,7 @@ async def test_deleted_designated_destination_notifies_nothing(rt, deliver_spy):
     _set_gate_park_pointer(rt, destination.id)
     _seed(rt, lambda: Destination.get(destination.id).delete())
 
-    workflow_id = await rt.ExternalFlow.start(subject={"type": "notification_probe", "id": 9005})
+    workflow_id = await rt.ExternalFlow.start(subject=NotificationProbe(id=9005))
     await _wait_run(rt, workflow_id, lambda run: run.state == RunState.PENDING_INPUT)
 
     await asyncio.sleep(1.0)
@@ -512,7 +526,7 @@ async def test_failed_delivery_leaves_run_parked_and_resumable(rt, deliver_spy, 
     )
     _set_gate_park_pointer(rt, destination.id)
 
-    workflow_id = await rt.InAppFlow.start(subject={"type": "notification_probe", "id": 9006})
+    workflow_id = await rt.InAppFlow.start(subject=NotificationProbe(id=9006))
     await _wait_run(rt, workflow_id, lambda run: run.state == RunState.PENDING_INPUT)
     notification = await _wait_notification(rt, workflow_id, "failed")
     assert _WEBHOOK_URL not in notification.last_error
@@ -530,7 +544,7 @@ async def test_replayed_park_notifies_once(rt, deliver_spy):
     )
     _set_gate_park_pointer(rt, destination.id)
 
-    workflow_id = await rt.ExternalFlow.start(subject={"type": "notification_probe", "id": 9007})
+    workflow_id = await rt.ExternalFlow.start(subject=NotificationProbe(id=9007))
     await _wait_run(rt, workflow_id, lambda run: run.state == RunState.PENDING_INPUT)
     await _wait_notification(rt, workflow_id, "delivered")
     assert len(deliver_spy.calls) == 1
@@ -582,7 +596,7 @@ async def test_each_park_round_gets_its_own_notification(rt, deliver_spy):
     )
     _set_gate_park_pointer(rt, destination.id)
 
-    workflow_id = await rt.DoubleParkFlow.start(subject={"type": "notification_probe", "id": 9008})
+    workflow_id = await rt.DoubleParkFlow.start(subject=NotificationProbe(id=9008))
     first_round = await _wait_run(rt, workflow_id, lambda run: run.state == RunState.PENDING_INPUT)
     await _wait_notification(rt, workflow_id, "delivered")
     assert len(deliver_spy.calls) == 1
@@ -651,7 +665,7 @@ async def test_respond_round_trip_finishes_the_run(rt, deliver_spy):
         rt, lambda: Destination.create(name="inbox-respond", kind="slack_webhook", url=_WEBHOOK_URL)
     )
     _set_gate_park_pointer(rt, destination.id)
-    workflow_id = await rt.InAppFlow.start(subject={"type": "notification_probe", "id": 9009})
+    workflow_id = await rt.InAppFlow.start(subject=NotificationProbe(id=9009))
     await _wait_run(rt, workflow_id, lambda run: run.state == RunState.PENDING_INPUT)
     notification = await _wait_notification(rt, workflow_id, "delivered")
     token = notification.correlation_token
@@ -677,7 +691,7 @@ async def test_concurrent_responds_resolve_to_one_answer(rt, deliver_spy):
         rt, lambda: Destination.create(name="inbox-race", kind="slack_webhook", url=_WEBHOOK_URL)
     )
     _set_gate_park_pointer(rt, destination.id)
-    workflow_id = await rt.InAppFlow.start(subject={"type": "notification_probe", "id": 9010})
+    workflow_id = await rt.InAppFlow.start(subject=NotificationProbe(id=9010))
     await _wait_run(rt, workflow_id, lambda run: run.state == RunState.PENDING_INPUT)
     notification = await _wait_notification(rt, workflow_id, "delivered")
     token = notification.correlation_token

--- a/backend/tests/test_profiling.py
+++ b/backend/tests/test_profiling.py
@@ -92,13 +92,7 @@ async def test_dispatch_shapes_the_profile_start(db_session, monkeypatch, refres
     run_id = await Profile.dispatch(repo, refresh_only=refresh_only)
 
     assert run_id == "profile-run"
-    assert calls == [
-        {
-            "subject": {"type": "project_repo", "id": repo.id},
-            "repo_id": repo.id,
-            "refresh_only": refresh_only,
-        }
-    ]
+    assert calls == [{"subject": repo, "repo_id": repo.id, "refresh_only": refresh_only}]
 
 
 class TestProfileRun:

--- a/backend/tests/test_proof_extension.py
+++ b/backend/tests/test_proof_extension.py
@@ -89,7 +89,7 @@ def test_boot_loads_the_external_extension(installed):
 
     assert extension.name == "field_notes"
     assert extension.package == _PACKAGE
-    assert extension.subject_type == "note"
+    assert extension.subject.subject_type == "note"
 
 
 def test_discovery_registers_the_tables_and_capabilities(installed):
@@ -114,7 +114,7 @@ def test_routes_read_off_the_loaded_extension(installed):
     prefixes = {router.prefix for router in extension.routers()}
     assert "/notes" in prefixes  # the extension's declared router
     assert "/transcripts/{call_id}" in prefixes  # the free agent-call read-side
-    assert "/note" in prefixes  # the subject read-side it gets for declaring subject_type
+    assert "/note" in prefixes  # the subject read-side it gets for declaring subject=Note
 
 
 def test_settings_resolve_off_the_loaded_extension(installed):
@@ -302,6 +302,7 @@ async def test_dispatch_starts_a_run_keyed_to_the_note(installed, monkeypatch):
     the note id, and the note id also rides the run as its typed input. The
     workflow's identity comes from its declaring extension, never the caller."""
     load_extension("field_notes")
+    from druks_field_notes.models import Note
     from druks_field_notes.workflows import Summarize
 
     assert Summarize.extension == "field_notes"
@@ -315,11 +316,12 @@ async def test_dispatch_starts_a_run_keyed_to_the_note(installed, monkeypatch):
 
     monkeypatch.setattr(Summarize, "start", _capture)
 
-    run_id = await Summarize.dispatch(note_id=42)
+    note = Note(id=42)
+    run_id = await Summarize.dispatch(note=note)
 
     assert run_id == "run-1"
-    assert started["subject"] == {"type": "note", "id": 42}
-    assert started["input"] == {"note_id": 42}
+    assert started["subject"] is note
+    assert started["input"] == {}
 
 
 async def test_run_summarizes_the_note_and_saves_it(installed, db_session, monkeypatch):
@@ -342,7 +344,9 @@ async def test_run_summarizes_the_note_and_saves_it(installed, db_session, monke
 
     monkeypatch.setattr(FieldNotes, "summarize", staticmethod(_summarize))
 
-    await Summarize.run.__wrapped__(Summarize(), note_id=note.id)
+    workflow = Summarize()
+    workflow._subject = note.identity
+    await Summarize.run.__wrapped__(workflow)
 
     saved = Note.get(note.id)
     assert saved is not None

--- a/backend/tests/test_proof_extension_install.py
+++ b/backend/tests/test_proof_extension_install.py
@@ -31,7 +31,7 @@ _CHECK = textwrap.dedent(
     assert "field_notes" in names, names
 
     extension = load_extension("field_notes")
-    assert extension.subject_type == "note"
+    assert extension.subject.subject_type == "note"
     assert extension.settings_model is not None
     assert list(extension.settings_model.model_fields) == ["board_size", "visibility", "sync_token"]
     assert [workflow.__name__ for workflow in extension.workflows()] == ["Summarize"]

--- a/backend/tests/test_scope_durable.py
+++ b/backend/tests/test_scope_durable.py
@@ -103,13 +103,13 @@ async def test_scope_parks_then_resumes_to_ready(rt, monkeypatch):
 
     project = Project.create(name="acme/widget")
     ProjectRepo.create(project_id=project.id, full_name="acme/widget")
-    item_id = WorkItem.create(
+    item = WorkItem.create(
         project_id=project.id,
         source="linear",
         title="Add SSE",
         remote_key="ACME-1",
         repo="acme/widget",
-    ).id
+    )
     db_session().commit()
 
     # Round 1 asks a question (parks); round 2 is ready (finishes). The agent
@@ -122,7 +122,7 @@ async def test_scope_parks_then_resumes_to_ready(rt, monkeypatch):
     monkeypatch.setattr("druks.agents.Agent._run", _run_agent)
 
     wfid = await rt.flow.start(
-        subject={"type": "work_item", "id": item_id},
+        subject=item,
         source="linear",
         remote_key="ACME-1",
     )
@@ -147,10 +147,10 @@ async def test_scope_parks_then_resumes_to_ready(rt, monkeypatch):
     try:
         finished = (
             session.query(Event)
-            .filter(Event.type == "run.finished", Event.subject_id == str(item_id))
+            .filter(Event.type == "run.finished", Event.subject_id == str(item.id))
             .one()
         )
-        item_status = session.get(WorkItem, item_id).status
+        item_status = session.get(WorkItem, item.id).status
     finally:
         session.close()
     # The finished event carries the result; the lane subscriber reacted to it.

--- a/backend/tests/test_scope_reply_rescope.py
+++ b/backend/tests/test_scope_reply_rescope.py
@@ -50,7 +50,7 @@ async def test_answers_parked_scope_by_subject(db_session, monkeypatch):
 
     monkeypatch.setattr(Run, "resume", answer)
 
-    await ScopeReply.answer(item.subject)
+    await ScopeReply.answer(item)
 
     assert answered == [(run.id, {})]
 
@@ -60,7 +60,7 @@ async def test_rejects_other_work_items(db_session):
     item = make_test_work_item(repo="acme/widget", title="t", source="linear", remote_key="ACME-1")
     _scope_run(db_session, work_item_id=item.id)
     with pytest.raises(WorkflowError, match="is not parked"):
-        await ScopeReply.answer({"type": "work_item", "id": item.id + 1})
+        await ScopeReply.answer(WorkItem(id=item.id + 1))
 
 
 @pytest.mark.asyncio
@@ -68,7 +68,7 @@ async def test_rejects_a_resolved_scope(db_session):
     item = make_test_work_item(repo="acme/widget", title="t", source="linear", remote_key="ACME-1")
     _scope_run(db_session, work_item_id=item.id, parked=False)
     with pytest.raises(WorkflowError, match="is not parked"):
-        await ScopeReply.answer(item.subject)
+        await ScopeReply.answer(item)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_signals.py
+++ b/backend/tests/test_signals.py
@@ -1,5 +1,13 @@
 import pytest
+from conftest import make_test_work_item
+from druks.build.models import ProjectRepo, WorkItem
 from druks.signals import publish, subscribe
+from druks.workflows import Workflow
+from sqlalchemy.orm import object_session
+
+
+def _work_item(**fields):
+    return make_test_work_item(repo="ClawHaven/acme-app", title="probe", **fields)
 
 
 @pytest.mark.asyncio
@@ -13,3 +21,58 @@ async def test_subscriber_failure_propagates_to_the_publisher():
 
     with pytest.raises(RuntimeError, match="boom"):
         await publish("test.subscriber_failure")
+
+
+@pytest.mark.asyncio
+async def test_subject_subscriber_receives_the_row(db_session):
+    item = _work_item(remote_key="ENG-748-SIGNAL")
+    received = []
+
+    @subscribe("test.subject_row", subject=WorkItem)
+    async def receive(*, subject: WorkItem) -> None:
+        received.append(subject)
+
+    await publish("test.subject_row", subject=item.identity)
+
+    assert received == [item]
+
+
+@pytest.mark.asyncio
+async def test_deleted_subject_skips_the_subscriber(db_session):
+    item = _work_item(remote_key="ENG-748-DELETED")
+    identity = item.identity
+    received = []
+
+    @subscribe("test.deleted_subject", subject=WorkItem)
+    async def receive(*, subject: WorkItem) -> None:
+        received.append(subject)
+
+    object_session(item).delete(item)
+    object_session(item).flush()
+    await publish("test.deleted_subject", subject=identity)
+
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_another_subjects_event_skips_the_subscriber(db_session):
+    item = _work_item()
+    repo = ProjectRepo.create(project_id=item.project_id, full_name="acme/other")
+    received = []
+
+    @subscribe("test.other_subject", subject=WorkItem)
+    async def receive(*, subject: WorkItem) -> None:
+        received.append(subject)
+
+    await publish("test.other_subject", subject=repo.identity)
+    await publish("test.other_subject", subject=None)
+
+    assert received == []
+
+
+def test_workflow_subject_requires_a_registered_class():
+    workflow = Workflow()
+    workflow._subject = {"type": "missing", "id": 1}
+
+    with pytest.raises(LookupError, match="no subject class is named"):
+        _ = workflow.subject

--- a/backend/tests/test_subject_lifecycle.py
+++ b/backend/tests/test_subject_lifecycle.py
@@ -1,8 +1,9 @@
 from datetime import timedelta
 
 import pytest
-from conftest import seed_dbos_status
+from conftest import make_test_work_item, seed_dbos_status
 from druks.build.contracts import ReviewWork
+from druks.build.models import WorkItem
 from druks.build.workflows import BuildWorkflow, Scope, ScopeReply
 from druks.durable.models import Run
 from druks.durable.reads import get_subject_phase
@@ -13,10 +14,14 @@ from uuid_utils import uuid7
 pytestmark = pytest.mark.asyncio
 
 
+def _work_item(**fields):
+    return make_test_work_item(repo="ClawHaven/acme-app", title="probe", **fields)
+
+
 def _subject_run(
     db_session,
     *,
-    subject: dict,
+    subject: WorkItem,
     kind: str,
     state: str,
     order: int = 0,
@@ -30,7 +35,7 @@ def _subject_run(
     )
     db_session.add(run)
     db_session.flush()
-    seed_dbos_status(db_session, run.id, state, subject=subject)
+    seed_dbos_status(db_session, run.id, state, subject=subject.identity)
     return run
 
 
@@ -38,7 +43,7 @@ async def test_gate_answer_resumes_only_a_run_parked_on_its_gate(db_session, mon
     # A subject can carry runs of several workflows at once; the gate names which one
     # answers, so a newer run of another kind never hides the parked one. A timed-out
     # run keeps its stale ``input_gate``, so parked-ness decides, not that column.
-    subject = {"type": "work_item", "id": 1}
+    subject = _work_item(remote_key="ENG-748-A")
     parked = _subject_run(
         db_session, subject=subject, kind=Scope.kind, state="pending_input", gate=ScopeReply.name
     )
@@ -53,7 +58,7 @@ async def test_gate_answer_resumes_only_a_run_parked_on_its_gate(db_session, mon
     await ScopeReply.answer(subject)
     assert resumed == [parked.id]
 
-    timed_out = {"type": "work_item", "id": 2}
+    timed_out = _work_item(remote_key="ENG-748-B")
     _subject_run(
         db_session,
         subject=timed_out,
@@ -71,7 +76,7 @@ async def test_workflow_cancel_takes_its_own_kind_and_passes_over_idle_subjects(
 ):
     # Webhooks redeliver, and a PR can close long after its build ended: cancelling what
     # is already gone is the no-op the caller expects, not an error.
-    subject = {"type": "work_item", "id": 3}
+    subject = _work_item(remote_key="ENG-748-C")
     build = _subject_run(db_session, subject=subject, kind=BuildWorkflow.kind, state="running")
     _subject_run(db_session, subject=subject, kind=Scope.kind, state="running", order=1)
     cancelled = []
@@ -84,14 +89,14 @@ async def test_workflow_cancel_takes_its_own_kind_and_passes_over_idle_subjects(
     await BuildWorkflow.cancel(subject)
     assert cancelled == [build.id]
 
-    idle = {"type": "work_item", "id": 4}
+    idle = _work_item(remote_key="ENG-748-D")
     _subject_run(db_session, subject=idle, kind=BuildWorkflow.kind, state="finished")
     await BuildWorkflow.cancel(idle)
     assert cancelled == [build.id]
 
 
 async def test_subject_phase_reads_the_driving_running_workflow(db_session, monkeypatch):
-    subject = {"type": "work_item", "id": 5}
+    subject = _work_item(remote_key="ENG-748-E")
     _subject_run(
         db_session, subject=subject, kind=Scope.kind, state="pending_input", gate=ScopeReply.name
     )
@@ -106,5 +111,5 @@ async def test_subject_phase_reads_the_driving_running_workflow(db_session, monk
 
     monkeypatch.setattr("druks.durable.reads.get_run_phase", phase)
 
-    assert await get_subject_phase(subject["type"], str(subject["id"])) == "agent_running"
+    assert await get_subject_phase(subject.subject_type, str(subject.id)) == "agent_running"
     assert seen == [driving.id]

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -158,10 +158,12 @@ than only on the VM.
 
 ## Events, signals, webhooks, and subjects
 
-A subject is the opaque `{"type": ..., "id": ...}` identity a run is about.
-Subjected lifecycle events enter an append-only event log. Extensions can add
-domain events, format feed rows, and provide subject summaries; Druks supplies
-pagination, activity composition, and a live SSE feed.
+A subject is the row a run is about. The extension owns it and hands it to druks
+whenever it starts a run or answers a gate; only the row's type and id travel
+further, because a run outlives the row it points at. Everything that happens to
+a run lands in an append-only event log. Extensions add their own events, format
+feed rows, and supply subject summaries; druks supplies pagination, activity
+composition, and a live feed.
 
 Signals connect producers to extension reactions. They are awaited and
 delivered at least once: webhook failures return an error so the provider can

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -125,7 +125,7 @@ Start a workflow with an explicit subject:
 
 ```python
 run_id = await Sweep.start(
-    subject={"type": "repository", "id": repo_id},
+    subject=repository,
     repo=full_name,
 )
 ```
@@ -307,7 +307,7 @@ workflow through the gate and its subject:
 
 ```python
 await ApproveReport.answer(
-    {"type": "repository", "id": repo_id},
+    repository,
     action="approve",
     note="Ship it.",
 )
@@ -334,7 +334,7 @@ the run and are re-raised to DBOS.
 Stop this workflow's active execution for a subject through the workflow class:
 
 ```python
-await Sweep.cancel({"type": "repository", "id": repo_id})
+await Sweep.cancel(repository)
 ```
 
 The workflow class supplies its kind; the caller never locates or handles the
@@ -343,10 +343,17 @@ running is a no-op, so a redelivered webhook stays idempotent.
 
 ## Give runs a subject read-side
 
-Set one subject type and return extension-owned summaries:
+A subject is the row your runs are about — a repository, a work item, a
+document. Subclass `Subject` instead of `Base`, and the class name is the
+subject type: `Repository` becomes `repository`.
 
 ```python
+from druks.db import Subject
 from druks.workflows import SubjectSummary
+
+
+class Repository(Subject):
+    __tablename__ = "repositories"
 
 
 class RepositorySummary(SubjectSummary):
@@ -355,10 +362,10 @@ class RepositorySummary(SubjectSummary):
 
 
 class NightWatch(Extension):
-    subject_type = "repository"
+    subject = Repository
 
     @classmethod
-    def subject_summary(cls, subject_id: str) -> RepositorySummary | None:
+    def subject_summary(cls, subject: Repository) -> RepositorySummary:
         ...
 
     @classmethod
@@ -366,46 +373,38 @@ class NightWatch(Extension):
         ...
 ```
 
-Druks mounts a board and per-subject point-in-time and SSE routes under
-`/api/night_watch/repository`. It composes each summary with generic run status,
-timeline, agent calls, artifacts, and the current gate. Override
-`subject_activity()` only for a transient application-specific phase.
+Druks then serves that subject under `/api/night_watch/repository`: a board of
+every row, a page for one row, and a live stream of either. Each response pairs
+your summary with the run's status, timeline, agent calls, artifacts, and the
+question it is waiting on. Override `subject_activity()` only to add a passing
+detail of your own, like "Building sandbox VM…".
 
-The row those runs are about subclasses `Subject` instead of `Base`. Its class
-name is the subject type, so the row spells its identity once and hands
-`subject` to any workflow or gate:
-
-```python
-from druks.db import Subject
-
-
-class Repository(Subject):
-    __tablename__ = "repositories"
-
-
-await NightWatch.dispatch(subject=repository.subject)
-```
-
-Two lifecycles meet on that row, and they keep separate words. The subject's own
-landing is the extension's — a work item ships, is scoped, is cancelled. Whether
-work is happening is the platform's, read off `get_subject_status(...)`:
-`status.is_parked` while a run waits on a human. Neither borrows the other's
-vocabulary.
-
-Use subject-keyed reads when extension policy reacts to lifecycle state or
-exposes a transient activity:
+Hand the row itself to anything that asks for a subject — starting a run,
+answering a gate, recording an event:
 
 ```python
-from druks.workflows import RunState, get_subject_phase, get_subject_status
-
-subject = {"type": "repository", "id": repo_id}
-status = get_subject_status(subject["type"], str(subject["id"]))
-if status.state == RunState.RUNNING:
-    phase = await get_subject_phase(subject["type"], str(subject["id"]))
+await NightWatch.dispatch(subject=repository)
 ```
 
-`status.kind` identifies the workflow currently driving the subject and
-`status.gate` identifies its parked ask.
+Inside the workflow, `self.subject` is that row — live, not a snapshot taken at
+dispatch. A run that parks on a gate for three days resumes against whatever the
+row says then, and finds nothing if it was deleted meanwhile.
+
+You name what happened to the row: a work item ships, gets scoped, gets
+cancelled. Whether a run is working on it is druks's to say, and you read that
+off the status:
+
+```python
+from druks.workflows import get_subject_phase, get_subject_status
+
+status = get_subject_status(repository.subject_type, str(repository.id))
+if status.is_parked:
+    ...  # a run stopped to ask a human something
+```
+
+`status.kind` names the workflow currently driving the row and `status.gate` the
+question it stopped on. While a run is working, `get_subject_phase(...)` returns
+the step it is on.
 
 ## Record events and react to signals
 
@@ -414,7 +413,7 @@ Record an extension event through the extension so ownership is stamped:
 ```python
 NightWatch.record_event(
     type="report.published",
-    subject={"type": "repository", "id": repo_id},
+    subject=repository,
     payload={"url": report_url},
 )
 ```
@@ -431,8 +430,8 @@ from druks.signals import subscribe
 
 
 @subscribe("run.finished", subject__type="repository")
-async def on_sweep_finished(*, subject: dict, **_: object) -> None:
-    ...
+async def on_sweep_finished(*, subject: Repository, **_: object) -> None:
+    await notify(subject.full_name)
 ```
 
 Signals are at-least-once. A subscriber exception propagates so webhook


### PR DESCRIPTION
ENG-748 — extension code held a subject as a `{"type", "id"}` dict at every boundary, so it converted constantly in both directions: ten places built the dict to call the SDK, eight more turned it back into a row (`WorkItem.get(subject["id"])` opened five subscribers). Now app code only ever holds the row, and the dict survives where it must — on the run and on the event, which outlive the row they point at.

**The row is the subject.** `Subject` is an abstract base owning the primary key; the class name is the subject type, so `WorkItem` is `work_item` and a subject never declares its identity twice. `item.identity` is the `{type, id}` a run or an event stamps in place of the row, and an unsaved row refuses to produce one rather than stamping `id: None`.

```python
class Repository(Subject):
    __tablename__ = "repositories"


class NightWatch(Extension):
    subject = Repository
```

**The SDK speaks rows.** `Gate.answer(row, …)`, `Workflow.cancel(row, …)`, `Workflow.start(subject=row)`, `Extension.record_event(subject=row)`. The `_Subject` pydantic model that validated hand-built dicts is deleted — the row is the contract, so there is no shape left to get wrong.

**Reactions receive rows.** A subscriber declares the subject it wants beside its other filters, and the body gets the row:

```python
@subscribe("run.pending_input", kind=BuildWorkflow.kind, gate=ReviewWork, subject=WorkItem)
async def review_park_marks_ticket_in_review(*, subject: WorkItem, **_: object) -> None:
    await subject.set_remote_status(SemanticStatus.IN_REVIEW)
```

`subject=WorkItem` narrows through the same matcher as every other filter, so an event from a subjectless run or about another subject never reaches the body. A row that was deleted since the event fired skips the subscriber instead of arriving as `None` — which also settles a latent crash, since `WorkItem.get(subject["id"]).set_status(...)` would have raised on a vanished item.

Inside a workflow `self.subject` is the row as well, resolved through the mapper registry SQLAlchemy already keeps. It reads live: a run that parks on a gate for three days resumes against whatever the row says then.

**`Extension.subject = WorkItem`** replaces `subject_type = "work_item"` — the class already knows its type, and a wrong class name is an import error where a mistyped string silently unmounted the subject routes. That declaration makes an entry module import its models earlier, which exposed a latent bug in table ownership: it was decided by import timing, so the first extension iterated claimed every extension's tables, and build's `prefix_tables = False` then exempted an external extension's unprefixed table from validation. Tables now belong to the module that declared the model, which is order-independent.

Unchanged on purpose: what a run stores stays `{type, id}`, `subject__type` filtering still matches the raw payload, and `Run.list_for_subject` / `get_subject_status` stay string-keyed platform internals. `Event.emit` also keeps taking the identity — two of its three callers run inside a workflow, where loading a row just to split it into two columns would be wasted work and a deleted row would break event recording.

The proof extension migrates as the second consumer, so the surface is exercised without build's history, and the scaffolding templates start authors on it.

Implemented by Codex (gpt-5.6-sol) under review, then reshaped over several passes: hydration keyed off the declared subject rather than an annotation, a subject registry deleted in favour of SQLAlchemy's, the type-and-id lookup folded into the one property that needed it, and `reference` renamed to `identity` to match the vocabulary already in the checklist. An adversarial pass caught the table-ownership bug, an unsaved row minting `id: None`, a non-numeric route id raising instead of 404, and abstract `Subject` intermediates registering themselves.

Known limitation, documented rather than worked around: `Subject` requires an integer primary key.

ruff + format clean; pyright 138 vs 143 on main; full backend suite green in CI.
