### PR TITLE
ENG-764: manual resync for installed skill collections

### DIFF
--- a/backend/druks/skills/models.py
+++ b/backend/druks/skills/models.py
@@ -15,7 +15,7 @@ class SkillCollection(Base, Uuid7Pk):
     name: Mapped[str] = mapped_column(String)
     source: Mapped[str] = mapped_column(String, unique=True)
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
-    updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
+    updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
 
     skills: Mapped[list["Skill"]] = relationship(
         back_populates="collection",
@@ -71,7 +71,7 @@ class Skill(Base, Uuid7Pk):
     path: Mapped[str] = mapped_column(String)
     content_hash: Mapped[str] = mapped_column(String)
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
-    updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
+    updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
 
     @classmethod
     def installed_names(cls) -> set[str]:

--- a/backend/druks/skills/routes.py
+++ b/backend/druks/skills/routes.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter, Body, HTTPException
 from githubkit.exception import RequestFailed, RequestTimeout
 
+from druks.api.dependencies import SettingsDep
 from druks.database import db_session
-from druks.settings import load_settings
 
 from .install import fetch_collection, remove_files
 from .models import Skill, SkillCollection
@@ -17,12 +17,14 @@ async def list_collections() -> list[SkillCollection]:
 
 
 @router.post("", response_model=CollectionResponse)
-async def install_collection(url: str = Body(..., embed=True)) -> SkillCollection:
+async def install_collection(
+    settings: SettingsDep,
+    url: str = Body(..., embed=True),
+) -> SkillCollection:
     if SkillCollection.get_for_source(url):
         raise HTTPException(
             status_code=409, detail=f"Collection {url!r} already installed; remove it first."
         )
-    settings = load_settings()
     try:
         contents = await fetch_collection(url, settings.skills_dir, Skill.installed_names())
     except (ValueError, RequestFailed, RequestTimeout) as error:
@@ -37,11 +39,10 @@ async def install_collection(url: str = Body(..., embed=True)) -> SkillCollectio
 
 
 @router.post("/{collection_id}/sync", response_model=CollectionResponse)
-async def sync_collection(collection_id: str) -> SkillCollection:
+async def sync_collection(collection_id: str, settings: SettingsDep) -> SkillCollection:
     collection = SkillCollection.get(collection_id)
     if not collection:
         raise HTTPException(status_code=404, detail=f"Collection {collection_id!r} not found")
-    settings = load_settings()
     current_skills = {skill.name: skill for skill in collection.skills}
     reserved_names = Skill.installed_names() - current_skills.keys()
     try:

--- a/backend/druks/skills/routes.py
+++ b/backend/druks/skills/routes.py
@@ -36,6 +36,48 @@ async def install_collection(url: str = Body(..., embed=True)) -> SkillCollectio
     return SkillCollection.create(source=url, name=contents.name, skills=contents.skills)
 
 
+@router.post("/{collection_id}/sync", response_model=CollectionResponse)
+async def sync_collection(collection_id: str) -> SkillCollection:
+    collection = SkillCollection.get(collection_id)
+    if not collection:
+        raise HTTPException(status_code=404, detail=f"Collection {collection_id!r} not found")
+    settings = load_settings()
+    current_skills = {skill.name: skill for skill in collection.skills}
+    reserved_names = Skill.installed_names() - current_skills.keys()
+    try:
+        contents = await fetch_collection(collection.source, settings.skills_dir, reserved_names)
+    except (ValueError, RequestFailed, RequestTimeout) as error:
+        raise HTTPException(status_code=422, detail=str(error)) from error
+    except OSError as error:
+        raise HTTPException(
+            status_code=500, detail=f"Could not write skills under {settings.skills_dir}: {error}"
+        ) from error
+
+    installed_skills = {skill.name: skill for skill in contents.skills}
+    for name, skill in current_skills.items():
+        installed_skill = installed_skills.pop(name, None)
+        if installed_skill:
+            if skill.description != installed_skill.description:
+                skill.description = installed_skill.description
+            if skill.content_hash != installed_skill.content_hash:
+                skill.content_hash = installed_skill.content_hash
+        else:
+            remove_files(skill.path)
+            collection.skills.remove(skill)
+    for installed_skill in installed_skills.values():
+        collection.skills.append(
+            Skill(
+                name=installed_skill.name,
+                description=installed_skill.description,
+                path=installed_skill.path,
+                content_hash=installed_skill.content_hash,
+            )
+        )
+    collection.updated_at = SkillCollection.utc_now()
+    db_session().flush()
+    return collection
+
+
 @router.patch("/{collection_id}/skills/{name}", response_model=SkillResponse)
 async def set_skill_enabled(
     collection_id: str,

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -1,5 +1,6 @@
 import io
 import tarfile
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -28,12 +29,24 @@ def _patch_download(monkeypatch, archive: bytes) -> None:
     monkeypatch.setattr(install_mod, "download_public_tarball", fake_download)
 
 
-def _skill_md(name: str) -> bytes:
-    return f"---\nname: {name}\ndescription: the {name} skill\n---\n# {name}\nbody\n".encode()
+def _skill_md(name: str, description: str = "") -> bytes:
+    description = description or f"the {name} skill"
+    return f"---\nname: {name}\ndescription: {description}\n---\n# {name}\nbody\n".encode()
 
 
 async def _fetch(url: str, skills_dir: Path, reserved: set[str] | None = None):
     return await install_mod.fetch_collection(url, skills_dir, reserved or set())
+
+
+def _install_collection(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    files: dict[str, bytes],
+) -> str:
+    _patch_download(monkeypatch, _tarball("owner-repo-abc", files))
+    response = client.post("/api/skills", json={"url": "https://github.com/owner/repo"})
+    assert response.status_code == 200
+    return response.json()["id"]
 
 
 async def test_fetch_collection_lands_every_skill(tmp_path, monkeypatch):
@@ -152,3 +165,162 @@ def test_collection_routes_install_list_remove(tmp_path, monkeypatch):
 
         assert client.delete(f"/api/skills/{collection_id}").status_code == 204
         assert client.get("/api/skills").json() == []
+
+
+def test_sync_updates_changed_skill_and_timestamps(tmp_path, monkeypatch, db_session):
+    settings = make_settings(tmp_path)
+    original_skill = _skill_md("alpha")
+    updated_skill = _skill_md("alpha", "updated description")
+    old_timestamp = datetime(2020, 1, 1, tzinfo=UTC)
+
+    with TestClient(configure_app_for_test(settings=settings)) as client:
+        collection_id = _install_collection(
+            client,
+            monkeypatch,
+            {"alpha/SKILL.md": original_skill},
+        )
+        collection = SkillCollection.get(collection_id)
+        skill = Skill.get("alpha")
+        original_hash = skill.content_hash
+        collection.updated_at = old_timestamp
+        skill.updated_at = old_timestamp
+        db_session.flush()
+
+        _patch_download(
+            monkeypatch,
+            _tarball("owner-repo-abc", {"alpha/SKILL.md": updated_skill}),
+        )
+        response = client.post(f"/api/skills/{collection_id}/sync")
+        assert response.status_code == 200
+        assert response.json()["skills"][0]["description"] == "updated description"
+
+        db_session.expire_all()
+        assert skill.description == "updated description"
+        assert skill.content_hash != original_hash
+        assert skill.updated_at > old_timestamp
+        assert collection.updated_at > old_timestamp
+        assert (settings.skills_dir / "alpha" / "SKILL.md").read_bytes() == updated_skill
+
+        skill_timestamp = skill.updated_at
+        collection.updated_at = old_timestamp
+        db_session.flush()
+        response = client.post(f"/api/skills/{collection_id}/sync")
+        assert response.status_code == 200
+
+        db_session.expire_all()
+        assert skill.updated_at == skill_timestamp
+        assert collection.updated_at > old_timestamp
+
+
+def test_sync_adds_new_skill(tmp_path, monkeypatch, db_session):
+    settings = make_settings(tmp_path)
+    alpha_skill = _skill_md("alpha")
+    beta_skill = _skill_md("beta")
+
+    with TestClient(configure_app_for_test(settings=settings)) as client:
+        collection_id = _install_collection(
+            client,
+            monkeypatch,
+            {"alpha/SKILL.md": alpha_skill},
+        )
+        _patch_download(
+            monkeypatch,
+            _tarball(
+                "owner-repo-abc",
+                {
+                    "alpha/SKILL.md": alpha_skill,
+                    "beta/SKILL.md": beta_skill,
+                },
+            ),
+        )
+
+        response = client.post(f"/api/skills/{collection_id}/sync")
+        assert response.status_code == 200
+        assert [skill["name"] for skill in response.json()["skills"]] == ["alpha", "beta"]
+
+        db_session.expire_all()
+        assert Skill.get("beta").collection_id == collection_id
+        assert (settings.skills_dir / "beta" / "SKILL.md").read_bytes() == beta_skill
+
+
+def test_sync_removes_missing_skill_and_files(tmp_path, monkeypatch, db_session):
+    settings = make_settings(tmp_path)
+    alpha_skill = _skill_md("alpha")
+    beta_skill = _skill_md("beta")
+
+    with TestClient(configure_app_for_test(settings=settings)) as client:
+        collection_id = _install_collection(
+            client,
+            monkeypatch,
+            {
+                "alpha/SKILL.md": alpha_skill,
+                "beta/SKILL.md": beta_skill,
+            },
+        )
+        beta_path = settings.skills_dir / "beta"
+        assert beta_path.is_dir()
+        _patch_download(
+            monkeypatch,
+            _tarball("owner-repo-abc", {"alpha/SKILL.md": alpha_skill}),
+        )
+
+        response = client.post(f"/api/skills/{collection_id}/sync")
+        assert response.status_code == 200
+        assert [skill["name"] for skill in response.json()["skills"]] == ["alpha"]
+
+        db_session.expire_all()
+        assert not Skill.get("beta")
+        assert not beta_path.exists()
+
+
+def test_sync_preserves_disabled_skill(tmp_path, monkeypatch, db_session):
+    alpha_skill = _skill_md("alpha")
+
+    with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
+        collection_id = _install_collection(
+            client,
+            monkeypatch,
+            {"alpha/SKILL.md": alpha_skill},
+        )
+        skill = Skill.get("alpha")
+        skill.enabled = False
+        db_session.flush()
+        _patch_download(
+            monkeypatch,
+            _tarball("owner-repo-abc", {"alpha/SKILL.md": alpha_skill}),
+        )
+
+        response = client.post(f"/api/skills/{collection_id}/sync")
+        assert response.status_code == 200
+        assert response.json()["skills"][0]["enabled"] is False
+
+        db_session.expire_all()
+        assert skill.enabled is False
+
+
+def test_sync_nonexistent_collection_returns_404(tmp_path):
+    with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
+        response = client.post("/api/skills/unknown/sync")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Collection 'unknown' not found"
+
+
+def test_sync_allows_collection_own_existing_skill_name(tmp_path, monkeypatch):
+    alpha_skill = _skill_md("alpha")
+
+    with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
+        collection_id = _install_collection(
+            client,
+            monkeypatch,
+            {"alpha/SKILL.md": alpha_skill},
+        )
+        _patch_download(
+            monkeypatch,
+            _tarball("owner-repo-abc", {"alpha/SKILL.md": alpha_skill}),
+        )
+
+        response = client.post(f"/api/skills/{collection_id}/sync")
+
+    assert response.status_code == 200
+    assert [skill["name"] for skill in response.json()["skills"]] == ["alpha"]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -213,6 +213,8 @@ export const api = {
   // onto the sandbox VMs.
   skillCollections: () => getJSON<SkillCollection[]>('/api/skills'),
   installSkillCollection: (url: string) => postJSON<SkillCollection>('/api/skills', { url }),
+  syncSkillCollection: (id: string) =>
+    postJSON<SkillCollection>(`/api/skills/${encodeURIComponent(id)}/sync`, undefined),
   removeSkillCollection: (id: string) =>
     deleteRequest(`/api/skills/${encodeURIComponent(id)}`),
   setSkillEnabled: (collectionId: string, name: string, enabled: boolean) =>

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -858,6 +858,19 @@ function SkillsPane() {
     }
   }
 
+  async function sync(id: string) {
+    setBusy(true)
+    setError(null)
+    try {
+      await api.syncSkillCollection(id)
+      await refresh()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   async function toggle(collectionId: string, name: string, enabled: boolean) {
     setBusy(true)
     setError(null)
@@ -904,7 +917,14 @@ function SkillsPane() {
           </div>
           <div className="skill-cols">
             {cols.map((c: SkillCollection) => (
-              <CollectionCard key={c.id} collection={c} busy={busy} onRemove={remove} onToggle={toggle} />
+              <CollectionCard
+                key={c.id}
+                collection={c}
+                busy={busy}
+                onSync={sync}
+                onRemove={remove}
+                onToggle={toggle}
+              />
             ))}
           </div>
         </div>
@@ -918,11 +938,13 @@ function SkillsPane() {
 function CollectionCard({
   collection,
   busy,
+  onSync,
   onRemove,
   onToggle,
 }: {
   collection: SkillCollection
   busy: boolean
+  onSync: (id: string) => Promise<void>
   onRemove: (id: string) => Promise<void>
   onToggle: (collectionId: string, name: string, enabled: boolean) => Promise<void>
 }) {
@@ -938,6 +960,17 @@ function CollectionCard({
             {collection.source}
           </span>
         </div>
+        <button
+          className="sc-sync"
+          onClick={(e) => {
+            e.stopPropagation()
+            void onSync(collection.id)
+          }}
+          disabled={busy}
+          title="sync collection from source"
+        >
+          sync
+        </button>
         <button
           className="sc-remove"
           onClick={(e) => {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1081,7 +1081,8 @@ input.set-select { background-image: none; padding-right: 12px; }
 .sc-id { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
 .sc-repo { font-family: var(--font-mono); font-size: 13px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .sc-meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
-.sc-remove { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); border: 1px solid var(--border); border-radius: 4px; padding: 5px 10px; flex-shrink: 0; cursor: pointer; background: none; }
+.sc-sync, .sc-remove { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); border: 1px solid var(--border); border-radius: 4px; padding: 5px 10px; flex-shrink: 0; cursor: pointer; background: none; }
+.sc-sync:hover { color: var(--text); background: var(--surface); border-color: var(--border-loud); }
 .sc-remove:hover { color: var(--bucket-dead); border-color: color-mix(in oklch, var(--bucket-dead) 45%, transparent); background: color-mix(in oklch, var(--bucket-dead) 10%, var(--surface)); }
 .sc-skills { display: flex; flex-direction: column; }
 .skill-row { display: grid; grid-template-columns: minmax(130px, 0.8fr) minmax(0, 1.5fr) auto; gap: 14px; align-items: center; padding: 10px 14px 10px 30px; border-bottom: 1px solid var(--border-soft); position: relative; }


### PR DESCRIPTION
## Summary
- `POST /api/skills/{id}/sync` re-fetches a collection's source repo and reconciles skills: updates changed description/content_hash, adds newly-discovered skills, removes skills no longer in the source (and their files), preserves `enabled` on untouched skills, and always bumps the collection's `updated_at`.
- `SkillCollection.updated_at` / `Skill.updated_at` gained `onupdate=Base.utc_now` — previously insert-only, so they never actually changed.
- Frontend: a "sync" action alongside remove/toggle in the Skills settings pane, with its own neutral hover styling (distinct from remove's destructive-red hover).

No scheduling/cron — manual trigger only, per [ENG-764](https://linear.app/fellaworks/issue/ENG-764/skills-manual-resync-for-installed-collections).

## Test plan
- [ ] CI: backend suite (`test_skills.py` — sync updates/adds/removes/preserves-disabled/404s/self-name-clash cases)
- [x] Frontend lint, 53 tests, and production build all pass locally
