### PR TITLE
ENG-766 - [ship] Hold the planner to intent ambiguity, and never implement from an empty plan

### DIFF
--- a/backend/druks/contrib/ship/contracts.py
+++ b/backend/druks/contrib/ship/contracts.py
@@ -8,7 +8,7 @@ from druks.contrib.ship.enums import (
     HumanFeedbackAction,
     ReviewDecision,
 )
-from druks.workflows import Gate, Workflow
+from druks.workflows import Gate, OperatorReply, Workflow
 
 if TYPE_CHECKING:
     from druks.contrib.ship.workflows import Build
@@ -99,6 +99,15 @@ class PlanData(BaseModel):
 
     def uses_recommended_answers(self, picks: dict[str, str]) -> bool:
         return all(question.is_recommended(picks.get(question.id)) for question in self.questions)
+
+    def is_confirmed_by(self, reply: OperatorReply) -> bool:
+        """A plan carrying acceptance criteria that the operator approved as it stands."""
+        return bool(
+            self.acceptance_criteria
+            and reply.action == "approve"
+            and not reply.note
+            and self.uses_recommended_answers(reply.answers)
+        )
 
     def get_answered_questions(self, picks: dict[str, str]) -> list[dict[str, str]]:
         # Each question the operator answered, paired with its answer — what the

--- a/backend/druks/contrib/ship/templates/build/generate_plan.md
+++ b/backend/druks/contrib/ship/templates/build/generate_plan.md
@@ -26,9 +26,8 @@ your acceptance criteria. Wrong shape here compounds into every step that follow
   by a code-reading evaluator who cannot run a browser, eyeball rendered output, or call
   external services. If you cannot express it as a machine-checkable assertion — diff exists,
   test passes, column present in migration, function has this signature — it is not an AC yet.
-- **Open questions are cheap now, expensive later.** A question surfaced in the plan costs a
-  paragraph. A confident answer is a decision, not a question: make it, plan with it, and note
-  it in the plan. Ask only when no confident decision can make the plan complete.
+- **A confident answer is a decision, not a question.** Make it, plan with it, and note it in
+  the plan. Ask only when no confident decision can make the plan decision-complete.
 - **One PR, one coherent change.** If the work bundles independent surfaces that could ship
   separately, a refactor with a feature, or independently shippable AC groups, ask one question
   naming the split seam and let the operator decide. Do not ask for a single feature spanning
@@ -79,12 +78,17 @@ The plan reviewer rejected your previous draft with the critique below. Fold eve
 
 {% endif %}
 {% if not answered_questions and not operator_note %}
-Before deep code reading, judge whether the ticket is ambiguous about intent: which reading of
-the request is meant, what feature surface is in play, or whether adjacent sub-features are
-included. If it is, stop there: return at most two `questions`, mark exactly one option per
-question `recommended: true`, give a short `plan_markdown` stating what you understood and what
-is blocked, and leave `acceptance_criteria` empty. Never early-exit for anything the repo can
-answer — read the code and decide.
+Before deep code reading, judge only whether the ticket is genuinely ambiguous about which
+change the operator wants. Ambiguity is never uncertainty about how the change works. A question
+the repo can answer is not ambiguity: read the code and decide. A question about observable
+external behavior — an API's actual response or a tool's real semantics — is not ambiguity
+either: go find out, then plan with the answer. Treat an "open questions" section in the source
+ticket as the operator thinking aloud, not a list to forward: answer what is answerable and ask
+only what is genuinely left.
+
+If genuine intent ambiguity remains, stop there: return at most two `questions`, mark exactly
+one option per question `recommended: true`, give a short `plan_markdown` stating what you
+understood and what is blocked, and leave `acceptance_criteria` empty.
 
 {% endif %}
 {% if build.journal.plan_revision == 0 %}
@@ -94,7 +98,7 @@ two or three sentences stating what druks understood the work to be.
 {% endif %}Never edit the ticket description and never post the plan itself.
 
 {% endif %}
