### PR TITLE
A mention only asks for a review if it writes to the repo

### DIFF
--- a/backend/druks/contrib/review/subscribers.py
+++ b/backend/druks/contrib/review/subscribers.py
@@ -5,11 +5,10 @@ from druks.settings import load_settings
 from druks.signals import subscribe
 
 
-@subscribe("pr.commented")
+@subscribe("pr.commented", payload__author_can_write=True)
 async def mention_asks_for_a_review(*, repo: str, pr_number: int, payload: dict) -> None:
-    """Addressing the reviewer app in a comment asks it to review that pull request.
-    A repo no project claims is left alone — there is nothing to review it against,
-    and a webhook that shrugs is right where a request would be told no."""
+    """Addressing the reviewer app asks it to review that pull request, and only someone
+    who writes to the repo may ask — a review is the account's to spend."""
     handle = await get_reviewer_github_client(load_settings()).get_mention_handle()
     is_mentioned = handle and f"@{handle}".casefold() in payload["body"].casefold()
     if is_mentioned and ProjectRepo.get_for_repo(repo):

--- a/backend/druks/core/webhooks/github.py
+++ b/backend/druks/core/webhooks/github.py
@@ -7,6 +7,10 @@ from druks.webhooks import Webhook, verify_hmac_sha256
 
 _REVIEW_ACTION = {"APPROVED": "approve", "CHANGES_REQUESTED": "request_changes"}
 
+# GitHub's standing for the commenter on that repo. These three write to it;
+# everyone else is a passer-by, and on a public repo that is the whole internet.
+_WRITERS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+
 
 class GitHubEvents(Webhook):
     """Verifies the GitHub HMAC, then emits ``pr.review_submitted`` /
@@ -66,7 +70,11 @@ class GitHubEvents(Webhook):
             "pr.commented",
             repo=_repo_name(self.data),
             pr_number=issue["number"],
-            payload={"author": sender["login"], "body": self.data["comment"]["body"]},
+            payload={
+                "author": sender["login"],
+                "author_can_write": self.data["comment"]["author_association"] in _WRITERS,
+                "body": self.data["comment"]["body"],
+            },
         )
         return _accepted()
 

--- a/backend/tests/test_review.py
+++ b/backend/tests/test_review.py
@@ -2,10 +2,12 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from druks.contrib.review import subscribers  # noqa: F401 — the import registers it
 from druks.contrib.review.datastructures import PullRequest
 from druks.contrib.review.workflows import PullRequestReview
 from druks.prompts import render_prompt
-from druks.testing import seed_run
+from druks.signals import publish
+from druks.testing import configure_app_for_test, make_settings, seed_run
 from druks.workflows import _bind_instance
 from fastapi.testclient import TestClient
 
@@ -14,8 +16,6 @@ pytestmark = pytest.mark.usefixtures("druks_without_remote_config")
 
 @pytest.fixture
 def client(tmp_path: Path, druks_db, monkeypatch):
-    from druks.testing import configure_app_for_test, make_settings
-
     monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
     with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
         yield client
@@ -98,3 +98,23 @@ async def test_the_reviewer_prompt_names_the_pull_request_it_is_about():
 
     assert "pull request #7 on `acme/app`" in output
     assert "at dev@example.com's request" in output
+
+
+async def test_a_passer_by_cannot_spend_a_review(monkeypatch):
+    # The repos druks reviews are public, so the mention is the whole internet's to write
+    # and each one would spend a run. The filter answers before the body asks GitHub.
+    dispatched = []
+
+    async def dispatch(**kwargs):
+        dispatched.append(kwargs)
+
+    monkeypatch.setattr(PullRequestReview, "dispatch", dispatch)
+
+    await publish(
+        "pr.commented",
+        repo="acme/app",
+        pr_number=7,
+        payload={"author": "passer-by", "author_can_write": False, "body": "@druks review"},
+    )
+
+    assert not dispatched


### PR DESCRIPTION
The repos druks reviews are public, so an @-mention on a pull request is the whole internet's to write, and every one of them spent a run.

GitHub already says where a commenter stands on the repo. The webhook carries that as a normalized fact on `pr.commented`, and the reviewer acts on owners, members and collaborators only. The authenticated `POST /reviews` route is unchanged.