### PR TITLE
Review a pull request against the repo it lands in

### DIFF
--- a/backend/druks/contrib/review/contracts.py
+++ b/backend/druks/contrib/review/contracts.py
@@ -1,0 +1,10 @@
+from typing import Literal
+
+from druks.agents import AgentOutput
+from druks.contrib.ship.contracts import FindingOutput
+
+
+class ReviewReport(AgentOutput):
+    decision: Literal["approve", "request_changes", "comment"]
+    summary: str
+    findings: list[FindingOutput]

--- a/backend/druks/contrib/review/extension.py
+++ b/backend/druks/contrib/review/extension.py
@@ -1,0 +1,19 @@
+from druks.agents import Agent
+from druks.contrib.review.contracts import ReviewReport
+from druks.extensions import Extension
+
+
+class Review(Extension):
+    name = "review"
+    icon = "git-pull-request"
+    description = (
+        "Reviews a pull request and posts the review back to GitHub — the decision, "
+        "a summary, and a comment on each line it has something to say about."
+    )
+
+    review_pull_request = Agent(
+        description="reads a pull request and writes the review",
+        prompt="review/review_pull_request.md",
+        contract=ReviewReport,
+        model="claude",
+    )

--- a/backend/druks/contrib/review/routes.py
+++ b/backend/druks/contrib/review/routes.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Body, Depends, HTTPException, status
+
+from druks.accounts.dependencies import current_account
+from druks.accounts.models import Account
+from druks.contrib.review.workflows import PullRequestReview
+from druks.contrib.ship.models import ProjectRepo
+
+router = APIRouter(prefix="/pull-requests", tags=["review"])
+
+
+@router.post("", status_code=status.HTTP_202_ACCEPTED)
+async def request_review(
+    repo: str = Body(..., embed=True),
+    pr_number: int = Body(..., embed=True, alias="prNumber"),
+    account: Account = Depends(current_account),
+) -> None:
+    if not ProjectRepo.get_for_repo(repo):
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            f"{repo} is not a registered project repo — add it to a project first",
+        )
+    await PullRequestReview.dispatch(repo=repo, pr_number=pr_number, requested_by=account.username)

--- a/backend/druks/contrib/review/templates/review_pull_request.md
+++ b/backend/druks/contrib/review/templates/review_pull_request.md
@@ -1,0 +1,61 @@
+# Pull Request Reviewer
+
+You are reviewing pull request #{{ workflow.input.pr_number }} on `{{ workflow.input.repo }}`,
+at {{ workflow.input.requested_by }}'s request.
+
+The repo is cloned at `{{ workspace.repo_path }}`, and `gh` is authenticated there as the
+reviewer app — that is the identity your review will be published under. Only your FINAL
+response must be the JSON matching the requested schema; everything before it is free-form and
+never parsed.
+
+## How to review
+
+Check the pull request out, read its diff end to end, then read the code it lands in. A diff on
+its own only shows the changed lines; the checkout is there so your review can be about more
+than them. That reading is the review — the diff is only where it starts.
+
+Four questions, in this order:
+
+1. **Does it do what it says?** Read the pull request's own description against the diff. A
+   change that quietly does more than it claims, or less, is the finding.
+2. **Is it right where it meets everything else?** Callers it didn't update, a contract or
+   shape something else depends on, data it writes that another reader has to parse, a
+   migration something else reads. Grep for those callers — do not assume they don't exist.
+3. **Does it fit how this project already solves this?** The helper that exists, the pattern
+   the neighbouring feature uses, the way errors are handled two files over. Divergence is not
+   automatically wrong; unexplained divergence is.
+4. **Will the next change here be safe?** Names that mean what they do, tests that pin
+   behavior rather than implementation, failures that surface instead of being logged and
+   swallowed.
+
+Every finding names its evidence — the file you opened, the helper that already exists, the
+caller that breaks. "I would have done this differently" is not a finding, and a clean diff
+earns no findings at all: padding a review with nits costs the author more than it gives them.
+
+Do not flag code the diff does not change. Reading the repo is how you judge the change, not an
+invitation to audit it.
+
+Severity:
+- **high** — a correctness bug, a security flaw, a data-loss path
+- **medium** — a maintainability problem the next change will trip on: an unsafe default, a
+  missing test for non-trivial new behavior, a log-then-continue that hides a failure
+- **low** — naming, comment drift, a simplification worth taking later
+
+## Post the review
+
+Publish it on the pull request yourself, as one review carrying all three parts together: your
+verdict — approve, request changes, or comment without blocking — your prose addressed to the
+author, and an inline comment on each line you have something to say about, anchored to the
+diff's post-image (the `+` side). Anything you cannot anchor to a line belongs in the prose.
+
+Post exactly once. If GitHub refuses an anchor, move that remark into the prose and post the
+review again — never leave the pull request without a review.
+
+## Then return
+
+- `decision` — `request_changes` when a high-severity finding stands, `comment` when you have
+  findings the author should weigh but none blocking, `approve` when the change is sound.
+- `summary` — the review body you posted.
+- `findings` — the remarks you posted, one entry each.
+
+This is druks's record of the review you published; the pull request is where it lives.

