### PR TITLE
A call delivers the skills it asked for

### DIFF
--- a/backend/druks/contrib/ship/prompt_context.py
+++ b/backend/druks/contrib/ship/prompt_context.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from druks.contrib.ship.journal import BuildJournal
 from druks.contrib.ship.models import ProjectRepo
+from druks.skills.models import Skill
 
 
 @dataclass(frozen=True)
@@ -24,5 +25,5 @@ class BuildPromptContext:
     task_owner_name: str | None
     task_owner_email: str | None
     related_repos: list[ProjectRepo]
-    skills: list[str]
+    skills: list[Skill]
     journal: BuildJournal

--- a/backend/druks/contrib/ship/templates/build/_skills.md
+++ b/backend/druks/contrib/ship/templates/build/_skills.md
@@ -4,6 +4,6 @@
 These are installed in this VM under your agent home. Open one when its subject matter comes up in the work — not up front, and not the whole set. If a skill is unavailable, carry on without it.
 
 {% for skill in build.skills %}
-- `/{{ skill }}`
+- `{{ skill.name }}` — {{ skill.description }}
 {% endfor %}
 {% endif %}

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -40,8 +40,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True, kw_only=True)
 class BuildWorkspace(RepoWorkspace):
-    # The base RepoWorkspace brings the cloned repo + token; a build run adds the
-    # PR branch and the reviewer MCP token its agents push and review through.
+    # The base RepoWorkspace brings the cloned repo + token; a build run adds its
+    # curated skills, PR branch, and reviewer MCP token.
+    skills: tuple[str, ...]
     branch: str | None = None
     # Reviewer-extension installation token for build's github MCP server,
     # minted per repo from the reviewer GitHub App. Required — there is no
@@ -62,6 +63,7 @@ class BuildWorkspace(RepoWorkspace):
         # cwd — Claude wedges (no stdout, forever) on ``--add-dir <cwd>``.
         kwargs = super().get_agent_run_kwargs(**kwargs)
         kwargs["add_dirs"] = (get_related_root(self.sandbox.ssh_username),)
+        kwargs["skills"] = self.skills
         return kwargs
 
 
@@ -147,9 +149,8 @@ class Build(Workflow):
         self._profile = resolved["profile"]
         self._settings = await self._load_settings()
 
-        if not await self._plan_phase():
-            return
-        await self._implement_phase()
+        if await self._plan_phase():
+            await self._implement_phase()
 
     async def get_workspace_kwargs(self, sandbox: "Sandbox") -> dict[str, Any]:
         # The BuildWorkspace fields: mint a fresh GitHub token, push it, and clone the
@@ -193,6 +194,7 @@ class Build(Workflow):
             "branch": branch,
             "github_token": github_token,
             "mcp_token": mcp_token,
+            "skills": tuple(self._profile.get("recommended_skills", [])),
         }
 
     async def get_prompt_context(self, **context: Any) -> dict[str, Any]:
@@ -211,7 +213,7 @@ class Build(Workflow):
             task_owner_name=self.input.task_owner_name,
             task_owner_email=self.input.task_owner_email,
             related_repos=target_repo.siblings(),
