### PR TITLE
Every subject shows itself

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -12,7 +12,7 @@ from druks.durable.activity import set_run_phase
 from druks.durable.engine import _step_engine, step_session
 from druks.durable.enums import AgentCallStatus
 from druks.durable.exceptions import WorkflowError
-from druks.durable.models import AgentCall, Artifact
+from druks.durable.models import AgentCall, Artifact, Run
 from druks.events.models import Event
 from druks.extensions.registry import agents
 from druks.harnesses.models import HarnessConnection
@@ -177,6 +177,7 @@ class Agent:
             Event.emit(
                 type="credential.fallback",
                 subject=workflow._subject,
+                label=Run.get(workflow_id).subject_label,
                 payload={"run_id": workflow_id, "harness": harness.name},
                 extension=type(workflow).extension,
             )

--- a/backend/druks/contrib/ship/models.py
+++ b/backend/druks/contrib/ship/models.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import ForeignKey, Index, func, select, text
+from sqlalchemy import ForeignKey, Index, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -179,19 +179,10 @@ class WorkItem(StoredSubject):
     __tablename__ = "work_items"
     __table_args__ = (
         Index("work_items_repo_idx", "repo", "pr_number"),
-        # One WorkItem per (source, remote_key) - i.e. one row per ticket
-        # in the remote tracker. Partial because GitHub-source rows
-        # without an ``#NNN`` ticket reference can still exist; the
-        # constraint only fires when remote_key is set. ``source`` is
-        # part of the key so Linear "ABC-1" and Jira "ABC-1" don't
-        # collide once we support multiple providers.
-        Index(
-            "work_items_remote_unique",
-            "source",
-            "remote_key",
-            unique=True,
-            sqlite_where=text("remote_key IS NOT NULL"),
-        ),
+        # One WorkItem per (source, remote_key) — one row per ticket in the remote
+        # tracker. ``source`` is part of the key so Linear "ABC-1" and Jira "ABC-1"
+        # don't collide once we support multiple providers.
+        Index("work_items_remote_unique", "source", "remote_key", unique=True),
         Index("work_items_project_idx", "project_id"),
         Index("work_items_status_idx", "status"),
     )
@@ -206,9 +197,9 @@ class WorkItem(StoredSubject):
     source: Mapped[str] = mapped_column(default="github")
     title: Mapped[str] = mapped_column(default="")
     # Human-readable issue key in the source: ``ACME-270`` / ``#42`` /
-    # ``JIRA-123``. Linear's GraphQL accepts the identifier wherever it
-    # accepts the UUID.
-    remote_key: Mapped[str | None]
+    # ``JIRA-123``. Every item is born from a ticket, so every item has one;
+    # Linear's GraphQL accepts the identifier wherever it accepts the UUID.
+    remote_key: Mapped[str]
     remote_url: Mapped[str | None]
     # The PR-target repo. Still on WorkItem (not derived from project)
     # because a Project can hold N repos but every WorkItem PRs into one.
@@ -225,6 +216,9 @@ class WorkItem(StoredSubject):
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
+    def get_label(self) -> str:
+        return self.remote_key
+
     @classmethod
     def create(
         cls,
@@ -232,7 +226,7 @@ class WorkItem(StoredSubject):
         project_id: int,
         source: str = "github",
         title: str,
-        remote_key: str | None = None,
+        remote_key: str,
         remote_url: str | None = None,
         repo: str,
     ) -> "WorkItem":
@@ -345,10 +339,7 @@ class WorkItem(StoredSubject):
             # cycle: the extension imports this module at file scope.
             import druks.contrib.ship.extension as ship_extension
 
-            payload = dict(event_payload or {})
-            if self.remote_key:
-                payload["ticket"] = self.remote_key
-            ship_extension.Ship.record_event(type=status, subject=self, payload=payload)
+            ship_extension.Ship.record_event(type=status, subject=self, payload=event_payload)
         self.status = status
         self.updated_at = Base.utc_now()
         db_session().flush()

