### PR TITLE
Ask the session whether it let go, not the pool

### DIFF
--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -472,7 +472,7 @@ async def test_subjectless_review_fails_loudly(rt):
     assert "'review'" in failed.failure
 
 
-def _fake_ephemeral_returning(action: str, seen: list[dict], pinned: list[int]):
+def _fake_ephemeral_returning(action: str, seen: list[dict], held: list[bool]):
     # Class-method stand-in for Client.ephemeral: a VM whose agent returns
     # ``action``.
     from datetime import UTC, datetime
@@ -484,12 +484,14 @@ def _fake_ephemeral_returning(action: str, seen: list[dict], pinned: list[int]):
     async def _fake_ephemeral(self, **_kw):
         async def _run_agent(**kwargs):
             seen.append(kwargs)
-            # The agent runs for minutes in production; the step's pooled DB
-            # connection must be back in the pool for that wait, not pinned by
-            # an idle-in-transaction session.
-            from druks.durable.engine import _step_engine
+            # The agent runs for minutes in production, so the step commits before
+            # handing over: its own session holds no connection through the wait.
+            # Ask that session — sessions are task-scoped and the agent is awaited
+            # in the step's task, so this is it. The pool cannot answer: it is
+            # shared, and another reader in this instant is not this step pinning.
+            from druks.database import db_session
 
-            pinned.append(_step_engine().pool.checkedout())
+            held.append(db_session().in_transaction())
             # The harness names the on-disk dir (and the row) from the supplied
             # call_id, so the result echoes it back as run_id.
             return AgentResult(
@@ -517,11 +519,11 @@ async def test_run_agent_step(rt, monkeypatch):
     from druks.durable.models import AgentCall
 
     seen: list[dict] = []
-    pinned: list[int] = []
+    held: list[bool] = []
     # Patch the class method (not the singleton instance): an instance-attr
     # patch leaves a shadowing leftover that breaks later sandbox tests.
     monkeypatch.setattr(
-        "druks.sandbox.client.Client.ephemeral", _fake_ephemeral_returning("stop", seen, pinned)
+        "druks.sandbox.client.Client.ephemeral", _fake_ephemeral_returning("stop", seen, held)
     )
     monkeypatch.setattr("druks.agents.render_prompt", _fake_render)
 
@@ -541,7 +543,7 @@ async def test_run_agent_step(rt, monkeypatch):
     # No account on the start: the fallback account (the module's op@ seed)
     # is charged.
     assert recorded[0].account_id == _account_id(rt.engine, "op@example.com")
-    assert pinned == [0]  # connection released while the agent runs
+    assert held == [False]  # the step let its connection go before the agent ran
 
 
 async def test_body_level_agent_output_lands_on_the_journal(rt, monkeypatch):
@@ -549,9 +551,9 @@ async def test_body_level_agent_output_lands_on_the_journal(rt, monkeypatch):
     receives on the journal — AgentBodyFlow asserts identity in-body and sinks
     the projection."""
     seen: list[dict] = []
-    pinned: list[int] = []
+    held: list[bool] = []
     monkeypatch.setattr(
-        "druks.sandbox.client.Client.ephemeral", _fake_ephemeral_returning("ship", seen, pinned)
+        "druks.sandbox.client.Client.ephemeral", _fake_ephemeral_returning("ship", seen, held)
     )
     monkeypatch.setattr("druks.agents.render_prompt", _fake_render)
 


### PR DESCRIPTION
`test_run_agent_step` failed twice this week on branches that touch no session, engine, or agent code (#125's rebase, #127's wire-field deletion), each time on `assert pinned == [0]`. It is a race the test runs against itself:

```
configure_engine(rt.engine)     → _step_engine() IS rt.engine
_wait_for(rt.engine, …)         → every 100ms: get_session(engine).get(Run, …)
                                  ↑ checks a connection OUT of that same pool
agent stub: pool.checkedout()   → samples the SHARED counter at one instant
assert pinned == [0]            → fails whenever the sample lands in that SELECT
```

`pool.checkedout()` counts every connection out of the pool, by anyone. A concurrent reader is not this step pinning a connection, so the instrument cannot answer the question the test is asking — and it gets louder as CI gets slower, which is why it hits PR branches and not main's quieter runs.

The behaviour is ours and worth pinning: an agent runs for minutes, so the step commits before handing over rather than holding an idle-in-transaction session. That question belongs to the session, not the pool:

```python
held.append(db_session().in_transaction())
...
assert held == [False]  # the step let its connection go before the agent ran
```

Sessions are task-scoped (`scopefunc=asyncio.current_task()`) and the agent is `await`ed inline in the step's task, so `db_session()` inside the stub is the session that committed — no other reader can spoil the answer. If the agent call is ever moved into its own task, that assertion goes vacuous; the comment says so.

Test-only change.
