### PR TITLE
Name the scaffold command where it is looked for

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ Python distribution registered through the `druks.extensions` entry-point
 group. Installing the distribution registers it; Druks does not need an
 extension-specific plugin list.
 
+Scaffold one with the published CLI, no checkout required:
+
+```bash
+uvx --from druks druks create extension night_watch
+```
+
+The generated project root carries an `AGENTS.md` with the contracts and a link
+to the authoring guide.
+
 The bundled `ship` extension is a concrete example. It coordinates coding
 agents through tickets and GitHub pull requests, but GitHub PR orchestration is
 `ship` behavior—not the definition of Druks.

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -7,14 +7,15 @@ before choosing which side should own a capability.
 
 ## Scaffold and prove the package
 
-From a Druks checkout:
-
 ```bash
-uv run druks create extension night_watch
+uvx --from druks druks create extension night_watch
 cd druks-night_watch
 uv sync
 uv run pytest
 ```
+
+From a Druks checkout, `uv run druks create extension night_watch` scaffolds with
+that checkout's CLI instead.
 
 The command writes a standalone `druks-night_watch` project in the current
 directory. Its `pyproject.toml` contains:


### PR DESCRIPTION
The README is the PyPI project description, and it named neither the scaffold command nor an install form. The guide reached the command only through "From a Druks checkout". Someone holding the published package had to install it and walk `--help` to learn that `create extension` exists.

Both now lead with `uvx --from druks druks create extension night_watch`, and the checkout form stays as the contributor variant.
