### PR TITLE
The plan carries what it ruled out, so nobody re-proposes it

### DIFF
--- a/backend/druks/build/contracts.py
+++ b/backend/druks/build/contracts.py
@@ -91,6 +91,9 @@ class PlanData(BaseModel):
     plan_markdown: str = ""
     questions: list[QuestionOutput] = Field(default_factory=list)
     acceptance_criteria: list[AcceptanceCriterionOutput] = Field(default_factory=list)
+    # Approaches the planner dropped — the judgment that otherwise dies at the
+    # plan-review park and gets re-proposed downstream.
+    rejected_approaches: list[str] = Field(default_factory=list)
     # Resolved by the planner; a revision carries None.
     assignee_github_login: str | None = None
 
@@ -116,6 +119,7 @@ class PlanOutput(AgentOutput):
     plan_markdown: str
     acceptance_criteria: list[AcceptanceCriterionOutput]
     questions: list[QuestionOutput] = Field(max_length=8)
+    rejected_approaches: list[str]
     # Required but nullable: the planner always reports the field, null when it
     # resolved no assignee login convincingly.
     assignee_github_login: str | None
@@ -128,6 +132,7 @@ class PlanOutput(AgentOutput):
             plan_markdown=self.plan_markdown,
             acceptance_criteria=self.acceptance_criteria,
             questions=self.questions,
+            rejected_approaches=self.rejected_approaches,
             assignee_github_login=self.assignee_github_login,
         )
 

--- a/backend/templates/prompts/build/build_workflow/_header.md
+++ b/backend/templates/prompts/build/build_workflow/_header.md
@@ -46,6 +46,14 @@
 {% endif %}
 {% endfor %}
 {% endif %}
+{% if build.journal.plan.rejected_approaches %}
+## Ruled out
+
+{% for approach in build.journal.plan.rejected_approaches %}
+- {{ approach.strip() }}
+{% endfor %}
+
+{% endif %}
 {% if build.journal.evaluations %}
 ## Prior implementation review
 

--- a/backend/templates/prompts/build/build_workflow/generate_plan.md
+++ b/backend/templates/prompts/build/build_workflow/generate_plan.md
@@ -104,6 +104,10 @@ When the source ticket asks for a manual smoke or visual check, do ONE of these 
 
 Smoke / manual-verify requests in the source are operator concerns, not implementer concerns. Honor the intent (the operator wants to test the UX) without making the agent loop block on something it can't satisfy.
 
+RULED OUT — the `rejected_approaches` schema field. Name each approach you considered and
+dropped, with the reason you dropped it. Every agent after you reads the list and takes it as
+settled, so an approach you rejected silently is one they will propose again.
+
 ASSIGNEE RESOLUTION — the `assignee_github_login` schema field. Resolve the ticket
 assignee's GitHub login via the github MCP from their name
 `{{ build.task_owner_name or "(unknown)" }}` or email

--- a/backend/templates/prompts/build/build_workflow/implement.md
+++ b/backend/templates/prompts/build/build_workflow/implement.md
@@ -17,7 +17,8 @@ acceptance criterion — nothing more, nothing less.
   operator through the structured return value.
 - **Minimum scope.** You are not here to improve the codebase, refactor adjacent code, or
   apply opinions about better approaches. Scope creep in either direction — doing more than
-  asked or quietly doing less — costs a revision round.
+  asked or quietly doing less — costs a revision round.{% if build.journal.plan.rejected_approaches %} The approaches listed under
+  **Ruled out** are settled — do not revisit them.{% endif %}
 - **You deliver by pushing.** You are working in a clone with push access already configured.
   When the implementation is complete, commit every change and push it to the work branch
   (see "Delivering your work" below). The pushed commit IS the deliverable — the evaluator

--- a/backend/tests/test_build_prompts.py
+++ b/backend/tests/test_build_prompts.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 from druks.build import workflows as build_workflows
+from druks.build.contracts import PlanData
 from druks.build.journal import BuildJournal
 from druks.build.models import Project, ProjectRepo
 from druks.build.prompt_context import BuildPromptContext
@@ -114,6 +115,26 @@ async def test_generate_plan_prompt_quotes_the_reviewer_critique():
     )
     assert "## Plan reviewer critique" in output
     assert "> Name the wire schema.\n> Split the migration." in output
