### PR TITLE
A critique folded into a redraft is resolved

### DIFF
--- a/backend/druks/build/constants.py
+++ b/backend/druks/build/constants.py
@@ -1,0 +1,7 @@
+# The github MCP server build ships into its own runs — build's requirement
+# (there is no build without github), not an operator-facing catalog entry.
+# Its token is per-repo, minted from the reviewer app at workspace setup.
+GITHUB_MCP_NAME = "github"
+GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
+
+PLAN_DRAFTS_PER_ROUND = 2

--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -97,7 +97,7 @@ class PlanData(BaseModel):
     def uses_recommended_answers(self, picks: dict[str, str]) -> bool:
         return all(question.is_recommended(picks.get(question.id)) for question in self.questions)
 
-    def get_answered(self, picks: dict[str, str]) -> list[dict[str, str]]:
+    def get_answered_questions(self, picks: dict[str, str]) -> list[dict[str, str]]:
         # Each question the operator answered, paired with its answer — what the
         # re-plan agent reads to resolve it.
         pairs = []

--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -73,7 +73,7 @@ class QuestionOutput(AgentOutput):
     prompt: str = Field(max_length=2048)
     options: list[QuestionOptionOutput] = Field(max_length=16)
 
-    def recommends(self, pick: str | None) -> bool:
+    def is_recommended(self, pick: str | None) -> bool:
         return any(option.recommended and option.id == pick for option in self.options)
 
 
@@ -95,13 +95,11 @@ class PlanData(BaseModel):
     assignee_github_login: str | None = None
 
     def uses_recommended_answers(self, picks: dict[str, str]) -> bool:
-        return all(question.recommends(picks.get(question.id)) for question in self.questions)
+        return all(question.is_recommended(picks.get(question.id)) for question in self.questions)
 
     def get_answered(self, picks: dict[str, str]) -> list[dict[str, str]]:
         # Each question the operator answered, paired with its answer — what the
-        # re-plan agent reads to resolve it. A pick matching an offered option maps
-        # to that option's label; anything else is the operator's own words, kept
-        # verbatim.
+        # re-plan agent reads to resolve it.
         pairs = []
         for question in self.questions:
             chosen = picks.get(question.id)

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -26,6 +26,7 @@ from druks.skills.models import Skill
 from druks.ticketing.datastructures import Ticket
 from druks.workflows import FatalError, Gate, Workflow, step
 
+from .constants import GITHUB_MCP_NAME, GITHUB_MCP_URL, PLAN_DRAFTS_PER_ROUND
 from .extension import Build
 from .journal import BuildJournal
 from .policy import RepoPolicy
@@ -36,14 +37,6 @@ if TYPE_CHECKING:
     from druks.sandbox.host import Sandbox
 
 logger = logging.getLogger(__name__)
-
-
-# The github MCP server build ships into its own runs — build's requirement
-# (there is no build without github), not an operator-facing catalog entry.
-# Its token is per-repo, minted from the reviewer app at workspace setup.
-GITHUB_MCP_NAME = "github"
-GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
-_PLAN_DRAFTS_PER_ROUND = 2
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -259,7 +252,7 @@ class BuildWorkflow(Workflow):
         operator_note = ""
         while True:
             unresolved_critique = ""
-            for _ in range(_PLAN_DRAFTS_PER_ROUND):
+            for _ in range(PLAN_DRAFTS_PER_ROUND):
                 draft_guidance = unresolved_critique
                 unresolved_critique = ""
                 plan = await Build.generate_plan(
@@ -283,7 +276,7 @@ class BuildWorkflow(Workflow):
                 and plan.uses_recommended_answers(operator_reply.answers)
             ):
                 return True
-            answered_questions = plan.get_answered(operator_reply.answers)
+            answered_questions = plan.get_answered_questions(operator_reply.answers)
             operator_note = operator_reply.note
 
     async def _implement_phase(self) -> None:

--- a/backend/druks/build/workflows.py
+++ b/backend/druks/build/workflows.py
@@ -43,6 +43,7 @@ logger = logging.getLogger(__name__)
 # Its token is per-repo, minted from the reviewer app at workspace setup.
 GITHUB_MCP_NAME = "github"
 GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
+_PLAN_DRAFTS_PER_ROUND = 2
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -250,39 +251,40 @@ class BuildWorkflow(Workflow):
         return self.settings()
 
     async def _plan_phase(self) -> bool:
-        """Gate mode: plan → park. Auto mode: machine review with one bounded
-        redraft. True → implement."""
-        gate = self._policy.plan_approval_gate(self._settings.auto_dispatch_on_plan_approval)
-        answered: list[dict[str, str]] = []
-        note = ""
+        """True → implement."""
+        human_approval_required = (
+            self._policy.plan_approval_gate(self._settings.auto_dispatch_on_plan_approval) != "none"
+        )
+        answered_questions: list[dict[str, str]] = []
+        operator_note = ""
         while True:
