### PR TITLE
Show when a skill collection last synced

### DIFF
--- a/backend/druks/skills/schemas.py
+++ b/backend/druks/skills/schemas.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import ConfigDict
 
 from druks.schemas import BaseResponse
@@ -9,6 +11,7 @@ class SkillResponse(BaseResponse):
     name: str
     description: str
     enabled: bool
+    updated_at: datetime
 
 
 class CollectionResponse(BaseResponse):
@@ -17,4 +20,5 @@ class CollectionResponse(BaseResponse):
     id: str
     source: str
     name: str
+    updated_at: datetime
     skills: list[SkillResponse]

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -148,7 +148,11 @@ def test_collection_routes_install_list_remove(tmp_path, monkeypatch):
         assert created.status_code == 200
         body = created.json()
         assert body["name"] == "o/r"
-        assert body["skills"] == [{"name": "alpha", "description": "one", "enabled": True}]
+        skill = body["skills"][0]
+        assert skill["name"] == "alpha"
+        assert skill["description"] == "one"
+        assert skill["enabled"] is True
+        assert "updatedAt" in skill
         collection_id = body["id"]
 
         # Disable the skill — flips enabled, kept in the collection.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -410,12 +410,14 @@ export interface Skill {
   name: string
   description: string
   enabled: boolean
+  updatedAt: string
 }
 
 export interface SkillCollection {
   id: string
   source: string
   name: string
+  updatedAt: string
   skills: Skill[]
 }
 

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -15,7 +15,7 @@ import {
   type UpdateExtensionsSettingsRequest,
   type UpdateUserSettingsRequest,
 } from '../api/types'
-import { absTime } from '../lib/format'
+import { absTime, relTimeFromIso } from '../lib/format'
 import { harnessColors } from '../lib/harnessColors'
 
 // The harness a model runs on, resolved from the registry — each harness lists
@@ -816,10 +816,11 @@ export function HarnessConnect({ harness }: { harness: Harness }) {
 }
 
 // ---------------------------------------------------------------------------
-// Skills — collections (real); per-skill enable has no backend, so read-only
+// Skills — a collection is a GitHub repo scanned into one-or-more skills,
+// synced or removed as a unit; each skill can be enabled or disabled on its own.
 // ---------------------------------------------------------------------------
 
-function SkillsPane() {
+export function SkillsPane() {
   const queryClient = useQueryClient()
   const collectionsQuery = useQuery({ queryKey: ['skills'], queryFn: () => api.skillCollections() })
   const [repo, setRepo] = useState('')
@@ -957,7 +958,7 @@ function CollectionCard({
           <span className="sc-repo">{collection.name}</span>
           <span className="sc-meta">
             {collection.skills.length} skill{collection.skills.length === 1 ? '' : 's'} ·{' '}
-            {collection.source}
+            {collection.source} · synced {relTimeFromIso(collection.updatedAt)}
           </span>
         </div>
         <button

--- a/frontend/src/components/SkillsPane.test.tsx
+++ b/frontend/src/components/SkillsPane.test.tsx
@@ -1,0 +1,50 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { SkillCollection } from '../api/types'
+import { SkillsPane } from './SettingsModal'
+
+function collection(overrides: Partial<SkillCollection> = {}): SkillCollection {
+  return {
+    id: 'col-1',
+    source: 'https://github.com/owner/repo',
+    name: 'owner/repo',
+    updatedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    skills: [{ name: 'alpha', description: 'the alpha skill', enabled: true, updatedAt: new Date().toISOString() }],
+    ...overrides,
+  }
+}
+
+function stubFetch(collections: SkillCollection[]) {
+  const fetchMock = vi.fn<(url: string) => Promise<Response>>(async (url) => {
+    if (url === '/api/skills') {
+      return new Response(JSON.stringify(collections), { status: 200 })
+    }
+    return new Response('{}', { status: 404 })
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function renderPane() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SkillsPane />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('SkillsPane', () => {
+  it('shows how long ago a collection last synced', async () => {
+    stubFetch([collection()])
+    renderPane()
+    expect(await screen.findByText(/synced 5m ago/)).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- `CollectionResponse` / `SkillResponse` now include `updated_at` — the timestamp has existed in the DB since ENG-764's `onupdate` fix, but was never exposed on the wire.
- The Skills settings pane shows "synced Xm ago" next to the source in `CollectionCard`, using the existing `relTimeFromIso` helper.
- Exported `SkillsPane` so it can be rendered in isolation, matching `AgentAccessPane`'s existing test pattern; added `SkillsPane.test.tsx` covering the new label.
- Fixed a stale comment above `SkillsPane` claiming per-skill enable had no backend (it already does, via the existing `PATCH .../skills/{name}` route).

## Test plan
- [x] `uv run pytest backend/tests/test_skills.py` — 14 passed
- [x] `npm run lint`, `npm test` (54 passed), `npm run build` — all clean
