### PR TITLE
Point the README off-page and document the PyPI publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/logo/web/DruksLogo_White.svg" />
-    <img src="docs/assets/logo/web/DruksLogo_Black.svg" alt="Druks" width="140" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/czpython/druks/main/docs/assets/logo/web/DruksLogo_White.svg" />
+    <img src="https://raw.githubusercontent.com/czpython/druks/main/docs/assets/logo/web/DruksLogo_Black.svg" alt="Druks" width="140" />
   </picture>
 </p>
 
@@ -20,7 +20,7 @@ workflow records the result of each completed durable operation in Postgres.
 After a restart or deploy, Druks replays the workflow and reuses those recorded
 results instead of repeating completed work. If the process was interrupted
 *inside* an operation, that operation may run again, so side effects still need
-idempotency. [Durability and recovery](docs/concepts.md#durability-and-recovery)
+idempotency. [Durability and recovery](https://github.com/czpython/druks/blob/main/docs/concepts.md#durability-and-recovery)
 explains the exact boundary.
 
 ## Install
@@ -39,12 +39,12 @@ bash <(curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/
 
 That command follows the edge channel while Druks has no stable release. Once
 versioned releases exist, install the script and image from the same tag as
-described in [the release process](docs/releasing.md#install-an-immutable-version).
+described in [the release process](https://github.com/czpython/druks/blob/main/docs/releasing.md#install-an-immutable-version).
 
 The first run creates `~/druks/.env`, generates secrets, and prints any values
 still required. Re-run the same command after filling them; it pulls images,
 runs migrations, and starts the stack. Re-running is also the upgrade path.
-See the [deployment runbook](deploy/README.md) for prerequisites, access
+See the [deployment runbook](https://github.com/czpython/druks/blob/main/deploy/README.md) for prerequisites, access
 control, verification, and rollback.
 
 For a laptop-only stack:
@@ -53,7 +53,7 @@ For a laptop-only stack:
 DRUKS_PROVIDER=docker bash <(curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh)
 ```
 
-Then follow [full local setup](docs/full-local.md) to start Drukbox and connect
+Then follow [full local setup](https://github.com/czpython/druks/blob/main/docs/full-local.md) to start Drukbox and connect
 the agent harnesses. A complete installation needs GitHub Apps because the
 bundled `ship` extension is installed; a standalone extension may have
 different integration requirements.
@@ -90,12 +90,12 @@ agents through tickets and GitHub pull requests, but GitHub PR orchestration is
 
 ## Documentation
 
-- **Evaluating Druks:** [Concepts and guarantees](docs/concepts.md)
-- **Installing locally:** [Full local setup](docs/full-local.md)
-- **Operating a remote stack:** [Deployment runbook](deploy/README.md)
-- **Configuring integrations and secrets:** [Configuration](docs/configuration.md)
-- **Building an application:** [Writing an extension](docs/writing-an-extension.md)
-- **Diagnosing a run or service:** [Troubleshooting](docs/troubleshooting.md)
-- **Contributing to Druks:** [Contribution guide](CONTRIBUTING.md)
-- **Reporting a vulnerability:** [Security policy](SECURITY.md)
-- **All documentation:** [Documentation index](docs/index.md)
+- **Evaluating Druks:** [Concepts and guarantees](https://github.com/czpython/druks/blob/main/docs/concepts.md)
+- **Installing locally:** [Full local setup](https://github.com/czpython/druks/blob/main/docs/full-local.md)
+- **Operating a remote stack:** [Deployment runbook](https://github.com/czpython/druks/blob/main/deploy/README.md)
+- **Configuring integrations and secrets:** [Configuration](https://github.com/czpython/druks/blob/main/docs/configuration.md)
+- **Building an application:** [Writing an extension](https://github.com/czpython/druks/blob/main/docs/writing-an-extension.md)
+- **Diagnosing a run or service:** [Troubleshooting](https://github.com/czpython/druks/blob/main/docs/troubleshooting.md)
+- **Contributing to Druks:** [Contribution guide](https://github.com/czpython/druks/blob/main/CONTRIBUTING.md)
+- **Reporting a vulnerability:** [Security policy](https://github.com/czpython/druks/blob/main/SECURITY.md)
+- **All documentation:** [Documentation index](https://github.com/czpython/druks/blob/main/docs/index.md)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,9 +1,10 @@
 # Releasing Druks
 
-Druks publishes the backend and sandbox as container images. `main` is the edge
-channel: a successful main build updates `latest` and also publishes an immutable
-`sha-<full-git-sha>` tag. A `v*` Git tag publishes the matching version tag and
-the immutable SHA tag; it does not move `latest`.
+Druks publishes the backend and sandbox as container images, and the Python
+distribution to PyPI. `main` is the edge channel: a successful main build updates
+`latest` and also publishes an immutable `sha-<full-git-sha>` tag. A `v*` Git tag
+publishes the matching version tag and the immutable SHA tag; it does not move
+`latest`.
 
 ## Prepare a release
 
@@ -24,6 +25,23 @@ git push origin v0.1.0
 
 Wait for both image workflows, then verify the version and SHA tags in GHCR and
 create the GitHub release from the same tag.
+
+## Publish to PyPI
+
+Publishing the GitHub release runs `release.yml`, which builds the released tag
+and uploads it over a PyPI Trusted Publisher. No token is stored; the `pypi`
+environment on this repository and the publisher registered on PyPI are what
+authorize the upload.
+
+To publish a tag whose release already exists, run the workflow manually and give
+it that tag:
+
+```bash
+gh workflow run release.yml -f tag=v0.1.0
+```
+
+PyPI rejects a version it already holds, so a version is published once. A
+mistaken upload needs a new version, not a retry.
 
 ## Install an immutable version
 


### PR DESCRIPTION
The README is the PyPI project description, where relative paths have no repository to resolve against — every documentation link and the logo were dead on the project page. They now address `github.com`, which GitHub renders identically.

`docs/releasing.md` described container images only. Publishing a GitHub release also uploads the distribution, so the procedure now covers that step and how to run it for a tag whose release already exists.