-            reviewer_notes = ""
-            redrafted = False
-            critique = ""
-            while True:
+            unresolved_critique = ""
+            for _ in range(_PLAN_DRAFTS_PER_ROUND):
+                draft_guidance = unresolved_critique
+                unresolved_critique = ""
                 plan = await Build.generate_plan(
-                    answered_questions=answered, operator_note=note, reviewer_notes=reviewer_notes
+                    answered_questions=answered_questions,
+                    operator_note=operator_note,
+                    reviewer_notes=draft_guidance,
                 )
-                if gate != "none" or plan.questions:
+                if human_approval_required or plan.questions:
                     break
-                grade = await Build.review_plan()
-                if grade.decision == ReviewDecision.APPROVE:
+                machine_review = await Build.review_plan()
+                if machine_review.decision == ReviewDecision.APPROVE:
                     return True
-                if redrafted:
-                    # Exhausted — park below, critique on the ask.
-                    critique = grade.body
-                    break
-                redrafted = True
-                reviewer_notes = grade.body
-            reply = await self.review(questions=plan.questions, context=critique)
+                unresolved_critique = machine_review.body
+            operator_reply = await self.review(
+                questions=plan.questions,
+                context=unresolved_critique,
+            )
             if (
-                reply.action == "approve"
-                and not reply.note
-                and plan.uses_recommended_answers(reply.answers)
+                operator_reply.action == "approve"
+                and not operator_reply.note
+                and plan.uses_recommended_answers(operator_reply.answers)
             ):
                 return True
-            answered = plan.get_answered(reply.answers)
-            note = reply.note
+            answered_questions = plan.get_answered(operator_reply.answers)
+            operator_note = operator_reply.note
 
     async def _implement_phase(self) -> None:
         while True:

--- a/backend/tests/test_build_plan_phase.py
+++ b/backend/tests/test_build_plan_phase.py
@@ -227,6 +227,42 @@ async def test_auto_mode_folds_the_critique_into_one_redraft(monkeypatch):
     assert [p["reviewer_notes"] for p in passes] == ["", "name the wire schema"]
 
 
+async def test_auto_mode_redraft_questions_park_without_the_folded_critique(monkeypatch):
+    """A redraft's questions park without repeating the critique already folded into it."""
+    flow = _flow(auto_dispatch=True)
+    passes = _fake_plans(
+        monkeypatch,
+        PlanData(plan_markdown="v1"),
+        PlanData(
+            plan_markdown="v2",
+            questions=[QuestionOutput(id="q1", prompt="Feature flag?", options=[])],
+        ),
+        PlanData(plan_markdown="v3"),
+    )
+    _fake_grades(
+        monkeypatch,
+        ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="name the rollout boundary"),
+        ReviewOutput(decision=ReviewDecision.APPROVE, body=""),
+    )
+    parks: list[tuple[list, str]] = []
+
+    async def fake_review(*, questions=None, context=""):
+        parks.append((list(questions or []), context))
+        return OperatorReply(action="request_changes", answers={"q1": "behind a flag"})
+
+    flow.review = fake_review
+
+    assert await flow._plan_phase() is True
+    assert len(parks) == 1
+    assert [question.id for question in parks[0][0]] == ["q1"]
+    assert parks[0][1] == ""
+    assert [p["reviewer_notes"] for p in passes] == [
+        "",
+        "name the rollout boundary",
+        "",
+    ]
+
+
 async def test_auto_mode_parks_after_the_bounded_redraft(monkeypatch):
     """Two straight rejections exhaust the machine loop — the run parks with the
     critique standing. The operator's request_changes re-arms one fresh redraft."""

--- a/backend/tests/test_build_workspace.py
+++ b/backend/tests/test_build_workspace.py
@@ -2,12 +2,8 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from druks.build.workflows import (
-    GITHUB_MCP_NAME,
-    GITHUB_MCP_URL,
-    BuildWorkflow,
-    BuildWorkspace,
-)
+from druks.build.constants import GITHUB_MCP_NAME, GITHUB_MCP_URL
+from druks.build.workflows import BuildWorkflow, BuildWorkspace
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.sandbox import host as host_mod
 from druks.sandbox.layout import get_related_root

--- a/backend/tests/test_contracts.py
+++ b/backend/tests/test_contracts.py
@@ -91,7 +91,7 @@ def test_needs_clarification_may_omit_the_delivery_fields():
     assert "pure function" in bailed.summary
 
 
-def test_get_answered_maps_picks_to_labels_and_keeps_free_text_verbatim():
+def test_answered_questions_map_picks_to_labels_and_keep_free_text_verbatim():
     # An answer is an offered option id (paired as its label) or the operator's own
     # words (kept verbatim); unanswered questions don't reach the re-plan agent.
     plan = O.PlanData(
@@ -109,7 +109,7 @@ def test_get_answered_maps_picks_to_labels_and_keeps_free_text_verbatim():
             O.QuestionOutput(id="q3", prompt="Feature flag?", options=[]),
         ]
     )
