### PR TITLE
A running run names its step

### DIFF
--- a/backend/druks/contrib/ship/extension.py
+++ b/backend/druks/contrib/ship/extension.py
@@ -16,9 +16,10 @@ from druks.contrib.ship.schemas import WorkItemSummary
 from druks.extensions import Extension
 from druks.workflows import Subject, SubjectActivity
 
+# Only what the timeline can't already show. A running agent has an agent call
+# to name it, so the phase that clears provisioning maps to nothing.
 _PHASE_META: dict[str, SubjectActivity] = {
     "provisioning_vm": SubjectActivity(label="Building sandbox VM…", kind="infra"),
-    "agent_running": SubjectActivity(label="Working…", kind="agent"),
 }
 
 

--- a/frontend/src/extensions/ship/WorkItemPage.tsx
+++ b/frontend/src/extensions/ship/WorkItemPage.tsx
@@ -20,7 +20,7 @@ import { Page } from '../../components/Page'
 import { queryGate } from '../../components/QueryGate'
 import { RunTranscript } from '../../components/RunTranscript'
 import { computeElapsed, dur, formatTokenCount, relTime, secondsSince } from '../../lib/format'
-import { parkedLine, statusLine } from './statusLine'
+import { parkedLine, runSubLine, statusLine } from './statusLine'
 import { agentCallPath, workItemPath } from './slug'
 import { useCanonicalPath } from '../../lib/useCanonicalPath'
 import { useTicker } from '../../lib/useTicker'
