### PR TITLE
A subject needs no row to be read

### DIFF
--- a/backend/druks/contrib/review/extension.py
+++ b/backend/druks/contrib/review/extension.py
@@ -1,10 +1,13 @@
 from druks.agents import Agent
 from druks.contrib.review.contracts import ReviewReport
+from druks.contrib.review.schemas import ReviewSummary
 from druks.extensions import Extension
+from druks.workflows import Subject
 
 
 class Review(Extension):
     name = "review"
+    subject_type = "pull_request"
     icon = "git-pull-request"
     description = (
         "Reviews a pull request and posts the review back to GitHub — the decision, "
@@ -17,3 +20,16 @@ class Review(Extension):
         contract=ReviewReport,
         model="claude",
     )
+
+    @classmethod
+    def get_subject_summary(cls, subject: Subject) -> ReviewSummary | None:
+        # A pull request is a subject by identity alone: any id shaped like one names
+        # one, whether or not druks has reviewed it, and the timeline says which.
+        return ReviewSummary.from_subject(subject)
+
+    @classmethod
+    def list_subjects(cls) -> list[ReviewSummary]:
+        """The reviews still going or stopped on a failure. A finished one lives on its
+        pull request, so it leaves the board as soon as it has something to show there."""
+        summaries = (cls.get_subject_summary(s) for s in Subject.list_open(cls.subject_type))
+        return [summary for summary in summaries if summary]

--- a/backend/druks/contrib/review/routes.py
+++ b/backend/druks/contrib/review/routes.py
@@ -2,29 +2,16 @@ from fastapi import APIRouter, Body, Depends, HTTPException, status
 
 from druks.accounts.dependencies import current_account
 from druks.accounts.models import Account
-from druks.contrib.review.schemas import ReviewsResponse, ReviewSummary
 from druks.contrib.review.workflows import PullRequestReview
 from druks.contrib.ship.models import ProjectRepo
-from druks.workflows import Subject
 
 router = APIRouter(prefix="/pull-requests", tags=["review"])
-
-
-@router.get("", response_model=ReviewsResponse, response_model_by_alias=True)
-async def list_reviews() -> ReviewsResponse:
-    """The reviews still going or stopped on a failure. A finished one lives on its
-    pull request, so it leaves this list as soon as it has something to show there."""
-    return ReviewsResponse(
-        reviews=[
-            ReviewSummary.from_subject(subject) for subject in Subject.list_open("pull_request")
-        ]
-    )
 
 
 @router.post("", status_code=status.HTTP_202_ACCEPTED)
 async def request_review(
     repo: str = Body(..., embed=True),
-    pr_number: int = Body(..., embed=True, alias="prNumber"),
+    pr_number: int = Body(..., embed=True, alias="prNumber", gt=0),
     account: Account = Depends(current_account),
 ) -> None:
     if not ProjectRepo.get_for_repo(repo):

--- a/backend/druks/contrib/review/schemas.py
+++ b/backend/druks/contrib/review/schemas.py
@@ -1,35 +1,29 @@
-from datetime import datetime
-
-from druks.schemas import BaseResponse
-from druks.workflows import Subject
+from druks.workflows import Subject, SubjectSummary
 
 
-class ReviewSummary(BaseResponse):
+class ReviewSummary(SubjectSummary):
+    # A pull request keeps no row, so its id is its whole record — "owner/repo#7"
+    # is where the review happened, and everything else on the row reads back out
+    # of it. Its status carries the lifecycle.
     repo: str
     pr_number: int
     pull_request_url: str
-    # Where the review got to, why it stopped, when it was asked for and by whom —
-    # its status answers the whole row. ``state`` is the platform's, verbatim; the
-    # words are the client's.
-    state: str
-    failure: str | None
-    triggered_at: datetime
-    requested_by: str
 
     @classmethod