-    assert plan.get_answered({"q1": "a", "q2": "kafka — we already run it"}) == [
+    assert plan.get_answered_questions({"q1": "a", "q2": "kafka — we already run it"}) == [
         {"question": "Which cache?", "answer": "Redis"},
         {"question": "Which queue?", "answer": "kafka — we already run it"},
     ]


### PR DESCRIPTION
Closes ENG-749. Readability only — no behaviour change.

## What it was

```python
while True:
    reviewer_notes = ""
    redrafted = False
    critique = ""
    while True:
        plan = await Build.generate_plan(..., reviewer_notes=reviewer_notes)
        if gate != "none" or plan.questions:
            break
        grade = await Build.review_plan()
        if grade.decision == ReviewDecision.APPROVE:
            return True
        if redrafted:
            critique = grade.body
            break
        redrafted = True
        reviewer_notes = grade.body
    reply = await self.review(questions=plan.questions, context=critique)
```

A loop inside a loop whose only exit was a `break`, leaving `plan` and `critique` behind for the outer scope to read. `reviewer_notes` and `critique` are both `grade.body`, and nothing said why one fact needed two variables.

## The thing that explains it

They were never one fact. **A critique the planner redrafts against is answered; only a critique nobody acted on belongs on the operator's ask.** So there are two roles — guidance going into the next draft, and an unresolved objection going to the operator — and which role a critique plays depends on whether a draft answered it.

Naming those two roles is what unlocks the shape. Drafting resolves the critique that produced it, so the round hands it over and clears it in the same breath, and the park carries whatever survives:

```python
while True:
    unresolved_critique = ""
    for _ in range(PLAN_DRAFTS_PER_ROUND):
        draft_guidance = unresolved_critique
        unresolved_critique = ""
        plan = await Build.generate_plan(..., reviewer_notes=draft_guidance)
        if human_approval_required or plan.questions:
            break
        machine_review = await Build.review_plan()
        if machine_review.decision == ReviewDecision.APPROVE:
            return True
        unresolved_critique = machine_review.body
    operator_reply = await self.review(questions=plan.questions, context=unresolved_critique)
```

The case where a redraft raises its own questions — the park must carry no critique, because the previous one was already folded in — now falls out of that clearing instead of needing a branch. The redraft budget is a bound rather than a repeated block, and `human_approval_required` states the policy fact instead of comparing a gate string mid-flow.

## Riders

`QuestionOutput.recommends` → `is_recommended`. Predicates are questions, not commands: `is_running` reads as one, `recommends(...)` reads as an imperative, and the house convention is `is_active` / `is_parked` / `is_known_druks_pr`.

`PlanData.get_answered` → `get_answered_questions`. It returns the answered questions and feeds a parameter named for them. Its comment also lost the second half, which restated the four lines beneath it; the free-text rule that half described is now stated where it is pinned, in the test. The fallback itself is untouched — the in-app gate no longer offers per-question free text, but the API still accepts it and MCP clients can send it.

Build's module constants moved into a new `druks/build/constants.py` — `PLAN_DRAFTS_PER_ROUND` alongside `GITHUB_MCP_NAME` and `GITHUB_MCP_URL`, which were already sitting in `workflows.py`. I had originally put the new constant next to them and treated that as the file's convention; the absence of a `constants.py` was the finding, not the permission.

## Verification

**Every pre-existing assertion passes unchanged.** If one had needed editing, the behaviour would have moved.

One test was **added**, for a gap found while working: a redraft that raises questions parks without repeating the critique already folded into it.

These tests cannot run under pytest locally — the session fixture needs Postgres, which the sandbox blocks — so I drove `_plan_phase` directly against fakes and confirmed four behaviours against the final body:

- bounded redraft exhausts, parks with the standing critique, and the operator's reply re-arms a fresh redraft — `reviewer_notes == ["", "critique-1", "", "critique-3"]`, where the empty third entry **is** the per-round reset
- a redraft raising questions parks with no critique
- gate mode parks every draft and never calls the machine reviewer
- auto mode approves on the machine's verdict without parking

Ruff check and format pass; 967 tests collect. Full backend execution is CI-gated as always.

## One thing accepted rather than fixed

`plan` is assigned inside the `for` and read after it — the same class of thing this ticket set out to remove. At one level and twelve lines it is unambiguously "the last draft", and every carrier that removes it costs more than it buys. Recording it as a decision, not an oversight.

## A dead end, so nobody re-walks it

`_implement_phase` directly below reads `self.journal.implementation_revision` instead of a local counter, which makes `self.journal.plan_revision` look like the obvious way to delete the old `redrafted` flag. It is not: `plan_revision` counts every draft in the run, while the budget resets each operator round.
