### PR TITLE
The subject namespace is the platform's, and it says so

### DIFF
--- a/backend/druks/contrib/review/routes.py
+++ b/backend/druks/contrib/review/routes.py
@@ -5,7 +5,7 @@ from druks.accounts.models import Account
 from druks.contrib.review.workflows import PullRequestReview
 from druks.contrib.ship.models import ProjectRepo
 
-router = APIRouter(prefix="/pull-requests", tags=["review"])
+router = APIRouter(prefix="/reviews")
 
 
 @router.post("", status_code=status.HTTP_202_ACCEPTED)

--- a/backend/druks/extensions/base.py
+++ b/backend/druks/extensions/base.py
@@ -11,6 +11,7 @@ from druks.events.models import Event
 from druks.models import StoredSubject
 from druks.user_settings.models import SettingsOverride
 
+from .exceptions import RouteDeclarationError
 from .registry import agents as agent_registry
 from .registry import autodiscover
 from .registry import workflows as workflow_registry
@@ -228,9 +229,15 @@ class Extension:
         modules = cls.discover()
         # /api/<name> wraps the author's own prefix so extensions can't shadow
         # the platform or each other; every route sits behind the identity gate.
+        # The extension's name tags them all, so a router says only what it serves.
         prefix = f"/api/{cls.name}"
         for router in cls.get_routers(modules):
-            app.include_router(router, prefix=prefix, dependencies=[Depends(current_account)])
+            app.include_router(
+                router,
+                prefix=prefix,
+                tags=[cls.name],
+                dependencies=[Depends(current_account)],
+            )
         dist = cls.frontend_dist()
         if dist:
             # /app, not /api: unknown /api/* paths must stay JSON 404s, never fall
@@ -259,6 +266,18 @@ class Extension:
                     declared.append(value)
         routers = [*declared, cls._get_transcript_routes()]
         if cls.subject_type:
+            # Declared routers mount ahead of these, so one that reaches into the
+            # subject's own segment takes the board or a detail read with it — and
+            # nothing collides at import, so the loss shows up as a 404 much later.
+            claimed = f"/{cls.subject_type}"
+            for router in declared:
+                for route in router.routes:
+                    if route.path == claimed or route.path.startswith(f"{claimed}/"):
+                        raise RouteDeclarationError(
+                            f"extension {cls.name!r} declares a route at {route.path}; "
+                            f"{claimed} is the subject read-side the platform mounts. "
+                            "Name your router for what it serves."
+                        )
             routers.append(cls._get_subject_routes(cls.subject_type))
         return routers
 

--- a/backend/druks/extensions/exceptions.py
+++ b/backend/druks/extensions/exceptions.py
@@ -12,6 +12,13 @@ class SettingsDeclarationError(Exception):
     operator PATCH."""
 
 
+class RouteDeclarationError(Exception):
+    """An extension declares a route inside the subject namespace the platform mounts
+    its own reads on. Raised at load, where the author's routers are enumerated —
+    they mount first, so the collision would otherwise take the board and detail
+    reads silently."""
+
+
 class SubscriberDeclarationError(Exception):
     """A subscriber's signature asks for a routing key — one a filter matches on but
     no body is handed. Raised at declaration, so it fails on import instead of

--- a/backend/druks/scaffolding/extension_template/package/routes.py-tpl
+++ b/backend/druks/scaffolding/extension_template/package/routes.py-tpl
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
 
-# Every APIRouter declared in a ``routes`` module mounts under /api/{{ name }}.
-# For DB access in a handler use ``from druks.db import db_session``.
-router = APIRouter(tags=["{{ name }}"])
+# Every APIRouter declared in a ``routes`` module mounts under /api/{{ name }},
+# tagged with the extension's name — declare only the prefix your own resource
+# is called. For DB access in a handler use ``from druks.db import db_session``.
+router = APIRouter()
 
 
 @router.get("/status")

--- a/backend/tests/druks-field_notes/druks_field_notes/routes.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/routes.py
@@ -7,7 +7,7 @@ from druks_field_notes.schemas import NoteView
 from druks_field_notes.workflows import Summarize
 
 # Every APIRouter declared here mounts under /api/field_notes.
-router = APIRouter(prefix="/notes", tags=["field_notes"])
+router = APIRouter(prefix="/notes")
 
 
 @router.get("", response_model=list[NoteView], response_model_by_alias=True)

--- a/backend/tests/test_extensions.py
+++ b/backend/tests/test_extensions.py
@@ -2,6 +2,7 @@ from types import ModuleType, SimpleNamespace
 
 import pytest
 from druks.extensions import Extension, loader
+from druks.extensions.exceptions import RouteDeclarationError
 from druks.extensions.loader import iter_extensions, load
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
@@ -91,3 +92,78 @@ def test_load_confines_extension_routers_to_the_extension_namespace(monkeypatch)
     client = TestClient(app)
     assert client.get("/api/evil/health/ping").status_code == 200
     assert client.get("/health/ping").status_code == 404