@@ -87,15 +87,6 @@ const STATE_GLYPH: Record<string, string> = {
   failed: '✕',
   cancelled: '⊘',
   orphaned: '⚠',
-}
-const STATE_LABEL: Record<string, string> = {
-  scheduled: 'scheduled',
-  running: 'running',
-  parked: 'waiting on you',
-  finished: 'finished',
-  failed: 'failed',
-  cancelled: 'cancelled',
-  orphaned: 'orphaned',
 }
 const CALL_GLYPH: Record<string, string> = {
   running: '●',
@@ -368,16 +359,7 @@ function RunRow({
   // A single call duplicates the run's own row (same label, same ledger) —
   // fold it into the parent instead of showing both.
   const collapseCalls = run.agentCalls.length <= 1
-  // A running run shows the live phase ("Building sandbox VM…", "Working…") as
-  // its sub-line; a parked one shows its gate; a failed one its reason.
-  const sub =
-    run.state === 'failed' && run.failure
-      ? (run.failure.split('—')[0] ?? run.failure).trim()
-      : run.state === 'parked'
-        ? (parkedLine(run.gate) ?? STATE_LABEL.parked)
-        : isRunning(run) && activity
-          ? activity.label
-          : (STATE_LABEL[run.state] ?? run.state)
+  const sub = runSubLine(run, activity, collapseCalls)
   return (
     <div className="wic-run">
       <div

--- a/frontend/src/extensions/ship/statusLine.test.ts
+++ b/frontend/src/extensions/ship/statusLine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import type { SubjectStatus } from '../../api/types'
-import { statusLine } from './statusLine'
+import type { AgentCallSummary, RunSummary, SubjectStatus } from '../../api/types'
+import { runSubLine, statusLine } from './statusLine'
 
 function status(overrides: Partial<SubjectStatus>): SubjectStatus {
   return {
@@ -55,5 +55,66 @@ describe('statusLine', () => {
 
   it('the hint is failed-only — an orphaned run with the code renders nothing', () => {
     expect(statusLine(status({ state: 'orphaned', reason: 'gate_timeout' }))).toBe('')
+  })
+})
+
+function run(overrides: Partial<RunSummary> = {}): RunSummary {
+  return {
+    id: 'r1',
+    kind: 'ship.build',
+    label: 'Build',
+    state: 'running',
+    accountUsername: 'system',
+    createdAt: '2026-07-26T00:00:00Z',
+    updatedAt: '2026-07-26T00:00:00Z',
+    failure: null,
+    gate: null,
+    agentCalls: [],
+    ...overrides,
+  }
+}
+
+function call(overrides: Partial<AgentCallSummary> = {}): AgentCallSummary {
+  return {
+    id: 'c1',
+    agent: 'generate_plan',
+    label: 'Generate plan',
+    accountUsername: 'system',
+    status: 'running',
+    startedAt: '2026-07-26T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('runSubLine', () => {
+  it('names the folded-in step instead of a generic phase', () => {
+    const only = run({ agentCalls: [call()] })
+    expect(runSubLine(only, null, true)).toBe('Generate plan')
+  })
+
+  it('leaves the step to its own row when the calls are split out', () => {
+    const many = run({ agentCalls: [call({ status: 'succeeded' }), call({ id: 'c2' })] })
+    expect(runSubLine(many, { label: 'Building sandbox VM…', kind: 'infra' }, false)).toBe(
+      'Building sandbox VM…',
+    )
+  })
+
+  it('shows the infra phase while no agent has started', () => {
+    expect(runSubLine(run(), { label: 'Building sandbox VM…', kind: 'infra' }, true)).toBe(
+      'Building sandbox VM…',
+    )
+  })
+
+  it('falls back to the state when nothing is running yet', () => {
+    expect(runSubLine(run({ state: 'scheduled' }), null, true)).toBe('scheduled')
+  })
+
+  it('reads a parked run as its gate', () => {
+    expect(runSubLine(run({ state: 'parked', gate: 'review' }), null, true)).toBe('Review the plan')
+  })
+
+  it('reads a failed run as its reason', () => {
+    const dead = run({ state: 'failed', failure: 'boom — stack trace here' })
+    expect(runSubLine(dead, null, true)).toBe('boom')
   })
 })

--- a/frontend/src/extensions/ship/statusLine.ts
+++ b/frontend/src/extensions/ship/statusLine.ts
@@ -1,4 +1,4 @@
-import type { SubjectStatus } from '../../api/types'
+import type { RunSummary, SubjectActivity, SubjectStatus } from '../../api/types'
 
 // Build's status-line copy, composed from the platform's status facts — the backend
 // ships data; the extension owns its own vocabulary.
@@ -32,4 +32,35 @@ export function statusLine(status: SubjectStatus): string {
     return `${kindLabel(status.kind)} timed out — re-trigger to retry`
   }
   return ''
+}
+
+const STATE_LABEL: Record<string, string> = {
+  scheduled: 'scheduled',
+  running: 'running',
+  parked: 'waiting on you',
+  finished: 'finished',
+  failed: 'failed',
+  cancelled: 'cancelled',
+  orphaned: 'orphaned',
+}
+
+// What a run row says it is doing. A folded-in step names itself, since its own
+// row isn't there to; the activity covers what the timeline can't show at all.
+export function runSubLine(
+  run: RunSummary,
+  activity: SubjectActivity | null | undefined,
+  collapsed: boolean,
+): string {
+  if (run.state === 'failed' && run.failure) {
+    return (run.failure.split('—')[0] ?? run.failure).trim()
+  }
+  if (run.state === 'parked') {
+    return parkedLine(run.gate) ?? STATE_LABEL[run.state] ?? run.state
+  }
+  if (run.state === 'running') {
+    const step = collapsed && run.agentCalls.find((call) => call.status === 'running')
+    if (step) return step.label
+    if (activity) return activity.label
+  }
+  return STATE_LABEL[run.state] ?? run.state
 }


### PR DESCRIPTION
## The bug

A running build showed **"Working…"** where it should have said **"Generate plan"**. The INFO panel on the same screen said "Generate plan" — so the name was right there, one component away.

Two different things render, and only one names the step:

- **INFO panel** → `statusLine(status)` → `kindLabel(status.agent)` → "Generate plan"
- **Timeline row** → `activity.label` → the phase → "Working…"

It only bites when a run has **one** call in flight, because the row folds the call into itself:

```js
const collapseCalls = run.agentCalls.length <= 1
```

Folded, the call's own row is gone, so the name goes with it and the generic phase fills the gap. A second call splits the rows and the names come back — which is why this looks intermittent, and why it hides the step at exactly the moment there's only one thing happening.

## The cause

`SubjectActivity` says what it is for:

> "The running sub-phase **the timeline can't show** ("Building sandbox VM…")"

It exists for the gap *before* an agent call exists. But the phase map broke its own contract:

```python
"provisioning_vm": "Building sandbox VM…"   # the timeline genuinely can't show this
"agent_running":   "Working…"                # the timeline shows this, and better
```

`agent_running` reported a label for the one case the timeline covers, and reported it worse. Its only real effect was handing the frontend a plausible generic string to render by mistake.

## The change

**Backend** — `agent_running` maps to nothing. `SubjectActivity` is infra-only again, so there is no generic label available to render wrongly. The phase itself still fires; it's what clears `provisioning_vm`.

**Frontend** — a running run's sub-line reads its running call's label when the calls are folded in, and the infra phase otherwise. Fixing the good option to win would have left the bad one reachable; removing it makes the correct thing the only thing.

The sub-line moves out of a five-branch ternary into `runSubLine` in `statusLine.ts`, which already declares itself the home of the extension's words. `STATE_LABEL` went with it — it had no other caller — so `WorkItemPage` loses a constant.

## Verification

`tsc`, `eslint`, `ruff` clean. Six new cases in `statusLine.test.ts` (14 pass): the folded step names itself; split calls leave the name to their own rows; the infra phase still shows before an agent starts; and parked/failed/scheduled are unchanged. The test factories build real `RunSummary`/`AgentCallSummary` values with no `as` casts, so they typecheck against the actual shapes.

Five backend files are unformatted on `main` and untouched here; left alone rather than padding the diff.