+
+
+async def test_ruled_out_approaches_cross_the_plan_review_park():
+    """The planner's rejected approaches ride the journal into implement — the park
+    reaps the warm VM, so the journal is the only thing that carries."""
+    build = _build()
+    build.journal.add(
+        PlanData(
+            plan_markdown="p",
+            rejected_approaches=["a status column on Run — derives from DBOS already"],
+        )
+    )
+    output = await render_prompt(
+        "build/build_workflow/implement.md",
+        build=build,
+        verification="VERIFICATION-BLOCK",
+        workspace=_workspace(),
+    )
+    assert "## Ruled out" in output
+    assert "a status column on Run — derives from DBOS already" in output
 
 
 async def test_the_planner_resolves_the_assignee_not_the_reviewer():


### PR DESCRIPTION
Partially closes ENG-751. Stacked on #83.

**Scope reduced after measurement — read the next section before reviewing.** The ticket asked for a full code map (files, symbols, call sites, ruled-out alternatives). This PR ships only `rejected_approaches`. The `verified_files` half was built, measured against production transcripts, and cut.

## Why the code map was cut

The ticket's premise: the planner reads and verifies the exact surface a change touches, the plan-review park reaps the warm VM, and `implement` starts cold and re-derives that map. The ticket said outright this had never been measured. It now has — four `implement` transcripts off the prod host, including the exact pair the ticket cites (ENG-740's 484 s plan → its 600 s implement).

ENG-740 implement, 92 shell commands:

| | calls | share |
|---|---|---|
| read repo files | 45 | 49% |
| search (rg/grep/find) | 18 | 20% |
| read `.codex/skills/*/SKILL.md` | 16 | 17% |
| git | 14 | 15% |

Search is 13–20% across all four runs — the ceiling on what a code map could remove. Three findings put it well below that:

1. **44 of 45 reads were already region-scoped** (`sed -n '120,180p'`), one whole-file. "Read regions, not whole files" was the *planner's* problem (Claude, whole-file reads, the 2.88M cache figure — that is ENG-750). Implement runs on codex and already does it.
2. **About half its reading is on files the plan never named.** The plan named 12 files; implement read 21 others — `conftest.py`, `signals.py`, `policy.py`, `durable/schemas.py`, `sse.test.ts`, `PageHeader`, `EmptyState`. Those are found while making the change. A map of what the *planner* read cannot contain them.
3. **The searches are pattern sweeps, not lookups.** `rg "@subscribe" backend/druks -A3`, `rg "set_status\(HandoffStatus|set_status\(None"`, `rg "class SubjectStatus"`. "Show me every subscriber" is not a question `{path, symbols}` answers.

So the assumed mechanism largely isn't what happens: implement re-derives *its own* map, which is a different and larger one than the planner's.

## What did survive, and why

`rejected_approaches` stands on separate reasoning — nothing to do with search cost. Nothing anywhere records what the planner considered and dropped. That judgment dies at the park and gets re-proposed by the implementer, the evaluator, or the next revision round. There is no substitute for it today, and it costs one field.

- `PlanOutput` and `PlanData` gain `rejected_approaches: list[str]`; `to_result()` carries it.
- `_header.md` renders a **Ruled out** section, guarded — empty renders nothing, no orphan heading. It sits in the shared header, so the evaluator and code reviewer see it too, not just implement.
- `generate_plan.md` tells the planner to name each dropped approach with its reason: an approach rejected silently is one someone proposes again.
- `implement.md` adds one clause to Minimum scope, itself guarded on the list being non-empty.

## Not done

The ticket's acceptance criterion "`PlanOutput` carries the verified surface (files, symbols, call sites…)" is deliberately unmet, per the measurement above. ENG-751 should be re-scoped or closed against this PR rather than treated as fully delivered.

A separate finding worth its own ticket: every agent call re-reads the same static `SKILL.md` files in ~250-line `sed` chunks — 16, 11, 9 and 6 calls across the four runs, 9–28% of each call's tool budget. It is a fixed, repo-independent tax paid by all seven build agents, and it is larger than anything this ticket was chasing.

## Verification

- `ruff check` + `ruff format --check` clean (281 files).
- `PlanOutput` JSON schema builds with `rejected_approaches` required (the strict agent schema bans defaults) and no trace of the cut model.
- Rendered `implement.md` against a real `BuildJournal`: the section and its bullet land. Against an empty journal: neither the heading nor the Minimum-scope clause renders.
- New test pins the crossing. Backend suite gates on CI.