### PR TITLE
ENG-759 - [ship] Declare merge intent at approval and let GitHub execute

### DIFF
--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -319,9 +319,10 @@ class Build(Workflow):
     async def _approved_work(self) -> bool:
         # GitHub announces the merge; the pr.closed reaction settles shipped.
         if self._policy.on_approval == "merge":
-            await self.merge()
-        else:
-            await self._clear_draft()
+            if await self.declare_merge_intent():
+                return True
+            return await self._work_gate()
+        await self._clear_draft()
         return True
 
     async def _triage(self) -> bool:
@@ -352,22 +353,17 @@ class Build(Workflow):
         return delivery
 
     @step
-    async def merge(self) -> None:
+    async def declare_merge_intent(self) -> bool:
+        """Whether GitHub accepted ownership of the merge."""
         github = get_github_client(load_settings())
         pull_request = await github.get_pull_request(self.input.repo, self.pr_number)
-        if pull_request.get("state") == "closed":
-            return
-        await github.squash_merge_pull_request(self.input.repo, self.pr_number)
-        if self._policy.delete_branch:
-            try:
-                await github.delete_branch(self.input.repo, self.branch)
-            except Exception:  # noqa: BLE001 — cleanup only
-                logger.warning(
-                    "Could not delete branch %s on %s.",
-                    self.branch,
-                    self.input.repo,
-                    exc_info=True,
-                )
+        if pull_request["state"] == "closed":
+            return True
+
+        await github.update_pull_request_branch(self.input.repo, self.pr_number)
+        if await github.enable_auto_merge(self.input.repo, pull_request["node_id"]):
+            return True
+        return await github.squash_merge_pull_request(self.input.repo, self.pr_number)
 
     # The provisioned branch + PR, published by the first implement — None until then
     # (planning runs against the default branch, and there is no PR to point at).

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -356,14 +356,7 @@ class Build(Workflow):
     async def declare_merge_intent(self) -> bool:
         """Whether GitHub accepted ownership of the merge."""
         github = get_github_client(load_settings())
-        pull_request = await github.get_pull_request(self.input.repo, self.pr_number)
-        if pull_request["state"] == "closed":
-            return True
-
-        await github.update_pull_request_branch(self.input.repo, self.pr_number)
-        if await github.enable_auto_merge(self.input.repo, pull_request["node_id"]):
-            return True
-        return await github.squash_merge_pull_request(self.input.repo, self.pr_number)
+        return await github.merge_when_ready(self.input.repo, self.pr_number)
 
     # The provisioned branch + PR, published by the first implement — None until then
     # (planning runs against the default branch, and there is no PR to point at).

--- a/backend/druks/core/apis/github.py
+++ b/backend/druks/core/apis/github.py
@@ -290,6 +290,17 @@ class GitHubClient:
                 return
             raise
 