-Generate the initial implementation plan. If the issue and repository support a confident answer, make that decision, plan with it, and note it instead of asking. Include open questions only when the plan cannot be made decision-complete from the issue and repository build. For each unavoidable question, set `recommended: true` on exactly one option. Return specific acceptance criteria describing what must be true for this PR to pass. When the work changes a protocol or wire contract, include exact request/response examples in the plan or acceptance criteria. Do not add standalone lint, test, or type-check acceptance criteria from the verification profile. A test explicitly requested by the issue remains a valid AC. A behavioral AC may include a `Verification:` note describing how the evaluator confirms that specific criterion.
+Generate the initial implementation plan. For each unavoidable question, set `recommended: true` on exactly one option. Return specific acceptance criteria describing what must be true for this PR to pass. When the work changes a protocol or wire contract, include exact request/response examples in the plan or acceptance criteria. Do not add standalone lint, test, or type-check acceptance criteria from the verification profile. A test explicitly requested by the issue remains a valid AC. A behavioral AC may include a `Verification:` note describing how the evaluator confirms that specific criterion.
 
 ACCEPTANCE CRITERIA MUST BE CODE-VERIFIABLE. Druks's evaluator inspects the diff and reads tests. It runs the configured verification profile as its own check set, separate from the binding acceptance criteria the implementer must satisfy. It cannot drive a browser, click through a UI, eyeball rendered output, exercise a real third-party API, or otherwise perform a runtime/visual smoke. Any criterion phrased as "manually smoke X", "load the app locally", "verify visually", "click through Y", "confirm in production", or "exercise the live N integration" is unfulfillable in this pipeline and will lock the PR in revision loops forever.
 

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -274,7 +274,8 @@ class Build(Workflow):
                 context=unresolved_critique,
             )
             if (
-                operator_reply.action == "approve"
+                plan.acceptance_criteria
+                and operator_reply.action == "approve"
                 and not operator_reply.note
                 and plan.uses_recommended_answers(operator_reply.answers)
             ):

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -273,12 +273,7 @@ class Build(Workflow):
                 questions=plan.questions,
                 context=unresolved_critique,
             )
-            if (
-                plan.acceptance_criteria
-                and operator_reply.action == "approve"
-                and not operator_reply.note
-                and plan.uses_recommended_answers(operator_reply.answers)
-            ):
+            if plan.is_confirmed_by(operator_reply):
                 return True
             answered_questions = plan.get_answered_questions(operator_reply.answers)
             operator_note = operator_reply.note

