### PR TITLE
The feed carries facts; the words are the client's

### DIFF
--- a/backend/druks/contrib/ship/extension.py
+++ b/backend/druks/contrib/ship/extension.py
@@ -13,10 +13,8 @@ from druks.contrib.ship.contracts import (
 )
 from druks.contrib.ship.models import WorkItem
 from druks.contrib.ship.schemas import WorkItemSummary
-from druks.db import db_session
-from druks.events import Event, FeedItem
 from druks.extensions import Extension
-from druks.workflows import SubjectActivity, WorkflowEvent, get_subject_phase
+from druks.workflows import SubjectActivity, get_subject_phase
 
 _PHASE_META: dict[str, SubjectActivity] = {
     "provisioning_vm": SubjectActivity(label="Building sandbox VM…", kind="infra"),
@@ -125,49 +123,6 @@ class Ship(Extension):
         contract=RepoProfilerOutput,
         model="codex",
     )
-    _LABEL = {
-        WorkflowEvent.RUNNING: "started",
-        WorkflowEvent.FINISHED: "finished",
-        WorkflowEvent.FAILED: "failed",
-        WorkflowEvent.CANCELLED: "cancelled",
-        WorkflowEvent.PARKED: "waiting on you",
-        "needs_answers": "needs answers",
-    }
-
-    @classmethod
-    def format_event(cls, event: Event) -> FeedItem:
-        wid = cls._work_item_id(event)
-        # ``session.get`` rides the identity map, so a feed with several events on
-        # the same work item costs one title lookup, not one per event.
-        item = db_session().get(WorkItem, wid) if wid else None
-        ticket_ref = (item.remote_key or "") if item else ""
-        workflow_name = event.payload.get("kind")
-        if workflow_name:
-            # The feed shows the workflow's local name, not its namespaced durable kind.
-            workflow_name = workflow_name.rsplit(".", 1)[-1]
-        label = cls._LABEL.get(event.type, event.type)
-        if event.type.startswith("workflow."):
-            kind, summary = event.type, (f"{workflow_name} {label}" if workflow_name else label)
-        else:
-            kind, summary = f"milestone.{event.type}", label
-        ref = ticket_ref or (f"work item {wid}" if wid else "")
-        if ref:
-            summary = f"{summary} — {ref}"
-        return FeedItem(
-            id=f"event:{event.id}",
-            at=event.created_at,
-            kind=kind,
-            source=workflow_name or "ship",
-            summary=summary,
-            link_path=f"/work-items/{wid}" if wid else None,
-            meta={"ticketRef": ticket_ref} if ticket_ref else {},
-        )
-
-    @staticmethod
-    def _work_item_id(event: Event) -> int | None:
-        if event.subject_type == "work_item" and event.subject_id:
-            return int(event.subject_id)
-        return
 
     @classmethod
     def subject_summary(cls, subject: WorkItem) -> WorkItemSummary:

--- a/backend/druks/contrib/ship/models.py
+++ b/backend/druks/contrib/ship/models.py
@@ -345,7 +345,10 @@ class WorkItem(StoredSubject):
             # cycle: the extension imports this module at file scope.
             import druks.contrib.ship.extension as ship_extension
 
-            ship_extension.Ship.record_event(type=status, subject=self, payload=event_payload)
+            payload = dict(event_payload or {})
+            if self.remote_key:
+                payload["ticket"] = self.remote_key
+            ship_extension.Ship.record_event(type=status, subject=self, payload=payload)
         self.status = status
         self.updated_at = Base.utc_now()
         db_session().flush()

--- a/backend/druks/events/__init__.py
+++ b/backend/druks/events/__init__.py
@@ -1,4 +1,3 @@
-from .feed import FeedItem
 from .models import Event
 
-__all__ = ["Event", "FeedItem"]
+__all__ = ["Event"]

--- a/backend/druks/events/builder.py
+++ b/backend/druks/events/builder.py
@@ -1,9 +1,8 @@
 from sqlalchemy import or_, select
 
 from druks.database import db_session
