### PR TITLE
SemanticStatus is the status a ticket is moved to: TicketStatus

### DIFF
--- a/backend/druks/build/models.py
+++ b/backend/druks/build/models.py
@@ -12,7 +12,7 @@ from druks.core.apis.github import get_github_client
 from druks.db import Base, Subject, db_session
 from druks.settings import load_settings
 from druks.ticketing.datastructures import Ticket
-from druks.ticketing.enums import SemanticStatus
+from druks.ticketing.enums import TicketStatus
 from druks.ticketing.exceptions import TrackerNotConfigured
 from druks.ticketing.helpers import get_tracker, is_tracker_source
 from druks.workflows import FatalError, SubjectStatus, get_subject_status
@@ -290,7 +290,7 @@ class WorkItem(Subject):
         build = get_subject_status(self.subject_type, str(self.id), kind=BuildWorkflow.kind)
         if build.is_parked:
             await BuildWorkflow.cancel(self, failure="pr merged while parked")
-        await self.set_remote_status(SemanticStatus.DONE)
+        await self.set_remote_status(TicketStatus.DONE)
 
     async def close_external(self) -> None:
         # The attempt was abandoned, not the ticket, so the ticket returns to the
@@ -306,7 +306,7 @@ class WorkItem(Subject):
                 await get_github_client(load_settings()).delete_branch(self.repo, self.branch)
         except Exception:  # noqa: BLE001 — cleanup only
             logger.warning("Skipped branch cleanup for %s.", self.repo, exc_info=True)
