### PR TITLE
The review list ticks its own clock, and comments reach a fresh install

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,7 @@ DRUKS_WEBHOOK_SECRET=<same secret configured on the app webhook>
 Webhook URL:
 `https://<webhook-host>/_external/github/events/`
 
-Subscribe to pull request, pull request review, and push events.
+Subscribe to issue comment, pull request, pull request review, and push events.
 
 | Repository permission | Access |
 | --- | --- |

--- a/frontend/src/extensions/review/ReviewsPage.tsx
+++ b/frontend/src/extensions/review/ReviewsPage.tsx
@@ -8,9 +8,9 @@ import { Page } from '../../components/Page'
 import { PageHeader } from '../../components/PageHeader'
 import { PRCell } from '../../components/PRCell'
 import { queryGate } from '../../components/QueryGate'
+import { RelTime } from '../../components/RelTime'
 import { RepoCell } from '../../components/RepoCell'
 import { StatusGlyph } from '../../components/StatusGlyph'
-import { relTimeFromIso } from '../../lib/format'
 
 // A finished review lives on its pull request; this page covers the window where
 // GitHub shows nothing — a review still working, or one that stopped on a failure.
@@ -67,7 +67,9 @@ function ReviewRow({ review }: { review: ReviewSummary }) {
       <span className="review-line mono dim">
         {live ? `${reviewLine(status)}…` : reviewLine(status)}
       </span>
-      <span className="review-when mono dim">{relTimeFromIso(review.triggeredAt)}</span>
+      <span className="review-when mono dim">
+        <RelTime iso={review.triggeredAt} />
+      </span>
       <span className="review-asker mono dim">{review.requestedBy}</span>
     </div>
   )

--- a/scripts/manifests/operator.json
+++ b/scripts/manifests/operator.json
@@ -9,6 +9,7 @@
     "active": true
   },
   "default_events": [
+    "issue_comment",
     "pull_request",
     "pull_request_review",
     "push"


### PR DESCRIPTION
Two fixes for the newly-shipped review extension.

**The review list's timestamp froze.** `ReviewsPage` rendered `relTimeFromIso(triggeredAt)` once; the `reviews` query has no refetch interval and nothing else re-renders the row, so "X ago" stuck at whatever it was at first paint. Replaced it with the self-ticking `RelTime` component, which forces its own re-render on a timer regardless of the parent — the label now advances on its own.

**A fresh install never received PR comments.** The review mention trigger listens for `issue_comment` (GitHub files PR comments under issues), but the operator manifest's `default_events` only requested `pull_request`, `pull_request_review`, and `push`. So a freshly-provisioned operator app got no comment webhooks and `@druks-reviewer` did nothing. Added `issue_comment` to `scripts/manifests/operator.json` and to the configuration doc's event list. druks has handlers for exactly these four events, and the operator app already carries the `issues`/`pull_requests` permission that comment delivery requires.