-            skills=self._profile.get("recommended_skills", []),
+            skills=Skill.list_delivered(self._profile.get("recommended_skills", [])),
             journal=self.journal,
         )
         return {

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -89,7 +89,7 @@ class AgentCallFiles(BaseResponse):
     response: ArtifactFile | None = None
     metadata: ArtifactFile | None = None
     # The capability manifest for the call: model, harness, MCP availability,
-    # enabled skills — presence only, never a secret value.
+    # delivered skills — presence only, never a secret value.
     manifest: ArtifactFile | None = None
     # The call's renderable output, rendered by kind; None unless it produced one.
     artifact: ArtifactDescriptor | None = None
@@ -99,14 +99,13 @@ class AgentCallFiles(BaseResponse):
         layout = call.artifact_layout
 
         def named(path: Path) -> ArtifactFile | None:
-            if not path.is_file():
-                return
-            stat = path.stat()
-            return ArtifactFile(
-                name=path.name,
-                size_bytes=stat.st_size,
-                updated_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
-            )
+            if path.is_file():
+                stat = path.stat()
+                return ArtifactFile(
+                    name=path.name,
+                    size_bytes=stat.st_size,
+                    updated_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
+                )
 
         descriptor = None
         if artifact:

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -6,6 +6,7 @@ import secrets
 import urllib.parse
 import uuid
 from abc import ABC, abstractmethod
+from collections.abc import Collection
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
@@ -59,7 +60,7 @@ _REFRESH_LOCK_TTL_SECONDS = 300
 # The capability manifest is a plain JSON dict written per AgentCall. Bump when
 # the recorded shape changes so a reader can tell manifests apart across
 # versions; the value is part of the hash, so a bump reshuffles the buckets.
-MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_SCHEMA_VERSION = 2
 
 Token = OAuthToken | CodexToken
 
@@ -112,6 +113,7 @@ class Harness(ABC):
         self,
         *,
         mcp_servers: tuple["McpServer", ...],
+        skills: Collection[str],
         extra_env: dict[str, str] | None,
     ) -> dict:
         """The capability manifest for one AgentCall: what this harness was
@@ -150,15 +152,14 @@ class Harness(ABC):
                     "token_present": env_var in delivered_env,
                 }
             )
-        # The skills tar both harnesses push excludes disabled skills, so the
-        # enabled set — not merely "a tree exists" — is the call's real skill
-        # capability.
+        # Only the delivered skill set is reachable in either CLI home, so the
+        # manifest records that per-call capability.
         capability = {
             "schema_version": MANIFEST_SCHEMA_VERSION,
             "model": self.model or "",
             "harness": self.name,
             "mcp_servers": mcp,
-            "skills_enabled": sorted(skill.name for skill in Skill.list_enabled()),
+            "skills_delivered": sorted(skill.name for skill in Skill.list_delivered(skills)),
         }
         canonical = json.dumps(capability, sort_keys=True, separators=(",", ":"))
         return {

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -62,6 +62,7 @@ class ClaudeHarness(Harness):
         github_token: str | None = None,
         include_plugins: bool = True,
         add_dirs: tuple[str, ...] = (),
+        skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
         connection_id: str | None = None,
@@ -120,6 +121,7 @@ class ClaudeHarness(Harness):
                 self.sandbox,
                 github_token=github_token,
                 include_plugins=include_plugins,
+                skills=skills,
                 connection_id=connection_id,
             ),
             env=extra_env,
@@ -360,6 +362,7 @@ def _claude_credentials(
     *,
     github_token: str | None,
     include_plugins: bool = True,
+    skills: tuple[str, ...] = (),
     connection_id: str | None = None,
 ) -> Credentials:
     """Build the Credentials bundle the runner SFTP-pushes into the sandbox.
@@ -408,7 +411,7 @@ def _claude_credentials(
         github_token=github_token,
         extra_config_files=files,
         extra_config_dirs=dirs,
-        extra_dir_excludes={".claude/skills": Skill.disabled_excludes()},
+        extra_dir_excludes={".claude/skills": Skill.delivery_excludes(skills)},
     )
 
 

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -542,6 +542,7 @@ class CodexHarness(Harness):
         # access so it needs no per-dir grants.
         include_plugins: bool = True,
         add_dirs: tuple[str, ...] = (),
+        skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
         connection_id: str | None = None,
@@ -570,7 +571,9 @@ class CodexHarness(Harness):
             args=tuple(cmd),
             stdin=_with_final_message_note(prompt).encode("utf-8"),
             credentials=self._codex_credentials(
-                github_token=github_token, connection_id=connection_id
+                github_token=github_token,
+                skills=skills,
+                connection_id=connection_id,
             ),
             env=extra_env,
             extra_artifact_filenames=("output.json", "session.jsonl"),
