### PR TITLE
A comment naming the reviewer asks for a review

### DIFF
--- a/backend/druks/contrib/review/subscribers.py
+++ b/backend/druks/contrib/review/subscribers.py
@@ -1,0 +1,18 @@
+from druks.contrib.review.workflows import PullRequestReview
+from druks.contrib.ship.models import ProjectRepo
+from druks.core.apis.github import get_reviewer_github_client
+from druks.settings import load_settings
+from druks.signals import subscribe
+
+
+@subscribe("pr.commented")
+async def mention_asks_for_a_review(*, repo: str, pr_number: int, payload: dict) -> None:
+    """Addressing the reviewer app in a comment asks it to review that pull request.
+    A repo no project claims is left alone — there is nothing to review it against,
+    and a webhook that shrugs is right where a request would be told no."""
+    handle = await get_reviewer_github_client(load_settings()).get_mention_handle()
+    is_mentioned = handle and f"@{handle}".casefold() in payload["body"].casefold()
+    if is_mentioned and ProjectRepo.get_for_repo(repo):
+        await PullRequestReview.dispatch(
+            repo=repo, pr_number=pr_number, requested_by=payload["author"]
+        )

--- a/backend/druks/core/apis/github.py
+++ b/backend/druks/core/apis/github.py
@@ -29,6 +29,9 @@ class ReviewComment:
 _INSTALLATION_ACCOUNTS_TTL_SECONDS = 600.0
 _INSTALLATION_ACCOUNTS_CACHE: dict[str, tuple[float, tuple[str, ...]]] = {}
 
+# An App's slug is fixed for the life of the App, so this needs no expiry.
+_MENTION_HANDLE_CACHE: dict[str, str] = {}
+
 
 F = TypeVar("F", bound=Callable[..., Awaitable[Any]])
 
@@ -159,6 +162,18 @@ class GitHubClient:
         result = tuple(dict.fromkeys(accounts))
         _INSTALLATION_ACCOUNTS_CACHE[self._app_id] = (now, result)
         return result
+
+    async def get_mention_handle(self) -> str:
+        """What a comment writes after ``@`` to address this App — its slug, which
+        GitHub resolves to the App's bot user. The App is the one that knows it;
+        nobody should have to configure it."""
+        cached = _MENTION_HANDLE_CACHE.get(self._app_id)
+        if cached:
+            return cached
+        response = await self._app.rest.apps.async_get_authenticated()
+        handle = getattr(response.parsed_data, "slug", None) or ""
+        _MENTION_HANDLE_CACHE[self._app_id] = handle
+        return handle
 
     async def _installation_id(self, repo: str) -> int:
         if repo in self._installation_cache:

--- a/backend/druks/core/webhooks/github.py
+++ b/backend/druks/core/webhooks/github.py
@@ -56,6 +56,20 @@ class GitHubEvents(Webhook):
         )
         return _accepted()
 
+    async def on_issue_comment_created(self) -> Response:
+        # GitHub files pull-request comments under issues; only those carry
+        # ``pull_request``. A non-User sender is an app talking to itself.
+        issue, sender = self.data["issue"], self.data["sender"]
+        if sender["type"] != "User" or "pull_request" not in issue:
+            return _accepted()
+        await publish(
+            "pr.commented",
+            repo=_repo_name(self.data),
+            pr_number=issue["number"],
+            payload={"author": sender["login"], "body": self.data["comment"]["body"]},
+        )
+        return _accepted()
+
     async def on_pull_request_closed(self) -> Response:
         pull_request = self.data["pull_request"]
         await publish(


### PR DESCRIPTION
[ENG-771](https://linear.app/fellaworks/issue/ENG-771/review-extension-25-mention-triggers-a-review) — part 2 of 5 of the `review` extension.

Addressing the reviewer app in a pull-request comment asks it for a review.

- Core `GitHubEvents` gains `on_issue_comment_created`, publishing a normalized `pr.commented` — repo, PR number, the comment's author and body. No reviewer knowledge in core, matching the rest of that file: GitHub facts in, extensions react.
- Comments on plain issues publish nothing (GitHub files PR comments under issues; only those carry `pull_request`), and neither do non-`User` senders — which is also what keeps the reviewer's own comments from looping, without a self-referential check.
- `contrib/review/subscribers.py` reacts: the app being mentioned dispatches a review, attributed to the commenter's GitHub login.
- **The handle is the app's own.** `GitHubClient.get_mention_handle` reads the App's slug from GitHub — the exact text a comment writes after `@` — so there is nothing to configure and nothing to keep in sync with the install. Cached per app id, since a slug is fixed for the life of an App.
- A repo no project claims is ignored rather than refused: a webhook that shrugs is right where the route's 404 is right. Each trigger owns that policy, which is why it isn't in `dispatch`.

Installing the app is the switch. Dedup is unchanged: mentioning twice while a review runs starts nothing new.