-    def from_subject(cls, subject: Subject) -> "ReviewSummary":
-        repo, _, pr_number = subject.id.partition("#")
-        status = subject.get_status()
-        return cls(
-            repo=repo,
-            pr_number=int(pr_number),
-            pull_request_url=f"https://github.com/{repo}/pull/{pr_number}",
-            state=status.state,
-            failure=status.failure,
-            triggered_at=status.triggered_at,
-            requested_by=status.account_username,
-        )
-
-
-class ReviewsResponse(BaseResponse):
-    reviews: list[ReviewSummary]
+    def from_subject(cls, subject: Subject) -> "ReviewSummary | None":
+        # Ids reach the read-side as free text off a URL, so a shape that names no
+        # pull request is a miss rather than a crashed row.
+        repo, _, number = subject.id.partition("#")
+        owner, _, name = repo.partition("/")
+        try:
+            pr_number = int(number)
+        except ValueError:
+            return
+        if owner and name and pr_number > 0:
+            return cls(
+                id=subject.id,
+                repo=repo,
+                pr_number=pr_number,
+                pull_request_url=f"https://github.com/{repo}/pull/{pr_number}",
+            )
+        return

--- a/backend/druks/contrib/review/workflows.py
+++ b/backend/druks/contrib/review/workflows.py
@@ -41,7 +41,7 @@ class PullRequestReview(Workflow):
         # review asked for by someone with no account runs as the system's.
         account = Account.get_for_username(requested_by)
         return await cls.start(
-            subject=Subject(id=f"{repo}#{pr_number}", subject_type="pull_request"),
+            subject=Subject(id=f"{repo}#{pr_number}", subject_type=Review.subject_type),
             account_id=account.id if account else None,
             repo=repo,
             pr_number=pr_number,

--- a/backend/druks/contrib/ship/extension.py
+++ b/backend/druks/contrib/ship/extension.py
@@ -14,7 +14,7 @@ from druks.contrib.ship.contracts import (
 from druks.contrib.ship.models import WorkItem
 from druks.contrib.ship.schemas import WorkItemSummary
 from druks.extensions import Extension
-from druks.workflows import SubjectActivity
+from druks.workflows import Subject, SubjectActivity
 
 _PHASE_META: dict[str, SubjectActivity] = {
     "provisioning_vm": SubjectActivity(label="Building sandbox VM…", kind="infra"),
@@ -24,7 +24,7 @@ _PHASE_META: dict[str, SubjectActivity] = {
 
 class Ship(Extension):
     name = "ship"
-    subject = WorkItem
+    subject_type = WorkItem.subject_type
     # These tables (projects, work_items, ...) are already unprefixed in core's
     # migration history, so they must stay that way.
     prefix_tables = False
@@ -125,8 +125,11 @@ class Ship(Extension):
     )
 
     @classmethod
-    def subject_summary(cls, subject: WorkItem) -> WorkItemSummary:
-        return WorkItemSummary.from_work_item(subject)
+    def get_subject_summary(cls, subject: Subject) -> WorkItemSummary | None:
+        item = WorkItem.get_for_subject(subject)
+        if item:
+            return WorkItemSummary.from_work_item(item)
+        return
 
     @classmethod
     def list_subjects(cls) -> list[WorkItemSummary]:
@@ -135,6 +138,6 @@ class Ship(Extension):
         return [WorkItemSummary.from_work_item(item) for item in WorkItem.list_open(limit=500)]
 
     @classmethod
-    async def subject_activity(cls, subject: WorkItem) -> SubjectActivity | None:
+    async def get_subject_activity(cls, subject: Subject) -> SubjectActivity | None:
         phase = await subject.get_phase()
         return _PHASE_META.get(phase or "")

--- a/backend/druks/extensions/base.py
+++ b/backend/druks/extensions/base.py
@@ -85,9 +85,11 @@ class Extension:
     # belong to the extension itself rather than one of its workflows. Mirrors a
     # workflow's ``Settings``.
     settings_model: ClassVar[type[BaseModel] | None] = None
-    # The row this extension's runs are about. Declaring it mounts the generic
-    # subject read-side; None means the extension has no subject read-side.
-    subject: ClassVar[type[StoredSubject] | None] = None
+    # What this extension's runs are about ("work_item", "pull_request"). Declaring
+    # it mounts the generic subject read-side; None means the extension has none.
+    # An extension that also keeps a row for its subject spells this
+    # ``WorkItem.subject_type`` rather than repeating the literal.
+    subject_type: ClassVar[str | None] = None
     # The checks this extension contributes to ``druks doctor`` — one per precondition
     # it owns (its API key set, its webhook secret present, its provider reachable).
     # ``druks doctor`` runs each through the same ``CheckResult`` report as its core
@@ -241,7 +243,7 @@ class Extension:
         its ``routes`` modules, plus the generic read-side it gets for free —
         ``/transcripts`` always, and the subject read-side
         (``/<subject_type>`` → status + timeline + live stream) when it declares a
-        ``subject``. Override to add a router built outside a ``routes`` module."""
+        ``subject_type``. Override to add a router built outside a ``routes`` module."""
         # Local, not module-top: keeps FastAPI off the import graph so the loader
         # stays importable app-lessly; enumerating routers is where it's really needed.
         from fastapi import APIRouter
@@ -256,8 +258,8 @@ class Extension:
                     seen.add(id(value))
                     declared.append(value)
         routers = [*declared, cls._get_transcript_routes()]
-        if cls.subject:
-            routers.append(cls._get_subject_routes())
+        if cls.subject_type:
+            routers.append(cls._get_subject_routes(cls.subject_type))
         return routers
 
     @classmethod
@@ -355,23 +357,21 @@ class Extension:
         return router
 
     @classmethod
-    def _get_subject_routes(cls) -> "APIRouter":
+    def _get_subject_routes(cls, subject_type: str) -> "APIRouter":
         """The board and one subject (header + status + timeline + activity), each with a
         point-in-time read and a ``/stream`` that pushes the whole snapshot on change.
-        Mounted at ``/api/<name>/<subject_type>`` once the extension declares ``subject``."""
+        Mounted at ``/api/<name>/<subject_type>`` once the extension declares
+        ``subject_type``. Every read here is keyed by identity, so an extension that
+        keeps no row for its subject gets the same surface as one that does."""
         from fastapi import APIRouter, HTTPException, status
         from fastapi.responses import StreamingResponse
 
         from druks.api.dependencies import EngineDep
-        from druks.database import db_session, session_scope
+        from druks.database import session_scope
         from druks.durable import reads
         from druks.durable.datastructures import Subject
         from druks.durable.live import SSE_HEADERS, stream
         from druks.durable.schemas import SubjectList, SubjectResponse, SubjectRow
-
-        subject_model = cls.subject
-        assert subject_model
-        subject_type = subject_model.subject_type
 
         router = APIRouter(prefix=f"/{subject_type}", tags=[f"{cls.name}:{subject_type}"])
 
@@ -387,15 +387,11 @@ class Extension:
             )
 
         async def subject_response(subject_id: str) -> SubjectResponse | None:
-            if not subject_id.isdigit():
-                return
-            subject = db_session().get(subject_model, int(subject_id))
-            if not subject:
-                return
-            summary = cls.subject_summary(subject)
+            subject = Subject(id=subject_id, subject_type=subject_type)
+            summary = cls.get_subject_summary(subject)
             if not summary:
                 return
-            activity = await cls.subject_activity(subject)
+            activity = await cls.get_subject_activity(subject)
             return reads.get_subject_response(
                 subject_type, subject_id, summary=summary, activity=activity
             )
@@ -415,14 +411,10 @@ class Extension:
                 stream(snapshot), media_type="text/event-stream", headers=SSE_HEADERS
             )
 
-        @router.get("/{subject_id}", response_model=SubjectResponse, response_model_by_alias=True)
-        async def read_subject(subject_id: str) -> SubjectResponse:
-            response = await subject_response(subject_id)
-            if not response:
-                raise HTTPException(status.HTTP_404_NOT_FOUND, f"No {subject_type} {subject_id!r}.")
-            return response
-
-        @router.get("/{subject_id}/stream", response_class=StreamingResponse)
+        # A subject id is whatever identifies it — "7" for a row, "owner/repo#7" for a
+        # pull request — so the id matcher spans separators, and the subject's own
+        # ``/stream`` is declared ahead of it to keep the greedy match off it.
+        @router.get("/{subject_id:path}/stream", response_class=StreamingResponse)
         async def stream_subject(subject_id: str, engine: EngineDep) -> StreamingResponse:
             async def snapshot() -> SubjectResponse | None:
                 with session_scope(engine):
@@ -431,6 +423,15 @@ class Extension:
             return StreamingResponse(
                 stream(snapshot), media_type="text/event-stream", headers=SSE_HEADERS
             )
+
+        @router.get(
+            "/{subject_id:path}", response_model=SubjectResponse, response_model_by_alias=True
+        )
+        async def read_subject(subject_id: str) -> SubjectResponse:
+            response = await subject_response(subject_id)
+            if not response:
+                raise HTTPException(status.HTTP_404_NOT_FOUND, f"No {subject_type} {subject_id!r}.")
+            return response
 
         return router
 
@@ -462,21 +463,24 @@ class Extension:
         )
 
     @classmethod
-    def subject_summary(cls, subject: Any) -> "SubjectSummary | None":
+    def get_subject_summary(cls, subject: "Subject") -> "SubjectSummary | None":
         """This extension's domain header for one subject — its own fields only; the
-        read-side composes it with the platform's generic status + timeline. Required
-        once ``subject`` is set."""
-        raise NotImplementedError(f"extension {cls.name!r} sets subject but no subject_summary")
+        read-side composes it with the platform's generic status + timeline. None when
+        the identity names nothing, which is how a subject id off a URL 404s. Required
+        once ``subject_type`` is set."""
+        raise NotImplementedError(
+            f"extension {cls.name!r} sets subject_type but no get_subject_summary"
+        )
 
     @classmethod
     def list_subjects(cls) -> "Sequence[SubjectSummary]":
         """This extension's subjects, newest-movement first, each as its domain summary.
         Returns a covariant ``Sequence`` so an extension can return ``list`` of its own
-        ``SubjectSummary`` subclass. Required once ``subject`` is set."""
-        raise NotImplementedError(f"extension {cls.name!r} sets subject but no list_subjects")
+        ``SubjectSummary`` subclass. Required once ``subject_type`` is set."""
+        raise NotImplementedError(f"extension {cls.name!r} sets subject_type but no list_subjects")
 
     @classmethod
-    async def subject_activity(cls, subject: Any) -> "SubjectActivity | None":
+    async def get_subject_activity(cls, subject: "Subject") -> "SubjectActivity | None":
         """The subject's live sub-phase, if any (e.g. "Building sandbox VM…"). Optional —
         override to surface a transient signal the running run pushes."""
         return

--- a/backend/druks/models.py
+++ b/backend/druks/models.py
@@ -80,6 +80,19 @@ class StoredSubject(Base):
 
         return Subject(id=str(self.id), subject_type=self.subject_type)
 
+    @classmethod
+    def get_for_subject(cls, subject: "Subject") -> Self | None:
+        """The row this identity names. A subject id is free text and reaches the
+        read-side straight off a URL, so an id this table could never hold is a miss
+        rather than an error."""
+        from druks.database import db_session
+
+        try:
+            key = int(subject.id)
+        except ValueError:
+            return
+        return db_session().get(cls, key)
+
     def get_status(self, *, workflow: "type[Workflow] | None" = None) -> "SubjectStatus":
         return self.subject.get_status(workflow=workflow)
 

--- a/backend/druks/scaffolding/extension_template/package/models.py-tpl
+++ b/backend/druks/scaffolding/extension_template/package/models.py-tpl
@@ -4,6 +4,7 @@ from druks.db import Base, StoredSubject
 # start with "{{ name }}_": the platform scopes this extension's migrations to that
 # prefix (its own history in ``alembic_version_{{ name }}``) and enforces it at boot.
 # One of these models is usually the thing your runs work on — a note, a repo, a
-# ticket. Subclass ``StoredSubject`` for that one, and set ``subject = ThatModel`` on the
-# Extension so druks can show it a board and a page.
+# ticket. Subclass ``StoredSubject`` for that one, and set
+# ``subject_type = ThatModel.subject_type`` on the Extension so druks can show it a
+# board and a page.
 # After adding a model: ``druks makemigrations {{ name }} -m "..." && druks init-db``.

--- a/backend/tests/druks-field_notes/druks_field_notes/extension.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/extension.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Literal
 from druks.agents import Agent
 from druks.doctor import CheckResult
 from druks.extensions import Extension
+from druks.workflows import Subject
 from pydantic import BaseModel, Field, SecretStr, field_validator
 
 from druks_field_notes.contracts import NoteSummary
@@ -34,7 +35,7 @@ def check_summary_api_key(settings: "Settings") -> CheckResult:
 
 class FieldNotes(Extension):
     name = "field_notes"
-    subject = Note
+    subject_type = Note.subject_type
     icon = "notebook"
     description = "Turns a jotted observation into a one-line summary with an agent."
 
@@ -83,8 +84,11 @@ class FieldNotes(Extension):
     )
 
     @classmethod
-    def subject_summary(cls, subject: Note) -> NoteView:
-        return NoteView.from_note(subject)
+    def get_subject_summary(cls, subject: Subject) -> NoteView | None:
+        note = Note.get_for_subject(subject)
+        if note:
+            return NoteView.from_note(note)
+        return
 
     @classmethod
     def list_subjects(cls) -> list[NoteView]:

--- a/backend/tests/ship/test_api_work_items.py
+++ b/backend/tests/ship/test_api_work_items.py
@@ -249,11 +249,11 @@ async def test_subject_activity_surfaces_running_phase(druks_db, monkeypatch):
     item = make_test_work_item(repo="ClawHaven/acme-app", title="x")
     seed_build_run(druks_db, work_item_id=item.id, state="running")
 
-    async def phase(_self):
+    async def phase(_run_id):
         return "provisioning_vm"
 
-    monkeypatch.setattr(WorkItem, "get_phase", phase)
-    activity = await ship_extension.Ship.subject_activity(item)
+    monkeypatch.setattr("druks.durable.reads.get_run_phase", phase)
+    activity = await ship_extension.Ship.get_subject_activity(item.subject)
     assert activity is not None
     assert activity.label == "Building sandbox VM…"
     assert activity.kind == "infra"
@@ -266,4 +266,4 @@ async def test_subject_activity_none_when_not_running(druks_db):
     item = make_test_work_item(repo="ClawHaven/acme-app", title="x")
     seed_build_run(druks_db, work_item_id=item.id, state="parked", input_gate="review_plan")
 
-    assert await ship_extension.Ship.subject_activity(item) is None
+    assert await ship_extension.Ship.get_subject_activity(item.subject) is None

--- a/backend/tests/test_extension_appless_load.py
+++ b/backend/tests/test_extension_appless_load.py
@@ -31,13 +31,13 @@ _FILES = {
 
         class Probe(Extension):
             name = "probe"
-            subject = ProbeItem
+            subject_type = ProbeItem.subject_type
 
             class Settings(BaseModel):
                 budget: int = Field(default=3, ge=1)
 
             @classmethod
-            def subject_summary(cls, subject):
+            def get_subject_summary(cls, subject):
                 return None
 
             @classmethod

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 from druks.durable import AgentCall, Run
+from druks.durable.datastructures import Subject
 from druks.durable.schemas import SubjectSummary
 from druks.extensions.base import Extension
 from druks.models import StoredSubject
@@ -21,13 +22,16 @@ class _ThingSummary(SubjectSummary):
 
 class _ThingExtension(Extension):
     name = "faketest"
-    subject = Thing
+    subject_type = Thing.subject_type
 
     _THINGS = {1: "First", 2: "Second"}
 
     @classmethod
-    def subject_summary(cls, subject: Thing) -> _ThingSummary:
-        return _ThingSummary(id=str(subject.id), title=cls._THINGS[subject.id])
+    def get_subject_summary(cls, subject: Subject) -> _ThingSummary | None:
+        thing = Thing.get_for_subject(subject)
+        if thing:
+            return _ThingSummary(id=str(thing.id), title=cls._THINGS[thing.id])
+        return
 
     @classmethod
     def list_subjects(cls) -> list[_ThingSummary]:
@@ -83,7 +87,8 @@ def client(tmp_path: Path, druks_db, monkeypatch):
     app = configure_app_for_test(settings=make_settings(tmp_path))
 
     holder = APIRouter()
-    holder.include_router(_ThingExtension._get_subject_routes(), prefix="/api/faketest")
+    routes = _ThingExtension._get_subject_routes(Thing.subject_type)
+    holder.include_router(routes, prefix="/api/faketest")
     catchall = next(
         i for i, r in enumerate(app.routes) if getattr(r, "path", "") == "/api/{path:path}"
     )

--- a/backend/tests/test_proof_extension.py
+++ b/backend/tests/test_proof_extension.py
@@ -9,7 +9,7 @@ def test_boot_loads_the_external_extension():
 
     assert extension.name == "field_notes"
     assert extension.package == _PACKAGE
-    assert extension.subject.subject_type == "note"
+    assert extension.subject_type == "note"
 
 
 def test_discovery_registers_the_tables_and_capabilities():

--- a/backend/tests/test_proof_extension_install.py
+++ b/backend/tests/test_proof_extension_install.py
@@ -12,7 +12,7 @@ _CHECK = textwrap.dedent(
     assert "field_notes" in names, names
 
     extension = load_extension("field_notes")
-    assert extension.subject.subject_type == "note"
+    assert extension.subject_type == "note"
     assert extension.settings_model is not None
     assert list(extension.settings_model.model_fields) == ["board_size", "visibility", "sync_token"]
     assert [workflow.__name__ for workflow in extension.workflows()] == ["Summarize"]

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -371,15 +371,30 @@ A subject is what your runs are about — a repository, a work item, a pull
 request. Identity is all the platform needs:
 
 ```python
-from druks.workflows import Subject, get_subject_status
+from druks.workflows import Subject
 
-await Review.start(subject=Subject(id=f"{repo}#{pr_number}", subject_type="pull_request"))
+pull_request = Subject(id=f"{repo}#{pr_number}", subject_type="pull_request")
+await Review.start(subject=pull_request)
 
-status = get_subject_status("pull_request", f"{repo}#{pr_number}")
+status = pull_request.get_status()
 ```
 
 Status, timeline, and the run's own subject record answer for that identity
-alone — no table of yours involved.
+alone — no table of yours involved. Declare that type on the extension and druks
+serves it a board, a page, and a live stream of either:
+
+```python
+class Review(Extension):
+    subject_type = "pull_request"
+
+    @classmethod
+    def get_subject_summary(cls, subject: Subject) -> PullRequestSummary:
+        ...
+
+    @classmethod
+    def list_subjects(cls) -> list[PullRequestSummary]:
+        ...
+```
 
 When the subject is also a row you keep — one you list, edit, and show fields
 from — subclass `StoredSubject` instead of `Base`, and the class name is the
@@ -400,10 +415,11 @@ class RepositorySummary(SubjectSummary):
 
 
 class NightWatch(Extension):
-    subject = Repository
+    subject_type = Repository.subject_type
 
     @classmethod
-    def subject_summary(cls, subject: Repository) -> RepositorySummary:
+    def get_subject_summary(cls, subject: Subject) -> RepositorySummary | None:
+        repository = Repository.get_for_subject(subject)
         ...
 
     @classmethod
@@ -411,11 +427,13 @@ class NightWatch(Extension):
         ...
 ```
 
-Druks then serves that subject under `/api/night_watch/repository`: a board of
-every row, a page for one row, and a live stream of either. Each response pairs
-your summary with the run's status, timeline, agent calls, artifacts, and the
-question it is waiting on. Override `subject_activity()` only to add a passing
-detail of your own, like "Building sandbox VM…".
+The reads are keyed by identity either way, so the row is yours to load —
+`get_for_subject()` turns the identity back into it. Druks serves the same
+`/api/night_watch/repository` surface it serves an identity-only subject: a
+board, a page for one, and a live stream of either. Each response pairs your
+summary with the run's status, timeline, agent calls, artifacts, and the
+question it is waiting on. Override `get_subject_activity()` only to add a
+passing detail of your own, like "Building sandbox VM…".
 
 Hand the row itself to anything that asks for a subject — starting a run,
 answering a gate, recording an event:
@@ -432,16 +450,14 @@ You name what happened to the row: a work item ships, gets cancelled. Whether a
 run is working on it is druks's to say, and you read that off the status:
 
 ```python
-from druks.workflows import get_subject_phase, get_subject_status
-
-status = get_subject_status(repository.subject_type, str(repository.id))
+status = repository.get_status()
 if status.is_parked:
     ...  # a run stopped to ask a human something
 ```
 
 `status.kind` names the workflow currently driving the row and `status.gate` the
-question it stopped on. While a run is working, `get_subject_phase(...)` returns
-the step it is on.
+question it stopped on. While a run is working, `await repository.get_phase()`
+returns the step it is on.
 
 ## Record events and react to signals
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -47,6 +47,10 @@ export interface SubjectStatus {
   // ("gate_timeout" = unanswered gate, not a crash).
   failure: string | null
   reason: string | null
+  // When druks last picked this subject up, and whose work it is — what a subject
+  // with a row of its own would keep in its own columns.
+  triggeredAt: string | null
+  accountUsername: string | null
 }
 
 // The live sub-phase a running run pushes ("Building sandbox VM…", "Working…") —

--- a/frontend/src/extensions/review/ReviewsPage.tsx
+++ b/frontend/src/extensions/review/ReviewsPage.tsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useMemo } from 'react'
 
 import { REVIEW, reviewApi } from './api'
-import type { ReviewSummary } from './api'
+import type { ReviewRow } from './api'
 import { reviewLine } from './reviewLine'
 import { useSSE } from '../../api/sse'
 import { EmptyState } from '../../components/EmptyState'
@@ -36,8 +36,8 @@ export function ReviewsPage() {
   })
   if (gate) return <Page className="page-reviews">{gate}</Page>
 
-  const reviews = reviewsQuery.data!
-  const failed = reviews.filter((review) => review.state === 'failed').length
+  const rows = reviewsQuery.data!
+  const failed = rows.filter((row) => row.status.state === 'failed').length
 
   return (
     <Page
@@ -46,12 +46,12 @@ export function ReviewsPage() {
       header={
         <PageHeader
           eyebrow="reviews"
-          count={reviews.length}
+          count={rows.length}
           meta={failed > 0 && <span>{failed} failed</span>}
         />
       }
     >
-      {reviews.length === 0 ? (
+      {rows.length === 0 ? (
         <EmptyState
           glyph="✓"
           msg="nothing under review"
@@ -59,8 +59,8 @@ export function ReviewsPage() {
         />
       ) : (
         <div className="reviews-list">
-          {reviews.map((review) => (
-            <ReviewRow key={review.pullRequestUrl} review={review} />
+          {rows.map((row) => (
+            <ReviewRowView key={row.summary.id} row={row} />
           ))}
         </div>
       )}
@@ -68,21 +68,22 @@ export function ReviewsPage() {
   )
 }
 
-function ReviewRow({ review }: { review: ReviewSummary }) {
-  const failed = review.state === 'failed'
-  const live = review.state === 'running' || review.state === 'scheduled'
+function ReviewRowView({ row }: { row: ReviewRow }) {
+  const { summary, status } = row
+  const failed = status.state === 'failed'
+  const live = status.state === 'running' || status.state === 'scheduled'
   return (
     <div className={`row row-review${failed ? ' row-failed' : ''}`}>
-      <StatusGlyph state={review.state} pulse={live} />
-      <RepoCell repoBare={bareName(review.repo)} />
-      <PRCell prNumber={review.prNumber} prUrl={review.pullRequestUrl} />
+      <StatusGlyph state={status.state} pulse={live} />
+      <RepoCell repoBare={bareName(summary.repo)} />
+      <PRCell prNumber={summary.prNumber} prUrl={summary.pullRequestUrl} />
       <span className="review-line mono dim">
-        {live ? `${reviewLine(review)}…` : reviewLine(review)}
+        {live ? `${reviewLine(status)}…` : reviewLine(status)}
       </span>
       <span className="review-when mono dim">
-        <RelTime iso={review.triggeredAt} />
+        {status.triggeredAt && <RelTime iso={status.triggeredAt} />}
       </span>
-      <span className="review-asker mono dim">{review.requestedBy}</span>
+      <span className="review-asker mono dim">{status.accountUsername}</span>
     </div>
   )
 }

--- a/frontend/src/extensions/review/api.ts
+++ b/frontend/src/extensions/review/api.ts
@@ -1,22 +1,22 @@
 import { getJSON } from '../../api/client'
-import type { RunState } from '../../api/types'
+import type { SubjectRow, SubjectSummary } from '../../api/types'
 
 // Review's identity on the platform: the name that keys its ``/api/review``
 // namespace and the subject type its runs are about.
 export const REVIEW = 'review'
 export const PULL_REQUEST = 'pull_request'
 
-export interface ReviewSummary {
+// A pull request keeps no row, so its subject id is its whole record and the rest
+// of the summary reads back out of it.
+export interface ReviewSummary extends SubjectSummary {
   repo: string
   prNumber: number
   pullRequestUrl: string
-  state: RunState
-  failure: string | null
-  triggeredAt: string
-  requestedBy: string
 }
+
+export type ReviewRow = SubjectRow<ReviewSummary>
 
 export const reviewApi = {
   open: () =>
-    getJSON<{ reviews: ReviewSummary[] }>(`/api/${REVIEW}/pull-requests`).then((r) => r.reviews),
+    getJSON<{ rows: ReviewRow[] }>(`/api/${REVIEW}/${PULL_REQUEST}`).then((r) => r.rows),
 }

--- a/frontend/src/extensions/review/reviewLine.ts
+++ b/frontend/src/extensions/review/reviewLine.ts
@@ -1,10 +1,10 @@
-import type { ReviewSummary } from './api'
+import type { SubjectStatus } from '../../api/types'
 
 // Review's copy, composed from the facts the backend ships — it sends data, the
 // extension owns its own vocabulary.
-export function reviewLine(review: ReviewSummary): string {
-  if (review.state === 'running' || review.state === 'scheduled') return 'Reviewing'
-  if (review.state === 'failed') return review.failure ?? 'Review failed'
-  if (review.state === 'cancelled') return 'Cancelled'
+export function reviewLine(status: SubjectStatus): string {
+  if (status.state === 'running' || status.state === 'scheduled') return 'Reviewing'
+  if (status.state === 'failed') return status.failure ?? 'Review failed'
+  if (status.state === 'cancelled') return 'Cancelled'
   return ''
 }

--- a/frontend/src/extensions/ship/statusLine.test.ts
+++ b/frontend/src/extensions/ship/statusLine.test.ts
@@ -11,6 +11,8 @@ function status(overrides: Partial<SubjectStatus>): SubjectStatus {
     gate: null,
     failure: null,
     reason: null,
+    triggeredAt: null,
+    accountUsername: null,
     ...overrides,
   }
 }


### PR DESCRIPTION
Declaring a subject meant declaring a table:

```python
subject: ClassVar[type[StoredSubject] | None] = None
```

The class bought two things — a truthiness check that mounted the routes, and one `db_session().get(model, int(subject_id))` in the detail resolver. Everything else in the contract already worked off `(subject_type, subject_id)` strings. So a pull request, whose identity is `owner/repo#7` and which keeps no row, could key a run and an event but never have a board.

The declaration is now the subject type itself, and the hooks take the identity:

```python
subject_type: ClassVar[str | None] = None

@classmethod
def get_subject_summary(cls, subject: Subject) -> SubjectSummary | None: ...
@classmethod
async def get_subject_activity(cls, subject: Subject) -> SubjectActivity | None: ...
```

The row lookup moves to the extension that owns the row, as the inverse of `StoredSubject.subject`:

```python
subject_type = WorkItem.subject_type

@classmethod
def get_subject_summary(cls, subject: Subject) -> WorkItemSummary | None:
    item = WorkItem.get_for_subject(subject)
    ...
```

`review` then deletes its own board. Its list endpoint and `ReviewsResponse` are gone, `ReviewSummary` is a `SubjectSummary` subclass, and the same query moves to `list_subjects()`, at the seam it belonged at. The POST that asks for a review stays where it was: the platform owns the subject's path, and an author writing that path themselves only works by coincidence. The dashboard now reads `SubjectRow<ReviewSummary>` — summary plus status — the shape ship's board already consumes.

A subject id is whatever identifies it, so the detail route had to stop assuming a key with no separators in it. `%2F` is decoded before Starlette matches, so `/{subject_id}` never matched `owner/repo#7` at all — the id matcher now spans separators, with the subject's own `/stream` declared ahead of it to keep the greedy match off it. One consequence worth knowing: a literal route mounted under a subject type's prefix after the platform's is unreachable, and a subject whose id is literally `stream` can't show its detail. Neither collides today.

That id arrives as free text off a URL, which makes the two places that read it a trust boundary. `str.isdigit()` was the wrong check in both: it accepts `"²"`, which `int()` rejects, and a 4301-digit string is a parse CPython refuses outright — either one a 500 where a 404 belongs. Both stopped testing the string and started parsing it, which is the question they were really asking:

```python
try:
    key = int(subject.id)
except ValueError:
    return
return db_session().get(cls, key)
```

Review's read of the id lives once, in `from_subject`, so the board can't be taken down by a single row it can't read, and it checks the repo half too — `#7` named a subject that serialized as `https://github.com//pull/7`. Asking for review of pull request `-1` used to be accepted and listed a row that 404'd when opened; the trigger takes `gt=0`.

Verified against the running app: board, detail and both streams resolve for an integer id and for `owner/repo#7`; `²`, a 4301-digit id, `-1`, `#7` and `repo#7` all 404; nothing else is shadowed.
