### PR TITLE
A workflow declares what its runs are about

### DIFF
--- a/backend/druks/contrib/review/datastructures.py
+++ b/backend/druks/contrib/review/datastructures.py
@@ -1,0 +1,51 @@
+from typing import Self
+
+from druks.contrib.review.schemas import ReviewSummary
+from druks.workflows import Subject
+
+
+class PullRequest(Subject):
+    """The pull request a review is about. Druks keeps no row for one, so the handle
+    is the whole record — ``owner/repo#7`` is what everything else reads back out of,
+    and its status carries the lifecycle."""
+
+    @classmethod
+    def get(cls, repo: str, number: int) -> Self:
+        return cls(id=f"{repo}#{number}")
+
+    @classmethod
+    def get_for_subject_id(cls, subject_id: str) -> Self | None:
+        # Ids reach the read side as free text off a URL, so a shape that names no
+        # pull request is a miss rather than a crashed read.
+        repo, _, number = subject_id.partition("#")
+        owner, _, name = repo.partition("/")
+        if owner and name and number.isdigit() and int(number) > 0:
+            return cls(id=subject_id)
+        return
+
+    @property
+    def repo(self) -> str:
+        return self.id.partition("#")[0]
+
+    @property
+    def number(self) -> int:
+        return int(self.id.partition("#")[2])
+
+    @property
+    def url(self) -> str:
+        return f"https://github.com/{self.repo}/pull/{self.number}"
+
+    def get_summary(self) -> ReviewSummary:
+        return ReviewSummary(
+            id=self.id,
+            label=self.label,
+            repo=self.repo,
+            pr_number=self.number,
+            pull_request_url=self.url,
+        )
+
+    @classmethod
+    def list_summaries(cls) -> list[ReviewSummary]:
+        """The reviews still going or stopped on a failure. A finished one lives on its
+        pull request, so it leaves the board as soon as it has something to show there."""
+        return [pull_request.get_summary() for pull_request in cls.list_open()]

--- a/backend/druks/contrib/review/extension.py
+++ b/backend/druks/contrib/review/extension.py
@@ -1,13 +1,10 @@
 from druks.agents import Agent
 from druks.contrib.review.contracts import ReviewReport
-from druks.contrib.review.schemas import ReviewSummary
 from druks.extensions import Extension
-from druks.workflows import Subject
 
 
 class Review(Extension):
     name = "review"
-    subject_type = "pull_request"
     icon = "git-pull-request"
     description = (
         "Reviews a pull request and posts the review back to GitHub — the decision, "
@@ -20,16 +17,3 @@ class Review(Extension):
         contract=ReviewReport,
         model="claude",
     )
-
-    @classmethod
-    def get_subject_summary(cls, subject: Subject) -> ReviewSummary | None:
-        # A pull request is a subject by identity alone: any id shaped like one names
-        # one, whether or not druks has reviewed it, and the timeline says which.
-        return ReviewSummary.from_subject(subject)
-
-    @classmethod
-    def list_subjects(cls) -> list[ReviewSummary]:
-        """The reviews still going or stopped on a failure. A finished one lives on its
-        pull request, so it leaves the board as soon as it has something to show there."""
-        summaries = (cls.get_subject_summary(s) for s in Subject.list_open(cls.subject_type))
-        return [summary for summary in summaries if summary]

--- a/backend/druks/contrib/review/schemas.py
+++ b/backend/druks/contrib/review/schemas.py
@@ -1,29 +1,9 @@
-from druks.workflows import Subject, SubjectSummary
+from druks.workflows import SubjectSummary
 
 
 class ReviewSummary(SubjectSummary):
-    # A pull request keeps no row, so its id is its whole record — "owner/repo#7"
-    # is where the review happened, and everything else on the row reads back out
-    # of it. Its status carries the lifecycle.
+    # The pull request's domain header — its handle, spelled out. Status (where the
+    # review stands) and the timeline come from the platform's subject read-side.
     repo: str
     pr_number: int
     pull_request_url: str
-
-    @classmethod
-    def from_subject(cls, subject: Subject) -> "ReviewSummary | None":
-        # Ids reach the read-side as free text off a URL, so a shape that names no
-        # pull request is a miss rather than a crashed row.
-        repo, _, number = subject.id.partition("#")
-        owner, _, name = repo.partition("/")
-        try:
-            pr_number = int(number)
-        except ValueError:
-            return
-        if owner and name and pr_number > 0:
-            return cls(
-                id=subject.id,
-                repo=repo,
-                pr_number=pr_number,
-                pull_request_url=f"https://github.com/{repo}/pull/{pr_number}",
-            )
-        return

--- a/backend/druks/contrib/review/workflows.py
+++ b/backend/druks/contrib/review/workflows.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 from druks.accounts.models import Account
+from druks.contrib.review.datastructures import PullRequest
 from druks.contrib.review.extension import Review
 from druks.contrib.ship.models import ProjectRepo
 from druks.contrib.ship.workspace import RepoWorkspace
@@ -8,7 +9,7 @@ from druks.core.apis.github import get_reviewer_github_client
 from druks.sandbox import repo as _repo
 from druks.sandbox.layout import get_github_token_remote_path, get_related_root, get_repo_root
 from druks.settings import load_settings
-from druks.workflows import Subject, Workflow
+from druks.workflows import Workflow
 
 if TYPE_CHECKING:
     from druks.sandbox.host import Sandbox
@@ -33,6 +34,7 @@ class PullRequestReview(Workflow):
     """Reviews one pull request against a checkout of the repo it targets and the
     repos around it; the reviewer reads, judges, and posts the review itself."""
 
+    subject = PullRequest
     workspace_class = ReviewWorkspace
 
     @classmethod
