### PR TITLE
Pipeline runs are ship.build

### DIFF
--- a/backend/migrations/versions/4c1f0ab7d2e9_pipeline_runs_are_ship_build.py
+++ b/backend/migrations/versions/4c1f0ab7d2e9_pipeline_runs_are_ship_build.py
@@ -1,0 +1,31 @@
+"""pipeline runs are ship.build
+
+Revision ID: 4c1f0ab7d2e9
+Revises: 9b8c7d6e5f4a
+Create Date: 2026-07-26 13:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4c1f0ab7d2e9"
+down_revision: str | Sequence[str] | None = "9b8c7d6e5f4a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # The workflow class is Build, so its kind is ship.build. The prefix swap in
+    # 9b8c7d6e5f4a carried the old class name through to ship.build_workflow, which
+    # matches no registered workflow; both spellings land on the real kind here.
+    op.execute(
+        "UPDATE durable_runs SET kind = 'ship.build' "
+        "WHERE kind IN ('ship.build_workflow', 'build.build_workflow')"
+    )
+
+
+def downgrade() -> None:
+    op.execute("UPDATE durable_runs SET kind = 'ship.build_workflow' WHERE kind = 'ship.build'")


### PR DESCRIPTION
Follow-up to #89.

That revision rewrote `durable_runs.kind` with a prefix swap, `'ship.' || substring(kind from 7)`. The pipeline's old kind was `build.build_workflow` — class `BuildWorkflow`, snake-cased — so it became `ship.build_workflow`. But the class is `Build` now, so its kind is `ship.build`, and nothing matches the migrated spelling. (`build.profile` → `ship.profile` was correct; only the pipeline rows are wrong.)

Where it shows:

- `Run.list_for_subject(..., kind=cls.kind)` filters `where(cls.kind == kind)`, so a pre-rename run drops out of its subject's timeline and off the board.
- `get_subject_status(..., kind=Build.kind)` in `WorkItem` — a PR merging on a pre-rename work item finds no parked run to cancel.

This revision lands both spellings on the real kind, so it is correct whether or not #89's revision has already been applied. The downgrade restores `ship.build_workflow`, which #89's own downgrade then maps back to `build.build_workflow`.

Not covered here: `dbos.workflow_status.name` still holds the pre-rename registered name for runs that were in flight at deploy. We never read that column, so history is unaffected — it only matters for recovering a run that was PENDING or ENQUEUED across the deploy, which a drain window covers.