--- a/backend/druks/contrib/review/workflows.py
+++ b/backend/druks/contrib/review/workflows.py
@@ -1,0 +1,52 @@
+from typing import TYPE_CHECKING, Any
+
+from druks.contrib.review.extension import Review
+from druks.contrib.ship.workspace import RepoWorkspace
+from druks.core.apis.github import get_reviewer_github_client
+from druks.sandbox import repo as _repo
+from druks.sandbox.layout import get_github_token_remote_path, get_repo_root
+from druks.settings import load_settings
+from druks.workflows import Subject, Workflow
+
+if TYPE_CHECKING:
+    from druks.sandbox.host import Sandbox
+
+
+class PullRequestReview(Workflow):
+    """Reviews one pull request against a checkout of the repo it targets; the
+    reviewer reads, judges, and posts the review itself."""
+
+    workspace_class = RepoWorkspace
+
+    @classmethod
+    async def dispatch(cls, *, repo: str, pr_number: int, requested_by: str) -> str:
+        return await cls.start(
+            subject=Subject(id=f"{repo}#{pr_number}", subject_type="pull_request"),
+            repo=repo,
+            pr_number=pr_number,
+            requested_by=requested_by,
+        )
+
+    async def run(self, repo: str, pr_number: int, requested_by: str) -> None:
+        await Review.review_pull_request()
+
+    async def get_workspace_kwargs(self, sandbox: "Sandbox") -> dict[str, Any]:
+        # Cloned at the default branch — the reviewer checks the pull request out
+        # itself. The token is the reviewer app's: it authenticates both the clone and
+        # ``gh``, so the review is authored under that identity, not the operator's.
+        repo = self.input.repo
+        github_token = await get_reviewer_github_client(load_settings()).token_for_repo(repo)
+        await sandbox.write_secret(
+            secret=github_token, remote=get_github_token_remote_path(sandbox.ssh_username)
+        )
+        await _repo.ensure(
+            sandbox,
+            repo_url=f"https://github.com/{repo}",
+            ref=None,
+            target_path=get_repo_root(sandbox.ssh_username),
+        )
+        return {
+            **await super().get_workspace_kwargs(sandbox),
+            "repo": repo,
+            "github_token": github_token,
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ druks = "druks.testing"
 # edits across the platform wiring.
 [project.entry-points."druks.extensions"]
 core = "druks.core.extension:Core"
+review = "druks.contrib.review.extension:Review"
 ship = "druks.contrib.ship.extension:Ship"
 usage = "druks.usage.extension:Usage"
 


### PR DESCRIPTION
[ENG-769](https://linear.app/fellaworks/issue/ENG-769/review-extension-15-review-a-pr-on-request-and-post-it-back) — part 1 of 5 of the `review` extension.

`POST /api/review/pull-requests` with `{repo, prNumber}` starts a run that reviews the pull request in a checkout of its repo and publishes the review on GitHub.

- `druks/contrib/review/`, registered by one `pyproject.toml` entry-point line.
- The subject is identity alone — `Subject(id=f"{repo}#{pr_number}", subject_type="pull_request")`. No table behind a review, and no run id handed back: the pull request is the handle, the platform dedups per subject, and the route answers 202 with no body.
- The run is a single durable operation: clone the repo (ship's `RepoWorkspace`), then one agent call. The token is the reviewer app's — it authenticates the clone and `gh`, so the review is authored under that identity.
- The reviewer does the reviewing. It checks the pull request out, reads the diff, reads the code the diff lands in, and publishes the review itself — verdict, prose, and inline comments together.
- It reviews against four questions — claim vs diff, the seams the change meets, the project's existing answer, and what the next change will cost — and every finding names the evidence it rests on.
- `ReviewReport(AgentOutput)` (`decision`, `summary`, ship's `FindingOutput`s) is druks's record of what the reviewer published, not instructions for publishing it.

The repo must be a registered `ProjectRepo`; the route 404s otherwise. Sibling repos are ENG-772.