@@ -41,7 +43,7 @@ class PullRequestReview(Workflow):
         # review asked for by someone with no account runs as the system's.
         account = Account.get_for_username(requested_by)
         return await cls.start(
-            subject=Subject(id=f"{repo}#{pr_number}", subject_type=Review.subject_type),
+            subject=PullRequest.get(repo, pr_number),
             account_id=account.id if account else None,
             repo=repo,
             pr_number=pr_number,

--- a/backend/druks/contrib/ship/extension.py
+++ b/backend/druks/contrib/ship/extension.py
@@ -11,10 +11,9 @@ from druks.contrib.ship.contracts import (
     ReviewOutput,
     TriageOutput,
 )
-from druks.contrib.ship.models import WorkItem
-from druks.contrib.ship.schemas import WorkItemSummary
+from druks.db import StoredSubject
 from druks.extensions import Extension
-from druks.workflows import Subject, SubjectActivity
+from druks.workflows import SubjectActivity
 
 # Only what the timeline can't already show. A running agent has an agent call
 # to name it, so the phase that clears provisioning maps to nothing.
@@ -25,7 +24,6 @@ _PHASE_META: dict[str, SubjectActivity] = {
 
 class Ship(Extension):
     name = "ship"
-    subject_type = WorkItem.subject_type
     # These tables (projects, work_items, ...) are already unprefixed in core's
     # migration history, so they must stay that way.
     prefix_tables = False
@@ -126,19 +124,6 @@ class Ship(Extension):
     )
 
     @classmethod
-    def get_subject_summary(cls, subject: Subject) -> WorkItemSummary | None:
-        item = WorkItem.get_for_subject(subject)
-        if item:
-            return WorkItemSummary.from_work_item(item)
-        return
-
-    @classmethod
-    def list_subjects(cls) -> list[WorkItemSummary]:
-        # The active board: whatever hasn't handed off yet. The 500 most-recent
-        # cover it; paginate if a board outgrows it.
-        return [WorkItemSummary.from_work_item(item) for item in WorkItem.list_open(limit=500)]
-
-    @classmethod
-    async def get_subject_activity(cls, subject: Subject) -> SubjectActivity | None:
+    async def get_subject_activity(cls, subject: StoredSubject) -> SubjectActivity | None:
         phase = await subject.get_phase()
         return _PHASE_META.get(phase or "")

--- a/backend/druks/contrib/ship/models.py
+++ b/backend/druks/contrib/ship/models.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import ForeignKey, Index, func, select
 from sqlalchemy.dialects.postgresql import JSONB
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from druks.contrib.ship.enums import HandoffStatus
 from druks.contrib.ship.policy import RepoPolicy
+from druks.contrib.ship.schemas import WorkItemSummary
 from druks.core.apis.github import get_github_client
 from druks.db import Base, StoredSubject, db_session
 from druks.settings import load_settings
@@ -16,6 +17,9 @@ from druks.ticketing.enums import TicketStatus
 from druks.ticketing.exceptions import TrackerNotConfigured
 from druks.ticketing.helpers import get_tracker, is_tracker_source
 from druks.workflows import FatalError
+
+if TYPE_CHECKING:
+    from druks.durable.schemas import SubjectSummary
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +110,15 @@ class ProjectRepo(StoredSubject):
         # a repo reached through the wrong project's URL is a miss, not a hit to reject.
         stmt = select(cls).where(cls.id == repo_id, cls.project_id == project_id).limit(1)
         return db_session().scalars(stmt).first()
+
+    def get_label(self) -> str:
+        return self.full_name
+
+    @classmethod
+    def list_summaries(cls) -> list["SubjectSummary"]:
+        # A repo is registered, not transient, so the board is all of them by name.
+        stmt = select(cls).order_by(cls.full_name)
+        return [repo.get_summary() for repo in db_session().scalars(stmt)]
 
     def siblings(self) -> list["ProjectRepo"]:
         return [repo for repo in self.project.repos if repo.full_name != self.full_name]
@@ -215,6 +228,15 @@ class WorkItem(StoredSubject):
 
     def get_label(self) -> str:
         return self.ticket_key
+
+    def get_summary(self) -> WorkItemSummary:
+        return WorkItemSummary.from_work_item(self)
+
+    @classmethod
+    def list_summaries(cls) -> list[WorkItemSummary]:
+        # The active board: whatever hasn't handed off yet. The 500 most-recent
+        # cover it; paginate if a board outgrows it.
+        return [item.get_summary() for item in cls.list_open(limit=500)]
 
     @classmethod
     def create(

--- a/backend/druks/contrib/ship/schemas.py
+++ b/backend/druks/contrib/ship/schemas.py
@@ -1,13 +1,15 @@
 from datetime import datetime
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field
 
-from druks.contrib.ship.models import Project, ProjectRepo, WorkItem
 from druks.schemas import BaseResponse
 from druks.workflows import SubjectSummary
 
 from .enums import HandoffStatus
+
+if TYPE_CHECKING:
+    from druks.contrib.ship.models import Project, ProjectRepo, WorkItem
 
 ProfileState = Literal["unprofiled", "running", "ready", "failed"]
 
@@ -23,7 +25,7 @@ class ProjectRepoSummary(BaseResponse):
     created_at: datetime
 
     @classmethod
-    def from_repo(cls, repo: ProjectRepo) -> "ProjectRepoSummary":
+    def from_repo(cls, repo: "ProjectRepo") -> "ProjectRepoSummary":
         # "ready" outranks a later failed re-profile: a stored profile stays usable.
         status = repo.get_status()
         profile = repo.effective_profile()
@@ -54,7 +56,7 @@ class ProjectSummary(BaseResponse):
     repos: list[ProjectRepoSummary] = Field(default_factory=list)
 
     @classmethod
-    def from_project(cls, project: Project) -> "ProjectSummary":
+    def from_project(cls, project: "Project") -> "ProjectSummary":
         return cls(
             id=project.id,
             name=project.name,
@@ -92,7 +94,7 @@ class Links(BaseResponse):
     ticket: str | None = None
 
     @classmethod
-    def from_work_item(cls, item: WorkItem) -> "Links":
+    def from_work_item(cls, item: "WorkItem") -> "Links":
         pr = f"https://github.com/{item.repo}/pull/{item.pr_number}" if item.pr_number else None
         return cls(repo=f"https://github.com/{item.repo}", pr=pr, ticket=item.ticket_url)
 
@@ -117,9 +119,10 @@ class WorkItemSummary(SubjectSummary):
     links: Links
 
     @classmethod
-    def from_work_item(cls, item: WorkItem) -> "WorkItemSummary":
+    def from_work_item(cls, item: "WorkItem") -> "WorkItemSummary":
         return cls(
             id=str(item.id),
+            label=item.label,
             source=item.source,  # type: ignore[arg-type]
             repo=item.repo,
             project_name=item.project.name,
@@ -149,7 +152,7 @@ class DashboardItem(BaseResponse):
     links: Links
 
     @classmethod
-    def from_work_item(cls, item: WorkItem) -> "DashboardItem":
+    def from_work_item(cls, item: "WorkItem") -> "DashboardItem":
         # History is terminal-only, so the stored lane is always set.
         return cls(
             key=f"code:{item.id}",

--- a/backend/druks/contrib/ship/subscribers.py
+++ b/backend/druks/contrib/ship/subscribers.py
@@ -15,7 +15,7 @@ async def any_workflow_start_returns_item_to_board(*, subject: WorkItem, **_: ob
     subject.set_status(None)
 
 
-@subscribe("pr.opened", workflow=Build, subject=WorkItem)
+@subscribe("pr.opened", workflow=Build)
 async def pr_open_mirrors_onto_item(
     *, subject: WorkItem, pr_number: int, branch: str, **_: object
 ) -> None:
@@ -24,20 +24,20 @@ async def pr_open_mirrors_onto_item(
     subject.update(pr_number=pr_number, branch=branch)
 
 
-@subscribe(WorkflowEvent.RUNNING, workflow=Build, subject=WorkItem)
+@subscribe(WorkflowEvent.RUNNING, workflow=Build)
 async def build_start_marks_ticket_in_progress(*, subject: WorkItem, **_: object) -> None:
     # Every (re)start and gate-resume of a build means the ticket is in progress —
     # including the return from a rework loop that had parked it In Review.
     await subject.set_ticket_status(TicketStatus.IN_PROGRESS)
 
 
-@subscribe(WorkflowEvent.PARKED, workflow=Build, gate=ReviewWork, subject=WorkItem)
+@subscribe(WorkflowEvent.PARKED, workflow=Build, gate=ReviewWork)
 async def review_park_marks_ticket_in_review(*, subject: WorkItem, **_: object) -> None:
     await subject.set_ticket_status(TicketStatus.IN_REVIEW)
 
 
-@subscribe(WorkflowEvent.FAILED, workflow=Build, subject=WorkItem)
-@subscribe(WorkflowEvent.CANCELLED, workflow=Build, subject=WorkItem)
+@subscribe(WorkflowEvent.FAILED, workflow=Build)
+@subscribe(WorkflowEvent.CANCELLED, workflow=Build)
 async def build_end_settles_the_item(*, subject: WorkItem, **_: object) -> None:
     # Nothing merged, so the attempt was abandoned — unless the PR already spoke:
     # ship() cancels the run it just shipped, and that cancel arrives here.

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -66,6 +66,7 @@ class BuildWorkspace(RepoWorkspace):
 
 
 class Build(Workflow):
+    subject = WorkItem
     steps_reuse_sandbox = True
     workspace_class = BuildWorkspace
     journal_class = BuildJournal
@@ -406,6 +407,7 @@ class Profile(Workflow):
     re-applies the operator's pinned verification over the stored baseline, for
     the reaction to a .druks/ship/config.yml push."""
 
+    subject = ProjectRepo
     workspace_class = RepoWorkspace
 
     @classmethod

--- a/backend/druks/durable/datastructures.py
+++ b/backend/druks/durable/datastructures.py
@@ -1,5 +1,9 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar, Self
+
+from druks.durable.schemas import SubjectSummary
+from druks.models import snake_name
 
 if TYPE_CHECKING:
     from druks.durable.schemas import RunResponse, SubjectStatus
@@ -8,14 +12,22 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class Subject:
-    """What a run is about, as identity alone — a pull request, an issue, a
-    conversation. ``Subject(id="owner/repo#7", subject_type="pull_request")`` is
-    all a run, an event, or a read ever needs, and it shows itself as that id.
+    """What a run is about, as identity alone — a pull request, a conversation.
+    Subclass it: the class name is the subject type, so ``PullRequest`` is
+    ``pull_request``, and the id is the whole record — ``owner/repo#7`` is what a
+    run, an event, or a read is keyed by, and what the subject shows itself as.
     An extension that also keeps a row of its own subclasses ``StoredSubject``
     instead."""
 
+    subject_type: ClassVar[str]
+
     id: str
-    subject_type: str
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        # Explicit args: ``slots=True`` rebuilds this class, leaving a zero-arg
+        # ``super()`` bound to the one it replaced.
+        super(Subject, cls).__init_subclass__(**kwargs)
+        cls.subject_type = snake_name(cls.__name__)
 
     @property
     def identity(self) -> dict[str, Any]:
@@ -26,6 +38,26 @@ class Subject:
         # An identity-only subject is already named by its id — "owner/repo#7" is
         # the handle, not a surrogate key.
         return self.id
+
+    @classmethod
+    def get_for_subject_id(cls, subject_id: str) -> Self | None:
+        """The subject this id names. Ids reach the read side as free text off a URL,
+        so override to return None for a shape this subject could never wear."""
+        return cls(id=subject_id)
+
+    def get_summary(self) -> SubjectSummary:
+        """The header its board and page show it under. Its id and label already say
+        what it is; override to add the fields only this extension knows."""
+        return SubjectSummary(id=self.id, label=self.label)
+
+    @classmethod
+    def list_summaries(cls) -> Sequence[SubjectSummary]:
+        """The subjects on this class's board, newest-movement first, each as its domain
+        summary. Returns a covariant ``Sequence`` so an extension can return a ``list``
+        of its own ``SubjectSummary`` subclass. Required once a workflow declares it."""
+        raise NotImplementedError(
+            f"a workflow declares {cls.__name__}, so it needs a list_summaries()"
+        )
 
     def get_status(self, *, workflow: "type[Workflow] | None" = None) -> "SubjectStatus":
         """Where this subject stands: the state of the run driving it, narrowed to one
@@ -47,8 +79,8 @@ class Subject:
         return await get_subject_phase(self.subject_type, self.id)
 
     @classmethod
-    def list_open(cls, subject_type: str, *, limit: int = 50) -> list["Subject"]:
-        """The subjects of this type whose newest run hasn't handed off — still going,
+    def list_open(cls, *, limit: int = 50) -> list[Self]:
+        """The subjects of this class whose newest run hasn't handed off — still going,
         or failed and wanting the operator. What an extension's active view lists when
         the subject is identity alone; a subject with rows of its own lists them with
         ``StoredSubject.list_open``."""
@@ -56,5 +88,5 @@ class Subject:
         from druks.database import db_session
         from druks.durable.models import Run
 
-        open_ids = db_session().scalars(Run.open_subject_ids(subject_type).limit(limit))
-        return [cls(id=subject_id, subject_type=subject_type) for subject_id in open_ids]
+        open_ids = db_session().scalars(Run.open_subject_ids(cls.subject_type).limit(limit))
+        return [cls(id=subject_id) for subject_id in open_ids]

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field, SerializeAsAny
 
@@ -8,7 +8,9 @@ from druks.harnesses.artifacts import normalize_token_usage
 from druks.schemas import BaseResponse
 
 from .enums import RunState
-from .models import AgentCall, Artifact, Run
+
+if TYPE_CHECKING:
+    from .models import AgentCall, Artifact, Run
 
 
 class TokenUsage(BaseResponse):
@@ -47,7 +49,7 @@ class AgentCallResponse(BaseResponse):
     tokens: TokenUsage | None = None
 
     @classmethod
-    def from_call(cls, call: AgentCall) -> "AgentCallResponse":
+    def from_call(cls, call: "AgentCall") -> "AgentCallResponse":
         return cls(
             id=call.id,
             agent=call.agent,
@@ -93,7 +95,7 @@ class AgentCallFiles(BaseResponse):
     artifact: ArtifactDescriptor | None = None
 
     @classmethod
-    def from_call(cls, call: AgentCall, artifact: Artifact | None) -> "AgentCallFiles":
+    def from_call(cls, call: "AgentCall", artifact: "Artifact | None") -> "AgentCallFiles":
         layout = call.artifact_layout
 
         def named(path: Path) -> ArtifactFile | None:
@@ -142,8 +144,8 @@ class RunResponse(BaseResponse):
     @classmethod
     def from_run(
         cls,
-        run: Run,
-        calls: list[AgentCall],
+        run: "Run",
+        calls: list["AgentCall"],
         *,
         input_request: dict[str, Any] | None,
     ) -> "RunResponse":
@@ -163,9 +165,11 @@ class RunResponse(BaseResponse):
 
 
 class SubjectSummary(BaseResponse):
-    # The base an extension's subject header subclasses; ``id`` keys the subject's
-    # status, timeline, and detail URL, and the extension adds its own domain fields.
+    # Every subject's header: ``id`` keys its status, timeline and detail URL, and
+    # ``label`` is the one line it shows itself as — read live off the subject, unlike
+    # the copy an event snapshots. A subject with more to say subclasses this.
     id: str
+    label: str
 
 
 class SubjectStatus(BaseResponse):

--- a/backend/druks/extensions/base.py
+++ b/backend/druks/extensions/base.py
@@ -1,6 +1,6 @@
 import importlib.util
 import re
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from druks.agents import Agent
     from druks.doctor import CheckResult
     from druks.durable.datastructures import Subject
-    from druks.durable.schemas import SubjectActivity, SubjectSummary
+    from druks.durable.schemas import SubjectActivity
     from druks.settings import Settings
     from druks.workflows import Workflow
 
@@ -85,11 +85,6 @@ class Extension:
     # belong to the extension itself rather than one of its workflows. Mirrors a
     # workflow's ``Settings``.
     settings_model: ClassVar[type[BaseModel] | None] = None
-    # What this extension's runs are about ("work_item", "pull_request"). Declaring
-    # it mounts the generic subject read-side; None means the extension has none.
-    # An extension that also keeps a row for its subject spells this
-    # ``WorkItem.subject_type`` rather than repeating the literal.
-    subject_type: ClassVar[str | None] = None
     # The checks this extension contributes to ``druks doctor`` — one per precondition
     # it owns (its API key set, its webhook secret present, its provider reachable).
     # ``druks doctor`` runs each through the same ``CheckResult`` report as its core
@@ -107,10 +102,11 @@ class Extension:
                 f"extension name {name!r} must match {NAME_RE.pattern!r} — it keys the "
                 "/api/<name> namespace, the version table, and settings keys"
             )
-        if cls.subject_type == "transcripts":
+        if "subject_type" in cls.__dict__:
             raise TypeError(
-                f"extension {name!r} declares a 'transcripts' subject; that segment "
-                "serves every extension's agent-call reads. Name the subject for what it is"
+                f"{cls.__name__} declares subject_type — a workflow declares what its runs "
+                "are about (``subject = YourSubject``), and an extension's subjects follow "
+                "from its workflows"
             )
         cls.table_prefix = f"{name}_"
         if "package" not in cls.__dict__:
@@ -156,6 +152,20 @@ class Extension:
         """The workflows living in this extension's package."""
         prefix = cls.package + "."
         return [wf for wf in workflow_registry.all() if wf.__module__.startswith(prefix)]
+
+    @classmethod
+    def subject_classes(cls) -> "list[type[Subject] | type[StoredSubject]]":
+        """What this extension's runs are about, read off the workflows that declare
+        them — each one gets a board and a page, ordered by subject type so the routes
+        it mounts are stable."""
+        declared = {wf._subject_class for wf in cls.workflows() if wf._subject_class}
+        for subject_class in declared:
+            if subject_class.subject_type == "transcripts":
+                raise TypeError(
+                    f"{subject_class.__name__} is a 'transcripts' subject; that segment "
+                    "serves every extension's agent-call reads. Name it for what it is"
+                )
+        return sorted(declared, key=lambda subject_class: subject_class.subject_type)
 
     @classmethod
     def discover(cls) -> list[ModuleType]:
@@ -252,9 +262,9 @@ class Extension:
     def get_routers(cls, modules: list[ModuleType]) -> "list[APIRouter]":
         """Every router mounted under the extension's namespace: the ones it declares in
         its ``routes`` modules, plus the generic read-side it gets for free —
-        ``/transcripts`` always, and the subject read-side
-        (``/<subject_type>`` → status + timeline + live stream) when it declares a
-        ``subject_type``. The platform's come first: those two segments are its own.
+        ``/transcripts`` always, and one subject read-side
+        (``/<subject_type>`` → status + timeline + live stream) per subject its
+        workflows declare. The platform's come first: those segments are its own.
         Override to add a router built outside a ``routes`` module."""
         # Local, not module-top: keeps FastAPI off the import graph so the loader
         # stays importable app-lessly; enumerating routers is where it's really needed.
@@ -272,10 +282,11 @@ class Extension:
         # The platform's routers are narrow — each confined to its own segment — so
         # matching them first costs an extension nothing anywhere else and leaves it
         # no way to take a read the platform serves, not even with a catch-all.
-        platform = [cls._get_transcript_routes()]
-        if cls.subject_type:
-            platform.append(cls._get_subject_routes(cls.subject_type))
-        return [*platform, *declared]
+        return [
+            cls._get_transcript_routes(),
+            *(cls._get_subject_routes(subject) for subject in cls.subject_classes()),
+            *declared,
+        ]
 
     @classmethod
     def _get_transcript_routes(cls) -> "APIRouter":
@@ -372,11 +383,13 @@ class Extension:
         return router
 
     @classmethod
-    def _get_subject_routes(cls, subject_type: str) -> "APIRouter":
+    def _get_subject_routes(
+        cls, subject_class: "type[Subject] | type[StoredSubject]"
+    ) -> "APIRouter":
         """The board and one subject (header + status + timeline + activity), each with a
         point-in-time read and a ``/stream`` that pushes the whole snapshot on change.
-        Mounted at ``/api/<name>/<subject_type>`` once the extension declares
-        ``subject_type``. Every read here is keyed by identity, so an extension that
+        Mounted at ``/api/<name>/<subject_type>`` for every subject the extension's
+        workflows declare. Every read here is keyed by identity, so an extension that
         keeps no row for its subject gets the same surface as one that does."""
         from fastapi import APIRouter, HTTPException, status
         from fastapi.responses import StreamingResponse
@@ -384,10 +397,10 @@ class Extension:
         from druks.api.dependencies import EngineDep
         from druks.database import session_scope
         from druks.durable import reads
-        from druks.durable.datastructures import Subject
         from druks.durable.live import SSE_HEADERS, stream
         from druks.durable.schemas import SubjectList, SubjectResponse, SubjectRow
 
+        subject_type = subject_class.subject_type
         router = APIRouter(prefix=f"/{subject_type}", tags=[f"{cls.name}:{subject_type}"])
 
         def board() -> SubjectList:
@@ -395,20 +408,21 @@ class Extension:
                 rows=[
                     SubjectRow(
                         summary=summary,
-                        status=Subject(id=summary.id, subject_type=subject_type).get_status(),
+                        status=reads.get_subject_status(subject_type, summary.id),
                     )
-                    for summary in cls.list_subjects()
+                    for summary in subject_class.list_summaries()
                 ]
             )
 
         async def subject_response(subject_id: str) -> SubjectResponse | None:
-            subject = Subject(id=subject_id, subject_type=subject_type)
-            summary = cls.get_subject_summary(subject)
-            if not summary:
+            subject = subject_class.get_for_subject_id(subject_id)
+            if subject is None:
                 return
-            activity = await cls.get_subject_activity(subject)
             return reads.get_subject_response(
-                subject_type, subject_id, summary=summary, activity=activity
+                subject_type,
+                subject_id,
+                summary=subject.get_summary(),
+                activity=await cls.get_subject_activity(subject),
             )
 
         @router.get("", response_model=SubjectList, response_model_by_alias=True)
@@ -478,24 +492,9 @@ class Extension:
         )
 
     @classmethod
-    def get_subject_summary(cls, subject: "Subject") -> "SubjectSummary | None":
-        """This extension's domain header for one subject — its own fields only; the
-        read-side composes it with the platform's generic status + timeline. None when
-        the identity names nothing, which is how a subject id off a URL 404s. Required
-        once ``subject_type`` is set."""
-        raise NotImplementedError(
-            f"extension {cls.name!r} sets subject_type but no get_subject_summary"
-        )
-
-    @classmethod
-    def list_subjects(cls) -> "Sequence[SubjectSummary]":
-        """This extension's subjects, newest-movement first, each as its domain summary.
-        Returns a covariant ``Sequence`` so an extension can return ``list`` of its own
-        ``SubjectSummary`` subclass. Required once ``subject_type`` is set."""
-        raise NotImplementedError(f"extension {cls.name!r} sets subject_type but no list_subjects")
-
-    @classmethod
-    async def get_subject_activity(cls, subject: "Subject") -> "SubjectActivity | None":
+    async def get_subject_activity(
+        cls, subject: "Subject | StoredSubject"
+    ) -> "SubjectActivity | None":
         """The subject's live sub-phase, if any (e.g. "Building sandbox VM…"). Optional —
         override to surface a transient signal the running run pushes."""
         return

--- a/backend/druks/models.py
+++ b/backend/druks/models.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, ClassVar, Self
 
@@ -9,8 +10,7 @@ from sqlalchemy.types import TypeDecorator
 from druks.core.utils.time import ensure_utc
 
 if TYPE_CHECKING:
-    from druks.durable.datastructures import Subject
-    from druks.durable.schemas import RunResponse, SubjectStatus
+    from druks.durable.schemas import RunResponse, SubjectStatus, SubjectSummary
     from druks.workflows import Workflow
 
 _CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
@@ -73,34 +73,51 @@ class StoredSubject(Base):
     def label(self) -> str:
         return self.get_label()
 
-    @property
-    def subject(self) -> "Subject":
-        """This row's identity — what a run, an event, or a read is keyed by."""
-        from druks.durable.datastructures import Subject
-
-        return Subject(id=str(self.id), subject_type=self.subject_type)
-
     @classmethod
-    def get_for_subject(cls, subject: "Subject") -> Self | None:
-        """The row this identity names. A subject id is free text and reaches the
+    def get_for_subject_id(cls, subject_id: str) -> Self | None:
+        """The row this subject id names. A subject id is free text and reaches the
         read-side straight off a URL, so an id this table could never hold is a miss
         rather than an error."""
         from druks.database import db_session
 
         try:
-            key = int(subject.id)
+            key = int(subject_id)
         except ValueError:
             return
         return db_session().get(cls, key)
 
+    def get_summary(self) -> "SubjectSummary":
+        """The header its board and page show it under. Its id and label already say
+        what it is; override to add the fields only this extension knows."""
+        # ``druks.durable`` imports the ORM models this module defines the base for,
+        # so nothing under it can be imported here at module scope.
+        from druks.durable.schemas import SubjectSummary
+
+        return SubjectSummary(id=str(self.id), label=self.label)
+
+    @classmethod
+    def list_summaries(cls) -> "Sequence[SubjectSummary]":
+        """The rows on this class's board, newest-movement first, each as its domain
+        summary. Returns a covariant ``Sequence`` so an extension can return a ``list``
+        of its own ``SubjectSummary`` subclass. Required once a workflow declares it."""
+        raise NotImplementedError(
+            f"a workflow declares {cls.__name__}, so it needs a list_summaries()"
+        )
+
     def get_status(self, *, workflow: "type[Workflow] | None" = None) -> "SubjectStatus":
-        return self.subject.get_status(workflow=workflow)
+        from druks.durable.reads import get_subject_status
+
+        return get_subject_status(self.subject_type, str(self.id), workflow=workflow)
 
     def get_timeline(self) -> "list[RunResponse]":
-        return self.subject.get_timeline()
+        from druks.durable.reads import list_subject_timeline
+
+        return list_subject_timeline(self.subject_type, str(self.id))
 
     async def get_phase(self) -> str | None:
-        return await self.subject.get_phase()
+        from druks.durable.reads import get_subject_phase
+
+        return await get_subject_phase(self.subject_type, str(self.id))
 
     @classmethod
     def list_open(cls, *, limit: int = 50) -> list[Self]:

--- a/backend/druks/scaffolding/extension_template/package/models.py-tpl
+++ b/backend/druks/scaffolding/extension_template/package/models.py-tpl
@@ -4,7 +4,7 @@ from druks.db import Base, StoredSubject
 # start with "{{ name }}_": the platform scopes this extension's migrations to that
 # prefix (its own history in ``alembic_version_{{ name }}``) and enforces it at boot.
 # One of these models is usually the thing your runs work on — a note, a repo, a
-# ticket. Subclass ``StoredSubject`` for that one, and set
-# ``subject_type = ThatModel.subject_type`` on the Extension so druks can show it a
-# board and a page.
+# ticket. Subclass ``StoredSubject`` for that one and point a workflow at it with
+# ``subject = ThatModel``, and druks shows it a board and a page. Something you keep no
+# row for subclasses ``druks.workflows.Subject`` instead — same board, same page.
 # After adding a model: ``druks makemigrations {{ name }} -m "..." && druks init-db``.

--- a/backend/druks/scaffolding/extension_template/package/subscribers.py-tpl
+++ b/backend/druks/scaffolding/extension_template/package/subscribers.py-tpl
@@ -3,7 +3,8 @@ from druks.workflows import WorkflowEvent  # noqa: F401
 
 # React to platform signals with declarative filters (equality against the published
 # kwargs; ``__`` descends into dicts). Defining a handler registers it — no body guards.
-# Filtering by ``subject=`` hands the body that row.
+# Filtering by ``subject=`` hands the body that subject; ``workflow=`` does too, through
+# the subject that workflow declares.
 #
 # @subscribe(WorkflowEvent.FINISHED, subject=YourSubject)
 # async def on_finished(*, subject: YourSubject, **_: object) -> None:

--- a/backend/druks/scaffolding/extension_template/package/workflows.py-tpl
+++ b/backend/druks/scaffolding/extension_template/package/workflows.py-tpl
@@ -1,4 +1,4 @@
-from druks.workflows import FatalError, Gate, Subject, Workflow, step  # noqa: F401
+from druks.workflows import FatalError, Gate, Workflow, step  # noqa: F401
 
 # Durable workflows. Subclass ``Workflow`` and implement exactly one of:
 #   async def run(self, ...)            — a single durable operation
@@ -7,8 +7,11 @@ from druks.workflows import FatalError, Gate, Subject, Workflow, step  # noqa: F
 # Set ``every = "<cron>"`` to schedule one; raise ``FatalError`` for a clean domain
 # stop; a ``Gate`` subclass parks the run for human input.
 #
-# Callers launch with ``cls.start(subject=..., **input)`` — a ``Subject(type, id)``, a
-# ``StoredSubject`` row, or None for a background run.
+# Declare what a workflow's runs are about with ``subject = YourSubject`` — the class,
+# with a table or without — and druks gives that subject a board and a page.
+#
+# Callers launch with ``cls.start(subject=..., **input)``: an instance of that class,
+# or None for a workflow that declares no subject.
 # Only if a workflow grows launch policy (dedupe, routing, subject lookup) wrap
 # start() in a ``dispatch()`` classmethod and point callers there instead.
 

--- a/backend/druks/signals.py
+++ b/backend/druks/signals.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from blinker import signal
 
-from druks.database import db_session
 from druks.extensions.exceptions import SubscriberDeclarationError
 
 __all__ = ["subscribe"]
@@ -21,12 +20,15 @@ def subscribe(name: str, **filters: Any) -> Callable[[Subscriber], Subscriber]:
 
     ``filters`` are equality matches against the published kwargs; ``__``
     descends into dicts (``payload__terminal=True``); a ``Gate`` class stands for
-    its ``name``. ``workflow=Build`` narrows to that workflow and
-    ``subject=WorkItem`` to that subject, handing the body its row. A non-matching
-    publication skips the subscriber, so the body starts at the real work."""
+    its ``name``. ``workflow=Build`` narrows to that workflow and to the subject
+    that workflow declares, handing the body that subject; ``subject=WorkItem``
+    on its own narrows to any workflow about one. A non-matching publication
+    skips the subscriber, so the body starts at the real work."""
 
     def register(fn: Subscriber) -> Subscriber:
         # Lazy import: druks.workflows imports this module.
+        from druks.durable.datastructures import Subject
+        from druks.models import StoredSubject
         from druks.workflows import Gate
 
         if asked_for_routing := sorted(_ROUTING & set(inspect.signature(fn).parameters)):
@@ -36,10 +38,24 @@ def subscribe(name: str, **filters: Any) -> Callable[[Subscriber], Subscriber]:
                 "the facts you react to."
             )
         workflow_class = filters.pop("workflow", None)
+        subject_class = filters.pop("subject", None)
+        if workflow_class and subject_class:
+            raise SubscriberDeclarationError(
+                f"{fn.__name__}() names both workflow= and subject= — "
+                f"{workflow_class.__name__} already declares what its runs are about."
+            )
         if workflow_class:
             filters["kind"] = workflow_class.kind
-        subject_class = filters.pop("subject", None)
+            subject_class = workflow_class._subject_class
         if subject_class:
+            if not (
+                isinstance(subject_class, type)
+                and issubclass(subject_class, Subject | StoredSubject)
+            ):
+                raise SubscriberDeclarationError(
+                    f"{fn.__name__}() filters on subject={subject_class!r}, which is not a "
+                    "Subject or StoredSubject subclass."
+                )
             filters["subject__type"] = subject_class.subject_type
         matches = {}
         for lookup, expected in filters.items():
@@ -56,10 +72,10 @@ def subscribe(name: str, **filters: Any) -> Callable[[Subscriber], Subscriber]:
                     return
             delivered = {key: value for key, value in published.items() if key not in _ROUTING}
             if subject_class:
-                row = db_session().get(subject_class, int(published["subject"]["id"]))
-                if not row:
+                subject = subject_class.get_for_subject_id(str(published["subject"]["id"]))
+                if subject is None:
                     return
-                delivered["subject"] = row
+                delivered["subject"] = subject
             await fn(**delivered)
 
         # weak=False: ``receiver`` is a local closure nothing else references, so a

--- a/backend/druks/testing.py
+++ b/backend/druks/testing.py
@@ -24,6 +24,7 @@ import druks.user_settings.models  # noqa: F401
 from druks.bootstrap import seed
 from druks.database import _session_factory, configure_session, create_engine_from_url, db_session
 from druks.durable import AgentCall, Run
+from druks.durable.datastructures import Subject
 from druks.durable.dbos_state import DBOS_SYSTEM_SCHEMA, workflow_status
 from druks.durable.engine import _dbos_database_url, configure_engine
 from druks.extensions.loader import import_extension_models, iter_extensions
@@ -264,11 +265,14 @@ def druks_without_remote_config(monkeypatch) -> None:
     monkeypatch.setattr("druks.extensions.config.fetch_file", _missing)
 
 
-async def run_workflow(workflow_class, *, subject: StoredSubject | None = None, **input) -> object:
+async def run_workflow(
+    workflow_class, *, subject: "Subject | StoredSubject | None" = None, **input
+) -> object:
     """Run a workflow's body against ``subject`` and return its result, without a
     durable engine — no checkpoints, no lifecycle events, no retries. Only the
     single-operation ``run()`` shape: a ``run_multistep`` body checkpoints each
     ``@step`` through the engine, which isn't here."""
+    workflow_class._validate_subject(subject)
     if workflow_class._body_method != "run":
         raise WorkflowError(
             f"{workflow_class.__name__} orchestrates steps, and every @step checkpoints "
@@ -291,7 +295,7 @@ def seed_run(
     session: Session,
     *,
     kind: str,
-    subject: StoredSubject | None = None,
+    subject: Subject | StoredSubject | None = None,
     state: str = "running",
     run_id: str | None = None,
     input_gate: str | None = None,

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -18,7 +18,6 @@ from pydantic import BaseModel, Field, create_model
 from uuid_utils import uuid7
 
 from druks.accounts.context import current_account_id
-from druks.database import db_session
 from druks.durable.activity import set_run_phase
 from druks.durable.datastructures import Subject
 from druks.durable.engine import _step_engine, register_schedule, run_queue, step_session
@@ -40,7 +39,7 @@ from druks.extensions.settings import (
     validate_setting_override,
     validate_settings_declaration,
 )
-from druks.models import Base, StoredSubject, snake_name
+from druks.models import StoredSubject, snake_name
 from druks.notifications.outbox import notifications_queue, send_notification
 from druks.sandbox.client import sandbox_client
 from druks.sandbox.constants import SANDBOX_HOST_ROTATE_BEFORE_SECONDS
@@ -133,6 +132,22 @@ def _resolve_body_method(cls: type["Workflow"]) -> str:
     )
 
 
+def _resolve_subject_class(cls: type["Workflow"]) -> "type[Subject] | type[StoredSubject] | None":
+    # The declaration and the run's live subject are the same word, so the class
+    # attribute comes off and the property answers in its place.
+    if "subject" not in cls.__dict__:
+        return cls._subject_class
+    declared = cls.__dict__["subject"]
+    if not (isinstance(declared, type) and issubclass(declared, Subject | StoredSubject)):
+        raise WorkflowError(
+            f"{cls.__name__}.subject must be a Subject or StoredSubject subclass — a run "
+            f"is about a kind of thing, not {declared!r}. A workflow about nothing "
+            "declares no subject at all."
+        )
+    del cls.subject
+    return declared
+
+
 def _input_model_from_signature(cls: type["Workflow"]) -> type[BaseModel] | None:
     # A workflow's input IS its body's signature: plain annotated parameters,
     # Python's native way to declare inputs. The SDK synthesizes a pydantic
@@ -217,6 +232,11 @@ class Gate(BaseModel):
 
     @classmethod
     async def answer(cls, subject: Subject | StoredSubject, **reply: Any) -> None:
+        if not isinstance(subject, Subject | StoredSubject):
+            raise WorkflowError(
+                f"{cls.__name__}.answer() takes the subject whose run is parked on it, "
+                f"not {type(subject).__name__}"
+            )
         runs = Run.list_for_subject(subject.subject_type, str(subject.id))
         parked = next((run for run in runs if run.is_parked and run.input_gate == cls.name), None)
         if parked:
@@ -463,6 +483,10 @@ class Workflow:
     # the loader's package registrations at definition time and namespacing
     # ``kind``. Never supplied or stored per run.
     extension: ClassVar[str | None] = None
+    # The subject class this workflow's runs are about, written ``subject = WorkItem``
+    # on the subclass and lifted off it in __init_subclass__ so the instance property
+    # below keeps the name. None for a workflow about nothing, which says so by silence.
+    _subject_class: ClassVar[type[Subject] | type[StoredSubject] | None] = None
     # When set to a cron string, the workflow also registers a schedule that
     # fires its run() on that cadence (no subject — a framework cron).
     every: ClassVar[str | None] = None
@@ -508,6 +532,7 @@ class Workflow:
                 "the declaring extension supplies the namespace"
             )
         cls.kind = f"{cls.extension}.{local_kind}" if cls.extension else local_kind
+        cls._subject_class = _resolve_subject_class(cls)
         validate_settings_declaration(cls.Settings)
         cls._body_method = _resolve_body_method(cls)
         # Before _wrap_steps: run()'s wrapper signature is (*args, **kwargs).
@@ -542,14 +567,11 @@ class Workflow:
 
     @property
     def subject(self) -> Any:
+        # Live, not a snapshot taken at dispatch: a long-parked run resumes against
+        # whatever the declared class says then, and finds nothing if it went away.
         if not self._subject:
             return
-        subject_type, subject_id = self._subject["type"], self._subject["id"]
-        for mapper in Base.registry.mappers:
-            model = mapper.class_
-            if issubclass(model, StoredSubject) and model.subject_type == subject_type:
-                return db_session().get(model, int(subject_id))
-        raise LookupError(f"no subject class is named {subject_type!r}")
+        return self._subject_class.get_for_subject_id(str(self._subject["id"]))
 
     async def announce(self, topic: str, **facts: Any) -> None:
         # The workflow announcing a domain event in its extension's vocabulary
@@ -678,7 +700,26 @@ class Workflow:
         SettingsOverride.set_workflow_setting(cls.kind, field, value)
 
     @classmethod
+    def _validate_subject(cls, subject: "Subject | StoredSubject | None") -> None:
+        # The declaration is the contract — subscribers derive their subject class
+        # from ``workflow=``, so it has to hold for every run.
+        if cls._subject_class:
+            if isinstance(subject, cls._subject_class):
+                return
+            given = "nothing" if subject is None else type(subject).__name__
+            raise WorkflowError(
+                f"{cls.__name__} is about {cls._subject_class.__name__}, not {given}"
+            )
+        if subject is None:
+            return
+        raise WorkflowError(
+            f"{cls.__name__} declares no subject — declare "
+            f"``subject = {type(subject).__name__}`` on it, or pass subject=None"
+        )
+
+    @classmethod
     async def cancel(cls, subject: Subject | StoredSubject, *, failure: str | None = None) -> None:
+        cls._validate_subject(subject)
         runs = Run.list_for_subject(subject.subject_type, str(subject.id), kind=cls.kind)
         run = next((run for run in runs if run.is_active), None)
         if run:
@@ -702,6 +743,7 @@ class Workflow:
         # fails at start, not inside the run.
         # subject is required (no default) so a run can't silently lose its
         # timeline by omission — pass subject=None explicitly for a background run.
+        cls._validate_subject(subject)
         if not account_id:
             # Browser-origin starts inherit the request's authenticated account;
             # dispatchers that know better pass account_id explicitly.

--- a/backend/tests/druks-field_notes/druks_field_notes/extension.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/extension.py
@@ -4,12 +4,9 @@ from typing import TYPE_CHECKING, Literal
 from druks.agents import Agent
 from druks.doctor import CheckResult
 from druks.extensions import Extension
-from druks.workflows import Subject
 from pydantic import BaseModel, Field, SecretStr, field_validator
 
 from druks_field_notes.contracts import NoteSummary
-from druks_field_notes.models import Note
-from druks_field_notes.schemas import NoteView
 
 if TYPE_CHECKING:
     from druks.settings import Settings
@@ -35,7 +32,6 @@ def check_summary_api_key(settings: "Settings") -> CheckResult:
 
 class FieldNotes(Extension):
     name = "field_notes"
-    subject_type = Note.subject_type
     icon = "notebook"
     description = "Turns a jotted observation into a one-line summary with an agent."
 
@@ -82,18 +78,6 @@ class FieldNotes(Extension):
         contract=NoteSummary,
         model="claude",
     )
-
-    @classmethod
-    def get_subject_summary(cls, subject: Subject) -> NoteView | None:
-        note = Note.get_for_subject(subject)
-        if note:
-            return NoteView.from_note(note)
-        return
-
-    @classmethod
-    def list_subjects(cls) -> list[NoteView]:
-        notes = Note.list_recent(limit=cls.settings().board_size)
-        return [NoteView.from_note(note) for note in notes]
 
     # The extension's own precondition, reported by `druks doctor` beside the
     # platform's: the summarizer's API key must be set.

--- a/backend/tests/druks-field_notes/druks_field_notes/models.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/models.py
@@ -4,6 +4,8 @@ from druks.db import StoredSubject, db_session
 from sqlalchemy import select
 from sqlalchemy.orm import Mapped, mapped_column
 
+from druks_field_notes.schemas import NoteSummary
+
 
 class Note(StoredSubject):
     __tablename__ = "field_notes_notes"
@@ -36,3 +38,14 @@ class Note(StoredSubject):
     def save_summary(self, summary: str) -> None:
         self.summary = summary
         db_session().flush()
+
+    def get_summary(self) -> NoteSummary:
+        return NoteSummary.from_note(self)
+
+    @classmethod
+    def list_summaries(cls) -> list[NoteSummary]:
+        # How many the board shows is an operator knob, so it lives on the extension.
+        from druks_field_notes.extension import FieldNotes
+
+        notes = cls.list_recent(limit=FieldNotes.settings().board_size)
+        return [note.get_summary() for note in notes]

--- a/backend/tests/druks-field_notes/druks_field_notes/routes.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/routes.py
@@ -3,16 +3,16 @@ from typing import Annotated
 from fastapi import APIRouter, Body, status
 
 from druks_field_notes.models import Note
-from druks_field_notes.schemas import NoteView
+from druks_field_notes.schemas import NoteSummary
 from druks_field_notes.workflows import Summarize
 
 # Every APIRouter declared here mounts under /api/field_notes.
 router = APIRouter(prefix="/notes")
 
 
-@router.get("", response_model=list[NoteView], response_model_by_alias=True)
-async def list_notes() -> list[NoteView]:
-    return [NoteView.from_note(note) for note in Note.list_recent()]
+@router.get("", response_model=list[NoteSummary], response_model_by_alias=True)
+async def list_notes() -> list[NoteSummary]:
+    return [NoteSummary.from_note(note) for note in Note.list_recent()]
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)

--- a/backend/tests/druks-field_notes/druks_field_notes/schemas.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/schemas.py
@@ -1,21 +1,24 @@
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from druks.workflows import SubjectSummary
 
-from druks_field_notes.models import Note
+if TYPE_CHECKING:
+    from druks_field_notes.models import Note
 
 
-class NoteView(SubjectSummary):
+class NoteSummary(SubjectSummary):
     # The note's domain header — what only field_notes knows. The platform's subject
-    # read-side composes it with the generic status + timeline; ``id`` is the subject key.
+    # read-side composes it with the generic status + timeline.
     body: str
     summary: str | None = None
     created_at: datetime
 
     @classmethod
-    def from_note(cls, note: Note) -> "NoteView":
+    def from_note(cls, note: "Note") -> "NoteSummary":
         return cls(
             id=str(note.id),
+            label=note.label,
             body=note.body,
             summary=note.summary,
             created_at=note.created_at,

--- a/backend/tests/druks-field_notes/druks_field_notes/subscribers.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/subscribers.py
@@ -6,7 +6,7 @@ from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
 
 
-@subscribe(WorkflowEvent.FINISHED, workflow=Summarize, subject=Note)
+@subscribe(WorkflowEvent.FINISHED, workflow=Summarize)
 async def note_summarized(*, subject: Note, **_: object) -> None:
     # A finished summarize is a milestone worth its own feed row. The workflow
     # lifecycle is the trigger; the extension only reacts.

--- a/backend/tests/druks-field_notes/druks_field_notes/workflows.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/workflows.py
@@ -8,6 +8,8 @@ class Summarize(Workflow):
     """Reads one note and writes its summary — a single durable operation: the
     agent produces the summary prose, and the run stores it on the note."""
 
+    subject = Note
+
     async def run(self) -> None:
         note = self.subject
         # The note body is the agent's prompt context; the summary it returns is the

--- a/backend/tests/druks-field_notes/tests/test_extension.py
+++ b/backend/tests/druks-field_notes/tests/test_extension.py
@@ -4,15 +4,15 @@ from druks_field_notes.models import Note
 from pydantic import ValidationError
 
 
-def test_list_subjects_honors_the_board_size(druks_db):
+def test_the_board_honors_the_board_size(druks_db):
     Note.create(body="first")
     newest = Note.create(body="second")
     FieldNotes.override_setting("board_size", 1)
 
-    subjects = FieldNotes.list_subjects()
+    summaries = Note.list_summaries()
 
-    assert [subject.id for subject in subjects] == [str(newest.id)]
-    assert subjects[0].body == "second"
+    assert [summary.id for summary in summaries] == [str(newest.id)]
+    assert summaries[0].body == "second"
 
 
 def test_settings_validate_the_sync_token():

--- a/backend/tests/ship/test_api_work_items.py
+++ b/backend/tests/ship/test_api_work_items.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import pytest
 from druks.contrib.ship.models import WorkItem
 from druks.testing import seed_call
-from druks.workflows import Subject
 from fastapi.testclient import TestClient
 
 from ship.factories import make_test_work_item, seed_build_run
@@ -62,8 +61,8 @@ def _ship(repo, pr_number):
         item.set_status("shipped")
 
 
-# The generic subject read-side — Ship declares subject=WorkItem, so the
-# platform mounts /api/ship/work_item (list) and /{id} (detail). Ship supplies
+# The generic subject read-side — Build declares subject = WorkItem, so the
+# platform mounts /api/ship/work_item (list) and /{id} (detail). WorkItem supplies
 # only the domain summary; status (RunState-aggregated) and the timeline are the
 # platform's. See test_generic_subjects.py for the platform-side contract.
 
@@ -148,10 +147,10 @@ def test_pending_gate_surfaces_input_request_on_the_run(druks_db):
 def test_detail_surfaces_running_run_before_its_first_call(druks_db):
     """The detail timeline surfaces a run that is running before its first agent
     call exists — the sandbox spin-up window the operator needs to see."""
-    work_item_id = make_test_work_item(repo="ClawHaven/acme-app", title="x").id
-    seed_build_run(druks_db, work_item_id=work_item_id, state="running")
+    item = make_test_work_item(repo="ClawHaven/acme-app", title="x")
+    seed_build_run(druks_db, work_item_id=item.id, state="running")
 
-    (entry,) = Subject(id=str(work_item_id), subject_type="work_item").get_timeline()
+    (entry,) = item.get_timeline()
     assert entry.state == "running"
     assert entry.agent_calls == []  # surfaces even with no call yet
 
@@ -260,7 +259,7 @@ async def test_subject_activity_surfaces_running_phase(druks_db, monkeypatch):
         return "provisioning_vm"
 
     monkeypatch.setattr("druks.durable.reads.get_run_phase", phase)
-    activity = await ship_extension.Ship.get_subject_activity(item.subject)
+    activity = await ship_extension.Ship.get_subject_activity(item)
     assert activity is not None
     assert activity.label == "Building sandbox VM…"
     assert activity.kind == "infra"
@@ -273,4 +272,4 @@ async def test_subject_activity_none_when_not_running(druks_db):
     item = make_test_work_item(repo="ClawHaven/acme-app", title="x")
     seed_build_run(druks_db, work_item_id=item.id, state="parked", input_gate="review_plan")
 
-    assert await ship_extension.Ship.get_subject_activity(item.subject) is None
+    assert await ship_extension.Ship.get_subject_activity(item) is None

--- a/backend/tests/ship/test_build_board_membership.py
+++ b/backend/tests/ship/test_build_board_membership.py
@@ -1,7 +1,6 @@
 import druks.contrib.ship.workflows  # noqa: F401  # registers ship.build, the seeded kind
 import pytest
 from druks.contrib.ship.enums import HandoffStatus
-from druks.contrib.ship.extension import Ship
 from druks.contrib.ship.models import WorkItem
 
 from ship.factories import make_test_work_item, seed_build_run
@@ -9,7 +8,7 @@ from ship.factories import make_test_work_item, seed_build_run
 
 def _board_ids(druks_db):
     druks_db.expire_all()
-    return {row.id for row in Ship.list_subjects()}
+    return {row.id for row in WorkItem.list_summaries()}
 
 
 @pytest.mark.parametrize("state", ["scheduled", "running", "parked", "failed"])

--- a/backend/tests/ship/test_project_repo_routes.py
+++ b/backend/tests/ship/test_project_repo_routes.py
@@ -92,3 +92,23 @@ def test_nested_repo_routes_are_scoped_to_their_project(client: TestClient, monk
     assert patched.json()["purpose"] == "infra"
     assert client.delete(right).status_code == 204
     assert ProjectRepo.get(repo_id) is None
+
+
+def test_the_repo_subject_read_side_mounts(client: TestClient, druks_db):
+    """Profile is about a repo, so the repo gets the board and the page it never had —
+    its own runs' status and timeline, keyed by the repo's id."""
+    from druks.contrib.ship.models import Project, ProjectRepo
+    from druks.contrib.ship.workflows import Profile
+    from druks.testing import seed_run
+
+    project = Project.create(name="Acme")
+    repo = ProjectRepo.create(project_id=project.id, full_name="acme/widget")
+    seed_run(druks_db, kind=Profile.kind, subject=repo, state="running")
+
+    (row,) = client.get("/api/ship/project_repo").json()["rows"]
+    assert row["summary"] == {"id": str(repo.id), "label": "acme/widget"}
+    assert row["status"]["state"] == "running"
+
+    detail = client.get(f"/api/ship/project_repo/{repo.id}").json()
+    assert detail["summary"]["label"] == "acme/widget"
+    assert [entry["kind"] for entry in detail["timeline"]] == [Profile.kind]

--- a/backend/tests/ship/test_subject_lifecycle.py
+++ b/backend/tests/ship/test_subject_lifecycle.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import pytest
 from druks.contrib.ship.contracts import ReviewWork
-from druks.contrib.ship.models import WorkItem
+from druks.contrib.ship.models import ProjectRepo, WorkItem
 from druks.contrib.ship.workflows import Build, Profile
 from druks.durable.models import Run
 from druks.models import Base
@@ -98,6 +98,18 @@ async def test_workflow_cancel_takes_its_own_kind_and_passes_over_idle_subjects(
     _subject_run(druks_db, subject=idle, kind=Build.kind, state="finished")
     await Build.cancel(idle)
     assert cancelled == [build.id]
+
+
+async def test_cancel_and_answer_hold_the_caller_to_the_declared_subject(druks_db):
+    # Build is about a work item; a repo names another timeline entirely, and a
+    # non-subject names none. Both fail at the door rather than quietly no-opping.
+    item = _work_item(ticket_key="ENG-748-F")
+    repo = ProjectRepo.create(project_id=item.project_id, full_name="acme/app")
+
+    with pytest.raises(WorkflowError, match="is about WorkItem, not ProjectRepo"):
+        await Build.cancel(repo)
+    with pytest.raises(WorkflowError, match="takes the subject"):
+        await ReviewWork.answer("acme/app", action="approve")
 
 
 async def test_subject_phase_reads_the_driving_running_workflow(druks_db, monkeypatch):

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -13,7 +13,7 @@ from druks.durable.engine import configure_engine, init_dbos, launch, shutdown
 from druks.extensions.registry import agents, workflows
 from druks.models import StoredSubject
 from druks.testing import init_db
-from druks.workflows import Gate, Workflow, step
+from druks.workflows import Gate, Subject, Workflow, step
 from pydantic import BaseModel
 from sqlalchemy import create_engine, select
 
@@ -58,6 +58,11 @@ class Widget(StoredSubject):
         return f"W-{self.id}"
 
 
+class Gadget(Subject):
+    # A second subject class, so "not the one this workflow declares" is a real case.
+    pass
+
+
 # run_multistep() below for fixtures using @step/a gate; run() for the rest.
 def _build_units():
     class Approve(Gate):
@@ -76,6 +81,8 @@ def _build_units():
         action: str = ""
 
     class SampleFlow(Workflow):
+        subject = Widget
+
         @step
         async def note_repo(self, repo: str) -> str:
             return f"recorded:{repo}"
@@ -123,6 +130,8 @@ def _build_units():
     class SubjectFlow(Workflow):
         # Records the subject the platform threaded in, and returns a BaseModel
         # so the result rides its workflow.finished event.
+        subject = Widget
+
         async def run(self) -> Decision:
             SINK.append(f"subj-id:{self.subject.id}")
             return Decision(action="ok")
@@ -139,9 +148,17 @@ def _build_units():
             SINK.append(f"gate-journal:{replies}")
 
     class ConfirmFlow(Workflow):
+        subject = Widget
+
         async def run_multistep(self) -> None:
             reply = await Confirm.wait()
             SINK.append(f"confirmed:{reply.action}")
+
+    class SubjectlessConfirmFlow(Workflow):
+        # The same no-on_wait gate, waited on by a run about nothing — nobody
+        # would ever see the park, so it must fail instead.
+        async def run_multistep(self) -> None:
+            await Confirm.wait()
 
     class ReviewFlow(Workflow):
         async def run_multistep(self) -> None:
@@ -150,6 +167,8 @@ def _build_units():
     class AttributedFlow(Workflow):
         # Records the attributed account before and after a park — resume must
         # never swap the payer.
+        subject = Widget
+
         async def run_multistep(self) -> None:
             SINK.append(f"acct-before:{self.account_id}")
             await Approve.wait()
@@ -163,6 +182,7 @@ def _build_units():
         SubjectFlow,
         DoubleGateFlow,
         ConfirmFlow,
+        SubjectlessConfirmFlow,
         ReviewFlow,
         AttributedFlow,
     )
@@ -220,6 +240,7 @@ def rt():
         subject_flow,
         double_gate_flow,
         confirm_flow,
+        subjectless_confirm_flow,
         review_flow,
         attributed_flow,
     ) = _build_units()
@@ -236,6 +257,7 @@ def rt():
             SubjectFlow=subject_flow,
             DoubleGateFlow=double_gate_flow,
             ConfirmFlow=confirm_flow,
+            SubjectlessConfirmFlow=subjectless_confirm_flow,
             ReviewFlow=review_flow,
             AttributedFlow=attributed_flow,
         )
@@ -253,6 +275,7 @@ def rt():
         workflows._items.pop("subject_flow", None)
         workflows._items.pop("double_gate_flow", None)
         workflows._items.pop("confirm_flow", None)
+        workflows._items.pop("subjectless_confirm_flow", None)
         workflows._items.pop("review_flow", None)
         workflows._items.pop("attributed_flow", None)
         if db_url_snap is None:
@@ -352,7 +375,7 @@ async def test_duplicate_start_shares_the_run_across_accounts(rt):
 
 
 async def test_step_gate_resume_finish(rt):
-    wfid = await rt.SampleFlow.start(subject=None, repo="owner/app")
+    wfid = await rt.SampleFlow.start(subject=Widget(id=111111), repo="owner/app")
 
     parked = await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.PARKED)
     assert parked.input_gate == "approve"
@@ -413,7 +436,7 @@ async def test_duplicate_replies_to_one_round_collapse(rt):
 async def test_fail_branch(rt):
     from sqlalchemy import text
 
-    wfid = await rt.SampleFlow.start(subject=None, repo="owner/app")
+    wfid = await rt.SampleFlow.start(subject=Widget(id=222222), repo="owner/app")
     parked = await _wait_for(rt.engine, wfid, lambda r: r.input_gate == "approve")
 
     await parked.resume(action="close")
@@ -432,7 +455,7 @@ async def test_fail_branch(rt):
 async def test_subjectless_gate_fails_loudly(rt):
     """A gate with no on_wait override fails a subjectless run now, instead of
     parking it unseen for the whole gate TTL."""
-    wfid = await rt.ConfirmFlow.start(subject=None)
+    wfid = await rt.SubjectlessConfirmFlow.start(subject=None)
     failed = await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.FAILED)
     assert failed.failure
     assert "'confirm'" in failed.failure
@@ -720,7 +743,7 @@ async def test_a_run_hydrates_the_subject_row_it_was_started_for(rt):
         db_session().flush()
         assert widget.identity == {"type": "widget", "id": widget.id}
 
-        run = Workflow()
+        run = rt.SubjectFlow()
         run._subject = widget.identity
 
         assert run.subject is widget
@@ -733,13 +756,27 @@ async def test_input_is_validated_at_start(rt):
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
-        await rt.SampleFlow.start(subject=None, repo=1)  # wrong type
+        await rt.SampleFlow.start(subject=Widget(id=333333), repo=1)  # wrong type
     with pytest.raises(WorkflowError):
-        await rt.SubjectFlow.start(subject=None, repo="x")  # takes no input
+        await rt.SubjectFlow.start(subject=Widget(id=333333), repo="x")  # takes no input
 
     wfid = await rt.RecordFeedback.start(subject=None, repo="owner/flat")
     await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.FINISHED)
     assert "owner/flat" in SINK
