### PR TITLE
Honor the review rules the repo keeps

### DIFF
--- a/backend/druks/contrib/review/templates/review_pull_request.md
+++ b/backend/druks/contrib/review/templates/review_pull_request.md
@@ -36,6 +36,12 @@ earns no findings at all: padding a review with nits costs the author more than 
 Do not flag code the diff does not change. Reading the repo is how you judge the change, not an
 invitation to audit it.
 
+Severity:
+- **high** — a correctness bug, a security flaw, a data-loss path
+- **medium** — a maintainability problem the next change will trip on: an unsafe default, a
+  missing test for non-trivial new behavior, a log-then-continue that hides a failure
+- **low** — naming, comment drift, a simplification worth taking later
+
 {% if siblings %}
 ## The rest of the project
 
@@ -55,11 +61,29 @@ you catch what a single-repo review structurally cannot. Don't clone repos the c
 nothing to do with — irrelevant reading costs the author the same wait as useful reading.
 {% endif %}
 
-Severity:
-- **high** — a correctness bug, a security flaw, a data-loss path
-- **medium** — a maintainability problem the next change will trip on: an unsafe default, a
-  missing test for non-trivial new behavior, a log-then-continue that hides a failure
-- **low** — naming, comment drift, a simplification worth taking later
+## What this repo asks of its reviewers
+
+Everything above is the floor. A repo can raise it, in two files that are already in your
+checkout — read whichever are there, and let each one override what came before it.
+
+**`.coderabbit.yaml` or `.coderabbit.yml`, at the root.** Written for another tool, but what it
+holds is this repo's standing instructions to whoever reviews it. Read it for those and ignore
+the rest of the file.
+
+- `reviews.path_instructions` — apply the entries whose globs match the files in front of you.
+  They are what this team has learned matters in that part of the codebase.
+- `reviews.path_filters` — paths excluded there are not yours to review. Say nothing about them.
+- `tone_instructions` and `reviews.profile` — the posture: how assertive to be, what counts as
+  blocking, how to mark something optional.
+
+**`.druks/review/checklist.md`.** The repo's rules for you specifically, so it is the last word:
+where it and anything above disagree, it wins. A repo keeps it for what it wants from this
+review and not from the other tool, so read it as the delta, not as a restatement — it will be
+short, and everything in it is deliberate.
+
+In both, the "do not" rules bind hardest of all. When a repo says never to flag something, you
+do not mention it, however tempting — every one of those lines is there because a reviewer got
+it wrong before, and repeating that mistake is how a review loses a team's trust.
 
 ## Post the review
 


### PR DESCRIPTION
[ENG-773](https://linear.app/fellaworks/issue/ENG-773/review-extension-45-reviews-honor-the-repos-review-config) — part 4 of 5 of the `review` extension.

A repo's review rules are a distinct thing from its coding standards. `AGENTS.md` says how to write code here — and agents read it from their checkout already, so druks does nothing about it. A review config says how to *review* here: posture, per-path emphasis, paths to skip, and most valuably the things a reviewer must not flag. The reviewer now honors that, in two layers.

**`.coderabbit.yaml`** — many repos already keep one, and the tuning in it was earned. The reviewer applies the `path_instructions` whose globs match the files under review, respects `path_filters`, and takes `tone_instructions`/`profile` as posture, ignoring the parts of the file that aren't about reviewing.

**`.druks/review/checklist.md`** — the repo's rules for this reviewer specifically, and the last word: where it and anything else disagree, it wins. Because the CodeRabbit config is honored underneath it, this file is a delta rather than a restatement — a repo adds druks-specific rules without migrating or duplicating anything.

In both, "do not" rules bind hardest: each of those lines exists because a reviewer got it wrong before.

The change is prompt only. Both files are already in the reviewer's checkout, so it reads them. druks fetches nothing and parses nothing, there is no schema and no config model, and a repo with neither file reviews exactly as it does today.

The severity list moved up under "How to review", where the method it calibrates lives; the new section sits after it, since a repo's own rules outrank our defaults.