### PR TITLE
A decision-complete ticket gets its named surface verified, not a cold survey

### DIFF
--- a/backend/templates/prompts/build/build_workflow/generate_plan.md
+++ b/backend/templates/prompts/build/build_workflow/generate_plan.md
@@ -10,6 +10,15 @@ your acceptance criteria. Wrong shape here compounds into every step that follow
 - **Read the codebase first.** The right approach is almost always the one the repo already
   uses for similar work. Name the files, layers, and data shapes that change. Inventing new
   abstractions where existing ones fit is a defect in the plan, not cleverness.
+- **Scale the read to the ticket.** A ticket that names the change, its call sites, and the
+  approach is decision-complete: verify the surface it names and plan from there. Do not
+  re-survey the subsystem to rediscover what the ticket already told you. A ticket that states
+  a problem and leaves the shape open gets the full exploration. Judge on substance — does it
+  name the surface and the approach? — never on length or author, and when the call is close,
+  explore: over-reading costs money, under-reading costs a bad plan.
+- **Verify what the ticket claims.** A named call site may have moved or gone since it was
+  written, so confirm each one at HEAD before you plan on it. Read the cited regions rather
+  than whole files — a whole file is re-processed on every turn.
 - **Preserve operator contracts verbatim.** Copy exact field shapes, JSON and endpoint
   contracts, template strings, do/don't decisions, and dependency nuance from the description
   and especially operator refinement comments into the plan. When in doubt, copy more.


### PR DESCRIPTION
Closes ENG-750. Built on the merged shape from #81.

## Why

The planner has one gear. It runs the same maximal survey-the-subsystem pass whatever it is handed, so a ticket that already did the analysis pays the same price as a one-liner.

Measured on ENG-740 — a ticket written after a long investigation, citing the conflicting sources of truth, the exact call sites, and the fix direction: **484 s / $3.17, 42 tool calls (18 whole-file reads + 18 greps), 2.88M cache-read tokens** for an 18 KB plan. The work was on target; it read the right files. It just re-derived from cold everything the ticket had already handed it, and read 18 files *whole* when specific regions were wanted.

Codex's plan-mode contract requires a plan be "decision complete, where the implementer does not need to make any decisions." The same bar should apply inbound: when the ticket is already decision-complete, verify it rather than rebuild it.

## What changed

Two bullets in `generate_plan.md`'s Core truths, next to the "Read the codebase first" rule they qualify:

- **Scale the read to the ticket** — a ticket naming the change, its call sites, and the approach is decision-complete: verify the surface it names and plan from there, no subsystem re-survey. One that states a problem and leaves the shape open still gets today's full exploration. Judge on substance, never length or author; when the call is close, explore.
- **Verify what the ticket claims** — a named call site may have moved since the ticket was written, so confirm each at HEAD. Read the cited regions rather than whole files, which are re-processed every turn.

That is the whole change. Prompt only — no contract, no storage, no workflow change, per the ticket's own scope note.

## Risk, stated

Mis-classifying an underspecified ticket as complete under-plans. The prompt biases explicitly toward full exploration when uncertain: over-reading costs money, under-reading costs a revision round.

## Verification

- Prompt renders (direct render with a real empty `BuildJournal`, same path `test_build_prompts.py` uses); both bullets present.
- No Python touched, so no lint delta; backend tests gate on CI.
- The acceptance criterion that matters is behavioral — a decision-complete ticket of ENG-740's size planning in materially less than 484 s — and needs a real run to confirm.