### PR TITLE
A feed row carries no payload

### DIFF
--- a/backend/druks/events/feed.py
+++ b/backend/druks/events/feed.py
@@ -1,7 +1,4 @@
 from datetime import datetime
-from typing import Any
-
-from pydantic import Field
 
 from druks.events.models import Event
 from druks.schemas import BaseResponse
@@ -22,24 +19,19 @@ class FeedItem(BaseResponse):
     subject_type: str | None = None
     subject_id: str | None = None
     subject_label: str | None = None
-    # Whatever else the event recorded, stated by its writer — a gate, a failure,
-    # a ticket key. What a row carries beyond identity is said at write time.
-    facts: dict[str, Any] = Field(default_factory=dict)
 
     @classmethod
     def from_event(cls, event: Event) -> "FeedItem":
-        facts = dict(event.payload)
         return cls(
             id=f"event:{event.id}",
             seq=event.id,
             at=event.created_at,
             kind=event.type,
             extension=event.extension,
-            workflow=facts.pop("kind", None),
+            workflow=event.payload.get("kind"),
             subject_type=event.subject_type,
             subject_id=event.subject_id,
             subject_label=event.subject_label,
-            facts=facts,
         )
 
 

--- a/backend/tests/test_events_feed.py
+++ b/backend/tests/test_events_feed.py
@@ -16,7 +16,7 @@ class Pallet(StoredSubject):
     __tablename__ = "faketest_pallets"
 
 
-def test_feed_carries_the_facts_a_row_is_worded_from(druks_db):
+def test_feed_carries_what_a_row_is_worded_from(druks_db):
     note = Note.create(body="the pump ran hot")
     Event.emit(
         type="workflow.running",
@@ -25,13 +25,7 @@ def test_feed_carries_the_facts_a_row_is_worded_from(druks_db):
         extension="field_notes",
         payload={"kind": Summarize.kind, "run": "wf1"},
     )
-    Event.emit(
-        type="summarized",
-        subject=note.identity,
-        label=note.label,
-        extension="field_notes",
-        payload={"words": 12},
-    )
+    Event.emit(type="summarized", subject=note.identity, label=note.label, extension="field_notes")
     druks_db.flush()
 
     by_kind = {row.kind: row for row in build_feed()[0]}
@@ -39,13 +33,11 @@ def test_feed_carries_the_facts_a_row_is_worded_from(druks_db):
     started = by_kind["workflow.running"]
     assert (started.extension, started.workflow) == ("field_notes", Summarize.kind)
     assert (started.subject_type, started.subject_id) == ("note", str(note.id))
-    # A note declares no label of its own, so it shows itself by identity; whatever
-    # is left of the payload once the workflow is promoted out of it is its facts.
-    assert (started.subject_label, started.facts) == (f"note {note.id}", {"run": "wf1"})
+    # A note declares no label of its own, so it shows itself by identity.
+    assert started.subject_label == f"note {note.id}"
 
-    # A milestone has no workflow behind it, and carries what its writer stated.
-    summarized = by_kind["summarized"]
-    assert (summarized.workflow, summarized.facts) == (None, {"words": 12})
+    # A milestone has no workflow behind it.
+    assert by_kind["summarized"].workflow is None
 
 
 def test_every_subject_shows_itself(druks_db):

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -342,8 +342,6 @@ export interface FeedItem {
   // How the subject showed itself ("ENG-767"), snapshotted at write. Absent
   // exactly when the subject is.
   subjectLabel?: string | null
-  // Whatever else the event recorded, stated by its writer — a gate, a failure.
-  facts: Record<string, unknown>
 }
 
 export interface FeedResponse {

--- a/frontend/src/lib/feed.test.ts
+++ b/frontend/src/lib/feed.test.ts
@@ -11,7 +11,6 @@ function event(fields: Partial<FeedItem>): FeedItem {
     seq: 1,
     at: '2026-07-26T12:00:00Z',
     kind: 'workflow.running',
-    facts: {},
     ...fields,
   }
 }


### PR DESCRIPTION
Closes the item left open on ENG-768.

`FeedItem.facts` shipped the event's whole payload — `run`, `gate`, `failure`, `result` — to a client that never read a key of it. I added it in #108 when `summary` left the wire, on a guess that a row would want a second line; nothing ever wanted one, and the row now reads from `kind`, `workflow`, and `subjectLabel`.

```
FeedItem: id, seq, at, kind, extension, workflow, subjectType, subjectId, subjectLabel
```

Nothing is lost: the payload stays on the `Event` row where its writer put it, and a client that one day wants a failure reason can be given exactly that, named.

The feed test drops its payload-readback assertions with the field; the frontend type and its test fixture drop the key.