-from druks.events.feed import FeedItem, generic_entry
+from druks.events.feed import FeedItem
 from druks.events.models import Event
-from druks.extensions.loader import get_extension
 
 _PAGE_LIMIT_DEFAULT = 200
 _FETCH_LIMIT = 500
@@ -15,48 +14,19 @@ def build_feed(
     before: int | None = None,
     limit: int = _PAGE_LIMIT_DEFAULT,
 ) -> tuple[list[FeedItem], str | None]:
-    items = _render(_events(extension=extension, before=before))
-    items.sort(key=lambda e: e.seq, reverse=True)
+    items = [FeedItem.from_event(event) for event in _events(extension, before)]
+    items.sort(key=lambda item: item.seq, reverse=True)
     page = items[:limit]
     next_cursor = str(page[-1].seq) if len(page) == limit and page else None
     return page, next_cursor
 
 
-def _events(*, extension: str | None, before: int | None) -> list[Event]:
+def _events(extension: str | None, before: int | None) -> list[Event]:
     # This extension's events plus any unscoped (core) ones. The log stores the extension;
     # the core never derives it from the subject.
     stmt = select(Event).order_by(Event.id.desc())
-    if before is not None:
+    if before:
         stmt = stmt.where(Event.id < before)
-    if extension is not None:
+    if extension:
         stmt = stmt.where(or_(Event.extension == extension, Event.extension.is_(None)))
     return list(db_session().scalars(stmt.limit(_FETCH_LIMIT)).all())
-
-
-def _render(rows: list[Event]) -> list[FeedItem]:
-    # Each event goes to its extension's ``format_event`` hook, so the core stays free
-    # of any extension's event types. Resolve each extension once per render; unscoped
-    # events (no extension) get a generic item.
-    extensions: dict[str | None, object] = {}
-
-    def extension_for(name: str | None):
-        if name not in extensions:
-            extensions[name] = _resolve_extension(name)
-        return extensions[name]
-
-    items: list[FeedItem] = []
-    for e in rows:
-        m = extension_for(e.extension)
-        item = m.format_event(e) if m else generic_entry(e)
-        item.seq = e.id  # the builder owns the ordering key, whatever the hook set for id
-        items.append(item)
-    return items
-
-
-def _resolve_extension(name: str | None):
-    if not name:
-        return None
-    try:
-        return get_extension(name)
-    except KeyError:
-        return None

--- a/backend/druks/events/feed.py
+++ b/backend/druks/events/feed.py
@@ -11,35 +11,37 @@ class FeedItem(BaseResponse):
     id: str
     # The event's monotonic log position (its pk) — the feed's ordering and
     # pagination key. ``at`` is whole-second and ties constantly; this never does.
-    # The builder stamps it from the Event, so an extension's format_event needn't.
-    seq: int = 0
+    seq: int
     at: datetime
-    # Dotted ``source.phase`` taxonomy. Open-ended — the frontend keys pill
-    # color off the prefix, so a new type lands in the right bucket for free.
+    # The event type verbatim: a lifecycle topic ("workflow.finished") or the
+    # milestone an extension recorded ("shipped"). The words are the client's.
     kind: str
-    # Coarse source label for the feed's source column (linear / github / codex
-    # / claude / worker / cron / watch).
-    source: str
-    summary: str
-    # Internal route the row deep-links to; None when it has no detail page.
-    link_path: str | None = None
-    # Free-form secondary-line metadata; the frontend renders known keys and
-    # ignores the rest, so new keys ship without a frontend change.
-    meta: dict[str, Any] = Field(default_factory=dict)
+    extension: str | None = None
+    # The durable kind of the workflow a lifecycle row is about ("ship.build").
+    workflow: str | None = None
+    subject_type: str | None = None
+    subject_id: str | None = None
+    # Whatever else the event recorded, stated by its writer — a gate, a failure,
+    # a ticket key. What a row carries beyond identity is said at write time.
+    facts: dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def from_event(cls, event: Event) -> "FeedItem":
+        facts = dict(event.payload)
+        return cls(
+            id=f"event:{event.id}",
+            seq=event.id,
+            at=event.created_at,
+            kind=event.type,
+            extension=event.extension,
+            workflow=facts.pop("kind", None),
+            subject_type=event.subject_type,
+            subject_id=event.subject_id,
+            facts=facts,
+        )
 
 
 class FeedResponse(BaseResponse):
     items: list[FeedItem]
     # Event sequence cursor for the next (older) page; None at the tail.
     next_cursor: str | None = None
