### PR TITLE
Skills are consulted when they come up, not read cover to cover first

### DIFF
--- a/backend/templates/prompts/build/build_workflow/_skills.md
+++ b/backend/templates/prompts/build/build_workflow/_skills.md
@@ -1,7 +1,7 @@
 {% if build.skills %}
 ## Skills
 
-Load each skill below before starting work and apply its expertise. If a skill is unavailable, continue without it.
+These are installed in this VM under your agent home. Open one when its subject matter comes up in the work — not up front, and not the whole set. If a skill is unavailable, carry on without it.
 
 {% for skill in build.skills %}
 - `/{{ skill }}`


### PR DESCRIPTION
One sentence in `_skills.md` was costing ~100 kB of context per codex agent call. It said:

> Load each skill below before starting work and apply its expertise.

Codex obeys that literally. Measured on prod transcripts:

| call | harness | skill cmds | skill text read | share of all command output |
| -- | -- | -- | -- | -- |
| ENG-740 `implement` | codex | 16 / 92 | 102 kB | 24% |
| ENG-740 `implement` (revision) | codex | 9 / 32 | 102 kB | **81%** |
| ENG-736 `implement` | codex | 6 / 68 | 47 kB | 12% |
| ENG-740 `generate_plan` | claude | 0 / 36 | 0 kB | 0% |

The revision row is the sharp one: a 101-second round that changed two files opened with seven `cat` calls over every recommended `SKILL.md` — byte-for-byte the same 102 kB the first pass had already read. Four fifths of everything it read was static skill prose. At ~25k tokens a pass and `max_implementation_revisions` defaulting to 5, that is up to 125k tokens of identical text per work item, before `triage_human_feedback` and `repo_profiler`.

The Claude-harness agents pay none of it. They have a native skill primitive and reach for a skill when it is relevant — on that plan run, never. Codex 0.145 exposes skills over its app-server protocol but the headless agent has no skill tool, only shell, so "load each one before starting work" becomes seven unconditional `cat`s. The transcript is unambiguous: the revision run's first seven actions are `cat /home/exedev/.codex/skills/*/SKILL.md`, no tool call involved.

## The change

The wording goes from eager to on-demand: the skills are installed in the VM, open one when its subject matter comes up, not up front and not the whole set. That is what the Claude agents already do.

This is prompt-only, one file, trivially reversible.

## Why it got worse recently

Skill routing used to ride the scope brief on the ticket, so this partial only rendered where a brief existed. #81 rehomed it onto the repo profile, which correctly fixed a silent breakage — and incidentally made the eager wording render on all seven build prompts.

## What this does not answer

Whether eager loading was earning anything. Nobody has compared implement quality with and without, and the Claude-side agents have been planning, reviewing and evaluating without reading a skill at all. Worth knowing, but it is a separate question from paying 102 kB for a two-file revision.

## Verification

- All seven build prompts render the new wording; an empty recommended-skills list still renders no `## Skills` section at all.
- `ruff` clean. No Python touched.
- The real measurement is a post-deploy `implement` run counted the same way — skill command count and skill text volume against the numbers above.
