### PR TITLE
Review the change where it reaches into the rest of the project

### DIFF
--- a/backend/druks/contrib/review/contracts.py
+++ b/backend/druks/contrib/review/contracts.py
@@ -8,3 +8,4 @@ class ReviewReport(AgentOutput):
     decision: Literal["approve", "request_changes", "comment"]
     summary: str
     findings: list[FindingOutput]
+    context_repos: list[str]

--- a/backend/druks/contrib/review/templates/review_pull_request.md
+++ b/backend/druks/contrib/review/templates/review_pull_request.md
@@ -20,7 +20,8 @@ Four questions, in this order:
    change that quietly does more than it claims, or less, is the finding.
 2. **Is it right where it meets everything else?** Callers it didn't update, a contract or
    shape something else depends on, data it writes that another reader has to parse, a
-   migration something else reads. Grep for those callers — do not assume they don't exist.
+   migration something else reads. Grep for those callers — do not assume they don't exist,
+   and remember that the ones that matter most often live in another repo of this project.
 3. **Does it fit how this project already solves this?** The helper that exists, the pattern
    the neighbouring feature uses, the way errors are handled two files over. Divergence is not
    automatically wrong; unexplained divergence is.
@@ -34,6 +35,25 @@ earns no findings at all: padding a review with nits costs the author more than 
 
 Do not flag code the diff does not change. Reading the repo is how you judge the change, not an
 invitation to audit it.
+
+{% if siblings %}
+## The rest of the project
+
+This repo is one of several in its project. The others are not cloned — clone the ones you
+decide to read into `{{ workspace.related_root }}`, by plain HTTPS URL; auth is already
+configured, and they are read-only references you must never push to. A clone that fails is
+lost context, not a blocker: carry on without it.
+
+{% for sibling in siblings %}
+- `{{ sibling.full_name }}`{% if sibling.purpose %} — {{ sibling.purpose }}{% endif +%}
+{% endfor %}
+
+Open one when the change reaches into it and the target repo can't answer for it: it calls a
+contract that lives there, it changes a shape or a payload something there consumes, it copies
+a helper that already exists there, or it breaks a caller there. Reading the neighbour is how
+you catch what a single-repo review structurally cannot. Don't clone repos the change has
+nothing to do with — irrelevant reading costs the author the same wait as useful reading.
+{% endif %}
 
 Severity:
 - **high** — a correctness bug, a security flaw, a data-loss path
@@ -57,5 +77,8 @@ review again — never leave the pull request without a review.
   findings the author should weigh but none blocking, `approve` when the change is sound.
 - `summary` — the review body you posted.
 - `findings` — the remarks you posted, one entry each.
+- `context_repos` — the other repos of this project you actually read, empty when you read
+  none. A finding that rests on one names it in its evidence too, so the author can follow the
+  reasoning without your checkout.
 
 This is druks's record of the review you published; the pull request is where it lives.

--- a/backend/druks/contrib/review/workflows.py
+++ b/backend/druks/contrib/review/workflows.py
@@ -1,10 +1,11 @@
 from typing import TYPE_CHECKING, Any
 
 from druks.contrib.review.extension import Review
+from druks.contrib.ship.models import ProjectRepo
 from druks.contrib.ship.workspace import RepoWorkspace
 from druks.core.apis.github import get_reviewer_github_client
 from druks.sandbox import repo as _repo
-from druks.sandbox.layout import get_github_token_remote_path, get_repo_root
+from druks.sandbox.layout import get_github_token_remote_path, get_related_root, get_repo_root
 from druks.settings import load_settings
 from druks.workflows import Subject, Workflow
 
@@ -12,11 +13,26 @@ if TYPE_CHECKING:
     from druks.sandbox.host import Sandbox
 
 
-class PullRequestReview(Workflow):
-    """Reviews one pull request against a checkout of the repo it targets; the
-    reviewer reads, judges, and posts the review itself."""
+class ReviewWorkspace(RepoWorkspace):
+    # The target repo's checkout, plus room beside it for the siblings the reviewer
+    # decides to open. Claude scopes file access to cwd + add_dirs, so the related
+    # root is granted before anything is cloned into it.
 
-    workspace_class = RepoWorkspace
+    @property
+    def related_root(self) -> str:
+        return get_related_root(self.sandbox.ssh_username)
+
+    def get_agent_run_kwargs(self, **kwargs: Any) -> dict[str, Any]:
+        kwargs = super().get_agent_run_kwargs(**kwargs)
+        kwargs["add_dirs"] = (self.related_root,)
+        return kwargs
+
+
+class PullRequestReview(Workflow):
+    """Reviews one pull request against a checkout of the repo it targets and the
+    repos around it; the reviewer reads, judges, and posts the review itself."""
+
+    workspace_class = ReviewWorkspace
 
     @classmethod
     async def dispatch(cls, *, repo: str, pr_number: int, requested_by: str) -> str:
@@ -31,9 +47,10 @@ class PullRequestReview(Workflow):
         await Review.review_pull_request()
 
     async def get_workspace_kwargs(self, sandbox: "Sandbox") -> dict[str, Any]:
-        # Cloned at the default branch — the reviewer checks the pull request out
-        # itself. The token is the reviewer app's: it authenticates both the clone and
-        # ``gh``, so the review is authored under that identity, not the operator's.
+        # Cloned at the default branch — the reviewer checks the pull request out itself.
+        # The token is the reviewer app's: it authenticates the clone and ``gh``, so the
+        # review is authored under that identity. Siblings stay uncloned — the reviewer
+        # clones the ones it opens, into a directory that must exist for the grant to hold.
         repo = self.input.repo
         github_token = await get_reviewer_github_client(load_settings()).token_for_repo(repo)
         await sandbox.write_secret(
@@ -45,8 +62,16 @@ class PullRequestReview(Workflow):
             ref=None,
             target_path=get_repo_root(sandbox.ssh_username),
         )
+        await sandbox.exec(["mkdir", "-p", get_related_root(sandbox.ssh_username)], timeout=10.0)
         return {
             **await super().get_workspace_kwargs(sandbox),
             "repo": repo,
             "github_token": github_token,
+        }
+
+    async def get_prompt_context(self, **context: Any) -> dict[str, Any]:
+        target = ProjectRepo.get_for_repo(self.input.repo, raise_on_missing=True)
+        return {
+            "siblings": target.siblings(),
+            **await super().get_prompt_context(**context),
         }


### PR DESCRIPTION
[ENG-772](https://linear.app/fellaworks/issue/ENG-772/review-extension-35-reviews-use-cross-repo-context) — part 3 of 5 of the `review` extension. The differentiator: the reviewer reasons across the project, not just the repo the PR lands in.

- `ReviewWorkspace` grants the agent file access to `related_root` beside its checkout. Nothing is pre-cloned — the reviewer clones the siblings it decides to open, exactly as ship's build agents do; the workflow only creates the directory and names the candidates.
- `get_prompt_context` resolves the target `ProjectRepo`'s `Project` siblings and hands them to the prompt with their purposes.
- The prompt says when a neighbour is worth opening — the change calls a contract that lives there, changes a shape something there consumes, copies a helper that already exists there, or breaks a caller there — and that clones the change has nothing to do with cost the author the same wait as useful ones.
- Review question 2 now ends "…and remember that the ones that matter most often live in another repo of this project", so cross-repo reading is part of the standing question rather than a separate errand.
- `ReviewReport` gains `context_repos: list[str]` — the siblings the reviewer actually read, reported by the agent in its own output. A finding resting on one names it in its evidence.

A project with no siblings renders no section and reviews exactly as before.