-
-
-def generic_entry(event: Event) -> FeedItem:
-    """Fallback when an extension has no opinion — show the raw type."""
-    return FeedItem(
-        id=f"event:{event.id}",
-        at=event.created_at,
-        kind=event.type,
-        source="system",
-        summary=event.type,
-    )

--- a/backend/druks/extensions/base.py
+++ b/backend/druks/extensions/base.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from pydantic import BaseModel
 
-from druks.events.feed import generic_entry
 from druks.events.models import Event
 from druks.models import StoredSubject
 from druks.user_settings.models import SettingsOverride
@@ -28,7 +27,6 @@ if TYPE_CHECKING:
     from druks.doctor import CheckResult
     from druks.durable.datastructures import Subject
     from druks.durable.schemas import SubjectActivity, SubjectSummary
-    from druks.events.feed import FeedItem
     from druks.settings import Settings
     from druks.workflows import Workflow
 
@@ -451,21 +449,14 @@ class Extension:
     ) -> None:
         """Record one of this extension's domain events to the log, stamped with the
         extension automatically. Apps record through here so the ``Event`` model
-        stays a platform internal — the write-side twin of ``format_event``."""
+        stays a platform internal. ``type`` is the milestone's own word ("shipped") —
+        the feed reads it as one, so an extension writes no rendering."""
         Event.emit(
             type=type,
             subject=subject.identity if subject else None,
             payload=payload,
             extension=cls.name,
         )
-
-    @classmethod
-    def format_event(cls, event: Event) -> "FeedItem":
-        """Render one of this extension's events into an activity-feed row. The core
-        feed dispatches each event to its extension by ``event.extension``, so the core
-        never learns an extension's event types — override to give them human
-        summaries."""
-        return generic_entry(event)
 
     @classmethod
     def subject_summary(cls, subject: Any) -> "SubjectSummary | None":

--- a/backend/tests/druks-field_notes/druks_field_notes/extension.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/extension.py
@@ -3,9 +3,7 @@ from typing import TYPE_CHECKING, Literal
 
 from druks.agents import Agent
 from druks.doctor import CheckResult
-from druks.events import Event, FeedItem
 from druks.extensions import Extension
-from druks.workflows import WorkflowEvent
 from pydantic import BaseModel, Field, SecretStr, field_validator
 
 from druks_field_notes.contracts import NoteSummary
@@ -83,22 +81,6 @@ class FieldNotes(Extension):
         contract=NoteSummary,
         model="claude",
     )
-
-    @classmethod
-    def format_event(cls, event: Event) -> FeedItem:
-        note_id = event.subject_id
-        if event.type == WorkflowEvent.FINISHED:
-            verb = "summarized"
-        else:
-            verb = event.type.rsplit(".", 1)[-1]
-        return FeedItem(
-            id=f"event:{event.id}",
-            at=event.created_at,
-            kind=event.type,
-            source="field_notes",
-            summary=f"note {note_id} {verb}" if note_id else verb,
-            link_path=f"/app/field_notes/notes/{note_id}" if note_id else None,
-        )
 
     @classmethod
     def subject_summary(cls, subject: Note) -> NoteView:

--- a/backend/tests/druks-field_notes/druks_field_notes/subscribers.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/subscribers.py
@@ -8,7 +8,6 @@ from druks_field_notes.workflows import Summarize
 
 @subscribe(WorkflowEvent.FINISHED, workflow=Summarize, subject=Note)
 async def note_summarized(*, subject: Note, **_: object) -> None:
-    # A finished summarize is a milestone worth its own feed row — record it so
-    # format_event can render it. The workflow lifecycle is the trigger; the
-    # extension only reacts.
+    # A finished summarize is a milestone worth its own feed row. The workflow
+    # lifecycle is the trigger; the extension only reacts.
     FieldNotes.record_event(type="summarized", subject=subject)

--- a/backend/tests/druks-field_notes/tests/test_extension.py
+++ b/backend/tests/druks-field_notes/tests/test_extension.py
@@ -1,26 +1,7 @@
 import pytest
-from druks.events import Event
 from druks_field_notes.extension import FieldNotes
 from druks_field_notes.models import Note
 from pydantic import ValidationError
-
-
-def test_format_event_describes_the_note():
-    event = Event(
-        id=1,
-        type="workflow.finished",
-        subject_type="note",
-        subject_id="7",
-        extension="field_notes",
-        payload={},
-        created_at=Event.utc_now(),
-    )
-
-    item = FieldNotes.format_event(event)
-
-    assert item.source == "field_notes"
-    assert item.summary == "note 7 summarized"
-    assert item.link_path == "/app/field_notes/notes/7"
 
 
 def test_list_subjects_honors_the_board_size(druks_db):

--- a/backend/tests/test_author_surface.py
+++ b/backend/tests/test_author_surface.py
@@ -30,7 +30,7 @@ AUTHOR_SURFACE = {
     "druks.db": {"Base", "StoredSubject", "db_session"},
     "druks.schemas": {"BaseResponse"},
     "druks.signals": {"subscribe"},
-    "druks.events": {"Event", "FeedItem"},
+    "druks.events": {"Event"},
     "druks.prompts": {"render_prompt"},
 }
 

--- a/backend/tests/test_events_feed.py
+++ b/backend/tests/test_events_feed.py
@@ -4,7 +4,7 @@ from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
 
 
-def test_feed_reads_run_and_milestone_events(druks_db):
+def test_feed_carries_the_facts_a_row_is_worded_from(druks_db):
     note = Note.create(body="the pump ran hot")
     Event.emit(
         type="workflow.running",
@@ -12,16 +12,22 @@ def test_feed_reads_run_and_milestone_events(druks_db):
         extension="field_notes",
         payload={"kind": Summarize.kind, "run": "wf1"},
     )
-    Event.emit(type="summarized", subject=note.identity, extension="field_notes")
+    Event.emit(
+        type="summarized", subject=note.identity, extension="field_notes", payload={"words": 12}
+    )
     druks_db.flush()
 
-    page, _ = build_feed()
-    by_kind = {e.kind: e for e in page}
-    assert "workflow.running" in by_kind and "summarized" in by_kind
+    by_kind = {row.kind: row for row in build_feed()[0]}
+
+    started = by_kind["workflow.running"]
+    assert (started.extension, started.workflow) == ("field_notes", Summarize.kind)
+    assert (started.subject_type, started.subject_id) == ("note", str(note.id))
+    # Whatever is left of the payload once the workflow is promoted out of it.
+    assert started.facts == {"run": "wf1"}
+
+    # A milestone has no workflow behind it, and carries what its writer stated.
     summarized = by_kind["summarized"]
-    assert summarized.link_path == f"/app/field_notes/notes/{note.id}"
-    assert f"note {note.id}" in summarized.summary
-    assert f"note {note.id}" in by_kind["workflow.running"].summary
+    assert (summarized.workflow, summarized.facts) == (None, {"words": 12})
 
 
 def test_feed_paginates_same_second_events_without_loss_or_repeat(druks_db):

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -161,9 +161,9 @@ than only on the VM.
 A subject is the row a run is about. The extension owns it and hands it to druks
 whenever it starts a run or answers a gate; only the row's type and id travel
 further, because a run outlives the row it points at. Everything that happens to
-a run lands in an append-only event log. Extensions add their own events, format
-feed rows, and supply subject summaries; druks supplies pagination, activity
-composition, and a live feed.
+a run lands in an append-only event log. Extensions add their own events and
+supply subject summaries; druks supplies pagination, activity composition, and a
+live feed of facts — a row's words are the client's.
 
 Signals connect producers to extension reactions. They are awaited and
 delivered at least once: webhook failures return an error so the provider can

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -443,18 +443,31 @@ NightWatch.record_event(
 )
 ```
 
-Override `format_event()` to turn extension events into `FeedItem` rows.
-Lifecycle events for subjected workflows are recorded automatically. Call
-`record_event()` inside a platform-bound transaction such as a request,
-durable step, or subscriber.
+`type` is the milestone's own word, which the feed reads as one — there is no
+rendering hook to implement. Lifecycle events for subjected workflows are
+recorded automatically. Call `record_event()` inside a platform-bound
+transaction such as a request, durable step, or subscriber.
+
+A feed row carries facts, never prose: its kind, the workflow it came from, the
+subject identity, and the event's payload — a client words them. Whatever a row
+should say beyond identity is stated by its writer, on the event:
+
+```python
+NightWatch.record_event(
+    type="report.published",
+    subject=repository,
+    payload={"repo": repository.full_name, "url": report_url},
+)
+```
 
 React with filters rather than body guards:
 
 ```python
 from druks.signals import subscribe
+from druks.workflows import WorkflowEvent
 
 
-@subscribe("run.finished", subject__type="repository")
+@subscribe(WorkflowEvent.FINISHED, subject=Repository)
 async def on_sweep_finished(*, subject: Repository, **_: object) -> None:
     await notify(subject.full_name)
 ```
@@ -644,10 +657,10 @@ Import from concern namespaces, not from `druks.durable` or internal modules:
 | `druks.extensions` | `Extension` |
 | `druks.agents` | `Agent`, `AgentOutput` |
 | `druks.workflows` | `Workflow`, `Gate`, `step`, run/agent response types, lifecycle enums and workflow errors |
-| `druks.db` | `Base`, `db_session` |
+| `druks.db` | `Base`, `StoredSubject`, `db_session` |
 | `druks.schemas` | `BaseResponse` |
 | `druks.signals` | `subscribe` |
-| `druks.events` | `Event`, `FeedItem` |
+| `druks.events` | `Event` |
 | `druks.prompts` | `render_prompt` |
 | `druks.webhooks` | `Webhook`, `verify_hmac_sha256` |
 | `druks.testing` | `run_workflow`, `seed_run`, `seed_call`, `init_db` — plus the fixtures the plugin registers |

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -329,12 +329,19 @@ export interface UpdateExtensionsSettingsRequest {
 
 export interface FeedItem {
   id: string
+  seq: number
   at: string
+  // A lifecycle topic ("workflow.finished") or the milestone an extension recorded
+  // ("shipped"). The words are this client's — see lib/feed.
   kind: string
-  source: string
-  summary: string
-  linkPath?: string | null
-  meta?: Record<string, unknown>
+  extension?: string | null
+  // The durable kind of the workflow a lifecycle row is about ("ship.build").
+  workflow?: string | null
+  subjectType?: string | null
+  subjectId?: string | null
+  // Whatever else the event recorded, stated by its writer — a gate, a failure,
+  // a ticket key.
+  facts: Record<string, unknown>
 }
 
 export interface FeedResponse {

--- a/frontend/src/extensions/registry.tsx
+++ b/frontend/src/extensions/registry.tsx
@@ -30,6 +30,9 @@ export interface ExtensionUI {
   home?: string
   routes: ExtensionRoute[]
   nav?: ExtensionNavEntry[]
+  // Where a feed row about one of this extension's subjects navigates. The shell knows
+  // an extension has subjects, never where its pages put them.
+  subjectPath?: (subject: { type: string; id: string }) => string | undefined
   // Whether the persistent system-health strip (webhook + spend) rides above this
   // extension's list and detail surfaces. Opt-in — an extension that doesn't track
   // code hosts leaves it off and the band never renders.

--- a/frontend/src/extensions/ship/ui.tsx
+++ b/frontend/src/extensions/ship/ui.tsx
@@ -20,6 +20,9 @@ registerExtensionUI({
     { href: `/${SHIP}/history`, label: 'history' },
     { href: `/${SHIP}/projects`, label: 'projects' },
   ],
+  // Ship's other subject, a project repo, has no page of its own — a row about one
+  // stays unclickable rather than landing on the work item that shares its id.
+  subjectPath: ({ type, id }) => (type === 'work_item' ? `/work-items/${id}` : undefined),
   routes: [
     { path: `/${SHIP}`, render: () => <WorkItemsPage /> },
     { path: `/${SHIP}/history`, render: () => <HistoryPage /> },

--- a/frontend/src/lib/feed.test.ts
+++ b/frontend/src/lib/feed.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import { eventLine } from './feed'
+// Ship's own registration, not a stand-in: its subjectPath is what makes a row navigate.
+import '../extensions/ship/ui'
+import type { FeedItem } from '../api/types'
+
+function event(fields: Partial<FeedItem>): FeedItem {
+  return {
+    id: 'event:1',
+    seq: 1,
+    at: '2026-07-26T12:00:00Z',
+    kind: 'workflow.running',
+    facts: {},
+    ...fields,
+  }
+}
+
+describe('eventLine', () => {
+  it('names the workflow and what it did', () => {
+    const line = eventLine(event({ kind: 'workflow.running', workflow: 'ship.build' }))
+
+    expect(line.label).toBe('build started')
+    expect(line.source).toBe('build')
+  })
+
+  it('calls a parked run waiting on you', () => {
+    expect(eventLine(event({ kind: 'workflow.parked', workflow: 'ship.build' })).label).toBe(
+      'build waiting on you',
+    )
+  })
+
+  it("reads an extension's own milestone as its own word", () => {
+    const line = eventLine(event({ kind: 'shipped', extension: 'ship' }))
+
+    expect(line.label).toBe('shipped')
+    expect(line.source).toBe('ship')
+    expect(line.bucket).toBe('event-kind-audit')
+  })
+
+  it('links a row where the extension says its subject lives', () => {
+    const line = eventLine(
+      event({
+        kind: 'workflow.finished',
+        workflow: 'ship.build',
+        extension: 'ship',
+        subjectType: 'work_item',
+        subjectId: '42',
+      }),
+    )
+
+    expect(line.subject).toBe('work item 42')
+    expect(line.path).toBe('/work-items/42')
+  })
+
+  it("leaves a row about a subject with no page of its own unclickable", () => {
+    const line = eventLine(
+      event({
+        kind: 'workflow.running',
+        workflow: 'ship.profile',
+        extension: 'ship',
+        subjectType: 'project_repo',
+        subjectId: '3',
+      }),
+    )
+
+    expect(line.label).toBe('profile started')
+    expect(line.subject).toBe('project repo 3')
+    expect(line.path).toBeUndefined()
+  })
+
+  it('reads an unregistered extension without words or a page', () => {
+    const line = eventLine(
+      event({ kind: 'summarized', extension: 'field_notes', subjectType: 'note', subjectId: '7' }),
+    )
+
+    expect(line.label).toBe('summarized')
+    expect(line.subject).toBe('note 7')
+    expect(line.path).toBeUndefined()
+  })
+
+  it('reads a core event with no subject at all', () => {
+    const line = eventLine(event({ kind: 'credential.fallback' }))
+
+    expect(line.label).toBe('credential.fallback')
+    expect(line.subject).toBe('')
+    expect(line.source).toBe('druks')
+  })
+})

--- a/frontend/src/lib/feed.ts
+++ b/frontend/src/lib/feed.ts
@@ -1,0 +1,72 @@
+import type { FeedItem } from '../api/types'
+import { getExtensionUI } from '../extensions/registry'
+
+// What a workflow doing something is called. The platform owns these words because it
+// owns the lifecycle; an extension's own milestones are already named by their type.
+const LIFECYCLE_VERBS: Record<string, string> = {
+  'workflow.running': 'started',
+  'workflow.parked': 'waiting on you',
+  'workflow.finished': 'finished',
+  'workflow.failed': 'failed',
+  'workflow.cancelled': 'cancelled',
+}
+
+export interface EventLine {
+  // What happened, in words: "build started", "shipped".
+  label: string
+  // Who it happened to, by identity. Empty for a row about nothing in particular.
+  subject: string
+  // The feed's source column — the workflow that ran, else the extension.
+  source: string
+  // Where the row navigates, when the extension has a page for its subject.
+  path?: string
+  // Pill class, so the operator can scan a column of kinds by colour.
+  bucket: string
+}
+
+export function eventLine(event: FeedItem): EventLine {
+  return {
+    label: label(event),
+    subject: subjectName(event),
+    source: localName(event.workflow) || event.extension || 'druks',
+    path: subjectPath(event),
+    bucket: isLifecycle(event) ? 'event-kind-agent' : 'event-kind-audit',
+  }
+}
+
+function label(event: FeedItem): string {
+  const verb = LIFECYCLE_VERBS[event.kind]
+  if (verb) {
+    const workflow = localName(event.workflow)
+    return workflow ? `${workflow} ${verb}` : verb
+  }
+  // An extension's milestone type is its own word ("shipped", "needs_answers"), and an
+  // unrecognised kind reads as itself rather than disappearing.
+  return words(event.kind)
+}
+
+function subjectName(event: FeedItem): string {
+  if (event.subjectType && event.subjectId) return `${words(event.subjectType)} ${event.subjectId}`
+  return ''
+}
+
+function subjectPath(event: FeedItem): string | undefined {
+  if (event.extension && event.subjectType && event.subjectId) {
+    const ui = getExtensionUI(event.extension)
+    return ui?.subjectPath?.({ type: event.subjectType, id: event.subjectId })
+  }
+  return undefined
+}
+
+function isLifecycle(event: FeedItem): boolean {
+  return event.kind in LIFECYCLE_VERBS
+}
+
+// "ship.build" → "build": the durable kind identifies the workflow, its tail names it.
+function localName(kind: string | null | undefined): string {
+  return kind ? (kind.split('.').pop() ?? '') : ''
+}
+
+function words(identifier: string): string {
+  return identifier.replace(/_/g, ' ')
+}

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -8,6 +8,7 @@ import type { FeedItem } from '../api/types'
 import { BackToExtension } from '../components/BackToExtension'
 import { EmptyState } from '../components/EmptyState'
 import { Page } from '../components/Page'
+import { eventLine } from '../lib/feed'
 import { relTimeFromIso } from '../lib/format'
 import { useFormatters } from '../lib/preferences'
 
@@ -131,22 +132,23 @@ function EventRow({
   absTime: (iso: string) => string
   onNavigate: (path: string) => void
 }) {
-  const clickable = Boolean(event.linkPath)
+  const line = eventLine(event)
   const handleClick = () => {
-    if (event.linkPath) onNavigate(event.linkPath)
+    if (line.path) onNavigate(line.path)
   }
   return (
     <div
-      className={`event-row${clickable ? ' event-row-clickable' : ''}`}
-      onClick={clickable ? handleClick : undefined}
+      className={`event-row${line.path ? ' event-row-clickable' : ''}`}
+      onClick={line.path ? handleClick : undefined}
       title={absTime(event.at)}
     >
       <span className="event-time mono dim">{relTimeFromIso(event.at)}</span>
-      <span className={`event-kind-pill mono ${eventKindClass(event.kind)}`}>
-        {event.kind}
+      <span className={`event-kind-pill mono ${line.bucket}`}>{event.kind}</span>
+      <span className="event-source mono dim">{line.source}</span>
+      <span className="event-summary">
+        {line.label}
+        {line.subject && <span className="dim"> — {line.subject}</span>}
       </span>
-      <span className="event-source mono dim">{event.source}</span>
-      <span className="event-summary">{event.summary}</span>
     </div>
   )
 }
@@ -200,24 +202,4 @@ function mergeEvents(prev: FeedItem[], next: FeedItem): FeedItem[] {
     return a.id < b.id ? 1 : -1
   })
   return merged.length > FEED_CAP ? merged.slice(0, FEED_CAP) : merged
-}
-
-/**
- * Map an event kind ("agent_run.started", "webhook.github", …) to a CSS
- * class so the operator can scan by color. Buckets reuse the dashboard
- * status palette (cyan for in-progress, magenta for human-gated, etc.)
- * so the same colors mean the same things across views.
- */
-function eventKindClass(kind: string): string {
-  // Run lifecycle shares the agent bucket; milestones (shipped / cancelled)
-  // are the outcome facts that used to arrive as audit.pr_merged.
-  if (kind.startsWith('run.')) return 'event-kind-agent'
-  if (kind.startsWith('milestone.')) return 'event-kind-audit'
-  if (kind.startsWith('agent_run.')) return 'event-kind-agent'
-  if (kind.startsWith('scope_run.')) return 'event-kind-scope'
-  if (kind.startsWith('webhook.')) return 'event-kind-webhook'
-  if (kind.startsWith('signal.')) return 'event-kind-signal'
-  if (kind.startsWith('job.')) return 'event-kind-job'
-  if (kind.startsWith('audit.')) return 'event-kind-audit'
-  return 'event-kind-other'
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1796,28 +1796,9 @@ input.set-select { background-image: none; padding-right: 12px; }
   color: var(--bucket-run);
   border-color: color-mix(in oklch, var(--bucket-run) 35%, transparent);
 }
-.event-kind-scope {
-  color: var(--bucket-plan);
-  border-color: color-mix(in oklch, var(--bucket-plan) 35%, transparent);
-}
-.event-kind-webhook {
-  color: var(--accent-amber);
-  border-color: color-mix(in oklch, var(--accent-amber) 30%, transparent);
-}
-.event-kind-signal {
-  color: var(--bucket-human);
-  border-color: color-mix(in oklch, var(--bucket-human) 35%, transparent);
-}
-.event-kind-job {
-  color: var(--accent-violet);
-  border-color: color-mix(in oklch, var(--accent-violet) 30%, transparent);
-}
 .event-kind-audit {
   color: var(--text-mid);
   border-color: var(--border);
-}
-.event-kind-other {
-  color: var(--text-dim);
 }
 
 /* ============================================================


### PR DESCRIPTION
Closes ENG-768.

`Extension.format_event` is deleted. A feed row carries facts and the client words them:

```
FeedItem: id, seq, at, kind, extension, workflow, subjectType, subjectId, facts
```

- `kind` is the event type verbatim (`workflow.finished`, `shipped`) — no invented namespace.
- `workflow` is the durable kind, promoted out of the payload.
- `facts` is whatever the event's writer stated (`record_event(payload=...)`); ship's milestones state their ticket key there.
- The builder is a pure projection of the event log — one query, no subject loading.

The shell words the lifecycle it owns (`workflow.parked` → "waiting on you"); an extension's milestone type is already its own word; rows are named by subject identity. An extension contributes navigation with one registry callback — `subjectPath: ({type, id}) => path` — and ship maps only `work_item`, so a `project_repo` row stays unclickable instead of landing on an unrelated ticket.

Deleted with the hook: `generic_entry`, ship's `_LABEL`/`format_event`/`_work_item_id`, field_notes' formatter, `eventKindClass`, and five orphaned pill styles. `FeedItem` leaves the author surface; `druks.events` exports only `Event`.
