### PR TITLE
A subject id is a string, whatever the row is keyed by

### DIFF
--- a/backend/druks/contrib/ship/models.py
+++ b/backend/druks/contrib/ship/models.py
@@ -230,7 +230,7 @@ class WorkItem(StoredSubject):
         return self.ticket_key
 
     def get_summary(self) -> WorkItemSummary:
-        return WorkItemSummary.from_work_item(self)
+        return WorkItemSummary.model_validate(self)
 
     @classmethod
     def list_summaries(cls) -> list[WorkItemSummary]:

--- a/backend/druks/contrib/ship/routes.py
+++ b/backend/druks/contrib/ship/routes.py
@@ -252,5 +252,5 @@ async def list_work_items_history(
     clamped = max(1, min(limit, _HISTORY_MAX_LIMIT))
     # Recent-history aggregation. History is "handoff" — druks finished a
     # unit and handed it off as shipped or cancelled.
-    items = [DashboardItem.from_work_item(wi) for wi in WorkItem.list_handoff(limit=clamped)]
+    items = [DashboardItem.model_validate(wi) for wi in WorkItem.list_handoff(limit=clamped)]
     return WorkItemsHistoryResponse(items=items)

--- a/backend/druks/contrib/ship/schemas.py
+++ b/backend/druks/contrib/ship/schemas.py
@@ -93,13 +93,6 @@ class Links(BaseResponse):
     pr: str | None = None
     ticket: str | None = None
 
-    @classmethod
-    def for_work_item(
-        cls, *, repo: str | None, pr_number: int | None, ticket_url: str | None
-    ) -> "Links":
-        pr = f"https://github.com/{repo}/pull/{pr_number}" if pr_number else None
-        return cls(repo=f"https://github.com/{repo}", pr=pr, ticket=ticket_url)
-
 
 class WorkItemSummary(SubjectSummary):
     # The work item's domain header — what only Ship knows. Status (where it is
@@ -113,18 +106,18 @@ class WorkItemSummary(SubjectSummary):
     project_name: str = Field(validation_alias=AliasPath("project", "name"))
     title: str
     ticket_key: str
-    ticket_url: str | None = None
     pr_number: int | None = None
     branch: str | None = None
     created_at: datetime
     updated_at: datetime
+    # Carried for the links below, which is where the UI reads it.
+    ticket_url: str | None = Field(default=None, exclude=True)
 
     @computed_field
     @property
     def links(self) -> Links:
-        return Links.for_work_item(
-            repo=self.repo, pr_number=self.pr_number, ticket_url=self.ticket_url
-        )
+        pr = f"https://github.com/{self.repo}/pull/{self.pr_number}" if self.pr_number else None
+        return Links(repo=f"https://github.com/{self.repo}", pr=pr, ticket=self.ticket_url)
 
 
 class DashboardItem(BaseResponse):
@@ -143,20 +136,11 @@ class DashboardItem(BaseResponse):
     status: HandoffStatus
     created_at: datetime
     updated_at: datetime
-    # Carried for the links below, never serialized on its own.
-    ticket_url: str | None = Field(default=None, exclude=True)
 
     @computed_field
     @property
     def key(self) -> str:
         return f"code:{self.source_id}"
-
-    @computed_field
-    @property
-    def links(self) -> Links:
-        return Links.for_work_item(
-            repo=self.repo, pr_number=self.pr_number, ticket_url=self.ticket_url
-        )
 
 
 class WorkItemsHistoryResponse(BaseResponse):

--- a/backend/druks/contrib/ship/schemas.py
+++ b/backend/druks/contrib/ship/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AliasPath, BaseModel, ConfigDict, Field, computed_field
 
 from druks.schemas import BaseResponse
 from druks.workflows import SubjectSummary
@@ -9,7 +9,7 @@ from druks.workflows import SubjectSummary
 from .enums import HandoffStatus
 
 if TYPE_CHECKING:
-    from druks.contrib.ship.models import Project, ProjectRepo, WorkItem
+    from druks.contrib.ship.models import Project, ProjectRepo
 
 ProfileState = Literal["unprofiled", "running", "ready", "failed"]
 
@@ -94,9 +94,11 @@ class Links(BaseResponse):
     ticket: str | None = None
 
     @classmethod
-    def from_work_item(cls, item: "WorkItem") -> "Links":
-        pr = f"https://github.com/{item.repo}/pull/{item.pr_number}" if item.pr_number else None
-        return cls(repo=f"https://github.com/{item.repo}", pr=pr, ticket=item.ticket_url)
+    def for_work_item(
+        cls, *, repo: str | None, pr_number: int | None, ticket_url: str | None
+    ) -> "Links":
+        pr = f"https://github.com/{repo}/pull/{pr_number}" if pr_number else None
+        return cls(repo=f"https://github.com/{repo}", pr=pr, ticket=ticket_url)
 
 
 class WorkItemSummary(SubjectSummary):
@@ -108,7 +110,7 @@ class WorkItemSummary(SubjectSummary):
     # Druks Project name (e.g. "Hey Fella"), not the repo. Required —
     # every WorkItem is born into a project, intake refuses tickets
     # whose Linear project doesn't map to one.
-    project_name: str
+    project_name: str = Field(validation_alias=AliasPath("project", "name"))
     title: str
     ticket_key: str
     ticket_url: str | None = None
@@ -116,58 +118,44 @@ class WorkItemSummary(SubjectSummary):
     branch: str | None = None
     created_at: datetime
     updated_at: datetime
-    links: Links
 
-    @classmethod
-    def from_work_item(cls, item: "WorkItem") -> "WorkItemSummary":
-        return cls(
-            id=item.id,
-            label=item.label,
-            source=item.source,  # type: ignore[arg-type]
-            repo=item.repo,
-            project_name=item.project.name,
-            title=item.title,
-            ticket_key=item.ticket_key,
-            ticket_url=item.ticket_url,
-            pr_number=item.pr_number,
-            branch=item.branch,
-            created_at=item.created_at,
-            updated_at=item.updated_at,
-            links=Links.from_work_item(item),
+    @computed_field
+    @property
+    def links(self) -> Links:
+        return Links.for_work_item(
+            repo=self.repo, pr_number=self.pr_number, ticket_url=self.ticket_url
         )
 
 
 class DashboardItem(BaseResponse):
-    key: str
-    source_id: int | str
+    model_config = ConfigDict(from_attributes=True)
+
+    source_id: int | str = Field(validation_alias="id")
     ticket_key: str
     title: str
     repo: str | None = None
     pr_number: int | None = None
-    project_name: str | None = None
-    # The stored handoff lane, verbatim — the FE words and colors it.
+    # Druks Project is required on WorkItem, so the dashboard always has a
+    # curated project name to render.
+    project_name: str | None = Field(default=None, validation_alias=AliasPath("project", "name"))
+    # The stored handoff lane, verbatim — the FE words and colors it. History is
+    # terminal-only, so it is always set.
     status: HandoffStatus
     created_at: datetime
     updated_at: datetime
-    links: Links
+    # Carried for the links below, never serialized on its own.
+    ticket_url: str | None = Field(default=None, exclude=True)
 
-    @classmethod
-    def from_work_item(cls, item: "WorkItem") -> "DashboardItem":
-        # History is terminal-only, so the stored lane is always set.
-        return cls(
-            key=f"code:{item.id}",
-            source_id=item.id,
-            ticket_key=item.ticket_key,
-            title=item.title,
-            repo=item.repo,
-            pr_number=item.pr_number,
-            # Druks Project is required on WorkItem, so the dashboard
-            # always has a curated project name to render.
-            project_name=item.project.name,
-            status=HandoffStatus(item.status),
-            created_at=item.created_at,
-            updated_at=item.updated_at,
-            links=Links.from_work_item(item),
+    @computed_field
+    @property
+    def key(self) -> str:
+        return f"code:{self.source_id}"
+
+    @computed_field
+    @property
+    def links(self) -> Links:
+        return Links.for_work_item(
+            repo=self.repo, pr_number=self.pr_number, ticket_url=self.ticket_url
         )
 
 

--- a/backend/druks/contrib/ship/schemas.py
+++ b/backend/druks/contrib/ship/schemas.py
@@ -121,7 +121,7 @@ class WorkItemSummary(SubjectSummary):
     @classmethod
     def from_work_item(cls, item: "WorkItem") -> "WorkItemSummary":
         return cls(
-            id=str(item.id),
+            id=item.id,
             label=item.label,
             source=item.source,  # type: ignore[arg-type]
             repo=item.repo,

--- a/backend/druks/durable/datastructures.py
+++ b/backend/druks/durable/datastructures.py
@@ -48,7 +48,7 @@ class Subject:
     def get_summary(self) -> SubjectSummary:
         """The header its board and page show it under. Its id and label already say
         what it is; override to add the fields only this extension knows."""
-        return SubjectSummary(id=self.id, label=self.label)
+        return SubjectSummary.model_validate(self)
 
     @classmethod
     def list_summaries(cls) -> Sequence[SubjectSummary]:

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -1,8 +1,8 @@
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from pydantic import Field, SerializeAsAny
+from pydantic import BeforeValidator, ConfigDict, Field, SerializeAsAny
 
 from druks.harnesses.artifacts import normalize_token_usage
 from druks.schemas import BaseResponse
@@ -163,11 +163,20 @@ class RunResponse(BaseResponse):
         )
 
 
+# A subject id is a string wherever it is read — the URL segment, the DBOS
+# attribute, the dedup key — while the row behind one is keyed by an integer. So it
+# takes either and is always a string.
+SubjectId = Annotated[str, BeforeValidator(str)]
+
+
 class SubjectSummary(BaseResponse):
     # Every subject's header: ``id`` keys its status, timeline and detail URL, and
     # ``label`` is the one line it shows itself as — read live off the subject, unlike
-    # the copy an event snapshots. A subject with more to say subclasses this.
-    id: str
+    # the copy an event snapshots. A subject with more to say subclasses this, and
+    # ``from_attributes`` builds any of them straight off the subject.
+    model_config = ConfigDict(from_attributes=True)
+
+    id: SubjectId
     label: str
 
 

--- a/backend/druks/models.py
+++ b/backend/druks/models.py
@@ -93,7 +93,7 @@ class StoredSubject(Base):
         # so nothing under it can be imported here at module scope.
         from druks.durable.schemas import SubjectSummary
 
-        return SubjectSummary(id=str(self.id), label=self.label)
+        return SubjectSummary.model_validate(self)
 
     @classmethod
     def list_summaries(cls) -> "Sequence[SubjectSummary]":

--- a/backend/tests/druks-field_notes/druks_field_notes/models.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/models.py
@@ -40,7 +40,7 @@ class Note(StoredSubject):
         db_session().flush()
 
     def get_summary(self) -> NoteSummary:
-        return NoteSummary.from_note(self)
+        return NoteSummary.model_validate(self)
 
     @classmethod
     def list_summaries(cls) -> list[NoteSummary]:

--- a/backend/tests/druks-field_notes/druks_field_notes/routes.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/routes.py
@@ -12,7 +12,7 @@ router = APIRouter(prefix="/notes")
 
 @router.get("", response_model=list[NoteSummary], response_model_by_alias=True)
 async def list_notes() -> list[NoteSummary]:
-    return [NoteSummary.from_note(note) for note in Note.list_recent()]
+    return [note.get_summary() for note in Note.list_recent()]
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)

--- a/backend/tests/druks-field_notes/druks_field_notes/schemas.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/schemas.py
@@ -1,10 +1,6 @@
 from datetime import datetime
-from typing import TYPE_CHECKING
 
 from druks.workflows import SubjectSummary
-
-if TYPE_CHECKING:
-    from druks_field_notes.models import Note
 
 
 class NoteSummary(SubjectSummary):
@@ -13,13 +9,3 @@ class NoteSummary(SubjectSummary):
     body: str
     summary: str | None = None
     created_at: datetime
-
-    @classmethod
-    def from_note(cls, note: "Note") -> "NoteSummary":
-        return cls(
-            id=str(note.id),
-            label=note.label,
-            body=note.body,
-            summary=note.summary,
-            created_at=note.created_at,
-        )

--- a/backend/tests/ship/test_api_work_items.py
+++ b/backend/tests/ship/test_api_work_items.py
@@ -105,7 +105,6 @@ def test_subject_detail_composes_summary_status_and_timeline(client: TestClient,
     summary = detail["summary"]
     assert summary["id"] == str(item.id)
     assert summary["ticketKey"] == "ACME-5"
-    assert summary["ticketUrl"] == "https://linear.app/acme/issue/ACME-5/detail"
     assert summary["links"]["ticket"] == "https://linear.app/acme/issue/ACME-5/detail"
     assert summary["links"]["pr"] == "https://github.com/ClawHaven/acme-app/pull/8"
     # Status is the platform's, aggregated from the item's runs — parked on a gate.

--- a/backend/tests/test_extension_appless_load.py
+++ b/backend/tests/test_extension_appless_load.py
@@ -41,9 +41,6 @@ _FILES = {
         class ProbeItem(StoredSubject):
             __tablename__ = "probe_items"
 
-            def get_summary(self) -> SubjectSummary:
-                return SubjectSummary(id=str(self.id))
-
             @classmethod
             def list_summaries(cls) -> list[SubjectSummary]:
                 return []

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -10,6 +10,7 @@ from druks.models import StoredSubject
 from druks.testing import seed_dbos_status
 from fastapi import APIRouter
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 from sqlalchemy import select
 from uuid_utils import uuid7
 
@@ -25,7 +26,7 @@ class Thing(StoredSubject):
     __tablename__ = "faketest_things"
 
     def get_summary(self) -> _ThingSummary:
-        return _ThingSummary(id=str(self.id), label=self.label, title=TITLES[self.id])
+        return _ThingSummary(id=self.id, label=self.label, title=TITLES[self.id])
 
     @classmethod
     def list_summaries(cls) -> list[_ThingSummary]:
@@ -115,6 +116,19 @@ def client(tmp_path: Path, druks_db, monkeypatch):
     finally:
         for route in holder.routes:
             app.router.routes.remove(route)
+
+
+def test_a_subject_id_is_a_string_whatever_the_row_is_keyed_by(druks_db):
+    # A row is keyed by an integer and every read of a subject id is a string — the
+    # URL segment, the DBOS attribute, the dedup key. The header takes either and is
+    # always the string, so no summary hand-stringifies a primary key.
+    summary = SubjectSummary.model_validate(Thing(id=7))
+    assert summary.id == "7"
+    assert SubjectSummary.model_validate(Ticket(id="owner/repo#7")).id == "owner/repo#7"
+
+    # Only the id widens: a label that arrives as a number is still a mistake.
+    with pytest.raises(ValidationError):
+        SubjectSummary(id=7, label=7)
 
 
 def test_status_aggregates_across_runs_and_timeline_spans_them(client: TestClient, druks_db):

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -413,9 +413,7 @@ class RepositorySummary(SubjectSummary):
 
 class Repository(StoredSubject):
     def get_summary(self) -> RepositorySummary:
-        return RepositorySummary(
-            id=str(self.id), label=self.label, open_findings=self.findings.count()
-        )
+        return RepositorySummary.model_validate(self)
 ```
 
 When you keep no row for it, subclass `Subject` instead — identity is all the

--- a/frontend/src/extensions/ship/api.ts
+++ b/frontend/src/extensions/ship/api.ts
@@ -43,7 +43,6 @@ export interface WorkItemSummary extends SubjectSummary {
   projectName: string
   title: string
   ticketKey: string
-  ticketUrl?: string | null
   prNumber?: number | null
   branch?: string | null
   createdAt: string
@@ -63,7 +62,6 @@ export interface DashboardItem {
   status: HandoffStatus
   createdAt: string
   updatedAt: string
-  links: Links
 }
 
 // Build's concrete subject views — the platform's generic board row and timeline


### PR DESCRIPTION
A subject id is a string everywhere it is read — the URL segment, the DBOS attribute, the dedup key, the event row — while the row behind one is keyed by an integer. Nothing named that, so every summary bridged it by hand:

```python
id=str(note.id)
```

And a constructor written for that one field went on to hand-copy the rest, which is how `NoteSummary.from_note` ended up listing five fields to transform one.

## The identifier is a type

```python
SubjectId = Annotated[str, BeforeValidator(str)]
```

Takes either and is always the string — the same settlement GraphQL, JSON:API and Protobuf all reached independently:

- **GraphQL's `ID`** — *"often numeric, it should always serialize as a String"*, and *"any string (such as `"4"`) or integer (such as `4`) input value will be accepted"*.
- **JSON:API** — *"The values of the `id`, `type`, and `lid` members MUST be strings."*
- **ProtoJSON** — `int64` becomes a decimal string, *"either numbers or strings are accepted"*, because JSON parsers are *"silently lossy if a number is an integer larger than 2**53"*.

Scoped to `id` rather than `ConfigDict(coerce_numbers_to_str=True)`, which would widen every string field on the model: a `label` or a `title` arriving as a number stays a mistake.

## What it removes

`from_attributes` on the header means a subject builds its own. The platform default on both bases is now `SubjectSummary.model_validate(self)`, and a note's summary is its columns rather than a constructor listing them — `from_note` is gone, and `field_notes`' `schemas.py` no longer imports its `models.py` at all.

What remains composes, and the next commit shows how little of it there was.

## Not a wire change

`id=str(item.id)` and `id=item.id` serialize identically. No response shape moves, so the frontend is untouched.

## Ship's own shapes follow

`WorkItemSummary` and `DashboardItem` each declared every field and then assigned every field, which buried the only two bits of real work: a project name reached through a relation, and a set of links.

```python
project_name: str = Field(validation_alias=AliasPath("project", "name"))

@computed_field
@property
def links(self) -> Links:
    return Links.for_work_item(repo=self.repo, pr_number=self.pr_number, ticket_url=self.ticket_url)
```

The relation is an alias and the links compute from fields the shape already carries, so both build with `model_validate` and neither constructor survives. `Links` keeps the one that earns it — the URL rule, in one place, called by both.

Both serialize byte-for-byte as before. `ticket_url` rides `DashboardItem` only to feed its links and stays off the wire via `exclude=True`, and `source_id` keeps its name through a validation alias.

`ProjectRepoSummary.from_repo` is deliberately untouched: it runs `repo.get_status()`, one database query per repo on `GET /api/ship/projects` — measured at 12 for 12 repos. Making it declarative would hide that, not fix it, and the fields it derives are the run state the platform now serves on the repo's own board. Its own ticket.