--- a/backend/druks/contrib/ship/schemas.py
+++ b/backend/druks/contrib/ship/schemas.py
@@ -108,7 +108,7 @@ class WorkItemSummary(SubjectSummary):
     # whose Linear project doesn't map to one.
     project_name: str
     title: str
-    remote_key: str | None = None
+    remote_key: str
     remote_url: str | None = None
     pr_number: int | None = None
     branch: str | None = None
@@ -137,7 +137,7 @@ class WorkItemSummary(SubjectSummary):
 class DashboardItem(BaseResponse):
     key: str
     source_id: int | str
-    ticket_ref: str | None = None
+    ticket_ref: str
     title: str
     repo: str | None = None
     pr_number: int | None = None

--- a/backend/druks/durable/datastructures.py
+++ b/backend/druks/durable/datastructures.py
@@ -6,8 +6,9 @@ from typing import Any
 class Subject:
     """What a run is about, as identity alone — a pull request, an issue, a
     conversation. ``Subject(id="owner/repo#7", subject_type="pull_request")`` is
-    all a run, an event, or a read ever needs; an extension that also keeps a row
-    of its own subclasses ``StoredSubject`` instead."""
+    all a run, an event, or a read ever needs, and it shows itself as that id.
+    An extension that also keeps a row of its own subclasses ``StoredSubject``
+    instead."""
 
     id: str
     subject_type: str
@@ -15,3 +16,9 @@ class Subject:
     @property
     def identity(self) -> dict[str, Any]:
         return {"type": self.subject_type, "id": self.id}
+
+    @property
+    def label(self) -> str:
+        # An identity-only subject is already named by its id — "owner/repo#7" is
+        # the handle, not a surrogate key.
+        return self.id

--- a/backend/druks/durable/dbos_state.py
+++ b/backend/druks/durable/dbos_state.py
@@ -88,6 +88,17 @@ def state_expression(
     return sa.func.coalesce(mapped, missing)
 
 
+def subject_label_expression(run_id: sa.ColumnElement) -> sa.ColumnElement:
+    # How the run's subject showed itself, stamped at start(); a subjectless cron
+    # has none.
+    return (
+        sa.select(workflow_status.c.attributes["subject_label"].as_string())
+        .where(workflow_status.c.workflow_uuid == run_id)
+        .correlate_except(workflow_status)
+        .scalar_subquery()
+    )
+
+
 def updated_at_expression(run_id: sa.ColumnElement) -> sa.ColumnElement:
     # DBOS stamps updated_at in epoch milliseconds; convert so it compares
     # against our timestamptz columns.

--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -16,6 +16,7 @@ from druks.database import db_session, get_session
 from druks.durable.dbos_state import (
     state_expression,
     subject_filter,
+    subject_label_expression,
     updated_at_expression,
     workflow_status,
 )
@@ -64,6 +65,9 @@ class Run(Base):
     # fresh; an already-loaded instance keeps what it read until expired.
     # Read-only; an operator ends a run through cancel().
     state: Mapped[str] = column_property(state_expression(id, input_gate, created_at))
+    # How the subject showed itself when this run started — read with the row, so
+    # every event the run writes names it without a second lookup.
+    subject_label: Mapped[str | None] = column_property(subject_label_expression(id))
     # Who asked; the system account when nobody did (crons, background work).
     account_id: Mapped[str] = mapped_column(
         ForeignKey("accounts.id", ondelete="RESTRICT"), default=SYSTEM_ACCOUNT_ID

--- a/backend/druks/events/feed.py
+++ b/backend/druks/events/feed.py
@@ -21,6 +21,7 @@ class FeedItem(BaseResponse):
     workflow: str | None = None
     subject_type: str | None = None
     subject_id: str | None = None
+    subject_label: str | None = None
     # Whatever else the event recorded, stated by its writer — a gate, a failure,
     # a ticket key. What a row carries beyond identity is said at write time.
     facts: dict[str, Any] = Field(default_factory=dict)
@@ -37,6 +38,7 @@ class FeedItem(BaseResponse):
             workflow=facts.pop("kind", None),
             subject_type=event.subject_type,
             subject_id=event.subject_id,
+            subject_label=event.subject_label,
             facts=facts,
         )
 

--- a/backend/druks/events/models.py
+++ b/backend/druks/events/models.py
@@ -25,6 +25,9 @@ class Event(Base):
     # What the event is about (a work item, a signal), supplied by the caller.
     # Opaque here: the log keys events without knowing the subject.
     subject_type: Mapped[str | None] = mapped_column(default=None)
+    # How the subject showed itself when the event was written — the feed labels
+    # rows without ever loading a subject. Absent exactly when the subject is.
+    subject_label: Mapped[str | None] = mapped_column(default=None)
     extension: Mapped[str | None] = mapped_column(default=None)
     # Append-only, so creation time is the event time. No updated_at.
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
@@ -36,6 +39,7 @@ class Event(Base):
         *,
         type: str,
         subject: dict[str, Any] | None = None,
+        label: str | None = None,
         payload: dict[str, Any] | None = None,
         extension: str | None = None,
     ) -> None:
@@ -45,6 +49,7 @@ class Event(Base):
                 type=type,
                 subject_type=subject.get("type"),
                 subject_id=str(subject["id"]) if "id" in subject else None,
+                subject_label=label or None,
                 extension=extension,
                 payload=payload or {},
             )

--- a/backend/druks/extensions/base.py
+++ b/backend/druks/extensions/base.py
@@ -454,6 +454,7 @@ class Extension:
         Event.emit(
             type=type,
             subject=subject.identity if subject else None,
+            label=subject.label if subject else None,
             payload=payload,
             extension=cls.name,
         )

--- a/backend/druks/models.py
+++ b/backend/druks/models.py
@@ -58,6 +58,16 @@ class StoredSubject(Base):
             return {"type": self.subject_type, "id": self.id}
         raise ValueError(f"unsaved {type(self).__name__} has no identity — flush it first")
 
+    def get_label(self) -> str:
+        """The one line this subject shows itself as. Override with a stable handle —
+        a ticket key, a PR number — never a mutable title: events snapshot it, and
+        the log should not disagree with itself."""
+        return f"{self.subject_type.replace('_', ' ')} {self.id}"
+
+    @property
+    def label(self) -> str:
+        return self.get_label()
+
     @classmethod
     def list_open(cls, *, limit: int = 50) -> list[Self]:
         """The rows whose newest run hasn't handed off — still going, or failed

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -408,6 +408,7 @@ def _log_run_event(
     Event.emit(
         type=WorkflowEvent.for_state(state),
         subject=subject,
+        label=run.subject_label,
         payload=payload,
         extension=workflows.get(run.kind).extension,
     )
@@ -751,6 +752,7 @@ class Workflow:
             attributes = {
                 "subject_type": subject.subject_type,
                 "subject_id": str(subject.id),
+                "subject_label": subject.label,
             }
         subject_record = subject.identity if subject else None
         try:

--- a/backend/migrations/versions/c8f04a1e9b27_events_carry_the_subjects_label.py
+++ b/backend/migrations/versions/c8f04a1e9b27_events_carry_the_subjects_label.py
@@ -1,0 +1,26 @@
+"""events carry the subject's label
+
+Revision ID: c8f04a1e9b27
+Revises: b5e91c2d7a34
+Create Date: 2026-07-27 00:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8f04a1e9b27"
+down_revision: str | Sequence[str] | None = "b5e91c2d7a34"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("events", sa.Column("subject_label", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("events", "subject_label")

--- a/backend/migrations/versions/d3a5c71f8e40_every_work_item_has_a_ticket_key.py
+++ b/backend/migrations/versions/d3a5c71f8e40_every_work_item_has_a_ticket_key.py
@@ -1,0 +1,37 @@
+"""every work item has a ticket key
+
+Revision ID: d3a5c71f8e40
+Revises: c8f04a1e9b27
+Create Date: 2026-07-27 01:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d3a5c71f8e40"
+down_revision: str | Sequence[str] | None = "c8f04a1e9b27"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column("work_items", "remote_key", existing_type=sa.String(), nullable=False)
+    # The uniqueness no longer needs to skip nulls.
+    op.drop_index("work_items_remote_unique", table_name="work_items")
+    op.create_index("work_items_remote_unique", "work_items", ["source", "remote_key"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("work_items_remote_unique", table_name="work_items")
+    op.create_index(
+        "work_items_remote_unique",
+        "work_items",
+        ["source", "remote_key"],
+        unique=True,
+        postgresql_where=sa.text("remote_key IS NOT NULL"),
+    )
+    op.alter_column("work_items", "remote_key", existing_type=sa.String(), nullable=True)

--- a/backend/tests/ship/factories.py
+++ b/backend/tests/ship/factories.py
@@ -1,14 +1,17 @@
 from druks.contrib.ship.models import Project, ProjectRepo, WorkItem
 from druks.contrib.ship.workflows import Build
 from druks.testing import seed_run
+from uuid_utils import uuid7
 
 
 def make_test_work_item(*, repo: str, **kwargs):
-    """A WorkItem with the Project / ProjectRepo binding it requires."""
+    """A WorkItem with the Project / ProjectRepo binding it requires. Every item
+    carries a ticket key, unique per source — tests that don't care get one."""
     project = Project.get_for_repo(repo)
     if not project:
         project = Project.create(name=repo)
         ProjectRepo.create(project_id=project.id, full_name=repo)
+    kwargs.setdefault("remote_key", f"TEST-{uuid7()}")
     return WorkItem.create(project_id=project.id, repo=repo, **kwargs)
 
 

--- a/backend/tests/ship/test_build_durable.py
+++ b/backend/tests/ship/test_build_durable.py
@@ -83,7 +83,7 @@ def _seed_work_item(engine, *, repo: str):
         project = Project(name=name)
         session.add(project)
         session.flush()
-        item = WorkItem(project_id=project.id, repo=repo, title="rt")
+        item = WorkItem(project_id=project.id, repo=repo, title="rt", remote_key=name)
         session.add(item)
         session.commit()
         session.refresh(item)

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -54,6 +54,9 @@ SINK: list[str] = []
 class Widget(StoredSubject):
     __tablename__ = "test_widgets"
 
+    def get_label(self) -> str:
+        return f"W-{self.id}"
+
 
 # run_multistep() below for fixtures using @step/a gate; run() for the rest.
 def _build_units():
@@ -304,7 +307,11 @@ async def test_attribution_rides_the_run_and_survives_resume(rt):
         attributes = conn.execute(
             select(workflow_status.c.attributes).where(workflow_status.c.workflow_uuid == wfid)
         ).scalar_one()
-    assert attributes == {"subject_type": "widget", "subject_id": "878787"}
+    assert attributes == {
+        "subject_type": "widget",
+        "subject_id": "878787",
+        "subject_label": "W-878787",
+    }
     assert parked.account_id == account_id
     assert f"acct-before:{account_id}" in SINK
 
@@ -445,7 +452,11 @@ async def test_subject_gate_parks_unchanged(rt):
         attributes = conn.execute(
             select(workflow_status.c.attributes).where(workflow_status.c.workflow_uuid == wfid)
         ).scalar_one()
-    assert attributes == {"subject_type": "widget", "subject_id": "636363"}
+    assert attributes == {
+        "subject_type": "widget",
+        "subject_id": "636363",
+        "subject_label": "W-636363",
+    }
 
     await parked.resume(action="go")
     await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.FINISHED)
@@ -833,6 +844,9 @@ async def test_run_events_carry_subject(rt):
 
     assert [e.type for e in events] == ["workflow.running", "workflow.finished"]
     assert {e.subject_type for e in events} == {"widget"}
+    # The label was stamped into the run's attributes at start and snapshotted
+    # onto each transition — the identity itself stays the bare key.
+    assert {e.subject_label for e in events} == {"W-4242"}
     assert all(e.payload["run"] == wfid for e in events)
 
 

--- a/backend/tests/test_events_feed.py
+++ b/backend/tests/test_events_feed.py
@@ -1,7 +1,19 @@
 from druks.events.builder import build_feed
 from druks.events.models import Event
+from druks.models import StoredSubject
 from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
+
+
+class Crate(StoredSubject):
+    __tablename__ = "faketest_crates"
+
+    def get_label(self) -> str:
+        return f"CRATE-{self.id}"
+
+
+class Pallet(StoredSubject):
+    __tablename__ = "faketest_pallets"
 
 
 def test_feed_carries_the_facts_a_row_is_worded_from(druks_db):
@@ -9,11 +21,16 @@ def test_feed_carries_the_facts_a_row_is_worded_from(druks_db):
     Event.emit(
         type="workflow.running",
         subject=note.identity,
+        label=note.label,
         extension="field_notes",
         payload={"kind": Summarize.kind, "run": "wf1"},
     )
     Event.emit(
-        type="summarized", subject=note.identity, extension="field_notes", payload={"words": 12}
+        type="summarized",
+        subject=note.identity,
+        label=note.label,
+        extension="field_notes",
+        payload={"words": 12},
     )
     druks_db.flush()
 
@@ -22,12 +39,33 @@ def test_feed_carries_the_facts_a_row_is_worded_from(druks_db):
     started = by_kind["workflow.running"]
     assert (started.extension, started.workflow) == ("field_notes", Summarize.kind)
     assert (started.subject_type, started.subject_id) == ("note", str(note.id))
-    # Whatever is left of the payload once the workflow is promoted out of it.
-    assert started.facts == {"run": "wf1"}
+    # A note declares no label of its own, so it shows itself by identity; whatever
+    # is left of the payload once the workflow is promoted out of it is its facts.
+    assert (started.subject_label, started.facts) == (f"note {note.id}", {"run": "wf1"})
 
     # A milestone has no workflow behind it, and carries what its writer stated.
     summarized = by_kind["summarized"]
     assert (summarized.workflow, summarized.facts) == (None, {"words": 12})
+
+
+def test_every_subject_shows_itself(druks_db):
+    # A subject that declares a handle reads as it; one that doesn't reads by
+    # identity. Either way it is snapshotted, so the row survives the row itself.
+    crate, pallet = Crate(id=7), Pallet(id=7)
+    druks_db.add_all([crate, pallet])
+    druks_db.flush()
+    assert crate.identity == {"type": "crate", "id": 7}
+    for subject in (crate, pallet):
+        Event.emit(
+            type="stocked", subject=subject.identity, label=subject.label, extension="faketest"
+        )
+    druks_db.delete(crate)
+    druks_db.flush()
+
+    by_type = {row.subject_type: row for row in build_feed()[0] if row.extension == "faketest"}
+
+    assert by_type["crate"].subject_label == "CRATE-7"
+    assert by_type["pallet"].subject_label == "pallet 7"
 
 
 def test_feed_paginates_same_second_events_without_loss_or_repeat(druks_db):

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -449,15 +449,14 @@ recorded automatically. Call `record_event()` inside a platform-bound
 transaction such as a request, durable step, or subscriber.
 
 A feed row carries facts, never prose: its kind, the workflow it came from, the
-subject identity, and the event's payload — a client words them. Whatever a row
-should say beyond identity is stated by its writer, on the event:
+subject identity, and the event's payload — a client words them. Give the subject
+a ``label`` — the one line it shows itself as — and every event written about it
+carries that from then on:
 
 ```python
-NightWatch.record_event(
-    type="report.published",
-    subject=repository,
-    payload={"repo": repository.full_name, "url": report_url},
-)
+class Repository(StoredSubject):
+    def get_label(self) -> str:
+        return self.full_name
 ```
 
 React with filters rather than body guards:

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -339,8 +339,10 @@ export interface FeedItem {
   workflow?: string | null
   subjectType?: string | null
   subjectId?: string | null
-  // Whatever else the event recorded, stated by its writer — a gate, a failure,
-  // a ticket key.
+  // How the subject showed itself ("ENG-767"), snapshotted at write. Absent
+  // exactly when the subject is.
+  subjectLabel?: string | null
+  // Whatever else the event recorded, stated by its writer — a gate, a failure.
   facts: Record<string, unknown>
 }
 

--- a/frontend/src/extensions/ship/AgentCallPage.tsx
+++ b/frontend/src/extensions/ship/AgentCallPage.tsx
@@ -99,7 +99,7 @@ function RunView({
               href={workItemPath(workItemId, summary.remoteKey, summary.title)}
               className="breadcrumb"
             >
-              {summary.remoteKey ?? `#${workItemId}`}
+              {summary.remoteKey}
             </Link>
             <span className="dim">/</span>
             <span title={runId}>#{runId.slice(0, 8)}</span>

--- a/frontend/src/extensions/ship/WorkItemPage.tsx
+++ b/frontend/src/extensions/ship/WorkItemPage.tsx
@@ -279,11 +279,11 @@ function InfoPanel({
           </div>
           <div className="ins-field">
             <span className="ins-field-k">source</span>
-            <span className="ins-field-v" title={wi.remoteKey ?? wi.source}>
+            <span className="ins-field-v" title={wi.remoteKey}>
               {wi.links.ticket ? (
                 <a className="ins-link" href={wi.links.ticket} target="_blank" rel="noreferrer">
                   {wi.source}
-                  {wi.remoteKey ? ` · ${wi.remoteKey}` : ''}
+                  {` · ${wi.remoteKey}`}
                   <span className="ins-link-arrow">↗</span>
                 </a>
               ) : (
@@ -455,8 +455,8 @@ function RightPane({ data, selection }: { data: WorkItemDetail; selection: Selec
   return (
     <>
       <div className="ins-hero">
-        <div className="ins-hero-line" title={`${wi.remoteKey ?? `#${wi.id}`} — ${wi.title}`}>
-          <span className="ins-hero-key">{wi.remoteKey ?? `#${wi.id}`}</span>
+        <div className="ins-hero-line" title={`${wi.remoteKey} — ${wi.title}`}>
+          <span className="ins-hero-key">{wi.remoteKey}</span>
           <span className="ins-hero-dash">—</span>
           {wi.title}
         </div>

--- a/frontend/src/extensions/ship/WorkItemsPage.tsx
+++ b/frontend/src/extensions/ship/WorkItemsPage.tsx
@@ -26,7 +26,7 @@ function matchesQuery(row: WorkItemRow, q: string): boolean {
   if (!q.trim()) return true
   const needle = q.toLowerCase()
   const { summary, status } = row
-  return `${summary.title} ${summary.remoteKey ?? ''} ${summary.repo} ${statusLine(status)}`
+  return `${summary.title} ${summary.remoteKey} ${summary.repo} ${statusLine(status)}`
     .toLowerCase()
     .includes(needle)
 }

--- a/frontend/src/extensions/ship/api.ts
+++ b/frontend/src/extensions/ship/api.ts
@@ -42,7 +42,7 @@ export interface WorkItemSummary extends SubjectSummary {
   repo: string
   projectName: string
   title: string
-  remoteKey?: string | null
+  remoteKey: string
   remoteUrl?: string | null
   prNumber?: number | null
   branch?: string | null

--- a/frontend/src/lib/feed.test.ts
+++ b/frontend/src/lib/feed.test.ts
@@ -38,7 +38,7 @@ describe('eventLine', () => {
     expect(line.bucket).toBe('event-kind-audit')
   })
 
-  it('links a row where the extension says its subject lives', () => {
+  it('names the subject as it showed itself, and links where the extension says', () => {
     const line = eventLine(
       event({
         kind: 'workflow.finished',
@@ -46,10 +46,11 @@ describe('eventLine', () => {
         extension: 'ship',
         subjectType: 'work_item',
         subjectId: '42',
+        subjectLabel: 'ENG-767',
       }),
     )
 
-    expect(line.subject).toBe('work item 42')
+    expect(line.subject).toBe('ENG-767')
     expect(line.path).toBe('/work-items/42')
   })
 
@@ -61,17 +62,24 @@ describe('eventLine', () => {
         extension: 'ship',
         subjectType: 'project_repo',
         subjectId: '3',
+        subjectLabel: 'acme/widget',
       }),
     )
 
     expect(line.label).toBe('profile started')
-    expect(line.subject).toBe('project repo 3')
+    expect(line.subject).toBe('acme/widget')
     expect(line.path).toBeUndefined()
   })
 
   it('reads an unregistered extension without words or a page', () => {
     const line = eventLine(
-      event({ kind: 'summarized', extension: 'field_notes', subjectType: 'note', subjectId: '7' }),
+      event({
+        kind: 'summarized',
+        extension: 'field_notes',
+        subjectType: 'note',
+        subjectId: '7',
+        subjectLabel: 'note 7',
+      }),
     )
 
     expect(line.label).toBe('summarized')

--- a/frontend/src/lib/feed.ts
+++ b/frontend/src/lib/feed.ts
@@ -14,7 +14,8 @@ const LIFECYCLE_VERBS: Record<string, string> = {
 export interface EventLine {
   // What happened, in words: "build started", "shipped".
   label: string
-  // Who it happened to, by identity. Empty for a row about nothing in particular.
+  // Who it happened to, as it showed itself. Empty for a row about nothing in
+  // particular.
   subject: string
   // The feed's source column — the workflow that ran, else the extension.
   source: string
@@ -27,7 +28,7 @@ export interface EventLine {
 export function eventLine(event: FeedItem): EventLine {
   return {
     label: label(event),
-    subject: subjectName(event),
+    subject: event.subjectLabel ?? '',
     source: localName(event.workflow) || event.extension || 'druks',
     path: subjectPath(event),
     bucket: isLifecycle(event) ? 'event-kind-agent' : 'event-kind-audit',
@@ -43,11 +44,6 @@ function label(event: FeedItem): string {
   // An extension's milestone type is its own word ("shipped", "needs_answers"), and an
   // unrecognised kind reads as itself rather than disappearing.
   return words(event.kind)
-}
-
-function subjectName(event: FeedItem): string {
-  if (event.subjectType && event.subjectId) return `${words(event.subjectType)} ${event.subjectId}`
-  return ''
 }
 
 function subjectPath(event: FeedItem): string | undefined {


### PR DESCRIPTION
Follow-up to #108 (ENG-768): feed rows lost their names ("ENG-767" became "work item 42").

**Every subject shows itself.** It reads as the handle it declares, or as its identity — there is no unlabelled subject, and no client-side composing:

```python
class WorkItem(StoredSubject):
    def get_label(self) -> str:
        return self.remote_key        # a note declares nothing → "note 7"
```

Authors override `get_label()`; everything reads `.label`. The override point is a plain method, so there is no decorator to forget — the same shape as every other author override in druks.

`identity` stays the bare `{type, id}` key everywhere; the label travels as metadata:

```
start(subject=item)   → DBOS attributes {subject_type, subject_id, subject_label}
Run.subject_label     → a column_property over those attributes, like state and
                        updated_at — it arrives with the row, no second query
every event a run     → reads run.subject_label; the run is the snapshot holder,
writes                  so nothing re-derives or re-fetches per event
record_event(subject) → reads it off the row in hand
```

**`WorkItem.remote_key` is NOT NULL.** Intake has only ever created items from a ticket (`Build.dispatch` always passes `ticket["identifier"]`), so the Optional was schema noise — and it had leaked into the wire, four frontend fallbacks, and a pyright error where the code passed it straight to something requiring `str`. Its unique index no longer skips nulls. `remote_url` stays nullable: Linear genuinely yields `None` for it.

Migrations add `events.subject_label` (nullable — absent exactly when the subject is) and make `work_items.remote_key` NOT NULL with a plain unique index. Neither backfills: druks takes the clean break.
