### PR TITLE
ENG-783 - A ticket's key has one name

### DIFF
--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -119,9 +119,6 @@ class Build(Workflow):
             account_id=assignee.id if assignee else None,
             repo=item.repo,
             source=item.source,
-            ticket_ref=item.ticket_key,
-            ticket_title=item.title,
-            ticket_url=item.ticket_url,
             task_owner_email=email,
             task_owner_name=ticket["assignee_name"],
         )
@@ -139,14 +136,6 @@ class Build(Workflow):
         repo: str,
         issue_number: int | None = None,
         source: str = "github",
-        # Human-readable ticket reference ("ACME-270", "#42"). Same value the
-        # WorkItem keeps as ``ticket_key``; carried separately on the input
-        # so the workflow can render it into prompts / PR titles without a
-        # WorkItem fetch.
-        ticket_ref: str | None = None,
-        # Ticket title as intake received it; the implementer uses it for the PR title.
-        ticket_title: str | None = None,
-        ticket_url: str | None = None,
         task_owner_email: str | None = None,
         task_owner_name: str | None = None,
     ) -> None:
@@ -207,15 +196,16 @@ class Build(Workflow):
         }
 
     async def get_prompt_context(self, **context: Any) -> dict[str, Any]:
+        work_item = self.subject
         target_repo = ProjectRepo.get_for_repo(self.input.repo, raise_on_missing=True)
         endpoint = load_settings().endpoint.rstrip("/")
-        work_item_url = f"{endpoint}/work-items/{self.subject.id}" if endpoint else ""
+        work_item_url = f"{endpoint}/work-items/{work_item.id}" if endpoint else ""
         prompt_context = BuildPromptContext(
             repo=self.input.repo,
             work_item_url=work_item_url,
             branch=self.branch,
             pr_number=self.pr_number,
-            ticket_ref=self.input.ticket_ref,
+            ticket_ref=work_item.ticket_key,
             source=self.input.source,
             issue_number=self.input.issue_number,
             task_owner_name=self.input.task_owner_name,

--- a/backend/tests/ship/test_build_dispatch.py
+++ b/backend/tests/ship/test_build_dispatch.py
@@ -12,10 +12,8 @@ async def test_dispatch_pulls_cancelled_item_back_onto_the_board(druks_db, monke
     item = make_test_work_item(repo="o/r", title="t", ticket_key="ACME-1")
     item.set_status(HandoffStatus.CANCELLED)
     seed_run(druks_db, kind=Build.kind, run_id="run-1")
-    started = {}
 
     async def fake_start(cls, **kwargs):
-        started.update(kwargs)
         return "run-1"
 
     monkeypatch.setattr(Build, "start", classmethod(fake_start))
@@ -36,9 +34,6 @@ async def test_dispatch_pulls_cancelled_item_back_onto_the_board(druks_db, monke
     assert run_id == "run-1"
     assert item.build_run_id == "run-1"
     assert item.status is None
-    assert started["ticket_ref"] == "ACME-1"
-    assert started["ticket_title"] == "t"
-    assert started["ticket_url"] == "https://tracker.test/ACME-1"
 
 
 async def test_redispatch_to_a_new_run_clears_prior_attempt_branch_and_pr(

--- a/frontend/src/components/TicketCell.tsx
+++ b/frontend/src/components/TicketCell.tsx
@@ -1,20 +1,15 @@
 interface Props {
-  ticketRef?: string | null
+  ticketKey: string
   ticketUrl?: string | null
-  fallback: string
 }
 
 /**
- * Ticket cell: the ticket ref (e.g. ``ACME-398``) rendered as a link to
- * Linear when ``ticketUrl`` is set, otherwise plain text. Falls back to
- * ``fallback`` (e.g. ``#<id>``) when there's no ref at all.
- *
- * Mirrors ``PRCell``: the anchor stops row-click propagation so clicking
- * the ticket opens Linear instead of triggering the row's navigate-into
+ * Mirrors ``PRCell``: the anchor stops row-click propagation so clicking the
+ * ticket opens it in the tracker instead of triggering the row's navigate-into
  * handler.
  */
-export function TicketCell({ ticketRef, ticketUrl, fallback }: Props) {
-  if (ticketRef && ticketUrl) {
+export function TicketCell({ ticketKey, ticketUrl }: Props) {
+  if (ticketUrl) {
     return (
       <span className="row-id mono">
         <a
@@ -24,10 +19,10 @@ export function TicketCell({ ticketRef, ticketUrl, fallback }: Props) {
           rel="noreferrer"
           onClick={(event) => event.stopPropagation()}
         >
-          {ticketRef}
+          {ticketKey}
         </a>
       </span>
     )
   }
-  return <span className="row-id mono">{ticketRef ?? fallback}</span>
+  return <span className="row-id mono">{ticketKey}</span>
 }

--- a/frontend/src/extensions/ship/WorkItemsPage.tsx
+++ b/frontend/src/extensions/ship/WorkItemsPage.tsx
@@ -48,7 +48,7 @@ function WorkItemRowView({
   return (
     <div className={`row row-work-item${failed ? ' row-failed' : ''}`} onClick={() => onOpen(row)}>
       <StatusGlyph state={status.state} pulse={parked || live} />
-      <TicketCell ticketRef={wi.ticketKey} ticketUrl={wi.links.ticket} fallback={`#${wi.id}`} />
+      <TicketCell ticketKey={wi.ticketKey} ticketUrl={wi.links.ticket} />
       <span className="row-title" title={wi.title}>
         {wi.title}
       </span>


### PR DESCRIPTION
Residue after #129: the column, both wire responses, and every frontend consumer
say `ticket_key`. Two places still said `ref`, carrying the same value.

**`TicketCell`** took `ticketRef?: string | null` plus a required `fallback`, and
ended on `{ticketRef ?? fallback}`. Its one caller passes `wi.ticketKey`, which is
a required `string` backed by a non-null column — so the optionality, the `??`
tail, and `fallback` itself were unreachable. The prop is now `ticketKey: string`
and the dead path is gone.

**`Build`'s input** carried three ticket fields. `ticket_title` and `ticket_url`
were write-only: dispatch set them, `run_multistep` declared them, and nothing
read them — `BuildPromptContext` has no title field, no template names either, and
the only reads repo-wide were two assertions pinning the wiring. `ticket_ref` was
read, but dispatch assigned it `item.ticket_key` unchanged and the workflow
already holds the row. All three are off the input; the prompt context renders
`ticket_ref` from `self.subject.ticket_key`.

`BuildPromptContext.ticket_ref` and the templates are unchanged — that field is
the prompt-facing reference, and it now reads the row instead of a frozen copy.

Renaming `ticket_ref` → `ticket_key` on the input was the obvious fix and the
wrong one: it buys one canonical spelling and leaves the input still carrying
ticket fields, so the next spelling question costs another drain. Removing the
fields settles it.