-        await self.set_remote_status(SemanticStatus.READY_FOR_AGENT)
+        await self.set_remote_status(TicketStatus.READY_FOR_AGENT)
 
     @classmethod
     def get_for_remote_key(
@@ -350,7 +350,7 @@ class WorkItem(Subject):
         self.updated_at = Base.utc_now()
         db_session().flush()
 
-    async def set_remote_status(self, status: SemanticStatus) -> None:
+    async def set_remote_status(self, status: TicketStatus) -> None:
         # No-op for sources without a configured tracker (github, absent creds).
         if not is_tracker_source(self.source):
             return

--- a/backend/druks/build/subscribers.py
+++ b/backend/druks/build/subscribers.py
@@ -4,7 +4,7 @@ from druks.build.extension import Build
 from druks.build.models import ProjectRepo, WorkItem
 from druks.build.workflows import BuildWorkflow, Profile
 from druks.signals import subscribe
-from druks.ticketing.enums import SemanticStatus
+from druks.ticketing.enums import TicketStatus
 from druks.workflows import get_subject_status
 
 # Projections
@@ -30,12 +30,12 @@ async def provision_mirrors_onto_item(
 async def build_start_marks_ticket_in_progress(*, subject: WorkItem, **_: object) -> None:
     # Every (re)start and gate-resume of a build means the ticket is in progress —
     # including the return from a rework loop that had parked it In Review.
-    await subject.set_remote_status(SemanticStatus.IN_PROGRESS)
+    await subject.set_remote_status(TicketStatus.IN_PROGRESS)
 
 
 @subscribe("run.pending_input", kind=BuildWorkflow.kind, gate=ReviewWork, subject=WorkItem)
 async def review_park_marks_ticket_in_review(*, subject: WorkItem, **_: object) -> None:
-    await subject.set_remote_status(SemanticStatus.IN_REVIEW)
+    await subject.set_remote_status(TicketStatus.IN_REVIEW)
 
 
 @subscribe("repo.pushed", to_default_branch=True)

--- a/backend/druks/ticketing/base.py
+++ b/backend/druks/ticketing/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import ClassVar, Self
 
 from .datastructures import Ticket
-from .enums import SemanticStatus
+from .enums import TicketStatus
 
 
 class Tracker(ABC):
@@ -13,7 +13,7 @@ class Tracker(ABC):
     known_exceptions: ClassVar[tuple[type[BaseException], ...]] = ()
 
     # Set by each provider's __init__ from its (provider-specific) settings.
-    _status_names: dict[SemanticStatus, str]
+    _status_names: dict[TicketStatus, str]
 
     @classmethod
     @abstractmethod
@@ -34,7 +34,7 @@ class Tracker(ABC):
     async def fetch_ticket(self, key: str) -> Ticket: ...
 
     @abstractmethod
-    async def set_status(self, ticket: Ticket, status: SemanticStatus) -> None: ...
+    async def set_status(self, ticket: Ticket, status: TicketStatus) -> None: ...
 
     @abstractmethod
     async def aclose(self) -> None: ...

--- a/backend/druks/ticketing/enums.py
+++ b/backend/druks/ticketing/enums.py
@@ -2,6 +2,9 @@ from enum import StrEnum
 
 
 class StatusKind(StrEnum):
+    """What a tracker's own status means to druks. Every provider names its
+    statuses differently, so reading one normalizes to these."""
+
     BACKLOG = "backlog"
     STARTED = "started"
     REVIEW = "review"
@@ -10,7 +13,10 @@ class StatusKind(StrEnum):
     UNKNOWN = "unknown"
 
 
-class SemanticStatus(StrEnum):
+class TicketStatus(StrEnum):
+    """The status druks asks a tracker to move a ticket to. Each provider maps
+    these to whatever it calls them."""
+
     IN_PROGRESS = "in_progress"
     IN_REVIEW = "in_review"
     DONE = "done"

--- a/backend/druks/ticketing/jira.py
+++ b/backend/druks/ticketing/jira.py
@@ -8,7 +8,7 @@ from druks.settings import load_settings
 
 from .base import Tracker
 from .datastructures import Ticket
-from .enums import SemanticStatus, StatusKind
+from .enums import StatusKind, TicketStatus
 from .exceptions import TrackerNotConfigured
 
 # Jira's statusCategory.key → druks's normalized kind. Jira folds done+canceled
@@ -24,13 +24,13 @@ _CATEGORY_KIND: dict[str, StatusKind] = {
 # requires a resolution and Fix versions, so native status moves work like Linear's.
 # READY_FOR_AGENT is supplied by the caller as the resting status; "Backlog" is the operator's
 # dispatch trigger, so druks deliberately does not land there.
-_STATIC_STATUS_NAMES: dict[SemanticStatus, str] = {
-    SemanticStatus.IN_PROGRESS: "In Progress",
-    SemanticStatus.IN_REVIEW: "Waiting CR",  # CR = code review; PR open, awaiting review
-    SemanticStatus.DONE: "Done",
+_STATIC_STATUS_NAMES: dict[TicketStatus, str] = {
+    TicketStatus.IN_PROGRESS: "In Progress",
+    TicketStatus.IN_REVIEW: "Waiting CR",  # CR = code review; PR open, awaiting review
+    TicketStatus.DONE: "Done",
     # This workflow has no cancel state; abandoned work closes as Done (its Done
     # transition takes no resolution/Fix-versions fields, so the move succeeds).
-    SemanticStatus.CANCELED: "Done",
+    TicketStatus.CANCELED: "Done",
 }
 
 
@@ -44,7 +44,7 @@ class Jira(Tracker):
         base_url: str,
         email: str,
         api_token: str,
-        status_names: dict[SemanticStatus, str],
+        status_names: dict[TicketStatus, str],
         client: Any | None = None,
     ) -> None:
         self._client = JiraClient(
@@ -60,7 +60,7 @@ class Jira(Tracker):
         names = dict(_STATIC_STATUS_NAMES)
         # Empty leaves READY_FOR_AGENT unmapped.
         if ready_for_agent_status:
-            names[SemanticStatus.READY_FOR_AGENT] = ready_for_agent_status
+            names[TicketStatus.READY_FOR_AGENT] = ready_for_agent_status
         return cls(
             base_url=settings.jira_base_url,
             email=settings.jira_email,
@@ -100,7 +100,7 @@ class Jira(Tracker):
     async def fetch_ticket(self, key: str) -> Ticket:
         return self._normalize(await self._client.get_issue(key))
 
-    async def set_status(self, ticket: Ticket, status: SemanticStatus) -> None:
+    async def set_status(self, ticket: Ticket, status: TicketStatus) -> None:
         name = self._status_names.get(status)
         if not name:
             raise ValueError(f"Jira has no configured status name for {status}")

--- a/backend/druks/ticketing/linear.py
+++ b/backend/druks/ticketing/linear.py
@@ -8,7 +8,7 @@ from druks.settings import load_settings
 
 from .base import Tracker
 from .datastructures import Ticket
-from .enums import SemanticStatus, StatusKind
+from .enums import StatusKind, TicketStatus
 from .exceptions import TrackerNotConfigured
 
 _STATE_KIND: dict[str, StatusKind] = {
@@ -22,11 +22,11 @@ _STATE_KIND: dict[str, StatusKind] = {
 
 # READY_FOR_AGENT is operator-set, so the caller supplies its name to
 # from_settings(); the rest are fixed.
-_STATIC_STATUS_NAMES: dict[SemanticStatus, str] = {
-    SemanticStatus.IN_PROGRESS: "In Progress",
-    SemanticStatus.IN_REVIEW: "In Review",
-    SemanticStatus.DONE: "Done",
-    SemanticStatus.CANCELED: "Canceled",
+_STATIC_STATUS_NAMES: dict[TicketStatus, str] = {
+    TicketStatus.IN_PROGRESS: "In Progress",
+    TicketStatus.IN_REVIEW: "In Review",
+    TicketStatus.DONE: "Done",
+    TicketStatus.CANCELED: "Canceled",
 }
 
 
@@ -38,7 +38,7 @@ class Linear(Tracker):
         self,
         *,
         api_key: str,
-        status_names: dict[SemanticStatus, str],
+        status_names: dict[TicketStatus, str],
         client: Any | None = None,
     ) -> None:
         self._client = LinearClient(api_key=api_key, client=client)
@@ -52,7 +52,7 @@ class Linear(Tracker):
         names = dict(_STATIC_STATUS_NAMES)
         # Empty leaves READY_FOR_AGENT unmapped.
         if ready_for_agent_status:
-            names[SemanticStatus.READY_FOR_AGENT] = ready_for_agent_status
+            names[TicketStatus.READY_FOR_AGENT] = ready_for_agent_status
         return cls(api_key=settings.linear_api_key, status_names=names)
 
     def _normalize(self, raw: dict[str, Any]) -> Ticket:
@@ -87,7 +87,7 @@ class Linear(Tracker):
     async def fetch_ticket(self, key: str) -> Ticket:
         return self._normalize(await self._client.get_issue(key))
 
-    async def set_status(self, ticket: Ticket, status: SemanticStatus) -> None:
+    async def set_status(self, ticket: Ticket, status: TicketStatus) -> None:
         name = self._status_names.get(status)
         if not name:
             raise ValueError(f"Linear has no configured status name for {status}")

--- a/backend/tests/test_lane_reactions.py
+++ b/backend/tests/test_lane_reactions.py
@@ -7,7 +7,7 @@ from druks.build.models import WorkItem
 from druks.build.workflows import BuildWorkflow
 from druks.durable import Run
 from druks.signals import publish
-from druks.ticketing.enums import SemanticStatus
+from druks.ticketing.enums import TicketStatus
 from uuid_utils import uuid7
 
 pytestmark = pytest.mark.asyncio
@@ -38,7 +38,7 @@ async def test_build_lifecycle_reaches_the_tracker(db_session, monkeypatch):
     await publish("run.pending_input", subject=subject, kind=BuildWorkflow.kind, gate="review_plan")
     await publish("run.running", subject=subject, kind="build.profile")
 
-    assert pushed == [SemanticStatus.IN_PROGRESS, SemanticStatus.IN_REVIEW]
+    assert pushed == [TicketStatus.IN_PROGRESS, TicketStatus.IN_REVIEW]
 
 
 async def test_pr_review_answers_through_the_review_gate(db_session, monkeypatch):

--- a/backend/tests/test_ticketing.py
+++ b/backend/tests/test_ticketing.py
@@ -1,6 +1,6 @@
 import pytest
 from druks.ticketing.datastructures import Ticket
-from druks.ticketing.enums import SemanticStatus, StatusKind
+from druks.ticketing.enums import StatusKind, TicketStatus
 from druks.ticketing.exceptions import TrackerNotConfigured
 from druks.ticketing.helpers import get_tracker
 from druks.ticketing.jira import Jira
@@ -61,10 +61,10 @@ def _linear_with(fake: _FakeLinearClient, *, status_names=None) -> Linear:
     provider = Linear.__new__(Linear)
     provider._client = fake  # type: ignore[attr-defined]
     provider._status_names = status_names or {  # type: ignore[attr-defined]
-        SemanticStatus.IN_PROGRESS: "In Progress",
-        SemanticStatus.DONE: "Done",
-        SemanticStatus.CANCELED: "Canceled",
-        SemanticStatus.READY_FOR_AGENT: "Ready for Agent",
+        TicketStatus.IN_PROGRESS: "In Progress",
+        TicketStatus.DONE: "Done",
+        TicketStatus.CANCELED: "Canceled",
+        TicketStatus.READY_FOR_AGENT: "Ready for Agent",
     }
     return provider
 
@@ -106,12 +106,12 @@ async def test_fetch_ticket_normalizes():
 
 
 @pytest.mark.asyncio
-async def test_set_status_maps_semantic_to_provider_name():
+async def test_set_status_maps_the_ticket_status_to_a_provider_name():
     fake = _FakeLinearClient()
     provider = _linear_with(fake)
     ticket = provider._normalize(SAMPLE_ISSUE)
-    await provider.set_status(ticket, SemanticStatus.DONE)
-    await provider.set_status(ticket, SemanticStatus.READY_FOR_AGENT)
+    await provider.set_status(ticket, TicketStatus.DONE)
+    await provider.set_status(ticket, TicketStatus.READY_FOR_AGENT)
     assert fake.calls == [
         ("update_issue_status", "uuid-issue-1", "Done"),
         ("update_issue_status", "uuid-issue-1", "Ready for Agent"),
@@ -120,10 +120,10 @@ async def test_set_status_maps_semantic_to_provider_name():
 
 @pytest.mark.asyncio
 async def test_set_status_unmapped_raises():
-    provider = _linear_with(_FakeLinearClient(), status_names={SemanticStatus.DONE: "Done"})
+    provider = _linear_with(_FakeLinearClient(), status_names={TicketStatus.DONE: "Done"})
     ticket = provider._normalize(SAMPLE_ISSUE)
     with pytest.raises(ValueError, match="no configured status"):
-        await provider.set_status(ticket, SemanticStatus.IN_REVIEW)
+        await provider.set_status(ticket, TicketStatus.IN_REVIEW)
 
 
 def test_get_tracker_resolves_configured_linear(tmp_path, monkeypatch):
@@ -194,9 +194,9 @@ async def test_remote_state_pushes_status(db_session, monkeypatch):
     fake = _FakeTracker()
     monkeypatch.setattr(models, "get_tracker", lambda source, **_: fake)
 
-    await item.set_remote_status(SemanticStatus.DONE)
+    await item.set_remote_status(TicketStatus.DONE)
 
-    assert fake.calls == [("linear", "ACME-1", SemanticStatus.DONE), "aclose"]
+    assert fake.calls == [("linear", "ACME-1", TicketStatus.DONE), "aclose"]
 
 
 @pytest.mark.asyncio
@@ -205,7 +205,7 @@ async def test_remote_state_skips_non_tracker_source(db_session):
 
     item = make_test_work_item(repo="acme/widget", source="github", remote_key="#5", title="t")
     # github has no tracker — a no-op that must not raise.
-    await item.set_remote_status(SemanticStatus.DONE)
+    await item.set_remote_status(TicketStatus.DONE)
 
 
 @pytest.mark.asyncio
@@ -225,7 +225,7 @@ async def test_remote_state_closes_on_failure(db_session, monkeypatch):
     boom = _Boom()
     monkeypatch.setattr(models, "get_tracker", lambda source, **_: boom)
 
-    await item.set_remote_status(SemanticStatus.DONE)
+    await item.set_remote_status(TicketStatus.DONE)
 
     assert "aclose" in boom.calls  # closed even on failure
 
@@ -300,9 +300,9 @@ def _jira_with(fake: _FakeJiraClient) -> Jira:
     provider = Jira.__new__(Jira)
     provider._client = fake  # type: ignore[attr-defined]
     provider._status_names = {  # type: ignore[attr-defined]
-        SemanticStatus.IN_PROGRESS: "In Progress",
-        SemanticStatus.DONE: "Done",
-        SemanticStatus.READY_FOR_AGENT: "Ready for Agent",
+        TicketStatus.IN_PROGRESS: "In Progress",
+        TicketStatus.DONE: "Done",
+        TicketStatus.READY_FOR_AGENT: "Ready for Agent",
     }
     return provider
 
@@ -340,7 +340,7 @@ async def test_jira_set_status_uses_transition():
     fake = _FakeJiraClient()
     provider = _jira_with(fake)
     ticket = provider._normalize(SAMPLE_JIRA_ISSUE)
-    await provider.set_status(ticket, SemanticStatus.DONE)
+    await provider.set_status(ticket, TicketStatus.DONE)
     assert ("transition_issue", "PROJ-7", "Done") in fake.calls
 
 
@@ -377,9 +377,8 @@ def test_get_tracker_resolves_configured_jira(tmp_path, monkeypatch):
     tracker = get_tracker("jira", ready_for_agent_status="Open")
     assert isinstance(tracker, Jira)
     assert tracker.source == "jira"
-    # The operator's READY_FOR_AGENT status name the caller supplies, mapped onto
-    # the semantic status for the actual move.
-    assert tracker._status_names[SemanticStatus.READY_FOR_AGENT] == "Open"
+    # The operator names their own READY_FOR_AGENT status; the move looks it up here.
+    assert tracker._status_names[TicketStatus.READY_FOR_AGENT] == "Open"
 
 
 def test_jira_status_names_match_internal_tools_workflow():
@@ -389,11 +388,11 @@ def test_jira_status_names_match_internal_tools_workflow():
     # so the ticket just never moves. Pin them.
     from druks.ticketing.jira import _STATIC_STATUS_NAMES
 
-    assert _STATIC_STATUS_NAMES[SemanticStatus.IN_PROGRESS] == "In Progress"
-    assert _STATIC_STATUS_NAMES[SemanticStatus.IN_REVIEW] == "Waiting CR"
-    assert _STATIC_STATUS_NAMES[SemanticStatus.DONE] == "Done"
+    assert _STATIC_STATUS_NAMES[TicketStatus.IN_PROGRESS] == "In Progress"
+    assert _STATIC_STATUS_NAMES[TicketStatus.IN_REVIEW] == "Waiting CR"
+    assert _STATIC_STATUS_NAMES[TicketStatus.DONE] == "Done"
     # No cancel state in this workflow — abandoned work closes as Done.
-    assert _STATIC_STATUS_NAMES[SemanticStatus.CANCELED] == "Done"
+    assert _STATIC_STATUS_NAMES[TicketStatus.CANCELED] == "Done"
 
 
 def test_get_tracker_unconfigured_jira_raises(tmp_path, monkeypatch):

--- a/backend/tests/test_webhooks_pull_request.py
+++ b/backend/tests/test_webhooks_pull_request.py
@@ -201,7 +201,7 @@ async def test_external_close_returns_ticket_to_resting_pool(db_session, tmp_pat
     provider's resting status (Linear → Backlog, Jira → Open) so the
     ticket doesn't strand in In Progress/Review."""
     from druks.build.models import WorkItem
-    from druks.ticketing.enums import SemanticStatus
+    from druks.ticketing.enums import TicketStatus
 
     pushed = []
 
@@ -217,14 +217,14 @@ async def test_external_close_returns_ticket_to_resting_pool(db_session, tmp_pat
         repo=repo, pr_number=pr_number, branch=branch, tmp_path=tmp_path, merged=False
     )
 
-    assert pushed == [(work_item_id, SemanticStatus.READY_FOR_AGENT)]
+    assert pushed == [(work_item_id, TicketStatus.READY_FOR_AGENT)]
 
 
 @pytest.mark.asyncio
 async def test_external_merge_pushes_done(db_session, tmp_path, monkeypatch):
     """An externally-merged PR mirrors druks's own merge op: ticket → Done."""
     from druks.build.models import WorkItem
-    from druks.ticketing.enums import SemanticStatus
+    from druks.ticketing.enums import TicketStatus
 
     pushed = []
 
@@ -240,7 +240,7 @@ async def test_external_merge_pushes_done(db_session, tmp_path, monkeypatch):
         repo=repo, pr_number=pr_number, branch=branch, tmp_path=tmp_path, merged=True
     )
 
-    assert pushed == [(work_item_id, SemanticStatus.DONE)]
+    assert pushed == [(work_item_id, TicketStatus.DONE)]
 
 
 @pytest.mark.asyncio
@@ -302,7 +302,7 @@ async def test_external_close_survives_policy_resolution_failure(db_session, tmp
     the ticket — the cancel and resting-pool reset still happen."""
     from druks.build import models as build_models
     from druks.build.policy import RepoPolicy
-    from druks.ticketing.enums import SemanticStatus
+    from druks.ticketing.enums import TicketStatus
 
     async def _boom(cls, repo):
         raise RuntimeError("github down")
@@ -333,7 +333,7 @@ async def test_external_close_survives_policy_resolution_failure(db_session, tmp
     )
 
     assert deleted == []  # cleanup skipped when policy can't be resolved
-    assert pushed == [SemanticStatus.READY_FOR_AGENT]  # ticket still reset
+    assert pushed == [TicketStatus.READY_FOR_AGENT]  # ticket still reset
     assert _milestone_count(work_item_id, "cancelled") == 1
 
 


### PR DESCRIPTION
`SemanticStatus` named the mechanism — "semantic" was doing the work of saying "not the provider's literal status name". What it actually is: the status druks asks a tracker to move a ticket to, which each provider then maps to whatever it calls that (`IN_REVIEW` is "In Review" in Linear and "Waiting CR" in Jira). So: `TicketStatus`, next to the `Ticket` it belongs to.

```python
await item.set_remote_status(TicketStatus.IN_PROGRESS)
```

Its neighbour `StatusKind` stays as it is — the two look alike but run in opposite directions, and nothing in the code said which to reach for, so each now carries one line: `StatusKind` is what a tracker's own status means to druks when it *reads* a ticket (Linear's "triage" normalizes to `UNKNOWN`); `TicketStatus` is what druks *writes*.

Rename only — no behavior, no wire values, no stored strings change. Two test names and a comment that leaned on the old word were reworded with it.

ruff + format clean; pyright unchanged at 68 on the touched packages.