### PR TITLE
The test fixtures own their database and Redis

### DIFF
--- a/.github/workflows/on-pull-request-backend.yml
+++ b/.github/workflows/on-pull-request-backend.yml
@@ -26,8 +26,8 @@ jobs:
     timeout-minutes: 15
     # The suite talks to a real Postgres (the harness runs each test in a rolled-back
     # transaction; the durable tests create their own databases) and a real Redis
-    # (flushed between tests). Defaults in backend/tests match localhost:5432 with
-    # druks/druks/druks and localhost:6379, so this mirrors local dev
+    # (flushed between tests). druks.testing carries its own defaults — the druks_test
+    # database and Redis index 15, never the application's — so this mirrors local dev
     # (deploy/compose.dev.yaml) and needs no env wiring. Images track deploy/compose.yaml.
     services:
       postgres:
@@ -35,7 +35,7 @@ jobs:
         env:
           POSTGRES_USER: druks
           POSTGRES_PASSWORD: druks
-          POSTGRES_DB: druks
+          POSTGRES_DB: druks_test
         ports:
           - 5432:5432
         options: >-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,9 +84,10 @@ For extension-surface changes, inspect the proof extension at
 
 ## Verification
 
-Backend tests need Postgres on `localhost:5432`, with user, password, and database
-`druks` by default. `DRUKS_DATABASE_URL` overrides the application/test database;
-DBOS integration tests also read `DRUKS_TEST_PG`. Start the development database
+Backend tests need Postgres on `localhost:5432` with user and password `druks`, and
+the `druks_test` database. `DRUKS_TEST_DATABASE_URL` overrides it —
+`DRUKS_DATABASE_URL` is the application's and the suite never reads it. DBOS
+integration tests also read `DRUKS_TEST_PG`. Start the development database
 with:
 
 ```bash

--- a/backend/druks/testing.py
+++ b/backend/druks/testing.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+import redis.asyncio as aioredis
 from dbos import run_dbos_database_migrations
 from fastapi.testclient import TestClient
 from sqlalchemy import text, update
@@ -47,9 +48,20 @@ __all__ = [
     "seed_run",
 ]
 
+# The fixtures never read the application's settings: DRUKS_DATABASE_URL and
+# DRUKS_REDIS_URL name a live instance, and these fixtures create tables and run
+# FLUSHDB. They carry their own keys, defaulting to a database and a Redis index
+# nothing else uses.
 TEST_DATABASE_URL = os.environ.get(
-    "DRUKS_DATABASE_URL", "postgresql+psycopg://druks:druks@localhost:5432/druks"
+    "DRUKS_TEST_DATABASE_URL", "postgresql+psycopg://druks:druks@localhost:5432/druks_test"
 )
+TEST_REDIS_URL = os.environ.get("DRUKS_TEST_REDIS_URL", "redis://127.0.0.1:6379/15")
+
+# Under pytest, druks IS the test instance. Settings are read from the environment
+# wherever they're needed — the app's Redis dialer among them — so overriding here is
+# what keeps the code under test on the same database and Redis the fixtures own.
+os.environ["DRUKS_DATABASE_URL"] = TEST_DATABASE_URL
+os.environ["DRUKS_REDIS_URL"] = TEST_REDIS_URL
 
 
 @pytest.fixture(scope="session")
@@ -132,7 +144,7 @@ def make_settings(tmp_path: Path, **overrides: object) -> Settings:
         "jira_base_url": None,
         "jira_email": None,
         "jira_api_token": None,
-        "redis_url": "redis://127.0.0.1:6379/0",
+        "redis_url": TEST_REDIS_URL,
         "log_level": "WARNING",
     }
     defaults.update(overrides)
@@ -184,11 +196,12 @@ def druks_client(druks_db: Session, tmp_path: Path) -> Iterator[TestClient]:
 
 @pytest.fixture
 async def druks_redis() -> AsyncIterator[None]:
-    # Drop the client the previous test left — its event loop is gone — then flush
-    # on a fresh one and close it again, so the test body starts with none bound
-    # and every consumer dials on the loop it runs on.
-    druks.redis._client = None
-    await druks.redis.get_client().flushdb()
+    # Bind the test Redis directly rather than through get_client(), which dials
+    # whatever the application is configured to use. Flush on a fresh client and
+    # close it again, so the test body starts with none bound and every consumer
+    # dials on the loop it runs on — the previous test's loop is gone.
+    druks.redis._client = aioredis.from_url(TEST_REDIS_URL)
+    await druks.redis._client.flushdb()
     await druks.redis.close_client()
     yield
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 from unittest import mock
 
 import pytest
@@ -9,6 +8,7 @@ from druks.extensions.loader import (
     register_workflow_package,
 )
 from druks.models import Base
+from druks.testing import TEST_DATABASE_URL
 
 # A Workflow class resolves its declaring extension at definition time, from
 # packages the loader registers before importing. Tests import workflow modules
@@ -62,9 +62,6 @@ def _no_durable_dispatch(request):
         yield
 
 
-TEST_DATABASE_URL = os.environ.get(
-    "DRUKS_DATABASE_URL", "postgresql+psycopg://druks:druks@localhost:5432/druks"
-)
 
 
 
@@ -114,8 +111,6 @@ _OWN_DATABASE_MODULES = {
     "test_build_durable",
     "test_durable_sdk",
     "test_notifications_durable",
-    "test_scope_durable",
-    "test_usage_durable",
     "test_harness_login_persistence",
     "test_extension_migrations",
     "test_proof_extension_migration",

--- a/backend/tests/test_extension_migrations.py
+++ b/backend/tests/test_extension_migrations.py
@@ -1,8 +1,8 @@
-import os
 from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from druks.testing import TEST_DATABASE_URL
 from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine
 
 # The real platform ``alembic.ini`` — its script_location is the one shared env.py
@@ -11,9 +11,6 @@ from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine
 # extension's own version_locations and version_table, isolated from core's history.
 _ALEMBIC_INI = Path(__file__).resolve().parent.parent / "alembic.ini"
 
-TEST_DATABASE_URL = os.environ.get(
-    "DRUKS_DATABASE_URL", "postgresql+psycopg://druks:druks@localhost:5432/druks"
-)
 
 _BASELINE = """\
 import sqlalchemy as sa

--- a/backend/tests/test_proof_extension_migration.py
+++ b/backend/tests/test_proof_extension_migration.py
@@ -1,9 +1,8 @@
-import os
 from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
-from druks.testing import init_db
+from druks.testing import TEST_DATABASE_URL, init_db
 from sqlalchemy import create_engine
 
 # The proof extension's real, shipped migration, run through the shared platform env
@@ -16,9 +15,6 @@ _ALEMBIC_INI = Path(__file__).resolve().parent.parent / "alembic.ini"
 _PACKAGE_ROOT = Path(__file__).resolve().parent / "druks-field_notes" / "druks_field_notes"
 _VERSIONS = _PACKAGE_ROOT / "migrations" / "versions"
 
-TEST_DATABASE_URL = os.environ.get(
-    "DRUKS_DATABASE_URL", "postgresql+psycopg://druks:druks@localhost:5432/druks"
-)
 
 
 def _config() -> Config:

--- a/deploy/compose.dev.init.sql
+++ b/deploy/compose.dev.init.sql
@@ -1,4 +1,4 @@
 -- Runs once on first boot (docker-entrypoint-initdb.d). POSTGRES_DB gave us
--- `druks` for the test suite; the dev server gets its own database so a
+-- `druks_test` for the test suite; the dev server gets its own database so a
 -- pytest run (which drops the public schema) can't eat dev data.
 CREATE DATABASE druks_dev OWNER druks;

--- a/deploy/compose.dev.yaml
+++ b/deploy/compose.dev.yaml
@@ -6,10 +6,10 @@
 #
 #   docker compose -f deploy/compose.dev.yaml up -d
 #
-# Postgres carries two databases: `druks` is the test database (the
-# pytest suite DROPs and rebuilds its schema every session — conftest and
-# CI both default to localhost:5432/druks), `druks_dev` is where the dev
-# server keeps its data, out of the suite's blast radius.
+# Postgres carries two databases: `druks_test` is the test database (the
+# pytest suite DROPs and rebuilds its schema every session), `druks_dev` is
+# where the dev server keeps its data. The suite reaches neither by accident —
+# druks.testing reads DRUKS_TEST_DATABASE_URL, never the application's.
 
 # Explicit project name: the default would be this directory's basename
 # ("deploy"), which any other repo's deploy/ compose would collide with.
@@ -24,7 +24,7 @@ services:
     environment:
       POSTGRES_USER: druks
       POSTGRES_PASSWORD: druks
-      POSTGRES_DB: druks
+      POSTGRES_DB: druks_test
     volumes:
       - dev_postgres_data:/var/lib/postgresql/data
       - ./compose.dev.init.sql:/docker-entrypoint-initdb.d/init.sql:ro

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,8 @@ Drukbox.
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `DRUKS_DATABASE_URL` | local `druks` Postgres | Application and DBOS database |
+| `DRUKS_TEST_DATABASE_URL` | local `druks_test` Postgres | What the shipped pytest fixtures use — never the application's |
+| `DRUKS_TEST_REDIS_URL` | `redis://127.0.0.1:6379/15` | What the shipped pytest fixtures flush |
 | `DRUKS_REDIS_URL` | `redis://127.0.0.1:6379/0` | Short-lived coordination and caches |
 | `DRUKS_DATA_DIR` | `/var/lib/druks` | Logs, artifacts, installed skills |
 | `DRUKS_LOG_LEVEL` | `INFO` | Python and DBOS log level |

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,10 +25,12 @@ browser header extension or `curl -H 'X-Edge-Email: you@example.com'`).
 The dev Compose project creates two databases:
 
 - `druks_dev` for the host-run application