@@ -646,7 +649,11 @@ class CodexHarness(Harness):
         return args
 
     def _codex_credentials(
-        self, *, github_token: str | None, connection_id: str | None = None
+        self,
+        *,
+        github_token: str | None,
+        skills: tuple[str, ...] = (),
+        connection_id: str | None = None,
     ) -> Credentials:
         # The credential file is synthesized from the DB row (raises when codex
         # isn't connected); the local config dir only adds config carry on top.
@@ -671,7 +678,7 @@ class CodexHarness(Harness):
             github_token=github_token,
             extra_config_files=files,
             extra_config_dirs=dirs,
-            extra_dir_excludes={".codex/skills": Skill.disabled_excludes()},
+            extra_dir_excludes={".codex/skills": Skill.delivery_excludes(skills)},
         )
 
 

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -102,8 +102,6 @@ class Sandbox:
     def ssh_username(self) -> str:
         return self.record.ssh_username
 
-    # File transfer
-
     async def upload_file(
         self,
         *,
@@ -141,9 +139,8 @@ class Sandbox:
         parts.append(f"printf %s {quoted_secret} > {quoted_remote}")
         parts.append(f"chmod {mode:o} {quoted_remote}")
         result = await self.exec(["sh", "-c", " && ".join(parts)], timeout=10.0)
-        # Fail loudly — this now carries the harness OAuth credentials, so a
-        # silent write failure would start the agent unauthenticated instead of
-        # failing the run. The secret never rides the message (only the path).
+        # A silent write failure would start the agent unauthenticated. The
+        # secret never rides the error message, only its destination path.
         if not result.ok:
             raise SandboxError(
                 f"failed to write secret to {remote}: "
@@ -183,8 +180,6 @@ class Sandbox:
                 f"remote tar exited {completed.exit_status} while extracting into {remote}",
             )
 
-    # One-shot exec
-
     async def run_agent(
         self,
         *,
@@ -199,6 +194,7 @@ class Sandbox:
         github_token: str | None = None,
         include_plugins: bool = True,
         add_dirs: tuple[str, ...] = (),
+        skills: tuple[str, ...] = (),
         extra_env: dict[str, Any] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
         connection_id: str | None = None,
@@ -251,6 +247,7 @@ class Sandbox:
                 github_token=github_token,
                 include_plugins=include_plugins,
                 add_dirs=add_dirs,
+                skills=skills,
                 extra_env=extra_env,
                 mcp_servers=mcp_servers,
                 call_id=run_id,
@@ -284,6 +281,7 @@ class Sandbox:
         github_token: str | None = None,
         include_plugins: bool = True,
         add_dirs: tuple[str, ...] = (),
+        skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
         call_id: str | None = None,
@@ -299,7 +297,11 @@ class Sandbox:
         persist_manifest(
             artifact_dir,
             call_id=run_id,
-            manifest=harness.get_manifest(mcp_servers=mcp_servers, extra_env=extra_env),
+            manifest=harness.get_manifest(
+                mcp_servers=mcp_servers,
+                skills=skills,
+                extra_env=extra_env,
+            ),
         )
 
         invocation = harness.build_invocation(
@@ -310,6 +312,7 @@ class Sandbox:
             github_token=github_token,
             include_plugins=include_plugins,
             add_dirs=add_dirs,
+            skills=skills,
             extra_env=extra_env,
             mcp_servers=mcp_servers,
             connection_id=connection_id,
@@ -519,8 +522,6 @@ class Sandbox:
             stderr=_as_str(completed.stderr),
         )
 
-    # Instruction lifecycle
-
     async def _start_instruction(
         self,
         *,
@@ -569,17 +570,14 @@ class Sandbox:
                 # never-started wrapper).
                 logger.debug("artifact missing or unreadable: %s", remote_path)
 
-    # Connection lifecycle
-
     async def ssh_connection(self) -> asyncssh.SSHClientConnection:
         return await self._ensure_conn()
 
     async def aclose(self) -> None:
-        if not self._conn:
-            return
-        self._conn.close()
-        await self._conn.wait_closed()
-        self._conn = None
+        if self._conn:
+            self._conn.close()
+            await self._conn.wait_closed()
+            self._conn = None
 
     async def __aenter__(self) -> Self:
         return self
@@ -591,8 +589,6 @@ class Sandbox:
         tb: TracebackType | None,
     ) -> None:
         await self.aclose()
-
-    # Internals
 
     async def _ensure_conn(self) -> asyncssh.SSHClientConnection:
         if self._conn:

--- a/backend/druks/skills/models.py
+++ b/backend/druks/skills/models.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from datetime import datetime
 
 from sqlalchemy import Boolean, ForeignKey, String, select
@@ -65,8 +66,8 @@ class Skill(Base, Uuid7Pk):
     description: Mapped[str] = mapped_column(String, default="")
     collection: Mapped[SkillCollection] = relationship(back_populates="skills")
     collection_id: Mapped[str] = mapped_column(ForeignKey("skill_collections.id"))
-    # Disabled skills stay on disk but the projection excludes them from the tar
-    # pushed to each VM (the harness drops ``disabled_names()`` from the upload).
+    # Disabled skills stay on disk but the delivery projection excludes them
+    # from every sandbox upload.
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     path: Mapped[str] = mapped_column(String)
     content_hash: Mapped[str] = mapped_column(String)
@@ -79,18 +80,25 @@ class Skill(Base, Uuid7Pk):
 
     @classmethod
     def list_enabled(cls) -> list["Skill"]:
-        # What a VM actually receives — a disabled skill is excluded from the
-        # tar (see disabled_excludes), so it's never really available to recommend.
+        # The operator's enabled catalog.
         stmt = select(cls).where(cls.enabled.is_(True)).order_by(cls.name)
         return list(db_session().scalars(stmt))
 
     @classmethod
-    def disabled_excludes(cls) -> tuple[str, ...]:
-        # ``tar --exclude`` patterns for disabled skills, anchored to the
-        # skills_dir tar root (``-C skills_dir .`` → members ``./<name>/...``),
-        # so the projection ships only enabled skills. They stay on disk.
-        names = db_session().execute(select(cls.name).where(cls.enabled.is_(False))).scalars()
-        return tuple(f"./{name}" for name in sorted(names))
+    def list_delivered(cls, requested: Collection[str]) -> list["Skill"]:
+        # What one call receives: the enabled skills it named, or the whole enabled
+        # catalog when it named none.
+        enabled = cls.list_enabled()
+        if requested:
+            return [skill for skill in enabled if skill.name in requested]
+        return enabled
+
+    @classmethod
+    def delivery_excludes(cls, requested: Collection[str]) -> tuple[str, ...]:
+        # Patterns are anchored to the skills_dir tar root (``-C skills_dir .``);
+        # excluded skills remain installed on disk.
+        delivered = {skill.name for skill in cls.list_delivered(requested)}
+        return tuple(f"./{name}" for name in sorted(cls.installed_names() - delivered))
 
     @classmethod
     def get(cls, name: str) -> "Skill | None":

--- a/backend/tests/ship/test_build_prompts.py
+++ b/backend/tests/ship/test_build_prompts.py
@@ -45,7 +45,12 @@ def _build() -> SimpleNamespace:
         task_owner_name=None,
         task_owner_email=None,
         related_repos=[],
-        skills=["python-house-rules"],
+        skills=[
+            SimpleNamespace(
+                name="python-house-rules",
+                description="Apply the Python house rules.",
+            )
+        ],
         journal=BuildJournal(),
     )
 
@@ -70,7 +75,7 @@ async def test_build_operation_prompt_renders(template):
     # The build-derived bits resolved — a leftover ``workflow`` ref would have
     # raised on StrictUndefined.
     assert "acme/widget" in output
-    assert "- `/python-house-rules`" in output
+    assert "- `python-house-rules` — Apply the Python house rules." in output
 
 
 async def test_implement_prompt_provisions_when_no_pr_exists():

--- a/backend/tests/ship/test_build_workspace.py
+++ b/backend/tests/ship/test_build_workspace.py
@@ -24,12 +24,14 @@ def test_build_workspace_grants_related_root_add_dir():
         branch="b",
         github_token="t",
         mcp_token="ghs_reviewer",
+        skills=("python-house-rules",),
     )
     kwargs = workspace.get_agent_run_kwargs(model="m")
 
     assert kwargs["model"] == "m"  # the run's own kwargs pass through
     assert kwargs["add_dirs"] == (get_related_root("exedev"),)
     assert kwargs["github_token"] == "t"
