### PR TITLE
Subscribers name the workflow, not its run kind

### DIFF
--- a/backend/druks/contrib/ship/models.py
+++ b/backend/druks/contrib/ship/models.py
@@ -287,7 +287,7 @@ class WorkItem(Subject):
         from druks.contrib.ship.workflows import Build
 
         self.set_status(HandoffStatus.SHIPPED)
-        build = get_subject_status(self.subject_type, str(self.id), kind=Build.kind)
+        build = get_subject_status(self.subject_type, str(self.id), workflow=Build)
         if build.is_parked:
             await Build.cancel(self, failure="pr merged while parked")
         await self.set_remote_status(TicketStatus.DONE)

--- a/backend/druks/contrib/ship/subscribers.py
+++ b/backend/druks/contrib/ship/subscribers.py
@@ -17,7 +17,7 @@ async def run_start_returns_item_to_board(*, subject: WorkItem, **_: object) -> 
     subject.set_status(None)
 
 
-@subscribe("run.state", kind=Build.kind, subject=WorkItem)
+@subscribe("run.state", workflow=Build, subject=WorkItem)
 async def provision_mirrors_onto_item(
     *, subject: WorkItem, pr_number: int, branch: str, **_: object
 ) -> None:
@@ -26,20 +26,20 @@ async def provision_mirrors_onto_item(
     subject.update(pr_number=pr_number, branch=branch)
 
 
-@subscribe("run.running", kind=Build.kind, subject=WorkItem)
+@subscribe("run.running", workflow=Build, subject=WorkItem)
 async def build_start_marks_ticket_in_progress(*, subject: WorkItem, **_: object) -> None:
     # Every (re)start and gate-resume of a build means the ticket is in progress —
     # including the return from a rework loop that had parked it In Review.
     await subject.set_remote_status(TicketStatus.IN_PROGRESS)
 
 
-@subscribe("run.pending_input", kind=Build.kind, gate=ReviewWork, subject=WorkItem)
+@subscribe("run.pending_input", workflow=Build, gate=ReviewWork, subject=WorkItem)
 async def review_park_marks_ticket_in_review(*, subject: WorkItem, **_: object) -> None:
     await subject.set_remote_status(TicketStatus.IN_REVIEW)
 
 
-@subscribe("run.failed", kind=Build.kind, subject=WorkItem)
-@subscribe("run.cancelled", kind=Build.kind, subject=WorkItem)
+@subscribe("run.failed", workflow=Build, subject=WorkItem)
+@subscribe("run.cancelled", workflow=Build, subject=WorkItem)
 async def build_end_settles_the_item(*, subject: WorkItem, **_: object) -> None:
     # Nothing merged, so the attempt was abandoned — unless the PR already spoke:
     # ship() cancels the run it just shipped, and that cancel arrives here.
@@ -66,7 +66,7 @@ async def pr_review_answers_the_gate(*, repo: str, pr_number: int, payload: dict
     item = WorkItem.get_for_pr(repo=repo, pr_number=pr_number, branch=payload["branch"])
     if not item:
         return
-    status = get_subject_status(item.subject_type, str(item.id), kind=Build.kind)
+    status = get_subject_status(item.subject_type, str(item.id), workflow=Build)
     if status.is_parked and status.gate == ReviewWork.name:
         await ReviewWork.answer(
             item,

--- a/backend/druks/durable/reads.py
+++ b/backend/druks/durable/reads.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from sqlalchemy import Engine
 
@@ -25,6 +25,9 @@ from .schemas import (
     TranscriptChunk,
 )
 
+if TYPE_CHECKING:
+    from druks.workflows import Workflow
+
 _TRANSCRIPT_POLL_SECONDS = 0.5
 _TRANSCRIPT_KEEPALIVE_SECONDS = 15.0
 _TERMINAL_CALL_STATES = {"succeeded", "failed", "abandoned"}
@@ -45,8 +48,9 @@ def list_subject_timeline(subject_type: str, subject_id: str) -> list[RunRespons
 
 
 def get_subject_status(
-    subject_type: str, subject_id: str, *, kind: str | None = None
+    subject_type: str, subject_id: str, *, workflow: "type[Workflow] | None" = None
 ) -> SubjectStatus:
+    kind = workflow.kind if workflow else None
     latest = Run.get_latest_for_subject(subject_type, subject_id, kind=kind)
     return _status(latest, _running_calls(latest))
 

--- a/backend/druks/extensions/base.py
+++ b/backend/druks/extensions/base.py
@@ -371,14 +371,16 @@ class Extension:
 
         subject_model = cls.subject
         assert subject_model
-        kind = subject_model.subject_type
+        subject_type = subject_model.subject_type
 
-        router = APIRouter(prefix=f"/{kind}", tags=[f"{cls.name}:{kind}"])
+        router = APIRouter(prefix=f"/{subject_type}", tags=[f"{cls.name}:{subject_type}"])
 
         def board() -> SubjectList:
             return SubjectList(
                 rows=[
-                    SubjectRow(summary=summary, status=reads.get_subject_status(kind, summary.id))
+                    SubjectRow(
+                        summary=summary, status=reads.get_subject_status(subject_type, summary.id)
+                    )
                     for summary in cls.list_subjects()
                 ]
             )
@@ -393,7 +395,9 @@ class Extension:
             if not summary:
                 return
             activity = await cls.subject_activity(subject)
-            return reads.get_subject_response(kind, subject_id, summary=summary, activity=activity)
+            return reads.get_subject_response(
+                subject_type, subject_id, summary=summary, activity=activity
+            )
 
         @router.get("", response_model=SubjectList, response_model_by_alias=True)
         async def list_subjects() -> SubjectList:
@@ -414,7 +418,7 @@ class Extension:
         async def read_subject(subject_id: str) -> SubjectResponse:
             response = await subject_response(subject_id)
             if not response:
-                raise HTTPException(status.HTTP_404_NOT_FOUND, f"No {kind} {subject_id!r}.")
+                raise HTTPException(status.HTTP_404_NOT_FOUND, f"No {subject_type} {subject_id!r}.")
             return response
 
         @router.get("/{subject_id}/stream", response_class=StreamingResponse)

--- a/backend/druks/signals.py
+++ b/backend/druks/signals.py
@@ -15,14 +15,17 @@ def subscribe(name: str, **filters: Any) -> Callable[[Subscriber], Subscriber]:
 
     ``filters`` are equality matches against the published kwargs; ``__``
     descends into dicts (``payload__terminal=True``); a ``Gate`` class stands for
-    its ``name``. ``subject=WorkItem`` narrows to that subject and hands the body
-    its row. A non-matching publication skips the subscriber, so the body starts
-    at the real work."""
+    its ``name``. ``workflow=Build`` narrows to that workflow's runs and
+    ``subject=WorkItem`` to that subject, handing the body its row. A non-matching
+    publication skips the subscriber, so the body starts at the real work."""
 
     def register(fn: Subscriber) -> Subscriber:
         # Lazy import: druks.workflows imports this module.
         from druks.workflows import Gate
 
+        workflow_class = filters.pop("workflow", None)
+        if workflow_class:
+            filters["kind"] = workflow_class.kind
         subject_class = filters.pop("subject", None)
         if subject_class:
             filters["subject__type"] = subject_class.subject_type

--- a/backend/tests/druks-field_notes/druks_field_notes/subscribers.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/subscribers.py
@@ -5,7 +5,7 @@ from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
 
 
-@subscribe("run.finished", kind=Summarize.kind, subject=Note)
+@subscribe("run.finished", workflow=Summarize, subject=Note)
 async def note_summarized(*, subject: Note, **_: object) -> None:
     # A finished summarize run is a milestone worth its own feed row — record it so
     # format_event can render it. The run lifecycle is the trigger; the extension

--- a/backend/tests/test_signals.py
+++ b/backend/tests/test_signals.py
@@ -1,6 +1,7 @@
 import pytest
 from conftest import make_test_work_item
 from druks.contrib.ship.models import ProjectRepo, WorkItem
+from druks.contrib.ship.workflows import Build, Profile
 from druks.signals import publish, subscribe
 from druks.workflows import Workflow
 from sqlalchemy.orm import object_session
@@ -68,6 +69,20 @@ async def test_another_subjects_event_skips_the_subscriber(db_session):
     await publish("test.other_subject", subject=None)
 
     assert received == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_filter_narrows_to_that_workflows_runs():
+    received = []
+
+    @subscribe("test.workflow_filter", workflow=Build)
+    async def receive(*, kind: str, **_: object) -> None:
+        received.append(kind)
+
+    await publish("test.workflow_filter", kind=Profile.kind)
+    await publish("test.workflow_filter", kind=Build.kind)
+
+    assert received == [Build.kind]
 
 
 def test_workflow_subject_requires_a_registered_class():


### PR DESCRIPTION
Two smells in the subscriber surface, one root cause.

```python
@subscribe("run.state", kind=Build.kind, subject=WorkItem)   # before
@subscribe("run.state", workflow=Build, subject=WorkItem)    # after
```

**Consistency.** Every other class-valued filter takes the class and lets `subscribe()` translate it — `gate=ReviewWork` → `.name`, `subject=WorkItem` → `.subject_type`. `kind=Build.kind` was the only one that made the author dereference the attribute themselves.

**Altitude.** `kind` is run substrate. It exists so DBOS can rebind a workflow function by name on recovery and so queue dedup can key on it — not vocabulary an extension author should have to learn. The class is what they hold, so the filter takes the class. `kind` stays the published wire kwarg; nothing author-facing names it anymore.

Same word, same leak on the read side, so it goes too: `get_subject_status(..., workflow=Build)`.

Also: the extension router's local `kind` held a *subject type*, not a workflow kind, and was passed positionally into `get_subject_status`. Renamed to `subject_type` — same value, honest name.

No behavior change. `test_workflow_filter_narrows_to_that_workflows_runs` pins match-and-skip on the new filter; the ship lane reactions already cover it end to end.
