### PR TITLE
Scaffolded extensions carry their own AGENTS.md

### DIFF
--- a/backend/druks/scaffolding/extension_template/AGENTS.md-tpl
+++ b/backend/druks/scaffolding/extension_template/AGENTS.md-tpl
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+`druks-{{ name }}` is a Druks extension: a standalone Python distribution that owns
+domain behavior while Druks supplies durable execution, agents, events, gates,
+webhooks, and the dashboard.
+
+## Read map
+
+- Extension contracts and the full author surface:
+  `{{ druks_path }}/docs/writing-an-extension.md`.
+- A worked extension to read alongside it:
+  `{{ druks_path }}/backend/tests/druks-field_notes/`.
+- Each stub module under `druks_{{ name }}/` documents its own role in comments.
+
+## Contracts
+
+- Installing this distribution is the registration. The
+  `[project.entry-points."druks.extensions"]` key must equal `{{ name }}`. Boot fails
+  loudly on a mismatched key, a duplicate name, an import error, or an unprefixed
+  table.
+- Druks discovers leaf modules named `workflows`, `routes`, `subscribers`, and
+  `webhooks`. A capability placed in `workflow.py` is never discovered. Any other
+  module name is inert until a discovered module imports it.
+- Import the concern namespaces — `druks.extensions`, `druks.workflows`,
+  `druks.agents`, `druks.db`, `druks.schemas`, `druks.signals`, `druks.events`,
+  `druks.prompts`, `druks.webhooks`, `druks.testing` — never `druks.durable` or an
+  internal module. The root `druks` package exports only its version.
+- Domain policy lives here. Generic agent, harness, workspace, sandbox, event, gate,
+  webhook, and settings plumbing belongs to Druks. When this extension needs
+  something the author surface lacks, widen the primitive that already owns the
+  concern rather than reaching past it.
+
+## Verify
+
+```bash
+uv run pytest
+```
+
+Installing Druks registers its pytest plugin, so `druks_db`, `druks_client`, and
+`druks_redis` are available without a `conftest.py`.

--- a/backend/tests/test_scaffolding.py
+++ b/backend/tests/test_scaffolding.py
@@ -1,4 +1,5 @@
 import importlib
+import re
 import sys
 
 import pytest
@@ -22,6 +23,11 @@ def test_create_extension_scaffolds_a_loadable_package(tmp_path):
         'night_watch = "druks_night_watch.extension:NightWatch"'
         in (target / "pyproject.toml").read_text()
     )
+
+    # AGENTS.md exists to route an agent to the author guide from a directory that
+    # ships none of it, so the rendered pointer has to land on the real file.
+    guide = re.search(r"`(\S+writing-an-extension\.md)`", (target / "AGENTS.md").read_text())
+    assert (target / guide.group(1)).is_file()
 
     # No rendered file may reference retired surfaces: the old storage namespace, the
     # taskiq worker, or the one-arg ``config`` workflow wording.

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -36,6 +36,9 @@ At boot Druks imports installed entry points and fails loudly on duplicate
 names, a mismatched entry-point key, malformed target, import failure, or
 unprefixed table.
 
+The project root also carries an `AGENTS.md` holding the contracts a coding agent
+cannot infer from the stubs, and a relative path back to this guide.
+
 ## Package layout
 
 The scaffold separates self-registering capability modules from ordinary


### PR DESCRIPTION
`druks create extension` emits a standalone distribution with nothing routing a coding agent to `docs/writing-an-extension.md`, and the wheel ships `backend/druks` only, so an install does not carry `docs/` either.

Adds `AGENTS.md-tpl` to the template tree, holding what the stubs cannot teach: entry-point key equality, leaf-module discovery names, the concern namespaces to import, and where domain policy stops. Per-role guidance stays in the stub comments. The guide pointer renders from `{{ druks_path }}`, the same checkout pin `pyproject.toml` already uses.

The copy loop is generic, so no scaffolding code changed.