-- `druks` for pytest, which rebuilds its schema during the suite
+- `druks_test` for pytest, which rebuilds its schema during the suite
 
-`.env.example` points the application at `druks_dev`. Do not point the
-development server at the pytest database.
+`.env.example` points the application at `druks_dev`. The suite reaches
+`druks_test` and Redis index 15 through `DRUKS_TEST_DATABASE_URL` and
+`DRUKS_TEST_REDIS_URL`, never through the application's own settings, so the two
+cannot be confused.
 
 Start the backend:
 

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -564,7 +564,7 @@ fixtures directly without a `conftest.py` or `pytest_plugins` declaration:
 | --- | --- |
 | `druks_db` | A SQLAlchemy `Session` bound to a per-test transaction. Commits become savepoints, and teardown rolls the outer transaction back. |
 | `druks_client` | An authenticated `TestClient` with installed extensions mounted, sharing `druks_db`'s connection. |
-| `druks_redis` | The configured Redis database, flushed before the test. |
+| `druks_redis` | The test Redis database, flushed before the test. |
 | `druks_without_dispatch` | Workflow starts and run-phase writes become no-ops, for tests that stand up no durable engine. |
 | `druks_without_remote_config` | Every `.druks` namespace lookup misses, so prompts resolve to bundled templates and config to its declared defaults. |
 
