### PR TITLE
The journal is the run's memory; announce() is its voice

### DIFF
--- a/backend/druks/contrib/ship/subscribers.py
+++ b/backend/druks/contrib/ship/subscribers.py
@@ -15,8 +15,8 @@ async def any_workflow_start_returns_item_to_board(*, subject: WorkItem, **_: ob
     subject.set_status(None)
 
 
-@subscribe(WorkflowEvent.STATE, workflow=Build, subject=WorkItem)
-async def provision_mirrors_onto_item(
+@subscribe("pr.opened", workflow=Build, subject=WorkItem)
+async def pr_open_mirrors_onto_item(
     *, subject: WorkItem, pr_number: int, branch: str, **_: object
 ) -> None:
     # The implementer's provisioned PR + branch, mirrored onto the work item —

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -334,7 +334,7 @@ class Build(Workflow):
         return await self._work_gate()
 
     # Body code, never @step: the agent calls inside memoize themselves and land
-    # on the record, and set_state must re-run on replay — a @step would skip them.
+    # on the journal a @step would skip rebuilding.
     async def implement(self) -> ImplementationOutput:
         delivery = await Ship.implement()
         # A bail is a stop, not a result: the implementer hit a contradiction in the
@@ -342,10 +342,10 @@ class Build(Workflow):
         # read off the dashboard instead of dug out of the transcript.
         if delivery.status == "needs_clarification":
             raise FatalError(f"implementation needs clarification: {delivery.summary}")
-        if not self.pr_number:
-            # First delivery: the implementer provisioned the branch + draft PR alongside
-            # its commits; publish the pair (the run.state signal mirrors it onto the item).
-            await self.set_state(branch=delivery.branch, pr_number=delivery.pr_number)
+        if self.journal.implementation_revision == 1:
+            # First delivery: the implementer provisioned the branch + draft PR
+            # alongside its commits — announce them onto the item.
+            await self.announce("pr.opened", pr_number=delivery.pr_number, branch=delivery.branch)
         return delivery
 
     @step
@@ -354,15 +354,17 @@ class Build(Workflow):
         github = get_github_client(load_settings())
         return await github.merge_when_ready(self.input.repo, self.pr_number)
 
-    # The provisioned branch + PR, published by the first implement — None until then
+    # The provisioned branch + PR off the first delivery — None until then
     # (planning runs against the default branch, and there is no PR to point at).
     @property
     def branch(self) -> str | None:
-        return getattr(self.state, "branch", None)
+        delivery = self.journal.last_implementation
+        return delivery.branch if delivery else None
 
     @property
     def pr_number(self) -> int | None:
-        return getattr(self.state, "pr_number", None)
+        delivery = self.journal.last_implementation
+        return delivery.pr_number if delivery else None
 
     @step
     async def _clear_draft(self) -> None:

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -354,17 +354,19 @@ class Build(Workflow):
         github = get_github_client(load_settings())
         return await github.merge_when_ready(self.input.repo, self.pr_number)
 
-    # The provisioned branch + PR off the first delivery — None until then
+    # The provisioned branch + PR, pinned to the FIRST delivery — None until then
     # (planning runs against the default branch, and there is no PR to point at).
+    # Rework deliveries reuse the pair; the item row and webhook routing key on it,
+    # so a delivery reporting different numbers must not move these reads.
     @property
     def branch(self) -> str | None:
-        delivery = self.journal.last_implementation
-        return delivery.branch if delivery else None
+        implementations = self.journal.implementations
+        return implementations[0].branch if implementations else None
 
     @property
     def pr_number(self) -> int | None:
-        delivery = self.journal.last_implementation
-        return delivery.pr_number if delivery else None
+        implementations = self.journal.implementations
+        return implementations[0].pr_number if implementations else None
 
     @step
     async def _clear_draft(self) -> None:

--- a/backend/druks/durable/enums.py
+++ b/backend/druks/durable/enums.py
@@ -23,14 +23,12 @@ OPEN_STATES = (*ACTIVE_STATES, RunState.FAILED)
 class WorkflowEvent(StrEnum):
     # Each state's signal topic, and what the feed stores. Naming them makes a
     # subscriber's topic typo-proof — a bare string can silently subscribe to a
-    # topic nobody publishes. ``STATE`` is the odd one: facts a running workflow
-    # learned, no state behind it.
+    # topic nobody publishes.
     RUNNING = "workflow.running"
     PARKED = "workflow.parked"
     FINISHED = "workflow.finished"
     FAILED = "workflow.failed"
     CANCELLED = "workflow.cancelled"
-    STATE = "workflow.state"
 
     @classmethod
     def for_state(cls, state: RunState) -> "WorkflowEvent":

--- a/backend/druks/signals.py
+++ b/backend/druks/signals.py
@@ -75,6 +75,6 @@ async def publish(name: str, **kwargs: Any) -> None:
 
     A subscriber exception propagates to the publisher: a webhook responds 5xx
     and the provider redelivers; the durable publish steps (run lifecycle,
-    ``set_state`` fan-out) enable DBOS retries. Delivery is therefore
+    ``announce`` fan-out) enable DBOS retries. Delivery is therefore
     at-least-once — subscribers must be idempotent."""
     await signal(name).send_async(None, **kwargs)

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -4,7 +4,6 @@ from contextlib import nullcontext, suppress
 from contextvars import ContextVar
 from datetime import UTC, datetime
 from functools import partial
-from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Self, TypeVar, get_args, get_type_hints
 
 from croniter import croniter
@@ -537,9 +536,6 @@ class Workflow:
         # key; None on system-owned runs (crons, old checkpoints).
         self.account_id: str | None = None
         self.journal = self.journal_class()
-        # Facts published with set_state, kept warm for sync reads (templates,
-        # workspace kwargs); the durable copy is the run's DBOS events.
-        self._state_facts: dict[str, Any] = {}
         # The run's warm VM, provisioned lazily and reaped at segment boundaries;
         # its lease expiry decides when it must rotate.
         self._host: Sandbox | None = None
@@ -555,39 +551,20 @@ class Workflow:
                 return db_session().get(model, int(subject_id))
         raise LookupError(f"no subject class is named {subject_type!r}")
 
-    @property
-    def state(self) -> Any:
-        # The facts the run published with set_state — nothing else. Input stays
-        # on self.input; a reader names which one it means. Durable by
-        # determinism: a recovery re-runs the body, whose set_state calls
-        # rebuild this in-memory copy (the event writes themselves replay as
-        # memoized steps).
-        return SimpleNamespace(**self._state_facts)
-
-    async def set_state(self, **facts: Any) -> None:
-        # Durably publish facts the run learned mid-flight (a provisioned PR
-        # number, a resolved branch). Body-only, enforced: inside a @step the
-        # in-memory update would vanish on replay (the step is skipped), which
-        # is exactly the state loss this call exists to prevent. Each fact is a
-        # DBOS workflow event (memoized — written once); the ``workflow.state``
-        # signal fans out in its own checkpointed step so reactions fire once,
-        # inside a session.
+    async def announce(self, topic: str, **facts: Any) -> None:
+        # The workflow announcing a domain event in its extension's vocabulary
+        # ("pr.opened", pr_number=12, branch="agent/eng-8"). The platform injects
+        # the routing subscribers filter on, and the publish runs as its own
+        # retrying checkpoint so a recovery replay doesn't re-fire it. Body-only,
+        # enforced: the checkpoint is a step, so it can't nest inside one.
         if _in_step.get():
-            raise WorkflowError("set_state() runs in the workflow body, not inside a @step")
-        for key, value in facts.items():
-            await DBOS.set_event_async(key, value)
-        self._state_facts.update(facts)
+            raise WorkflowError("announce() runs in the workflow body, not inside a @step")
 
         async def _fan_out() -> None:
             async with step_session():
-                await publish(
-                    WorkflowEvent.STATE,
-                    subject=self._subject,
-                    kind=self.kind,
-                    **facts,
-                )
+                await publish(topic, subject=self._subject, kind=self.kind, **facts)
 
-        await DBOS.run_step_async(StepOptions(name="run.state", **_IO_RETRIES), _fan_out)
+        await DBOS.run_step_async(StepOptions(name=topic, **_IO_RETRIES), _fan_out)
 
     async def review(
         self, *, questions: list[BaseModel] | None = None, context: str = ""

--- a/backend/tests/ship/test_build_durable.py
+++ b/backend/tests/ship/test_build_durable.py
@@ -4,11 +4,13 @@ from types import SimpleNamespace
 
 import psycopg
 import pytest
+from druks.contrib.ship.models import Project, WorkItem
 from druks.database import configure_session, get_session
 from druks.durable import Run, RunState
 from druks.durable.engine import configure_engine, init_dbos, launch, shutdown
 from druks.testing import init_db
 from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
 PG_BASE = os.environ.get("DRUKS_TEST_PG", "postgresql://druks:druks@localhost:5432")
 DB = "druks_build_durable_test"
@@ -74,9 +76,6 @@ def _seed_work_item(engine, *, repo: str):
     # The run.* subscribers dereference the subject row (a subscriber failure
     # now fails the lifecycle step), so the item must exist, not just its id.
     from uuid import uuid4
-
-    from druks.contrib.ship.models import Project, WorkItem
-    from sqlalchemy.orm import Session
 
     with Session(engine) as session:
         name = f"rt-{uuid4().hex[:8]}"
@@ -206,8 +205,8 @@ def _stub(
 
     github_calls = []
 
-    async def _merge_when_ready(*args, **kwargs):
-        github_calls.append("merge_when_ready")
+    async def _merge_when_ready(repo, pr_number):
+        github_calls.append(("merge_when_ready", repo, pr_number))
         return merge_when_ready_accepted
 
     fake_github = SimpleNamespace(
@@ -243,7 +242,13 @@ async def test_happy_path_declares_merge_intent(rt, monkeypatch):
 
     done = await _wait(rt.engine, workflow_id, lambda run: run.state == RunState.FINISHED)
     assert not done.failure
-    assert github_calls == ["merge_when_ready"]
+    # The merge intent carries the journal-backed number of the first delivery.
+    assert github_calls == [("merge_when_ready", "acme/widget", 42)]
+
+    # The pr.opened announce mirrored the delivery onto the item.
+    with Session(rt.engine) as session:
+        refreshed = session.get(WorkItem, item.id)
+        assert (refreshed.pr_number, refreshed.branch) == (42, "agent/acme-1")
 
     # Shipped settles via GitHub's pr.closed webhook (test_webhooks_pull_request),
     # not the run — the run's job ends when GitHub accepts the merge intent. The durable
@@ -282,7 +287,7 @@ async def test_rejected_merge_intent_reparks_work_gate(rt, monkeypatch):
         ),
     )
     assert not reparked.failure
-    assert github_calls == ["merge_when_ready"]
+    assert [call[0] for call in github_calls] == ["merge_when_ready"]
     await reparked.cancel()
 
 

--- a/backend/tests/ship/test_lane_reactions.py
+++ b/backend/tests/ship/test_lane_reactions.py
@@ -93,17 +93,15 @@ async def test_pr_review_answers_through_the_review_gate(druks_db, monkeypatch):
     ]
 
 
-async def test_provision_state_reaches_the_work_item(druks_db):
+async def test_pr_open_reaches_the_work_item(druks_db):
     item = make_test_work_item(repo="acme/widget", title="t", source="linear", remote_key="ACME-8")
 
     await publish(
-        WorkflowEvent.STATE,
+        "pr.opened",
         subject=item.identity,
         kind=Build.kind,
         pr_number=12,
         branch="agent/eng-8",
-        ticket_ref="ACME-8",
-        issue_number=None,
     )
 
     refreshed = WorkItem.get(item.id)

--- a/backend/tests/test_run_state.py
+++ b/backend/tests/test_run_state.py
@@ -274,19 +274,28 @@ async def test_gate_timeout_stamps_its_failure_code(druks_db, _inline_steps):
 
 
 @pytest.mark.asyncio
-async def test_announce_carries_the_runs_routing(druks_db, _inline_steps):
-    # The body states its facts; the platform injects what subscribers filter on.
+async def test_announce_carries_the_runs_routing(druks_db):
+    # The body states its facts; the platform injects what subscribers filter on,
+    # and the publish rides its own named checkpoint — the boundary that keeps a
+    # recovery replay from re-firing it.
     workflow = Workflow()
     workflow._subject = {"type": "note", "id": 7}
     received = []
+    checkpoints = []
 
     @subscribe("test.announced", kind=workflow.kind)
     async def _receive(*, subject: dict, **facts: object) -> None:
         received.append((subject, facts))
 
-    await workflow.announce("test.announced", pr_number=12)
+    async def run_inline(options, fn):
+        checkpoints.append(options["name"])
+        return await fn()
+
+    with mock.patch("druks.workflows.DBOS.run_step_async", side_effect=run_inline):
+        await workflow.announce("test.announced", pr_number=12)
 
     assert received == [({"type": "note", "id": 7}, {"pr_number": 12})]
+    assert checkpoints == ["test.announced"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_run_state.py
+++ b/backend/tests/test_run_state.py
@@ -11,7 +11,7 @@ from druks.events.models import Event
 from druks.models import Base
 from druks.signals import subscribe
 from druks.testing import seed_run
-from druks.workflows import WorkflowEvent, _emit_run_event, _execute_run
+from druks.workflows import Workflow, WorkflowEvent, _emit_run_event, _execute_run
 from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
 from sqlalchemy import select, update
@@ -271,3 +271,33 @@ async def test_gate_timeout_stamps_its_failure_code(druks_db, _inline_steps):
 
     ambient_session().expire_all()
     assert Run.get(run.id).failure_code == "gate_timeout"
+
+
+@pytest.mark.asyncio
+async def test_announce_carries_the_runs_routing(druks_db, _inline_steps):
+    # The body states its facts; the platform injects what subscribers filter on.
+    workflow = Workflow()
+    workflow._subject = {"type": "note", "id": 7}
+    received = []
+
+    @subscribe("test.announced", kind=workflow.kind)
+    async def _receive(*, subject: dict, **facts: object) -> None:
+        received.append((subject, facts))
+
+    await workflow.announce("test.announced", pr_number=12)
+
+    assert received == [({"type": "note", "id": 7}, {"pr_number": 12})]
+
+
+@pytest.mark.asyncio
+async def test_announce_refuses_inside_a_step():
+    from druks.durable.exceptions import WorkflowError
+    from druks.workflows import _in_step
+
+    workflow = Workflow()
+    token = _in_step.set(True)
+    try:
+        with pytest.raises(WorkflowError, match="workflow body"):
+            await workflow.announce("test.announced", pr_number=12)
+    finally:
+        _in_step.reset(token)

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -195,6 +195,18 @@ Two rules:
 - Never mutate body-held state inside a `@step`: a completed step is skipped
   on replay, so the write disappears.
 
+### Announcing domain events
+
+When another component should react to something the body just did, announce it:
+
+```python
+await self.announce("pr.opened", pr_number=delivery.pr_number, branch=delivery.branch)
+```
+
+The platform routes it to subscribers filtering on your workflow and subject, and
+the publish is its own durable checkpoint — a recovery replay does not re-fire it.
+Announce from the body, not inside a `@step`.
+
 ### Schedules and settings
 
 Set `every` to declare a cron:


### PR DESCRIPTION
Closes ENG-775. Design settled in review of #119 (Codex pass + three forks resolved).

## Deleted: the second memory

`set_state()` / `self.state` / `WorkflowEvent.STATE` were a second "what the run knows" store beside the journal, one dot from `Run.state` while holding an unrelated concept. The duplication was total: the branch + PR number it carried already arrive in the journal as the validated `ImplementationOutput`; its DBOS key writes had no reader (only `"phase"` is read via `get_event`); `self.state` was an untyped `SimpleNamespace` read with `getattr(..., None)`.

## Kept: the voice

```python
# Build's body — the extension's own vocabulary, plain facts
await self.announce("pr.opened", pr_number=delivery.pr_number, branch=delivery.branch)

# ship's subscriber — signature unchanged, only topic and name moved
@subscribe("pr.opened", workflow=Build, subject=WorkItem)
async def pr_open_mirrors_onto_item(*, subject: WorkItem, pr_number: int, branch: str, **_: object) -> None:
    subject.update(pr_number=pr_number, branch=branch)
```

`announce(topic, **facts)` publishes with the run's `subject` + `kind` injected, inside the same retrying DBOS checkpoint the old fan-out used — a recovery replay doesn't re-fire it. Body-only, enforced.

Build reads `branch`/`pr_number` off the journal, pinned to the first delivery — the pair the item row and webhook routing key on. The first-delivery gate becomes `implementation_revision == 1` — deliberately: the journal already holds the delivery when the agent call returns, so the old `if not self.pr_number` would never fire. The gate only ever sees successes (`needs_clarification` raises first; the contract has no third status).

## Forks resolved in design (not relitigated here)

- **Not GitHub's `pull_request.opened` webhook:** unroutable — `get_for_pr` keys on the very columns this stamp writes; only the run knows which subject its PR belongs to. Webhooks keep owning the PR's fate (`pr.closed` still ships the item).
- **Not a direct row write in the body:** unmemoized side effect that re-runs on replay; done right it's a `@step` with the same checkpoint cost, but it would be ship's first `WorkItem` write outside `subscribers.py`. Projections keep one door.
- **No contract objects on the wire; no rename:** the mechanism disappears instead of getting a new noun.

## Deploy note — drain in-flight builds past first delivery

The adversarial pass sharpened this beyond a routine drain: an in-flight Build past its first delivery carries two recorded `DBOS.setEvent` operations where the new body runs the `pr.opened` step, so replay raises `DBOSUnexpectedStepError` — and the `run.failed` emit then lands on the *second* recorded `setEvent` and mismatches too. The run dies with **no failure fact, no `workflow.failed` signal, and its WorkItem stranded on the board**. Runs still in the plan phase replay cleanly. Drain builds past first delivery at deploy; no guard code, per the durable-by-design rule.

## Verification

Ruff + format clean (the six format offenders are pre-existing on main, untouched). Pyright: net zero on the touched set, all remaining errors pre-existing. Backend suite gates in CI.

## The adversarial pass

4 lenses, 11 agents, 7 findings → 6 confirmed, all addressed:

1. **A real regression caught:** `last_implementation` tracks the *newest* delivery, but the old gate froze `branch`/`pr_number` at the *first* — the pair the item row and webhook routing key on. The reads now pin to `implementations[0]`, with the why in place.
2. The deploy note above (two findings, merged) — including the silent-death cascade my own version missed.
3. The durable happy path now proves the pair lands end to end: the merge intent carries the journal-backed `42`, and the WorkItem row mirrors the announced delivery.
4. The routing test captures the checkpoint name, so the step wrapper that keeps a replay from re-firing can't be deleted green.
5. (nit, folded into 3) the merge stub now records its arguments instead of discarding them.

One finding refuted: the in-step guard test pinning `_in_step` directly is the platform's own enforcement seam, same as the existing private-API tests in that file.