+    assert kwargs["skills"] == ("python-house-rules",)
     assert "mcp_servers" not in kwargs
     assert "extra_env" not in kwargs
 
@@ -45,6 +47,7 @@ async def test_build_workspace_declares_its_github_mcp(druks_db):
         branch="b",
         github_token="t",
         mcp_token="ghs_reviewer",
+        skills=("python-house-rules",),
     )
     kwargs = await workspace.with_mcp_servers(**workspace.get_agent_run_kwargs())
 
@@ -97,11 +100,13 @@ async def test_get_workspace_kwargs_clones_primary_only(monkeypatch: pytest.Monk
 
     workflow = Build()
     workflow.input = Build._run_input_model(repo="o/extension")
+    workflow._profile = {"recommended_skills": ["python-house-rules"]}
     kwargs = await workflow.get_workspace_kwargs(sandbox)
 
     assert ensured == ["https://github.com/o/extension"]
     assert ["mkdir", "-p", get_related_root("exedev")] in execs
     assert kwargs["mcp_token"] == "ghs_reviewer"
+    assert kwargs["skills"] == ("python-house-rules",)
     assert "related" not in kwargs
 
 
@@ -119,6 +124,7 @@ async def test_get_workspace_kwargs_fails_loudly_without_the_reviewer_app(
 
     workflow = Build()
     workflow.input = Build._run_input_model(repo="o/extension")
+    workflow._profile = {"recommended_skills": ["python-house-rules"]}
 
     with pytest.raises(FatalError, match="reviewer GitHub App"):
         await workflow.get_workspace_kwargs(sandbox)

--- a/backend/tests/test_manifest.py
+++ b/backend/tests/test_manifest.py
@@ -9,7 +9,7 @@ from druks.mcp import models
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.sandbox.datastructures import McpServer
 from druks.skills.datastructures import InstalledSkill
-from druks.skills.models import Skill, SkillCollection
+from druks.skills.models import SkillCollection
 from druks.testing import make_settings, seed_call, seed_run
 from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
@@ -23,12 +23,13 @@ def _build(
     *,
     harness: Harness | None = None,
     mcp_servers: tuple[McpServer, ...] = (),
+    skills: tuple[str, ...] = (),
     extra_env: dict[str, str] | None = None,
 ) -> dict:
     # get_manifest never touches the live sandbox, so the harness builds
     # without sandbox settings — the same shape argv unit tests use.
     harness = harness or ClaudeHarness(model="claude-opus-4-8", fast_mode=False, effort=None)
-    return harness.get_manifest(mcp_servers=mcp_servers, extra_env=extra_env)
+    return harness.get_manifest(mcp_servers=mcp_servers, skills=skills, extra_env=extra_env)
 
 
 def _seed_skills(*names: str, disabled: tuple[str, ...] = ()) -> None:
@@ -45,12 +46,9 @@ def _seed_skills(*names: str, disabled: tuple[str, ...] = ()) -> None:
             skill.enabled = False
 
 
-# --- the recorded capability set ------------------------------------------
-
-
 def test_manifest_records_the_delivered_capability_set(druks_db):
     """Records model, harness, each MCP server's declared/delivered/token
-    presence, and the enabled skills."""
+    presence, and the delivered skills."""
     models.McpServer.create(name="linear", url=_LINEAR_URL, token=_TOKEN)
     _seed_skills("alpha", "beta")
 
@@ -64,15 +62,17 @@ def test_manifest_records_the_delivered_capability_set(druks_db):
     # requirement (get_required_mcp_servers), so it reads delivered but not declared.
     manifest = _build(
         mcp_servers=(linear, github),
+        skills=("alpha",),
         extra_env={
             _LINEAR_ENV: _TOKEN,
             get_bearer_token_env_var("github"): "ghs_from_build",
         },
     )
 
+    assert manifest["schema_version"] == 2
     assert manifest["model"] == "claude-opus-4-8"
     assert manifest["harness"] == "claude"
-    assert manifest["skills_enabled"] == ["alpha", "beta"]
+    assert manifest["skills_delivered"] == ["alpha"]
 
     linear_entry = next(s for s in manifest["mcp_servers"] if s["name"] == "linear")
     assert linear_entry["declared"] is True
@@ -135,12 +135,9 @@ def test_records_the_delivered_server_not_the_registry_duplicate(druks_db):
     assert linear_entry["token_present"] is True
 
 
-# --- hash: identical capabilities bucket together --------------------------
-
-
 def test_hash_is_stable_for_identical_capabilities(druks_db):
     """Identical capability sets hash the same; changing the model, MCP token
-    availability, or the enabled skill set moves the hash."""
+    availability, or the delivered skill set moves the hash."""
     models.McpServer.create(name="linear", url=_LINEAR_URL, token=_TOKEN)
     linear = McpServer(name="linear", url=_LINEAR_URL, bearer_token_env_var=_LINEAR_ENV)
     with_token = {"mcp_servers": (linear,), "extra_env": {_LINEAR_ENV: _TOKEN}}
@@ -158,23 +155,15 @@ def test_hash_is_stable_for_identical_capabilities(druks_db):
     assert without_token["manifest_hash"] != baseline["manifest_hash"]
 
 
-def test_disabling_a_skill_changes_the_recorded_set_and_the_hash(druks_db):
-    """The skills tar excludes disabled skills, so the enabled set is the call's
-    real skill capability: recorded and hashed, so two calls with different
-    enabled skills bucket apart."""
-    _seed_skills("alpha", "beta")
-    both = _build()
-    assert both["skills_enabled"] == ["alpha", "beta"]
+def test_curated_skills_change_the_recorded_set_and_the_hash(druks_db):
+    """Curated manifests omit disabled skills and hash each delivered set."""
+    _seed_skills("alpha", "beta", disabled=("beta",))
+    with_enabled = _build(skills=("alpha", "beta"))
+    disabled_only = _build(skills=("beta",))
 
-    Skill.get("beta").enabled = False
-    druks_db.flush()
-    one = _build()
-
-    assert one["skills_enabled"] == ["alpha"]
-    assert one["manifest_hash"] != both["manifest_hash"]
-
-
-# --- presence, never the value -------------------------------------------
+    assert with_enabled["skills_delivered"] == ["alpha"]
+    assert disabled_only["skills_delivered"] == []
+    assert with_enabled["manifest_hash"] != disabled_only["manifest_hash"]
 
 
 def test_manifest_records_token_presence_never_the_value(druks_db):
@@ -220,9 +209,6 @@ def test_manifest_stays_presence_only_for_a_declared_header_server(druks_db):
     assert grafana_entry["declared"] is True
     assert grafana_entry["delivered"] is True
     assert grafana_entry["token_present"] is False
-
-
-# --- persistence + surfacing in transcript files -------------------------
 
 
 def test_persist_writes_manifest_into_the_call_dir(tmp_path, druks_db):

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -117,11 +117,18 @@ def test_collection_create_get_cascade_delete(druks_db):
     assert Skill.installed_names() == {"alpha", "beta"}
     assert [c.name for c in SkillCollection.list_all()] == ["o/r"]
 
-    # Skills land enabled; disabling drops them from the projection's tar.
-    assert Skill.disabled_excludes() == ()
+    assert [skill.name for skill in Skill.list_delivered(())] == ["alpha", "beta"]
+    assert Skill.delivery_excludes(()) == ()
+    assert [skill.name for skill in Skill.list_delivered(("alpha",))] == ["alpha"]
+    assert Skill.delivery_excludes(("alpha",)) == ("./beta",)
+
     Skill.get("alpha").enabled = False
     druks_db.flush()
-    assert Skill.disabled_excludes() == ("./alpha",)
+
+    assert [skill.name for skill in Skill.list_delivered(())] == ["beta"]
+    assert Skill.delivery_excludes(()) == ("./alpha",)
+    assert Skill.list_delivered(("alpha",)) == []
+    assert Skill.delivery_excludes(("alpha",)) == ("./alpha", "./beta")
 
     collection.delete()
     assert SkillCollection.list_all() == []

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -193,9 +193,10 @@ encryption envelope; they are ordinary Postgres fields whose values are
 withheld or masked by the API. Database and backup access must therefore be
 treated as credential access.
 
-Enabled MCP servers and skills are injected through both harnesses. A workspace
-may also require and credential an MCP server for its own application. Each
-agent call records what was declared and delivered so later evaluation can
+Enabled MCP servers are injected through both harnesses. A call receives the
+enabled skills it requests, or every enabled skill when it requests none. A
+workspace may also require and credential an MCP server for its own application.
+Each agent call records what was declared and delivered so later evaluation can
 distinguish capability sets without storing the tokens.
 
 ## Process and access topology

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -283,9 +283,10 @@ under a derived variable and are never returned by the API.
 
 The dashboard installs skill collections from GitHub repositories.
 `DRUKS_SKILLS_DIR` selects the shared writable directory; otherwise it defaults
-to `<DRUKS_DATA_DIR>/skills`. Enabled skills are copied into both CLI homes in
-each sandbox. Disabled skills are excluded from the upload and from the
-per-agent capability manifest.
+to `<DRUKS_DATA_DIR>/skills`. A call receives the enabled skills it requests, or
+every enabled skill when it requests none; build requests the repo profile's
+recommended set. Other installed skills are excluded from the upload, and the
+per-agent capability manifest records the delivered set.
 
 ## Credential custody and secrets at rest
 


### PR DESCRIPTION
Skills were described three times per agent call and no two descriptions agreed. `Skill.list_enabled()` built the tar both harnesses push — all 23. `profile["recommended_skills"]` rendered the prompt's `## Skills` block — 9 bare, slash-prefixed names. The capability manifest recorded `skills_enabled` — 23 again.

The 9 are the curated set: the repo profiler picks per-repo from the catalog and the result is re-filtered against enabled skills. For this repo it keeps the Python/FastAPI/SQLAlchemy/migration skills and drops django-*, celery, next-*. That judgment was then discarded — the tar shipped all 23, so Claude routed on 23 uncurated descriptions and codex got 9 names it could only evaluate by opening the file.

## One rule, three consumers

`Skill.list_delivered(requested)` answers what a call receives: the enabled skills it named, or the whole enabled catalog when it named none. `Skill.delivery_excludes` derives the tar patterns from it, `Harness.get_manifest` records its names, and build's prompt lists its rows. The three lists now share a definition instead of agreeing by coincidence. `Skill.disabled_excludes()` is gone — dropping the disabled set is what the rule already does.

`skills` joins the per-call knobs each invocation already carries (`include_plugins`, `add_dirs`, `mcp_servers`, `connection_id`), threaded from `Sandbox.run_agent` through `run_prompt` into both harnesses' credential bundles. `BuildWorkspace` carries the profile's recommended set; `RepoWorkspace` and `ReviewWorkspace` pass nothing and keep the uncurated default — the profiler is the thing that produces the curation, so it needs the whole catalog.

## Listing and recording

The prompt renders `` `python-house-rules` — Use for any Python code change… `` instead of `/python-house-rules`. The slash form implies a command to type; neither harness wants it, since codex wants a directory name and Claude's `Skill` tool takes a bare name. The description is what lets an agent triage a skill without reading it. `BuildPromptContext.skills` carries `Skill` rows to make that possible.

The manifest key becomes `skills_delivered`, and `MANIFEST_SCHEMA_VERSION` bumps to 2 so the hash buckets reshuffle. The record now moves when the delivered set moves.

## The trade

An unrecommended skill used to be installed-but-unlisted, so an agent could still stumble into it. It is now absent from the VM, and recovery is a re-profile (`refresh_only` already exists) rather than a code change. A stale curated list is one re-profile away; 23 mostly-irrelevant descriptions in the router's context are permanent.