--- a/backend/tests/test_build_durable.py
+++ b/backend/tests/test_build_durable.py
@@ -115,6 +115,7 @@ def _stub(
 ):
     import druks.contrib.ship.workflows as m
     from druks.contrib.ship.contracts import (
+        AcceptanceCriterionOutput,
         CodeReviewOutput,
         EvaluationOutput,
         ImplementationOutput,
@@ -159,7 +160,16 @@ def _stub(
     # projections read them exactly as in prod. Returns the invocation log
     # (agent ids, in order).
     results = {
-        "generate_plan": PlanData(plan_markdown="p"),
+        # Acceptance criteria are what a human approve confirms — an empty plan
+        # is never confirmed, so this fixture needs one to reach the work gate.
+        "generate_plan": PlanData(
+            plan_markdown="p",
+            acceptance_criteria=[
+                AcceptanceCriterionOutput(
+                    id="AC-1", description="It ships.", verification="Read it."
+                )
+            ],
+        ),
         "review_plan": ReviewOutput(decision=ReviewDecision.APPROVE, body=""),
         "implement": ImplementationOutput.model_validate(
             {

--- a/backend/tests/test_build_plan_phase.py
+++ b/backend/tests/test_build_plan_phase.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 from druks.contrib.ship.contracts import (
+    AcceptanceCriterionOutput,
     PlanData,
     QuestionOptionOutput,
     QuestionOutput,
@@ -51,6 +52,16 @@ def _no_review_agent(monkeypatch) -> None:
     monkeypatch.setattr(Ship, "review_plan", fail_review_agent)
 
 
+def _acceptance_criteria() -> list[AcceptanceCriterionOutput]:
+    return [
+        AcceptanceCriterionOutput(
+            id="AC-1",
+            description="The planned change is implemented.",
+            verification="Read the changed code.",
+        )
+    ]
+
+
 async def test_gate_mode_parks_every_plan_and_never_calls_the_reviewer(monkeypatch):
     """Gate mode: generate → park, the reviewer never runs; operator answers
     and notes thread into the next pass."""
@@ -68,7 +79,7 @@ async def test_gate_mode_parks_every_plan_and_never_calls_the_reviewer(monkeypat
             ],
         ),
         PlanData(plan_markdown="v2"),
-        PlanData(plan_markdown="v3"),
+        PlanData(plan_markdown="v3", acceptance_criteria=_acceptance_criteria()),
     )
     _no_review_agent(monkeypatch)
 
@@ -108,6 +119,7 @@ async def test_approve_confirming_recommendations_proceeds_without_redraft(monke
         monkeypatch,
         PlanData(
             plan_markdown="v1",
+            acceptance_criteria=_acceptance_criteria(),
             questions=[
                 QuestionOutput(
                     id="q1",
@@ -131,6 +143,47 @@ async def test_approve_confirming_recommendations_proceeds_without_redraft(monke
     assert len(passes) == 1
 
 
+async def test_approve_confirming_recommendations_on_empty_plan_redrafts(monkeypatch):
+    """Approving recommended options on an empty-AC plan triggers a second plan."""
+    flow = _flow()
+    passes = _fake_plans(
+        monkeypatch,
+        PlanData(
+            plan_markdown="blocked",
+            questions=[
+                QuestionOutput(
+                    id="q1",
+                    prompt="Which cache?",
+                    options=[
+                        QuestionOptionOutput(id="a", label="Redis", recommended=True),
+                        QuestionOptionOutput(id="b", label="Memcache", recommended=False),
+                    ],
+                )
+            ],
+        ),
+        PlanData(
+            plan_markdown="v2",
+            acceptance_criteria=_acceptance_criteria(),
+        ),
+    )
+    _no_review_agent(monkeypatch)
+    replies = iter(
+        [
+            OperatorReply(action="approve", answers={"q1": "a"}),
+            OperatorReply(action="approve"),
+        ]
+    )
+
+    async def fake_review(*, questions=None, context=""):
+        return next(replies)
+
+    flow.review = fake_review
+
+    assert await flow._plan_phase() is True
+    assert len(passes) == 2
+    assert passes[1]["answered_questions"] == [{"question": "Which cache?", "answer": "Redis"}]
+
+
 async def test_approve_diverging_from_recommendation_redrafts(monkeypatch):
     """Approving a different option folds that answer into a second plan."""
     flow = _flow()
@@ -149,7 +202,7 @@ async def test_approve_diverging_from_recommendation_redrafts(monkeypatch):
                 )
             ],
         ),
-        PlanData(plan_markdown="v2"),
+        PlanData(plan_markdown="v2", acceptance_criteria=_acceptance_criteria()),
     )
     _no_review_agent(monkeypatch)
     replies = iter(
@@ -184,7 +237,7 @@ async def test_approve_with_note_redrafts(monkeypatch):
                 )
             ],
         ),
-        PlanData(plan_markdown="v2"),
+        PlanData(plan_markdown="v2", acceptance_criteria=_acceptance_criteria()),
     )
     _no_review_agent(monkeypatch)
     replies = iter(

--- a/backend/tests/test_contracts.py
+++ b/backend/tests/test_contracts.py
@@ -5,6 +5,7 @@
 import pytest
 from druks.contrib.ship import contracts as O
 from druks.contrib.ship.enums import ReviewDecision
+from druks.workflows import OperatorReply
 from pydantic import ValidationError
 
 MODELS = [
@@ -144,6 +145,19 @@ def test_agreement_needs_every_question_picked_as_recommended():
     assert not confirmed.uses_recommended_answers({"q1": "a"})
     assert not without_recommendation.uses_recommended_answers({"q1": "a"})
     assert O.PlanData().uses_recommended_answers({})
+
+
+def test_confirmation_needs_acceptance_criteria_and_an_unchanged_approval():
+    criteria = [
+        O.AcceptanceCriterionOutput(id="AC-1", description="It ships.", verification="Read it.")
+    ]
+    complete = O.PlanData(acceptance_criteria=criteria)
+
+    assert complete.is_confirmed_by(OperatorReply(action="approve"))
+    assert not complete.is_confirmed_by(OperatorReply(action="approve", note="one more thing"))
+    assert not complete.is_confirmed_by(OperatorReply(action="request_changes"))
+    # An empty plan is never confirmed, however the operator answered it.
+    assert not O.PlanData().is_confirmed_by(OperatorReply(action="approve"))
 
 
 def test_ask_contracts_cap_identity_and_cardinality():


### PR DESCRIPTION
A planning run on 2026-07-26 made four tool calls, all to the tracker, and zero file reads. It parked asking two questions and returned no acceptance criteria. Both questions were answerable: one from the repo — the code it claimed to collide with is not on `main` — and one by a short experiment against the GitHub API.

The planner was not short of access. `get_workspace_kwargs` clones per agent call, planning runs included, and `_header.md` tells the agent the repo is checked out at `repo_path`.

## The exit was too wide

The ambiguity exit invited a judgment "before deep code reading" and its only guard was one trailing clause, so it covered anything the planner had not looked into yet. It now covers only which change the operator wants:

- Ambiguity is never uncertainty about how the change works.
- A question the repo can answer is not ambiguity — read the code and decide.
- A question about observable external behavior is not ambiguity either — go find out, then plan with the answer.
- An "open questions" section in the source is the operator thinking aloud, not a list to forward.

The exit itself stays. It earns its keep on genuinely ambiguous tickets, and its mechanics are unchanged: at most two questions, one recommended option each, empty acceptance criteria.

The limit on asking at all moved into Core truths, which renders on every pass — the previous wording lived partly inside the first-pass-only block, so a redraft carried no rule.

## An empty plan can no longer reach the implementer

Approving with no note and all-recommended answers skipped the redraft and went straight to implement. Right for a complete plan whose questions were confirmed; wrong for an exit plan, which by contract has no acceptance criteria and a body saying the work is blocked. Approving the run above would have dispatched the implementer with nothing to build against, and the evaluator would have audited the diff against nothing. A plan with no acceptance criteria now always redrafts.

## Out of scope

`_plan_phase` skips the machine plan reviewer whenever a human gate is on, so what reaches the operator is always an unreviewed first draft. Deliberate, and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