+    async def merge_when_ready(self, repo: str, pr_number: int) -> bool:
+        """Whether GitHub accepted ownership of the merge."""
+        pull_request = await self.get_pull_request(repo, pr_number)
+        if pull_request["state"] == "closed":
+            return True
+
+        await self.update_pull_request_branch(repo, pr_number)
+        if await self.enable_auto_merge(repo, pull_request["node_id"]):
+            return True
+        return await self.squash_merge_pull_request(repo, pr_number)
+
     @_retry_on_401
     async def update_pull_request_body(
         self,

--- a/backend/druks/core/apis/github.py
+++ b/backend/druks/core/apis/github.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, TypeVar
 
 from githubkit import AppAuthStrategy, AppInstallationAuthStrategy, GitHub
-from githubkit.exception import RequestFailed
+from githubkit.exception import GraphQLFailed, RequestFailed
 
 from druks.core.apis.exceptions import GitHubAppNotConfiguredError, GitHubAppNotInstalledError
 from druks.settings import Settings
@@ -242,17 +242,53 @@ class GitHubClient:
         return response.parsed_data.model_dump()
 
     @_retry_on_401
-    async def squash_merge_pull_request(self, repo: str, pr_number: int) -> dict[str, Any]:
+    async def squash_merge_pull_request(self, repo: str, pr_number: int) -> bool:
         # No commit_title: GitHub then titles the squash commit from the PR title.
         owner, name = repo.split("/", 1)
         gh = await self._for_repo(repo)
-        response = await gh.rest.pulls.async_merge(
-            owner,
-            name,
-            pr_number,
-            data={"merge_method": "squash"},
-        )
-        return response.parsed_data.model_dump()
+        try:
+            response = await gh.rest.pulls.async_merge(
+                owner,
+                name,
+                pr_number,
+                data={"merge_method": "squash"},
+            )
+        except RequestFailed as exc:
+            if exc.response.status_code in {405, 409}:
+                return False
+            raise
+        return response.parsed_data.merged
+
+    @_retry_on_401
+    async def enable_auto_merge(self, repo: str, node_id: str) -> bool:
+        gh = await self._for_repo(repo)
+        try:
+            await gh.async_graphql(
+                """
+                mutation EnablePullRequestAutoMerge($id: ID!) {
+                  enablePullRequestAutoMerge(
+                    input: {pullRequestId: $id, mergeMethod: SQUASH}
+                  ) {
+                    pullRequest { id }
+                  }
+                }
+                """,
+                {"id": node_id},
+            )
+        except GraphQLFailed:
+            return False
+        return True
+
+    @_retry_on_401
+    async def update_pull_request_branch(self, repo: str, pr_number: int) -> None:
+        owner, name = repo.split("/", 1)
+        gh = await self._for_repo(repo)
+        try:
+            await gh.rest.pulls.async_update_branch(owner, name, pr_number)
+        except RequestFailed as exc:
+            if exc.response.status_code == 422:
+                return
+            raise
 
     @_retry_on_401
     async def update_pull_request_body(

--- a/backend/tests/test_build_durable.py
+++ b/backend/tests/test_build_durable.py
@@ -111,8 +111,7 @@ def _stub(
     *,
     plan_approval="human",
     auto_dispatch=False,
-    auto_merge_accepted=True,
-    merge_accepted=True,
+    merge_when_ready_accepted=True,
 ):
     import druks.contrib.ship.workflows as m
     from druks.contrib.ship.contracts import (
@@ -197,26 +196,12 @@ def _stub(
 
     github_calls = []
 
-    async def _get_pull_request(*args, **kwargs):
-        github_calls.append("get_pull_request")
-        return {"state": "open", "node_id": "PR_node"}
-
-    async def _update_pull_request_branch(*args, **kwargs):
-        github_calls.append("update_pull_request_branch")
-
-    async def _enable_auto_merge(*args, **kwargs):
-        github_calls.append("enable_auto_merge")
-        return auto_merge_accepted
-
-    async def _squash_merge_pull_request(*args, **kwargs):
-        github_calls.append("squash_merge_pull_request")
-        return merge_accepted
+    async def _merge_when_ready(*args, **kwargs):
+        github_calls.append("merge_when_ready")
+        return merge_when_ready_accepted
 
     fake_github = SimpleNamespace(
-        get_pull_request=_get_pull_request,
-        update_pull_request_branch=_update_pull_request_branch,
-        enable_auto_merge=_enable_auto_merge,
-        squash_merge_pull_request=_squash_merge_pull_request,
+        merge_when_ready=_merge_when_ready,
         create_issue_comment=_noop,
     )
     monkeypatch.setattr(m, "get_github_client", lambda *args, **kwargs: fake_github)
@@ -239,7 +224,7 @@ async def _start_to_work_gate(rt, item):
     return workflow_id, parked
 
 
-async def test_happy_path_enables_auto_merge(rt, monkeypatch):
+async def test_happy_path_declares_merge_intent(rt, monkeypatch):
     _, github_calls = _stub(monkeypatch, rt)
 
     item = _seed_work_item(rt.engine, repo="acme/widget")
@@ -248,11 +233,7 @@ async def test_happy_path_enables_auto_merge(rt, monkeypatch):
 
     done = await _wait(rt.engine, workflow_id, lambda run: run.state == RunState.FINISHED)
     assert not done.failure
-    assert github_calls == [
-        "get_pull_request",
-        "update_pull_request_branch",
-        "enable_auto_merge",
-    ]
+    assert github_calls == ["merge_when_ready"]
 
     # Shipped settles via GitHub's pr.closed webhook (test_webhooks_pull_request),
     # not the run — the run's job ends when GitHub accepts the merge intent. The durable
@@ -269,33 +250,11 @@ async def test_happy_path_enables_auto_merge(rt, monkeypatch):
     assert [e.type for e in events if e.type.startswith("run.")][-1] == "run.finished"
 
 
-async def test_auto_merge_rejection_falls_back_to_squash_merge(rt, monkeypatch):
+async def test_rejected_merge_intent_reparks_work_gate(rt, monkeypatch):
     _, github_calls = _stub(
         monkeypatch,
         rt,
-        auto_merge_accepted=False,
-    )
-
-    item = _seed_work_item(rt.engine, repo="acme/fallback")
-    workflow_id, parked = await _start_to_work_gate(rt, item)
-    await parked.resume(action="approve")
-
-    done = await _wait(rt.engine, workflow_id, lambda run: run.state == RunState.FINISHED)
-    assert not done.failure
-    assert github_calls == [
-        "get_pull_request",
-        "update_pull_request_branch",
-        "enable_auto_merge",
-        "squash_merge_pull_request",
-    ]
-
-
-async def test_rejected_auto_merge_and_squash_merge_repark_work_gate(rt, monkeypatch):
-    _, github_calls = _stub(
-        monkeypatch,
-        rt,
-        auto_merge_accepted=False,
-        merge_accepted=False,
+        merge_when_ready_accepted=False,
     )
 
     item = _seed_work_item(rt.engine, repo="acme/repark")
@@ -313,12 +272,7 @@ async def test_rejected_auto_merge_and_squash_merge_repark_work_gate(rt, monkeyp
         ),
     )
     assert not reparked.failure
-    assert github_calls == [
-        "get_pull_request",
-        "update_pull_request_branch",
-        "enable_auto_merge",
-        "squash_merge_pull_request",
-    ]
+    assert github_calls == ["merge_when_ready"]
     await reparked.cancel()
 
 

--- a/backend/tests/test_build_durable.py
+++ b/backend/tests/test_build_durable.py
@@ -91,13 +91,13 @@ def _seed_work_item(engine, *, repo: str):
         return item
 
 
-async def _wait(engine, wfid, predicate, timeout=20.0):
+async def _wait(engine, workflow_id, predicate, timeout=20.0):
     deadline = asyncio.get_event_loop().time() + timeout
     while asyncio.get_event_loop().time() < deadline:
         session = get_session(engine)
         try:
-            row = session.get(Run, wfid)
-            if row is not None and predicate(row):
+            row = session.get(Run, workflow_id)
+            if row and predicate(row):
                 return row
         finally:
             session.close()
@@ -105,7 +105,15 @@ async def _wait(engine, wfid, predicate, timeout=20.0):
     raise AssertionError("timed out")
 
 
-def _stub(monkeypatch, rt, *, plan_approval="human", auto_dispatch=False):
+def _stub(
+    monkeypatch,
+    rt,
+    *,
+    plan_approval="human",
+    auto_dispatch=False,
+    auto_merge_accepted=True,
+    merge_accepted=True,
+):
     import druks.contrib.ship.workflows as m
     from druks.contrib.ship.contracts import (
         CodeReviewOutput,
@@ -119,8 +127,8 @@ def _stub(monkeypatch, rt, *, plan_approval="human", auto_dispatch=False):
 
     flow = rt.flow
 
-    async def _noop(*a, **k):
-        return None
+    async def _noop(*args, **kwargs):
+        return
 
     for name in (
         "set_pr_draft",
@@ -187,47 +195,67 @@ def _stub(monkeypatch, rt, *, plan_approval="human", auto_dispatch=False):
 
     monkeypatch.setattr(Agent, "_run", _run)
 
+    github_calls = []
+
+    async def _get_pull_request(*args, **kwargs):
+        github_calls.append("get_pull_request")
+        return {"state": "open", "node_id": "PR_node"}
+
+    async def _update_pull_request_branch(*args, **kwargs):
+        github_calls.append("update_pull_request_branch")
+
+    async def _enable_auto_merge(*args, **kwargs):
+        github_calls.append("enable_auto_merge")
+        return auto_merge_accepted
+
+    async def _squash_merge_pull_request(*args, **kwargs):
+        github_calls.append("squash_merge_pull_request")
+        return merge_accepted
+
     fake_github = SimpleNamespace(
-        get_pull_request=lambda *a, **k: _dict({"state": "open"}),
-        squash_merge_pull_request=lambda *a, **k: _dict({"merged": True}),
+        get_pull_request=_get_pull_request,
+        update_pull_request_branch=_update_pull_request_branch,
+        enable_auto_merge=_enable_auto_merge,
+        squash_merge_pull_request=_squash_merge_pull_request,
         create_issue_comment=_noop,
     )
-    monkeypatch.setattr(m, "get_github_client", lambda *a, **k: fake_github)
-    return invoked
+    monkeypatch.setattr(m, "get_github_client", lambda *args, **kwargs: fake_github)
+    return invoked, github_calls
 
 
-async def _dict(d):
-    return d
-
-
-async def test_happy_path_to_merge(rt, monkeypatch):
-    _stub(monkeypatch, rt)
-
-    item = _seed_work_item(rt.engine, repo="acme/widget")
-    wfid = await rt.flow.start(
-        repo="acme/widget",
-        subject=item,
-    )
-
+async def _start_to_work_gate(rt, item):
+    workflow_id = await rt.flow.start(repo=item.repo, subject=item)
     parked = await _wait(
         rt.engine,
-        wfid,
-        lambda r: r.state == RunState.PENDING_INPUT and r.input_gate == "review",
+        workflow_id,
+        lambda run: run.state == RunState.PENDING_INPUT and run.input_gate == "review",
     )
     await parked.resume(action="approve", answers={})
-
     parked = await _wait(
         rt.engine,
-        wfid,
-        lambda r: r.state == RunState.PENDING_INPUT and r.input_gate == "review_work",
+        workflow_id,
+        lambda run: run.state == RunState.PENDING_INPUT and run.input_gate == "review_work",
     )
+    return workflow_id, parked
+
+
+async def test_happy_path_enables_auto_merge(rt, monkeypatch):
+    _, github_calls = _stub(monkeypatch, rt)
+
+    item = _seed_work_item(rt.engine, repo="acme/widget")
+    workflow_id, parked = await _start_to_work_gate(rt, item)
     await parked.resume(action="approve")
 
-    done = await _wait(rt.engine, wfid, lambda r: r.state == RunState.FINISHED)
-    assert done.failure is None
+    done = await _wait(rt.engine, workflow_id, lambda run: run.state == RunState.FINISHED)
+    assert not done.failure
+    assert github_calls == [
+        "get_pull_request",
+        "update_pull_request_branch",
+        "enable_auto_merge",
+    ]
 
     # Shipped settles via GitHub's pr.closed webhook (test_webhooks_pull_request),
-    # not the run — the run's job ends at the merge call. The run's durable
+    # not the run — the run's job ends when GitHub accepts the merge intent. The durable
     # residue is the event log of its state transitions.
     from druks.events.models import Event
 
@@ -241,24 +269,77 @@ async def test_happy_path_to_merge(rt, monkeypatch):
     assert [e.type for e in events if e.type.startswith("run.")][-1] == "run.finished"
 
 
+async def test_auto_merge_rejection_falls_back_to_squash_merge(rt, monkeypatch):
+    _, github_calls = _stub(
+        monkeypatch,
+        rt,
+        auto_merge_accepted=False,
+    )
+
+    item = _seed_work_item(rt.engine, repo="acme/fallback")
+    workflow_id, parked = await _start_to_work_gate(rt, item)
+    await parked.resume(action="approve")
+
+    done = await _wait(rt.engine, workflow_id, lambda run: run.state == RunState.FINISHED)
+    assert not done.failure
+    assert github_calls == [
+        "get_pull_request",
+        "update_pull_request_branch",
+        "enable_auto_merge",
+        "squash_merge_pull_request",
+    ]
+
+
+async def test_rejected_auto_merge_and_squash_merge_repark_work_gate(rt, monkeypatch):
+    _, github_calls = _stub(
+        monkeypatch,
+        rt,
+        auto_merge_accepted=False,
+        merge_accepted=False,
+    )
+
+    item = _seed_work_item(rt.engine, repo="acme/repark")
+    workflow_id, parked = await _start_to_work_gate(rt, item)
+    first_parked_at = parked.input_requested_at
+    await parked.resume(action="approve")
+
+    reparked = await _wait(
+        rt.engine,
+        workflow_id,
+        lambda run: (
+            run.state == RunState.PENDING_INPUT
+            and run.input_gate == "review_work"
+            and run.input_requested_at != first_parked_at
+        ),
+    )
+    assert not reparked.failure
+    assert github_calls == [
+        "get_pull_request",
+        "update_pull_request_branch",
+        "enable_auto_merge",
+        "squash_merge_pull_request",
+    ]
+    await reparked.cancel()
+
+
 async def test_auto_mode_machine_review_replaces_the_plan_gate(rt, monkeypatch):
     """plan_approval resolves to none: the machine reviewer approves the plan and
     the run reaches the work gate with no plan park — review_plan runs exactly
     once, where it substitutes for the operator."""
-    invoked = _stub(monkeypatch, rt, plan_approval=None, auto_dispatch=True)
+    invoked, _ = _stub(monkeypatch, rt, plan_approval=None, auto_dispatch=True)
 
     item = _seed_work_item(rt.engine, repo="acme/gizmo")
-    wfid = await rt.flow.start(
+    workflow_id = await rt.flow.start(
         repo="acme/gizmo",
         subject=item,
     )
 
     parked = await _wait(
         rt.engine,
-        wfid,
-        lambda r: r.state == RunState.PENDING_INPUT and r.input_gate == "review_work",
+        workflow_id,
+        lambda run: run.state == RunState.PENDING_INPUT and run.input_gate == "review_work",
     )
     assert invoked[:2] == ["generate_plan", "review_plan"]
     await parked.resume(action="approve")
-    done = await _wait(rt.engine, wfid, lambda r: r.state == RunState.FINISHED)
-    assert done.failure is None
+    done = await _wait(rt.engine, workflow_id, lambda run: run.state == RunState.FINISHED)
+    assert not done.failure

--- a/backend/tests/test_github.py
+++ b/backend/tests/test_github.py
@@ -7,7 +7,7 @@ import pytest
 from druks.core.apis.exceptions import GitHubAppNotInstalledError
 from druks.core.apis.github import GitHubClient
 from githubkit import GitHub
-from githubkit.exception import RequestFailed
+from githubkit.exception import GraphQLFailed, RequestFailed
 
 
 class _Parsed:
@@ -77,6 +77,18 @@ async def test_create_review_omits_empty_comments() -> None:
     }
 
 
+async def test_enable_auto_merge_uses_squash_mutation() -> None:
+    gh = SimpleNamespace(async_graphql=AsyncMock())
+    client = _TestGitHubClient(gh)
+
+    assert await client.enable_auto_merge("ClawHaven/example", "PR_node")
+
+    query, variables = gh.async_graphql.await_args.args
+    assert "enablePullRequestAutoMerge" in query
+    assert "mergeMethod: SQUASH" in query
+    assert variables == {"id": "PR_node"}
+
+
 class _FakeResponse:
     def __init__(self, status_code: int) -> None:
         self.status_code = status_code
@@ -86,6 +98,66 @@ def _make_request_failed(status_code: int) -> RequestFailed:
     exc = RequestFailed.__new__(RequestFailed)
     exc.response = _FakeResponse(status_code)  # type: ignore[assignment]
     return exc
+
+
+async def test_enable_auto_merge_absorbs_graphql_rejection() -> None:
+    error = GraphQLFailed(SimpleNamespace(errors=["rejected"]))  # type: ignore[arg-type]
+    client = _TestGitHubClient(SimpleNamespace(async_graphql=AsyncMock(side_effect=error)))
+
+    assert not await client.enable_auto_merge("ClawHaven/example", "PR_node")
+
+
+async def test_enable_auto_merge_raises_transport_failure() -> None:
+    error = _make_request_failed(500)
+    client = _TestGitHubClient(SimpleNamespace(async_graphql=AsyncMock(side_effect=error)))
+
+    with pytest.raises(RequestFailed) as raised:
+        await client.enable_auto_merge("ClawHaven/example", "PR_node")
+
+    assert raised.value is error
+
+
+@pytest.mark.parametrize("status_code", [405, 409])
+async def test_squash_merge_pull_request_absorbs_not_mergeable_status(
+    status_code: int,
+) -> None:
+    pulls = SimpleNamespace(async_merge=AsyncMock(side_effect=_make_request_failed(status_code)))
+    client = _TestGitHubClient(SimpleNamespace(rest=SimpleNamespace(pulls=pulls)))
+
+    assert not await client.squash_merge_pull_request("ClawHaven/example", 7)
+
+
+async def test_squash_merge_pull_request_raises_other_failures() -> None:
+    error = _make_request_failed(422)
+    pulls = SimpleNamespace(async_merge=AsyncMock(side_effect=error))
+    client = _TestGitHubClient(SimpleNamespace(rest=SimpleNamespace(pulls=pulls)))
+
+    with pytest.raises(RequestFailed) as raised:
+        await client.squash_merge_pull_request("ClawHaven/example", 7)
+
+    assert raised.value is error
+
+
+async def test_update_pull_request_branch_accepts_already_current_branch() -> None:
+    pulls = SimpleNamespace(
+        async_update_branch=AsyncMock(side_effect=_make_request_failed(422)),
+    )
+    client = _TestGitHubClient(SimpleNamespace(rest=SimpleNamespace(pulls=pulls)))
+
+    await client.update_pull_request_branch("ClawHaven/example", 7)
+
+    pulls.async_update_branch.assert_awaited_once_with("ClawHaven", "example", 7)
+
+
+async def test_update_pull_request_branch_raises_other_failures() -> None:
+    error = _make_request_failed(409)
+    pulls = SimpleNamespace(async_update_branch=AsyncMock(side_effect=error))
+    client = _TestGitHubClient(SimpleNamespace(rest=SimpleNamespace(pulls=pulls)))
+
+    with pytest.raises(RequestFailed) as raised:
+        await client.update_pull_request_branch("ClawHaven/example", 7)
+
+    assert raised.value is error
 
 
 class _OwnerReposClient(GitHubClient):

--- a/backend/tests/test_github.py
+++ b/backend/tests/test_github.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock, Mock, call
 
 import druks.core.apis.github as github_api
 import pytest
@@ -158,6 +158,74 @@ async def test_update_pull_request_branch_raises_other_failures() -> None:
         await client.update_pull_request_branch("ClawHaven/example", 7)
 
     assert raised.value is error
+
+
+def _merge_when_ready_client(
+    *,
+    state: str = "open",
+    auto_merge_accepted: bool = True,
+    squash_merge_accepted: bool = True,
+) -> tuple[_TestGitHubClient, Mock]:
+    client = _TestGitHubClient(SimpleNamespace())
+    operations = Mock()
+    get_pull_request = AsyncMock(return_value={"state": state, "node_id": "PR_node"})
+    update_pull_request_branch = AsyncMock()
+    enable_auto_merge = AsyncMock(return_value=auto_merge_accepted)
+    squash_merge_pull_request = AsyncMock(return_value=squash_merge_accepted)
+    operations.attach_mock(get_pull_request, "get_pull_request")
+    operations.attach_mock(update_pull_request_branch, "update_pull_request_branch")
+    operations.attach_mock(enable_auto_merge, "enable_auto_merge")
+    operations.attach_mock(squash_merge_pull_request, "squash_merge_pull_request")
+    client.get_pull_request = get_pull_request
+    client.update_pull_request_branch = update_pull_request_branch
+    client.enable_auto_merge = enable_auto_merge
+    client.squash_merge_pull_request = squash_merge_pull_request
+    return client, operations
+
+
+async def test_merge_when_ready_short_circuits_closed_pull_request() -> None:
+    client, operations = _merge_when_ready_client(state="closed")
+
+    assert await client.merge_when_ready("ClawHaven/example", 7)
+    assert operations.mock_calls == [call.get_pull_request("ClawHaven/example", 7)]
+
+
+async def test_merge_when_ready_queues_after_updating_branch() -> None:
+    client, operations = _merge_when_ready_client()
+
+    assert await client.merge_when_ready("ClawHaven/example", 7)
+    assert operations.mock_calls == [
+        call.get_pull_request("ClawHaven/example", 7),
+        call.update_pull_request_branch("ClawHaven/example", 7),
+        call.enable_auto_merge("ClawHaven/example", "PR_node"),
+    ]
+
+
+async def test_merge_when_ready_falls_back_to_direct_merge() -> None:
+    client, operations = _merge_when_ready_client(auto_merge_accepted=False)
+
+    assert await client.merge_when_ready("ClawHaven/example", 7)
+    assert operations.mock_calls == [
+        call.get_pull_request("ClawHaven/example", 7),
+        call.update_pull_request_branch("ClawHaven/example", 7),
+        call.enable_auto_merge("ClawHaven/example", "PR_node"),
+        call.squash_merge_pull_request("ClawHaven/example", 7),
+    ]
+
+
+async def test_merge_when_ready_reports_unsettled_merge() -> None:
+    client, operations = _merge_when_ready_client(
+        auto_merge_accepted=False,
+        squash_merge_accepted=False,
+    )
+
+    assert not await client.merge_when_ready("ClawHaven/example", 7)
+    assert operations.mock_calls == [
+        call.get_pull_request("ClawHaven/example", 7),
+        call.update_pull_request_branch("ClawHaven/example", 7),
+        call.enable_auto_merge("ClawHaven/example", "PR_node"),
+        call.squash_merge_pull_request("ClawHaven/example", 7),
+    ]
 
 
 class _OwnerReposClient(GitHubClient):


### PR DESCRIPTION
Approving the work gate fired `PUT /pulls/{n}/merge` immediately. The approval usually lands while CI is still running, branch protection refuses, and the 405 killed the run — that is what happened to ENG-736 on 2026-07-25, 37 seconds before its checks went green.

druks now declares intent and GitHub executes. `pr.closed(merged=True)` was already the only thing that settles SHIPPED; the direct merge was the vestige contradicting it.

## What the probe established

Measured on a scratch repo with `strict: true` and the required context `checks`, the same protection shape as `main`:

| probe | result |
| -- | -- |
| enable auto-merge on a CLEAN PR | rejected — `Pull request Pull request is in clean status` |
| enable auto-merge on a BLOCKED PR | succeeds |
| main moves → PR BEHIND, then its check goes green | **never merges**; GitHub does not update a queued branch |
| `PUT /pulls/{n}/update-branch` | new head SHA, auto-merge survives, check re-runs, merged |

So auto-merge alone is not enough here. `declare_merge_intent` updates the branch first, then enables auto-merge, and falls back to an immediate squash merge for the PR GitHub already considers mergeable — the case where auto-merge has nothing to wait for and is refused. The fallback is decided by GitHub's own rejection, never by matching its error text.

If neither settles, the work gate re-parks instead of raising. A PR that cannot merge right now is a park-and-retry condition, not a dead run.

`allow_auto_merge` is already enabled on this repo, so there is no operator prerequisite.

## Branch deletion

The merge path deleted the branch a second time inside a `try/except` that swallowed the failure — `delete_branch_on_merge` already covers it, so that call is gone. `RepoPolicy.delete_branch` stays: `WorkItem.close_external` is the abandoned-PR path, where GitHub deletes nothing.

## Notes for review

`githubkit` stays behind `GitHubClient` — the client absorbs the statuses that are normal domain outcomes (422 already-up-to-date, 405/409 not-mergeable, a rejected mutation) and answers a domain fact, the same shape `delete_branch` already used. Nothing under `contrib/` imports `githubkit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