+
+
+async def test_start_holds_a_run_to_the_declared_subject(rt):
+    # Subscribers derive their subject class from ``workflow=``, so the declaration
+    # has to be true of every run — a wrong one, a missing one, and an unexpected
+    # one all fail before anything is enqueued.
+    from druks.durable import WorkflowError
+
+    with pytest.raises(WorkflowError, match="is about Widget, not Gadget"):
+        await rt.SubjectFlow.start(subject=Gadget(id="g1"))
+    with pytest.raises(WorkflowError, match="is about Widget, not nothing"):
+        await rt.SubjectFlow.start(subject=None)
+    with pytest.raises(WorkflowError, match="declares no subject"):
+        await rt.ReviewFlow.start(subject=Widget(id=999999))
 
 
 async def test_run_signature_is_enforced(rt):
@@ -835,7 +872,7 @@ async def test_run_events_carry_subject(rt):
     # run-state transition emits a run-level event keyed to it.
     from druks.events.models import Event
 
-    wfid = await rt.RecordFeedback.start(subject=Widget(id=4242), repo="owner/evented")
+    wfid = await rt.SubjectFlow.start(subject=Widget(id=4242))
     await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.FINISHED)
 
     session = get_session(rt.engine)

--- a/backend/tests/test_extension_appless_load.py
+++ b/backend/tests/test_extension_appless_load.py
@@ -26,30 +26,27 @@ _FILES = {
         from druks.extensions import Extension
         from pydantic import BaseModel, Field
 
-        from .models import ProbeItem
-
 
         class Probe(Extension):
             name = "probe"
-            subject_type = ProbeItem.subject_type
 
             class Settings(BaseModel):
                 budget: int = Field(default=3, ge=1)
-
-            @classmethod
-            def get_subject_summary(cls, subject):
-                return None
-
-            @classmethod
-            def list_subjects(cls):
-                return []
     """,
     "models.py": """
         from druks.db import StoredSubject
+        from druks.durable.schemas import SubjectSummary
 
 
         class ProbeItem(StoredSubject):
             __tablename__ = "probe_items"
+
+            def get_summary(self) -> SubjectSummary:
+                return SubjectSummary(id=str(self.id))
+
+            @classmethod
+            def list_summaries(cls) -> list[SubjectSummary]:
+                return []
     """,
     "routes.py": """
         from fastapi import APIRouter
@@ -74,8 +71,12 @@ _FILES = {
     "workflows.py": """
         from druks.workflows import Workflow
 
+        from .models import ProbeItem
+
 
         class Inspect(Workflow):
+            subject = ProbeItem
+
             async def run(self, widget: str) -> None:
                 ...
     """,
@@ -162,6 +163,8 @@ def test_surfaces_are_enumerable_from_the_loaded_extension(installed):
     router_prefixes = {router.prefix for router in extension.routers()}
     assert "/widgets" in router_prefixes  # the extension's own router
     assert "/transcripts/{call_id}" in router_prefixes  # the free read-side
+    # Its one workflow declares ProbeItem, so the subject read-side mounts too.
+    assert "/probe_item" in router_prefixes
 
     capability_modules = {module.__name__ for module in extension.capability_modules()}
     assert f"{_PACKAGE}.subscribers" in capability_modules

--- a/backend/tests/test_extensions.py
+++ b/backend/tests/test_extensions.py
@@ -3,8 +3,22 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from druks.extensions import Extension, loader
 from druks.extensions.loader import iter_extensions, load
+from druks.workflows import Subject
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
+
+
+class Widget(Subject):
+    """What the fake extensions below are about. A workflow is what declares a subject
+    in a real extension; these stand in for that."""
+
+    @classmethod
+    def list_summaries(cls) -> list:
+        return []
+
+
+def _subject_classes(cls) -> list[type[Subject]]:
+    return [Widget]
 
 
 def test_iter_extensions_discovers_the_bundled_extensions():
@@ -122,15 +136,11 @@ def test_nothing_an_extension_declares_can_take_a_read_the_platform_serves(monke
     class Greedy(Extension):
         name = "greedy"
         package = "greedy"
-        subject_type = "widget"
+        subject_classes = classmethod(_subject_classes)
 
         @classmethod
         def discover(cls) -> list[ModuleType]:
             return [_routes_module("greedy", router=greedy)]
-
-        @classmethod
-        def list_subjects(cls) -> list:
-            return []
 
     client = _mount(Greedy, monkeypatch)
     assert client.get("/api/greedy/widget").json() == {"rows": []}
@@ -151,15 +161,11 @@ def test_a_composed_router_loads(monkeypatch):
     class Composed(Extension):
         name = "composed"
         package = "composed"
-        subject_type = "widget"
+        subject_classes = classmethod(_subject_classes)
 
         @classmethod
         def discover(cls) -> list[ModuleType]:
             return [_routes_module("composed", router=parent)]
-
-        @classmethod
-        def list_subjects(cls) -> list:
-            return []
 
     assert _mount(Composed, monkeypatch).get("/api/composed/parts/nested").json() == {
         "who": "nested"
@@ -169,12 +175,37 @@ def test_a_composed_router_loads(monkeypatch):
 def test_a_subject_cannot_take_the_transcripts_segment():
     """Every extension's agent-call reads live there, so the collision is between two
     platform surfaces — an author would never see which one answered."""
-    with pytest.raises(TypeError, match="agent-call reads"):
 
-        class Colliding(Extension):
-            name = "colliding"
-            package = "colliding"
-            subject_type = "transcripts"
+    class Transcripts(Subject):
+        pass
+
+    class Colliding(Extension):
+        name = "colliding"
+        package = "colliding"
+
+        @classmethod
+        def workflows(cls):
+            return [SimpleNamespace(_subject_class=Transcripts)]
+
+    with pytest.raises(TypeError, match="agent-call reads"):
+        Colliding.subject_classes()
+
+
+def test_an_extension_declaring_a_subject_type_is_rejected():
+    """The workflow says what its runs are about; an extension repeating it would be a
+    second spelling that can go stale."""
+    with pytest.raises(TypeError, match="declares subject_type"):
+
+        class Stale(Extension):
+            name = "stale"
+            subject_type = "widget"
+
+
+def test_an_extensions_subjects_come_from_its_workflows():
+    ship = next(extension for extension in iter_extensions() if extension.name == "ship")
+    ship.discover()
+
+    assert [s.subject_type for s in ship.subject_classes()] == ["project_repo", "work_item"]
 
 
 def test_the_extension_name_tags_every_route(monkeypatch):

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from druks.database import db_session
 from druks.durable import AgentCall, Run
 from druks.durable.datastructures import Subject
 from druks.durable.schemas import SubjectSummary
@@ -9,42 +10,54 @@ from druks.models import StoredSubject
 from druks.testing import seed_dbos_status
 from fastapi import APIRouter
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 from uuid_utils import uuid7
-
-
-class Thing(StoredSubject):
-    __tablename__ = "faketest_things"
 
 
 class _ThingSummary(SubjectSummary):
     title: str
 
 
-class _ThingExtension(Extension):
-    name = "faketest"
-    subject_type = Thing.subject_type
+TITLES = {1: "First", 2: "Second"}
 
-    _THINGS = {1: "First", 2: "Second"}
+
+class Thing(StoredSubject):
+    __tablename__ = "faketest_things"
+
+    def get_summary(self) -> _ThingSummary:
+        return _ThingSummary(id=str(self.id), label=self.label, title=TITLES[self.id])
 
     @classmethod
-    def get_subject_summary(cls, subject: Subject) -> _ThingSummary | None:
-        thing = Thing.get_for_subject(subject)
-        if thing:
-            return _ThingSummary(id=str(thing.id), title=cls._THINGS[thing.id])
+    def list_summaries(cls) -> list[_ThingSummary]:
+        return [thing.get_summary() for thing in db_session().scalars(select(cls))]
+
+
+class Ticket(Subject):
+    """The other half of the contract: a subject with no row, whose id spans the
+    separators a URL path is cut on."""
+
+    @classmethod
+    def get_for_subject_id(cls, subject_id: str) -> "Ticket | None":
+        if "#" in subject_id:
+            return cls(id=subject_id)
         return
 
     @classmethod
-    def list_subjects(cls) -> list[_ThingSummary]:
-        return [
-            _ThingSummary(id=str(subject_id), title=title)
-            for subject_id, title in cls._THINGS.items()
-        ]
+    def list_summaries(cls) -> list[SubjectSummary]:
+        # No get_summary() of its own: a subject with nothing to add is named by
+        # the header every subject already has.
+        return [ticket.get_summary() for ticket in cls.list_open()]
+
+
+class _ThingExtension(Extension):
+    name = "faketest"
 
 
 def _seed_run(
     session,
     *,
     subject_id,
+    subject_type="thing",
     kind="faketest.flow",
     state="running",
     input_request=None,
@@ -62,7 +75,7 @@ def _seed_run(
     )
     session.add(run)
     session.flush()
-    seed_dbos_status(session, run.id, state, subject={"type": "thing", "id": subject_id})
+    seed_dbos_status(session, run.id, state, subject={"type": subject_type, "id": subject_id})
     return run
 
 
@@ -81,14 +94,16 @@ def client(tmp_path: Path, druks_db, monkeypatch):
     from druks.testing import configure_app_for_test, make_settings
 
     monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
-    for subject_id in _ThingExtension._THINGS:
+    for subject_id in TITLES:
         druks_db.merge(Thing(id=subject_id))
     druks_db.flush()
     app = configure_app_for_test(settings=make_settings(tmp_path))
 
     holder = APIRouter()
-    routes = _ThingExtension._get_subject_routes(Thing.subject_type)
-    holder.include_router(routes, prefix="/api/faketest")
+    for subject_class in (Thing, Ticket):
+        holder.include_router(
+            _ThingExtension._get_subject_routes(subject_class), prefix="/api/faketest"
+        )
     catchall = next(
         i for i, r in enumerate(app.routes) if getattr(r, "path", "") == "/api/{path:path}"
     )
@@ -112,7 +127,7 @@ def test_status_aggregates_across_runs_and_timeline_spans_them(client: TestClien
     _seed_call(druks_db, live, agent="implement", status="running")
 
     detail = client.get("/api/faketest/thing/1").json()
-    assert detail["summary"] == {"id": "1", "title": "First"}
+    assert detail["summary"] == {"id": "1", "label": "thing 1", "title": "First"}
     assert detail["status"]["state"] == "running"
     assert [entry["kind"] for entry in detail["timeline"]] == ["faketest.prepare", "faketest.flow"]
     # Calls group under their own run, not the subject at large.
@@ -190,3 +205,45 @@ def test_list_returns_every_subject_with_status(client: TestClient, druks_db):
 
 def test_unknown_subject_is_404(client: TestClient, druks_db):
     assert client.get("/api/faketest/thing/nope").status_code == 404
+    # An id the subject could never wear misses the same way, row or no row.
+    assert client.get("/api/faketest/ticket/nope").status_code == 404
+
+
+def test_an_id_spanning_separators_reaches_the_board_and_its_page(client: TestClient, druks_db):
+    # A row-less subject's id is free text — "owner/repo#7" carries the path
+    # separator and the fragment marker, and both reads still key on the whole id.
+    _seed_run(druks_db, subject_type="ticket", subject_id="owner/repo#7", state="parked")
+
+    board = client.get("/api/faketest/ticket").json()
+    assert [row["summary"]["id"] for row in board["rows"]] == ["owner/repo#7"]
+
+    detail = client.get("/api/faketest/ticket/owner/repo%237").json()
+    assert detail["summary"] == {"id": "owner/repo#7", "label": "owner/repo#7"}
+    assert detail["status"]["state"] == "parked"
+    assert [entry["kind"] for entry in detail["timeline"]] == ["faketest.flow"]
+
+
+@pytest.mark.parametrize("path", ["thing/nope", "ticket/owner/nope"])
+def test_a_subjects_stream_wins_over_the_greedy_id_matcher(client: TestClient, druks_db, path):
+    # The id matcher spans separators, so ``/stream`` has to stay a suffix and not
+    # get swallowed into the id — whatever shape the id is. A stream for a subject
+    # that names nothing closes at once, which is what proves it got there.
+    response = client.get(f"/api/faketest/{path}/stream")
+
+    assert response.status_code == 200
+    assert response.text == ""
+
+
+@pytest.mark.parametrize("subject_class", [Thing, Ticket])
+def test_the_literal_routes_are_declared_ahead_of_the_id_matcher(subject_class):
+    # FastAPI matches in declaration order; both boards would be unreachable if the
+    # id matcher came first.
+    router = _ThingExtension._get_subject_routes(subject_class)
+    prefix = f"/{subject_class.subject_type}"
+
+    assert [route.path for route in router.routes] == [
+        prefix,
+        f"{prefix}/stream",
+        f"{prefix}/{{subject_id:path}}/stream",
+        f"{prefix}/{{subject_id:path}}",
+    ]

--- a/backend/tests/test_notifications_durable.py
+++ b/backend/tests/test_notifications_durable.py
@@ -68,6 +68,8 @@ def _build_park_flows():
             return
 
     class InAppFlow(Workflow):
+        subject = NotificationProbe
+
         async def run_multistep(self) -> None:
             reply = await self.review(
                 questions=[
@@ -81,12 +83,22 @@ def _build_park_flows():
             _REVIEW_REPLIES.append(reply)
 
     class ExternalFlow(Workflow):
+        subject = NotificationProbe
+
+        async def run_multistep(self) -> None:
+            await ParkNote.wait(
+                input_request={"presentation": "external", "label": "Answer on the ticket"}
+            )
+
+    class SubjectlessFlow(Workflow):
         async def run_multistep(self) -> None:
             await ParkNote.wait(
                 input_request={"presentation": "external", "label": "Answer on the ticket"}
             )
 
     class ExternalUrlFlow(Workflow):
+        subject = NotificationProbe
+
         async def run_multistep(self) -> None:
             await ParkNote.wait(
                 input_request={
@@ -97,11 +109,13 @@ def _build_park_flows():
             )
 
     class DoubleParkFlow(Workflow):
+        subject = NotificationProbe
+
         async def run_multistep(self) -> None:
             await ParkNote.wait(input_request={"presentation": "external", "label": "Round one"})
             await ParkNote.wait(input_request={"presentation": "external", "label": "Round two"})
 
-    return InAppFlow, ExternalFlow, ExternalUrlFlow, DoubleParkFlow
+    return InAppFlow, ExternalFlow, SubjectlessFlow, ExternalUrlFlow, DoubleParkFlow
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -126,7 +140,13 @@ def rt():
         session.commit()
     finally:
         session.close()
-    in_app_flow, external_flow, external_url_flow, double_park_flow = _build_park_flows()
+    (
+        in_app_flow,
+        external_flow,
+        subjectless_flow,
+        external_url_flow,
+        double_park_flow,
+    ) = _build_park_flows()
     os.environ["DRUKS_DATABASE_URL"] = URL
     # The outbox module was imported above — its queue + workflow register
     # before launch(), which is the wiring this whole module runs through.
@@ -137,13 +157,20 @@ def rt():
             engine=engine,
             InAppFlow=in_app_flow,
             ExternalFlow=external_flow,
+            SubjectlessFlow=subjectless_flow,
             ExternalUrlFlow=external_url_flow,
             DoubleParkFlow=double_park_flow,
         )
     finally:
         shutdown()
         engine.dispose()
-        for kind in ("in_app_flow", "external_flow", "external_url_flow", "double_park_flow"):
+        for kind in (
+            "in_app_flow",
+            "external_flow",
+            "subjectless_flow",
+            "external_url_flow",
+            "double_park_flow",
+        ):
             workflows._items.pop(kind, None)
         if db_url_snap is None:
             os.environ.pop("DRUKS_DATABASE_URL", None)
@@ -510,7 +537,7 @@ async def test_subjectless_park_notifies_nothing(rt, deliver_spy):
     )
     _set_gate_park_pointer(rt, destination.id)
 
-    workflow_id = await rt.ExternalFlow.start(subject=None)
+    workflow_id = await rt.SubjectlessFlow.start(subject=None)
     await _wait_run(rt, workflow_id, lambda run: run.state == RunState.PARKED)
 
     await asyncio.sleep(1.0)

--- a/backend/tests/test_proof_extension.py
+++ b/backend/tests/test_proof_extension.py
@@ -9,7 +9,7 @@ def test_boot_loads_the_external_extension():
 
     assert extension.name == "field_notes"
     assert extension.package == _PACKAGE
-    assert extension.subject_type == "note"
+    assert [subject.__name__ for subject in extension.subject_classes()] == ["Note"]
 
 
 def test_discovery_registers_the_tables_and_capabilities():

--- a/backend/tests/test_proof_extension_install.py
+++ b/backend/tests/test_proof_extension_install.py
@@ -12,7 +12,7 @@ _CHECK = textwrap.dedent(
     assert "field_notes" in names, names
 
     extension = load_extension("field_notes")
-    assert extension.subject_type == "note"
+    assert [subject.__name__ for subject in extension.subject_classes()] == ["Note"]
     assert extension.settings_model is not None
     assert list(extension.settings_model.model_fields) == ["board_size", "visibility", "sync_token"]
     assert [workflow.__name__ for workflow in extension.workflows()] == ["Summarize"]

--- a/backend/tests/test_review.py
+++ b/backend/tests/test_review.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+from druks.contrib.review.datastructures import PullRequest
+from druks.contrib.review.workflows import PullRequestReview
+from druks.testing import seed_run
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path: Path, druks_db, monkeypatch):
+    from druks.testing import configure_app_for_test, make_settings
+
+    monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
+    with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
+        yield client
+
+
+def test_a_pull_requests_identity_is_its_handle():
+    # This spelling is the dedup key, the route, the event identity and the replay
+    # lookup all at once — normalising or rearranging it splits one review in two.
+    pull_request = PullRequest.get("acme/app", 7)
+
+    assert pull_request.identity == {"type": "pull_request", "id": "acme/app#7"}
+    assert (pull_request.repo, pull_request.number) == ("acme/app", 7)
+    assert pull_request.label == "acme/app#7"
+
+
+@pytest.mark.parametrize("subject_id", ["acme/app", "acme/app#", "acme/app#0", "app#7", "#7"])
+def test_an_id_that_names_no_pull_request_is_a_miss(subject_id):
+    assert PullRequest.get_for_subject_id(subject_id) is None
+
+
+def test_a_pull_request_heads_its_own_page():
+    summary = PullRequest.get_for_subject_id("acme/app#7").get_summary()
+
+    assert summary.repo == "acme/app"
+    assert summary.pr_number == 7
+    assert summary.pull_request_url == "https://github.com/acme/app/pull/7"
+
+
+def test_the_pull_request_board_and_page_mount(client: TestClient, druks_db):
+    # PullRequestReview declares PullRequest, so the extension mounts its board and
+    # page — keyed by a handle that carries both a path separator and a `#`.
+    pull_request = PullRequest.get("acme/app", 7)
+    seed_run(druks_db, kind=PullRequestReview.kind, subject=pull_request, state="running")
+
+    (row,) = client.get("/api/review/pull_request").json()["rows"]
+    assert row["summary"]["id"] == "acme/app#7"
+    assert row["status"]["state"] == "running"
+
+    detail = client.get("/api/review/pull_request/acme/app%237").json()
+    assert detail["summary"]["pullRequestUrl"] == "https://github.com/acme/app/pull/7"
+    assert [entry["kind"] for entry in detail["timeline"]] == [PullRequestReview.kind]
+    assert client.get("/api/review/pull_request/acme/app").status_code == 404

--- a/backend/tests/test_scaffolding.py
+++ b/backend/tests/test_scaffolding.py
@@ -27,13 +27,16 @@ def test_create_extension_scaffolds_a_loadable_package(tmp_path):
     )
 
     # No rendered file may reference retired surfaces: the old storage namespace, the
-    # taskiq worker, or the one-arg ``config`` workflow wording.
+    # taskiq worker, the one-arg ``config`` workflow wording, or either spelling of a
+    # subject type an author no longer writes — the workflow's declaration is the one.
     for path in rendered:
         text = path.read_text()
         lowered = text.lower()
         assert "druks.storage" not in text
         assert "taskiq" not in lowered
         assert "``config``" not in text
+        assert "subject_type" not in text
+        assert "Subject(" not in text
 
     # The generated extension.py must survive Extension.__init_subclass__ validation,
     # and load() must mount both the API routes and the shipped dist/ frontend.

--- a/backend/tests/test_signals.py
+++ b/backend/tests/test_signals.py
@@ -1,7 +1,6 @@
 import pytest
 from druks.extensions.exceptions import SubscriberDeclarationError
 from druks.signals import publish, subscribe
-from druks.workflows import Workflow
 from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
 from sqlalchemy.orm import object_session
@@ -71,19 +70,40 @@ async def test_another_subjects_event_skips_the_subscriber(druks_db):
 
 
 @pytest.mark.asyncio
-async def test_workflow_filter_narrows_to_that_workflow():
+async def test_workflow_filter_narrows_to_that_workflow(druks_db):
     # The body names the fact it came for; the kind it was matched on is routing,
-    # so it never reaches the signature.
+    # so it never reaches the signature. Summarize declares its subject, so the
+    # filter narrows to notes too and the body is handed the row.
+    item = _note()
     received = []
 
     @subscribe("test.workflow_filter", workflow=Summarize)
-    async def receive(*, ticket: str, **_: object) -> None:
-        received.append(ticket)
+    async def receive(*, subject: Note, ticket: str, **_: object) -> None:
+        received.append((subject, ticket))
 
-    await publish("test.workflow_filter", kind="field_notes.other", ticket="ENG-1")
-    await publish("test.workflow_filter", kind=Summarize.kind, ticket="ENG-2")
+    await publish(
+        "test.workflow_filter", kind="field_notes.other", subject=item.identity, ticket="ENG-1"
+    )
+    await publish("test.workflow_filter", kind=Summarize.kind, subject=None, ticket="ENG-2")
+    await publish(
+        "test.workflow_filter", kind=Summarize.kind, subject=item.identity, ticket="ENG-3"
+    )
 
-    assert received == ["ENG-2"]
+    assert received == [(item, "ENG-3")]
+
+
+def test_a_workflows_subject_and_an_explicit_one_are_never_written_together():
+    with pytest.raises(SubscriberDeclarationError, match="already declares"):
+
+        @subscribe("test.both_spellings", workflow=Summarize, subject=Note)
+        async def receive(*, subject: Note, **_: object) -> None: ...
+
+
+def test_a_subject_filter_must_name_a_subject_class():
+    with pytest.raises(SubscriberDeclarationError, match="not a Subject or StoredSubject"):
+
+        @subscribe("test.not_a_subject", subject=Summarize)
+        async def receive(**_: object) -> None: ...
 
 
 def test_a_subscriber_asking_for_routing_fails_at_declaration():
@@ -93,9 +113,9 @@ def test_a_subscriber_asking_for_routing_fails_at_declaration():
         async def receive(*, run: str, kind: str, **_: object) -> None: ...
 
 
-def test_workflow_subject_requires_a_registered_class():
-    workflow = Workflow()
-    workflow._subject = {"type": "missing", "id": 1}
+def test_a_run_resolves_its_subject_through_the_declaration(druks_db):
+    item = _note()
+    workflow = Summarize()
+    workflow._subject = item.identity
 
-    with pytest.raises(LookupError, match="no subject class is named"):
-        _ = workflow.subject
+    assert workflow.subject is item

--- a/backend/tests/test_workflow_identity.py
+++ b/backend/tests/test_workflow_identity.py
@@ -10,6 +10,7 @@ from druks.extensions.exceptions import MalformedExtension
 from druks.extensions.loader import register_workflow_package, resolve_workflow_extension
 from druks.extensions.registry import workflows
 from druks.workflows import Gate, Workflow, _log_run_event, step
+from druks_field_notes.models import Note
 
 
 @pytest.fixture(autouse=True)
@@ -144,3 +145,23 @@ def test_lifecycle_event_stamps_the_declaring_extension(druks_db):
 
 def test_display_label_reads_the_local_kind():
     assert get_display_label("field_notes.summarize") == "Summarize"
+
+
+def test_a_declared_subject_is_lifted_off_the_class():
+    # The declaration and the run's live subject share the name, so the class
+    # attribute comes off and the instance property answers in its place.
+    register_workflow_package("alpha_pkg", "alpha")
+    flow = _workflow("Sweep", "alpha_pkg.workflows", subject=Note)
+
+    assert flow._subject_class is Note
+    assert "subject" not in flow.__dict__
+    assert flow().subject is None  # a run with no subject has none to resolve
+
+
+@pytest.mark.parametrize("declared", ["note", None])
+def test_a_subject_that_is_not_a_subject_class_is_rejected(declared):
+    # ``subject = None`` included: written out it would shadow the instance
+    # property with a permanent None, so a workflow about nothing writes nothing.
+    register_workflow_package("alpha_pkg", "alpha")
+    with pytest.raises(WorkflowError, match="must be a Subject or StoredSubject"):
+        _workflow("Sweep", "alpha_pkg.workflows", subject=declared)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -42,7 +42,7 @@ name must match `Extension.name`. The same name scopes:
 
 ### An extension owns
 
-- domain workflows and the policy for starting them
+- domain workflows, what each one is about, and the policy for starting them
 - agents, prompts, and structured output contracts
 - domain models, migrations, HTTP routes, and subject summaries
 - normalized reactions to events and provider-specific webhook behavior
@@ -158,12 +158,13 @@ than only on the VM.
 
 ## Events, signals, webhooks, and subjects
 
-A subject is the row a run is about. The extension owns it and hands it to druks
-whenever it starts a run or answers a gate; only the row's type and id travel
-further, because a run outlives the row it points at. Everything that happens to
-a run lands in an append-only event log. Extensions add their own events and
-supply subject summaries; druks supplies pagination, activity composition, and a
-live feed of facts — a row's words are the client's.
+A subject is what a run is about, and it is always a class — a row the extension
+keeps, or identity alone. The workflow declares which, so druks knows the kind of
+thing before any run about it exists; only the subject's type and id travel
+further, because a run outlives what it points at. Everything that happens to a
+run lands in an append-only event log. Extensions add their own events and give
+their subject class a summary; druks supplies pagination, activity composition,
+and a live feed of facts — a subject's words are the client's.
 
 Signals connect producers to extension reactions. They are awaited and
 delivered at least once: webhook failures return an error so the provider can

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -55,9 +55,9 @@ application modules:
 
 | Path | Contract |
 | --- | --- |
-| `extension.py` | `Extension` subclass, agents, extension settings, subject read-side |
+| `extension.py` | `Extension` subclass, agents, extension settings |
 | `workflows.py` | durable `Workflow` and `Gate` subclasses |
-| `models.py` | SQLAlchemy models with `<name>_` table names |
+| `models.py` | SQLAlchemy models with `<name>_` table names, `StoredSubject` among them |
 | `contracts.py` | `AgentOutput` contracts |
 | `schemas.py` | HTTP responses and subject summaries |
 | `routes.py` | FastAPI routers |
@@ -133,7 +133,7 @@ again, so use provider idempotency keys for writes. Keep decisions in replayable
 control flow and I/O inside steps. See
 [durability and recovery](concepts.md#durability-and-recovery).
 
-Start a workflow with an explicit subject:
+Start a workflow with an explicit subject — an instance of the class it declares:
 
 ```python
 run_id = await Sweep.start(
@@ -142,7 +142,7 @@ run_id = await Sweep.start(
 )
 ```
 
-Pass `subject=None` deliberately for background work. A subject has at most one
+A workflow that declares none passes `subject=None`. A subject has at most one
 active run of a workflow kind; a duplicate start returns the active run id —
 attribution never changes that (two accounts starting the same subject share
 the one run). Wrap `start()` in a domain `dispatch()` method when the extension
@@ -368,83 +368,91 @@ running is a no-op, so a redelivered webhook stays idempotent.
 ## Give runs a subject read-side
 
 A subject is what your runs are about — a repository, a work item, a pull
-request. Identity is all the platform needs:
+request. It is always a class, and the workflow names it:
 
 ```python
-from druks.workflows import Subject
-
-pull_request = Subject(id=f"{repo}#{pr_number}", subject_type="pull_request")
-await Review.start(subject=pull_request)
-
-status = pull_request.get_status()
+class Sweep(Workflow):
+    subject = Repository
 ```
 
-Status, timeline, and the run's own subject record answer for that identity
-alone — no table of yours involved. Declare that type on the extension and druks
-serves it a board, a page, and a live stream of either:
+That declaration is what lets druks show the subject's life, and offer what may
+be done to it, before any run about it exists. `start()`, `cancel()`, and
+`Gate.answer()` hold you to it: a workflow that declares a subject is launched
+with one of that class, and a workflow about nothing passes `subject=None`.
 
-```python
-class Review(Extension):
-    subject_type = "pull_request"
-
-    @classmethod
-    def get_subject_summary(cls, subject: Subject) -> PullRequestSummary:
-        ...
-
-    @classmethod
-    def list_subjects(cls) -> list[PullRequestSummary]:
-        ...
-```
-
-When the subject is also a row you keep — one you list, edit, and show fields
-from — subclass `StoredSubject` instead of `Base`, and the class name is the
-subject type: `Repository` becomes `repository`.
+When the subject is a row you keep — one you list, edit, and show fields from —
+subclass `StoredSubject` instead of `Base`. The class name is the subject type:
+`Repository` becomes `repository`.
 
 ```python
 from druks.db import StoredSubject
-from druks.workflows import SubjectSummary
 
 
 class Repository(StoredSubject):
     __tablename__ = "repositories"
 
+    def get_label(self) -> str:
+        return self.full_name
+
+    @classmethod
+    def list_summaries(cls) -> list[SubjectSummary]:
+        return [repository.get_summary() for repository in cls.list_open()]
+```
+
+Say which rows are on the board and druks has the rest: every subject already
+answers with its id and its `label`, which is the one line it shows itself as.
+Add a summary of your own only when the board should show more:
+
+```python
+from druks.workflows import SubjectSummary
+
 
 class RepositorySummary(SubjectSummary):
-    name: str
     open_findings: int
 
 
-class NightWatch(Extension):
-    subject_type = Repository.subject_type
-
-    @classmethod
-    def get_subject_summary(cls, subject: Subject) -> RepositorySummary | None:
-        repository = Repository.get_for_subject(subject)
-        ...
-
-    @classmethod
-    def list_subjects(cls) -> list[RepositorySummary]:
-        ...
+class Repository(StoredSubject):
+    def get_summary(self) -> RepositorySummary:
+        return RepositorySummary(
+            id=str(self.id), label=self.label, open_findings=self.findings.count()
+        )
 ```
 
-The reads are keyed by identity either way, so the row is yours to load —
-`get_for_subject()` turns the identity back into it. Druks serves the same
-`/api/night_watch/repository` surface it serves an identity-only subject: a
-board, a page for one, and a live stream of either. Each response pairs your
-summary with the run's status, timeline, agent calls, artifacts, and the
-question it is waiting on. Override `get_subject_activity()` only to add a
-passing detail of your own, like "Building sandbox VM…".
+When you keep no row for it, subclass `Subject` instead — identity is all the
+platform needs, and the id is the whole record, which is also its label:
 
-Hand the row itself to anything that asks for a subject — starting a run,
+```python
+from druks.workflows import Subject
+
+
+class PullRequest(Subject):
+    @classmethod
+    def list_summaries(cls) -> list[SubjectSummary]:
+        return [pull_request.get_summary() for pull_request in cls.list_open()]
+```
+
+Any id names one of these, so a detail read always answers. Override
+`get_for_subject_id()` to return None for a shape yours could never wear —
+`owner/repo#7` is a pull request, `nonsense` is a 404.
+
+Druks serves the same `/api/night_watch/repository` surface either way: a board,
+a page for one, and a live stream of either, mounted for every subject your
+workflows declare. Each response pairs your summary with the run's status,
+timeline, agent calls, artifacts, and the question it is waiting on. Override
+`get_subject_activity()` on the extension only to add a passing detail of your
+own, like "Building sandbox VM…".
+
+Hand the subject itself to anything that asks for one — starting a run,
 answering a gate, recording an event:
 
 ```python
 await NightWatch.dispatch(subject=repository)
 ```
 
-Inside the workflow, `self.subject` is that row — live, not a snapshot taken at
-dispatch. A run that parks on a gate for three days resumes against whatever the
-row says then, and finds nothing if it was deleted meanwhile.
+Inside the workflow, `self.subject` is resolved through the declared class —
+live, not a snapshot taken at dispatch. A run that parks on a gate for three
+days resumes against whatever the row says then, and finds nothing if it was
+deleted meanwhile.
 
 You name what happened to the row: a work item ships, gets cancelled. Whether a
 run is working on it is druks's to say, and you read that off the status:
@@ -498,6 +506,11 @@ from druks.workflows import WorkflowEvent
 async def on_sweep_finished(*, subject: Repository, **_: object) -> None:
     await notify(subject.full_name)
 ```
+
+`subject=Repository` narrows to any workflow about a repository. Narrowing to
+one workflow with `workflow=Sweep` says the same thing and more, because the
+workflow declares its subject — so the two are never written together, and the
+body is handed its subject either way.
 
 Signals are at-least-once. A subscriber exception propagates so webhook
 providers or DBOS retry the publication; make reactions idempotent.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -29,10 +29,12 @@ export type RunState =
   // The run's DBOS workflow row is gone; it will never start.
   | 'orphaned'
 
-// The base every extension's subject summary satisfies; ``id`` keys its status,
-// timeline, and detail URL.
+// Every subject's header: ``id`` keys its status, timeline and detail URL, and
+// ``label`` is the one line it shows itself as — a work item's ticket key, a repo's
+// full name, a pull request's handle.
 export interface SubjectSummary {
   id: string
+  label: string
 }
 
 export interface SubjectStatus {


### PR DESCRIPTION
A subject was spelled three ways, and which one an author wrote depended on where they were standing:

```python
@subscribe(WorkflowEvent.RUNNING, workflow=Build, subject=WorkItem)   # a class
class Ship(Extension):  subject_type = "work_item"                    # a string
class Build(Workflow):  ...                                           # nothing at all
```

The one place that produces a run said nothing about what the run is about, so the read side searched for it — and the search only ever found subjects that happened to have a table.

## A workflow declares its subject

```python
class Build(Workflow):
    subject = WorkItem

class Profile(Workflow):
    subject = ProjectRepo        # same extension, different subject

class PullRequestReview(Workflow):
    subject = PullRequest        # no table

class RefreshTokens(Workflow):
    ...                          # about nothing, and says so by silence
```

A run is one episode in the life of something that outlives it. Druks can only show that life, or offer what may be done to it, before any run about it exists, if the workflow says what kind of thing it is about — and the workflow is the only place that noun is known at import time.

The declaration is the lookup, so the mapper walk in `Workflow.subject` is gone rather than replaced. `start()`, `Workflow.cancel()` and `Gate.answer()` hold a caller to it: a wrong subject, a missing one, and an unexpected one all fail before anything is enqueued. Subscribers derive their subject class from `workflow=`, so the declaration has to be true.

## What moved

| where the subject was spelled | before | after |
| -- | -- | -- |
| subscriber, with `workflow=` | `subject=WorkItem` | derived — and no longer written beside it |
| subscriber, without `workflow=` | `subject=WorkItem` | kept — "any workflow about a work item" |
| extension | `subject_type = "work_item"` | deleted — derived from its workflows |
| workflow | nothing | `subject = WorkItem` |

`Subject` is now subclassable and derives its `subject_type` from the class name, the way `StoredSubject` already did; it stays a separate frozen dataclass, with no base shared with the ORM. Both answer `subject_type`, `id`, `identity` and `label`, and both now answer `get_for_subject_id()`, `get_summary()` and `list_summaries()` — the summary and listing `Extension` used to carry, moved to the class that owns the data.

An extension's mounted subject types follow from its workflows, so `Ship` mounts two: `ProjectRepo` gets the board and page it never had, and its profiling runs stop being stamped, deduped and queryable with nowhere to show it. Review's `PullRequest` becomes a real class that owns its own id parsing, which leaves its `schemas.py` as response fields only. The route-collision guard now runs once per mounted subject rather than once per extension.

## Known cost

`subject = WorkItem` is a plain class attribute and buys zero type-checking — `self.subject` is still `Any`, and `Build.start(subject=a_repo)` type-checks clean. Runtime enforcement is the guarantee.

Class names become durable: renaming a subject class changes its `subject_type`, and with it route prefixes, dedup keys, event identities and replay lookup. There is no alias and no override.

Acting on another extension's subject is now an import edge between pluggable apps. The alternative was two extensions agreeing on a magic string and composing two different ids for one thing.