@@ -610,16 +610,18 @@ call = seed_call(
 app when a test needs its own client or an unauthenticated request path;
 `druks_client` covers the normal authenticated case.
 
-Set `DRUKS_DATABASE_URL` to a dedicated disposable Postgres database before
-running tests. Never point it at a live Druks instance. The plugin creates
-`citext`, imports installed extension models, runs SQLAlchemy `create_all`,
-seeds platform reference rows, and builds the DBOS system tables through DBOS's
-database migrations. It never resets or drops a schema; per-test writes made
-through `druks_db` are rolled back.
+The fixtures never read the application's settings. They read
+`DRUKS_TEST_DATABASE_URL` and `DRUKS_TEST_REDIS_URL`, defaulting to a local
+`druks_test` database and Redis index 15, and they point the code under test at
+the same pair — so a run cannot reach whatever `DRUKS_DATABASE_URL` and
+`DRUKS_REDIS_URL` name. Create the database once (`createdb druks_test`); the dev
+Compose project already does.
 
-Redis must also be reachable. Set `DRUKS_REDIS_URL` to a disposable Redis
-database when using `druks_redis`: that fixture runs `FLUSHDB`, so pointing it at
-a live instance wipes it.
+On that database the plugin creates `citext`, imports installed extension models,
+runs SQLAlchemy `create_all`, seeds platform reference rows, and builds the DBOS
+system tables through DBOS's database migrations. It never resets or drops a
+schema; per-test writes made through `druks_db` are rolled back. `druks_redis`
+runs `FLUSHDB` on the test index.
 
 ## Frontends
 


### PR DESCRIPTION
`druks.testing` decided what to destroy by reading the application's own configuration.

`TEST_DATABASE_URL` read `DRUKS_DATABASE_URL` — documented in `docs/configuration.md` as "Application and DBOS database" — and ran `CREATE EXTENSION citext`, `create_all` and `seed` on it. `druks_redis` never had a test URL at all: it called `druks.redis.get_client()`, the production dialer, which reads `load_settings().redis_url`, and then ran `FLUSHDB`.

`load_settings()` is `return Settings()` — uncached, with `env_file=".env"` — so it re-reads the developer's `.env` on every call. No exported variable was needed; a `.env` in the working directory was enough. And the repository suite makes the flush `autouse`, so `uv run pytest backend/` did it hundreds of times per run.

Redis was the sharper half. `FLUSHDB` is unrecoverable and lands on the coordination plane: the `SET NX` locks that elect one refresher per credential (a double refresh can revoke the grant), the sandbox rotation gates, and the 24-hour webhook dedup claims whose loss means duplicate durable runs on redelivery.

## The change

The fixtures carry their own keys and never read the application's:

```
DRUKS_TEST_DATABASE_URL   default  postgresql+psycopg://druks:druks@localhost:5432/druks_test
DRUKS_TEST_REDIS_URL      default  redis://127.0.0.1:6379/15
```

No fallback, no refusal, no collision check — a name and an index nothing else uses. Under pytest the code under test is pointed at the same pair, because settings are read from the environment wherever they are needed; otherwise the fixture would flush one index while the app under test wrote another.

An index split is complete isolation here: every key druks touches is a namespaced literal, and production issues no `FLUSHALL`, `SWAPDB`, `KEYS` or `SCAN`. druks already fans services out by index — drukbox uses `/2`.

## Alternatives rejected

**Derive `test_<name>` and CREATE it** (pytest-django's shape) requires `CREATE DATABASE` rights, which breaks any author whose role owns only their own database; a derived database accumulates schema drift, which is why pytest-django needs `--reuse-db`/`--create-db`; and it has no Redis analogue, so a second mechanism ships anyway.

**Refuse when unset** puts a failure on every scaffolded author's first `uv run pytest` — the scaffold writes no `.env` — which is ceremony bolted onto the surface that is the product.

## Incidental

The URL constant had four copies, all reading the application's variable. Two of them (`test_extension_migrations`, `test_proof_extension_migration`) run Alembic and raw DDL, so a suite pointed at one database could migrate another; `test_proof_extension_migration` additionally calls `init_db` and disposes the shared engine, which only makes sense if both name one database. They now share the single definition in `druks.testing`.

`_OWN_DATABASE_MODULES` listed `test_scope_durable` and `test_usage_durable`, neither of which exists.

## Verification

931 passed, 52 skipped, ruff clean.

Isolation proved directly rather than argued: with `DRUKS_DATABASE_URL` and `DRUKS_REDIS_URL` exported at a live dev instance, a full suite run left a sentinel key in Redis db 0 and a sentinel table in `druks_dev` intact, while the test index was used and flushed. Before this change the same run would have flushed that Redis database.

CI moves to `POSTGRES_DB: druks_test`; dev compose does the same and keeps carving out `druks_dev`. Contributors need `druks_test` to exist once — dev compose creates it.