+
+
+def _routes_module(name: str, **routers: APIRouter) -> ModuleType:
+    module = ModuleType(f"{name}.routes")
+    module.__dict__.update(routers)
+    return module
+
+
+def test_declared_routers_mount_ahead_of_the_platforms():
+    """Order is the contract: the author's routers are matched first, so the platform's
+    own reads are the fallback, never the shadow."""
+
+    class Ordered(Extension):
+        name = "ordered"
+        package = "ordered"
+        subject_type = "widget"
+
+    module = _routes_module("ordered", router=APIRouter(prefix="/parts"))
+    paths = [router.prefix for router in Ordered.get_routers([module])]
+    assert paths == ["/parts", "/transcripts/{call_id}", "/widget"]
+
+
+@pytest.mark.parametrize("prefix", ["/widget", "/widget/settings"])
+def test_a_router_reaching_into_the_subject_namespace_is_rejected(prefix: str):
+    """Declared routers mount first, so this one would take the board or a detail read
+    with it — and nothing collides at import, so it has to fail here."""
+
+    class Claiming(Extension):
+        name = "claiming"
+        package = "claiming"
+        subject_type = "widget"
+
+    claimed = APIRouter(prefix=prefix)
+
+    @claimed.get("")
+    def _read() -> dict:
+        return {}
+
+    with pytest.raises(RouteDeclarationError, match="subject read-side"):
+        Claiming.get_routers([_routes_module("claiming", router=claimed)])
+
+
+def test_a_router_named_like_the_subject_is_left_alone():
+    """The rule is the segment, not the spelling — ``/widgets`` is an author's own
+    resource and says nothing about the platform's ``/widget``."""
+
+    class Neighbour(Extension):
+        name = "neighbour"
+        package = "neighbour"
+        subject_type = "widget"
+
+    Neighbour.get_routers([_routes_module("neighbour", router=APIRouter(prefix="/widgets"))])
+
+
+def test_the_extension_name_tags_every_route(monkeypatch):
+    """An author writes what their router serves; the platform says whose it is."""
+    router = APIRouter(prefix="/parts")
+
+    @router.get("")
+    def _parts() -> dict:
+        return {}
+
+    class Tagged(Extension):
+        name = "tagged"
+        package = "tagged"
+
+        @classmethod
+        def discover(cls) -> list[ModuleType]:
+            return [_routes_module("tagged", router=router)]
+
+    monkeypatch.setattr(loader, "iter_extensions", lambda: [Tagged])
+    monkeypatch.setattr(loader, "import_extension_models", lambda: None)
+    app = FastAPI()
+    load(app)
+    assert app.openapi()["paths"]["/api/tagged/parts"]["get"]["tags"] == ["tagged"]

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -569,7 +569,25 @@ HTTP request, durable step, or other platform-bound session.
 HTTP response models subclass `druks.schemas.BaseResponse`, whose snake_case
 fields serialize as camelCase. Request models are ordinary Pydantic models.
 Every router declared in a discovered `routes.py` is mounted below the
-extension namespace.
+extension namespace, tagged with the extension's name — a router declares only
+the prefix its own resource is called:
+
+```python
+router = APIRouter(prefix="/reviews")
+```
+
+Two spellings run through druks, and they never mean the same thing:
+
+| | |
+| --- | --- |
+| `snake_case` | identity — a subject type, a run's kind, an event's attributes |
+| `kebab-case` | a URL segment — your route prefixes, your frontend paths |
+
+So `pull_request` names the subject the platform serves reads for, and
+`/reviews` names the resource your own POST creates. A router may not declare a
+route inside a subject's own segment: yours mount first, so it would take the
+board or a detail read with it, and druks refuses at load rather than let that
+go quiet.
 
 ## Extension settings and checks
 


### PR DESCRIPTION
Declaring a subject mounts a read surface the extension writes none of, and review's trigger sat next to it looking like the same noun spelled twice:

```
POST /api/review/pull-requests      the author's router
GET  /api/review/pull_request       the platform's board
```

They were never the same noun. `GET /api/review/pull_request` is not a list of pull requests — it is the board of open review *runs*, keyed by subject. What the POST creates is a review, so that is what it is called now:

```python
router = APIRouter(prefix="/reviews")
```

Nothing changes about authoring. An extension declares routers in `routes.py` and they mount under its namespace, exactly as before — there is no way to attach an action to the platform's subject path, and there should not be: the operation is the author's own resource and belongs on its own path. ship has proved that since the subject read-side landed, serving `/api/ship/work_item` beside `/api/ship/work-items` with nothing to reconcile.

Two spellings run through druks and never mean the same thing: snake_case is identity — a subject type, a run's kind, an event's attributes — and kebab-case is a URL segment. Under that rule `pull_request` and `pull-requests` were never in conflict. It is how the repo already behaved and it had never been written down.

What did need enforcing is the one case where the two surfaces genuinely collide. Declared routers mount ahead of the platform's, so a router reaching into the subject's own segment takes the board or a detail read with it — and nothing collides at import, so the loss surfaces much later as a 404 from a route nobody deleted. That fails at load now, naming the segment and what owns it. The rule is exact: the subject's segment, whatever the method, and no resemblance check — `/widgets` is an author's own resource and says nothing about `/widget`.

The order the guard protects is pinned by a test rather than left to a list literal.

An extension's routers are also tagged with its name at mount, where the platform already applies the prefix and the identity gate. `tags=` had drifted to mean two things across four routers — the extension in two, the resource in the others — and a router now declares only what its own resource is called.
