### PR TITLE
Scaffold from an installed Druks, not just a checkout

### DIFF
--- a/backend/druks/scaffolding/__init__.py
+++ b/backend/druks/scaffolding/__init__.py
@@ -1,8 +1,6 @@
-import os
 from importlib import metadata
 from pathlib import Path
 
-import druks
 from druks.extensions.base import NAME_RE
 
 _TEMPLATE = Path(__file__).parent / "extension_template"
@@ -11,16 +9,6 @@ _TEMPLATE = Path(__file__).parent / "extension_template"
 _TPL_SUFFIX = "-tpl"
 # The template's package directory; renamed to ``druks_<name>`` on copy.
 _PACKAGE_DIR = "package"
-
-
-def _druks_path(target: Path) -> str:
-    # The uv source pin for the druks checkout this CLI runs from, relative to the
-    # scaffolded package — cwd varies, so a hardcoded ../druks only resolved when
-    # the target happened to be a sibling of the checkout.
-    for parent in Path(druks.__file__).resolve().parents:
-        if (parent / "pyproject.toml").is_file():
-            return os.path.relpath(parent, target.resolve())
-    return "../druks"  # not a checkout (installed wheel); keep the sibling guess
 
 
 def create_extension(name: str, parent: Path) -> Path:
@@ -45,7 +33,6 @@ def create_extension(name: str, parent: Path) -> Path:
     values = {
         "{{ name }}": name,
         "{{ Name }}": "".join(part.capitalize() for part in name.split("_")),
-        "{{ druks_path }}": _druks_path(target),
     }
     for source in sorted(_TEMPLATE.rglob("*")):
         if source.is_dir():

--- a/backend/druks/scaffolding/extension_template/AGENTS.md-tpl
+++ b/backend/druks/scaffolding/extension_template/AGENTS.md-tpl
@@ -7,9 +7,9 @@ webhooks, and the dashboard.
 ## Read map
 
 - Extension contracts and the full author surface:
-  `{{ druks_path }}/docs/writing-an-extension.md`.
+  https://github.com/czpython/druks/blob/main/docs/writing-an-extension.md.
 - A worked extension to read alongside it:
-  `{{ druks_path }}/backend/tests/druks-field_notes/`.
+  https://github.com/czpython/druks/tree/main/backend/tests/druks-field_notes.
 - Each stub module under `druks_{{ name }}/` documents its own role in comments.
 
 ## Contracts

--- a/backend/druks/scaffolding/extension_template/pyproject.toml-tpl
+++ b/backend/druks/scaffolding/extension_template/pyproject.toml-tpl
@@ -11,10 +11,6 @@ dev = [
     "pytest-asyncio>=1.3.0",
 ]
 
-# Local checkout of druks core; point at the published package once one exists.
-[tool.uv.sources]
-druks = { path = "{{ druks_path }}", editable = true }
-
 # The platform discovers this extension here — installing the package is the
 # whole registration.
 [project.entry-points."druks.extensions"]

--- a/backend/tests/test_scaffolding.py
+++ b/backend/tests/test_scaffolding.py
@@ -1,5 +1,4 @@
 import importlib
-import re
 import sys
 
 import pytest
@@ -23,11 +22,6 @@ def test_create_extension_scaffolds_a_loadable_package(tmp_path):
         'night_watch = "druks_night_watch.extension:NightWatch"'
         in (target / "pyproject.toml").read_text()
     )
-
-    # AGENTS.md exists to route an agent to the author guide from a directory that
-    # ships none of it, so the rendered pointer has to land on the real file.
-    guide = re.search(r"`(\S+writing-an-extension\.md)`", (target / "AGENTS.md").read_text())
-    assert (target / guide.group(1)).is_file()
 
     # No rendered file may reference retired surfaces: the old storage namespace, the
     # taskiq worker, or the one-arg ``config`` workflow wording.

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -37,7 +37,15 @@ names, a mismatched entry-point key, malformed target, import failure, or
 unprefixed table.
 
 The project root also carries an `AGENTS.md` holding the contracts a coding agent
-cannot infer from the stubs, and a relative path back to this guide.
+cannot infer from the stubs, and a link back to this guide.
+
+The scaffold depends on the published `druks`. To develop an extension against a
+local checkout instead, pin it:
+
+```toml
+[tool.uv.sources]
+druks = { path = "../druks", editable = true }
+```
 
 ## Package layout
 


### PR DESCRIPTION
The scaffold pinned druks to the first directory above `druks.__file__` holding a `pyproject.toml`. From a checkout that is the checkout; from a wheel it is whatever project owns the surrounding virtualenv, so a scaffolded extension pinned druks to the author's own package and failed on `uv sync`.

druks is on PyPI, so `dependencies = ["druks"]` resolves on its own — the pin goes away instead of growing a condition. Developing against a local checkout is one line, which the guide now shows.

`AGENTS.md` points at the published guide instead of a relative path into a checkout it cannot assume.
