### PR TITLE
The frontend says parked too

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -22,7 +22,7 @@
 export type RunState =
   | 'scheduled'
   | 'running'
-  | 'pending_input'
+  | 'parked'
   | 'finished'
   | 'failed'
   | 'cancelled'

--- a/frontend/src/extensions/ship/WorkItemPage.tsx
+++ b/frontend/src/extensions/ship/WorkItemPage.tsx
@@ -82,7 +82,7 @@ export function WorkItemPage({ workItemId }: Props) {
 const STATE_GLYPH: Record<string, string> = {
   scheduled: '·',
   running: '●',
-  pending_input: '◆',
+  parked: '◆',
   finished: '✓',
   failed: '✕',
   cancelled: '⊘',
@@ -91,7 +91,7 @@ const STATE_GLYPH: Record<string, string> = {
 const STATE_LABEL: Record<string, string> = {
   scheduled: 'scheduled',
   running: 'running',
-  pending_input: 'waiting on you',
+  parked: 'waiting on you',
   finished: 'finished',
   failed: 'failed',
   cancelled: 'cancelled',
@@ -105,7 +105,7 @@ const CALL_GLYPH: Record<string, string> = {
 }
 const isRunning = (run: RunSummary) => run.state === 'running'
 const isActiveRun = (run: RunSummary) =>
-  run.state === 'running' || run.state === 'pending_input' || run.state === 'scheduled'
+  run.state === 'running' || run.state === 'parked' || run.state === 'scheduled'
 
 interface Metrics {
   elapsed: number
@@ -133,7 +133,7 @@ interface Status {
 const STATE_CLS: Record<RunState, string> = {
   scheduled: 'queued',
   running: 'running',
-  pending_input: 'needsyou',
+  parked: 'needsyou',
   finished: 'merged',
   failed: 'failed',
   cancelled: 'cancelled',
@@ -144,7 +144,7 @@ const STATE_CLS: Record<RunState, string> = {
 // The pill renders build's status line over the platform's facts; the
 // tone comes from the lifecycle state. Live (a dot animates) while a run is active.
 function statusView(status: SubjectStatus): Status {
-  const live = status.state === 'running' || status.state === 'pending_input'
+  const live = status.state === 'running' || status.state === 'parked'
   return { cls: STATE_CLS[status.state], label: statusLine(status), live }
 }
 
@@ -373,8 +373,8 @@ function RunRow({
   const sub =
     run.state === 'failed' && run.failure
       ? (run.failure.split('—')[0] ?? run.failure).trim()
-      : run.state === 'pending_input'
-        ? (parkedLine(run.gate) ?? STATE_LABEL.pending_input)
+      : run.state === 'parked'
+        ? (parkedLine(run.gate) ?? STATE_LABEL.parked)
         : isRunning(run) && activity
           ? activity.label
           : (STATE_LABEL[run.state] ?? run.state)

--- a/frontend/src/extensions/ship/WorkItemsPage.tsx
+++ b/frontend/src/extensions/ship/WorkItemsPage.tsx
@@ -38,11 +38,11 @@ function WorkItemRowView({
   row: WorkItemRow
   onOpen: (row: WorkItemRow) => void
 }) {
-  // Active lanes: pending_input → parked on you, failed → needs you to retry or
+  // Active lanes: parked → parked on you, failed → needs you to retry or
   // cancel, running/scheduled → a step is live.
   const { summary: wi, status } = row
   const failed = status.state === 'failed'
-  const parked = status.state === 'pending_input'
+  const parked = status.state === 'parked'
   const live = status.state === 'running' || status.state === 'scheduled'
   const when = relTime(secondsSince(wi.updatedAt))
   return (
@@ -132,7 +132,7 @@ export function WorkItemsPage() {
   )
   const needsYou = active.filter(
     (row) =>
-      (row.status.state === 'pending_input' || row.status.state === 'failed') &&
+      (row.status.state === 'parked' || row.status.state === 'failed') &&
       matchesQuery(row, query),
   )
   const inFlight = active.filter(

--- a/frontend/src/extensions/ship/statusLine.test.ts
+++ b/frontend/src/extensions/ship/statusLine.test.ts
@@ -17,20 +17,20 @@ function status(overrides: Partial<SubjectStatus>): SubjectStatus {
 
 describe('statusLine', () => {
   it('parked renders build’s line for the gate identity', () => {
-    expect(statusLine(status({ state: 'pending_input', gate: 'review_work' }))).toBe(
+    expect(statusLine(status({ state: 'parked', gate: 'review_work' }))).toBe(
       'Review implementation',
     )
-    expect(statusLine(status({ state: 'pending_input', gate: 'review' }))).toBe(
+    expect(statusLine(status({ state: 'parked', gate: 'review' }))).toBe(
       'Review the plan',
     )
   })
 
   it('an unmapped gate reads as a generic park', () => {
-    expect(statusLine(status({ state: 'pending_input', gate: 'unknown' }))).toBe('Waiting on you')
+    expect(statusLine(status({ state: 'parked', gate: 'unknown' }))).toBe('Waiting on you')
   })
 
   it('parked without a gate falls back', () => {
-    expect(statusLine(status({ state: 'pending_input' }))).toBe('Waiting on you')
+    expect(statusLine(status({ state: 'parked' }))).toBe('Waiting on you')
   })
 
   it('running shows the live agent over the kind', () => {

--- a/frontend/src/extensions/ship/statusLine.ts
+++ b/frontend/src/extensions/ship/statusLine.ts
@@ -20,7 +20,7 @@ function kindLabel(kind: string): string {
 }
 
 export function statusLine(status: SubjectStatus): string {
-  if (status.state === 'pending_input') {
+  if (status.state === 'parked') {
     return parkedLine(status.gate) ?? 'Waiting on you'
   }
   if (status.state === 'running' || status.state === 'scheduled') {

--- a/frontend/src/lib/states.ts
+++ b/frontend/src/lib/states.ts
@@ -9,7 +9,7 @@ interface StateStyle {
 export const STATES: Record<RunState, StateStyle> = {
   scheduled: { color: 'var(--bucket-run)', glyph: '●', label: 'in-progress' },
   running: { color: 'var(--bucket-run)', glyph: '●', label: 'in-progress' },
-  pending_input: { color: 'var(--bucket-human)', glyph: '◆', label: 'waiting-on-you' },
+  parked: { color: 'var(--bucket-human)', glyph: '◆', label: 'waiting-on-you' },
   finished: { color: 'var(--outcome-merged)', glyph: '✓', label: 'finished' },
   failed: { color: 'var(--bucket-dead)', glyph: '✕', label: 'failed' },
   cancelled: { color: 'var(--outcome-abandoned)', glyph: '◯', label: 'cancelled' },

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1903,7 +1903,7 @@ input.set-select { background-image: none; padding-right: 12px; }
 }
 .wic-node-scheduled { color: var(--wic-scheduled); border-color: var(--border); }
 .wic-node-running, .wic-node-cancelling { color: var(--wic-running); border-color: var(--wic-running); animation: pulse 1.6s ease-in-out infinite; }
-.wic-node-pending_input { color: var(--wic-human); border-color: var(--wic-human); animation: pulse 1.6s ease-in-out infinite; }
+.wic-node-parked { color: var(--wic-human); border-color: var(--wic-human); animation: pulse 1.6s ease-in-out infinite; }
 .wic-node-finished  { color: var(--wic-finished);  border-color: var(--wic-finished); }
 .wic-node-failed    { color: var(--wic-failed);     border-color: var(--wic-failed); }
 .wic-node-cancelled { color: var(--wic-cancelled);  border-color: var(--wic-cancelled); }
@@ -1914,7 +1914,7 @@ input.set-select { background-image: none; padding-right: 12px; }
 .wic-op-owner { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-faint); margin-left: 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .wic-op-sub { font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .wic-sub-running, .wic-sub-cancelling { color: var(--wic-running); }
-.wic-sub-pending_input { color: var(--wic-human); }
+.wic-sub-parked { color: var(--wic-human); }
 .wic-sub-failed    { color: var(--wic-failed); }
 .wic-sub-scheduled { color: var(--text-faint); }
 


### PR DESCRIPTION
Fixes a live break on `main` from #102, and the break is my fault: the state rename landed on both sides of the wire in that PR's working tree, but the final commit staged `backend` and `docs` only, so the frontend half never made it in.

## What's broken on main

The backend serves `state: "parked"`; the frontend still keys `pending_input`.

* `STATES['parked']` is `undefined`, so `StatusGlyph` reads `.color` off undefined and **throws** — a render crash anywhere a parked run's glyph shows (board rows, work item page).
* `statusLine`'s `status.state === 'pending_input'` never matches, so a parked run falls through to the wrong line.
* `WorkItemsPage`'s parked lane and `WorkItemPage`'s glyph/label/`needsyou` class all lose their parked branch, and `wic-node-parked` has no styles.

`tsc` does not catch it: the frontend is internally consistent, it just disagrees with the server. That's why #102 went green.

## The fix

The same mechanical rename, the half that got left behind — `types.ts`, `states.ts`, `statusLine` (+ its test), both ship pages, and two CSS class names. No behaviour change beyond making the frontend agree with the wire again.

## Verification

Ran the frontend toolchain this time rather than reasoning about it: `tsc -b` clean, `eslint .` clean, `vitest run` 53 passed across 11 files.
