### PR TITLE
A repo's profiling state is read where its runs are

### DIFF
--- a/backend/druks/contrib/review/datastructures.py
+++ b/backend/druks/contrib/review/datastructures.py
@@ -38,7 +38,6 @@ class PullRequest(Subject):
     def get_summary(self) -> ReviewSummary:
         return ReviewSummary(
             id=self.id,
-            label=self.label,
             repo=self.repo,
             pr_number=self.number,
             pull_request_url=self.url,

--- a/backend/druks/contrib/ship/models.py
+++ b/backend/druks/contrib/ship/models.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from sqlalchemy import ForeignKey, Index, func, select
 from sqlalchemy.dialects.postgresql import JSONB
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from druks.contrib.ship.enums import HandoffStatus
 from druks.contrib.ship.policy import RepoPolicy
-from druks.contrib.ship.schemas import WorkItemSummary
+from druks.contrib.ship.schemas import ProjectRepoSummary, WorkItemSummary
 from druks.core.apis.github import get_github_client
 from druks.db import Base, StoredSubject, db_session
 from druks.settings import load_settings
@@ -17,9 +17,6 @@ from druks.ticketing.enums import TicketStatus
 from druks.ticketing.exceptions import TrackerNotConfigured
 from druks.ticketing.helpers import get_tracker, is_tracker_source
 from druks.workflows import FatalError
-
-if TYPE_CHECKING:
-    from druks.durable.schemas import SubjectSummary
 
 logger = logging.getLogger(__name__)
 
@@ -114,8 +111,11 @@ class ProjectRepo(StoredSubject):
     def get_label(self) -> str:
         return self.full_name
 
+    def get_summary(self) -> "ProjectRepoSummary":
+        return ProjectRepoSummary.model_validate(self)
+
     @classmethod
-    def list_summaries(cls) -> list["SubjectSummary"]:
+    def list_summaries(cls) -> list["ProjectRepoSummary"]:
         # A repo is registered, not transient, so the board is all of them by name.
         stmt = select(cls).order_by(cls.full_name)
         return [repo.get_summary() for repo in db_session().scalars(stmt)]
@@ -123,6 +123,7 @@ class ProjectRepo(StoredSubject):
     def siblings(self) -> list["ProjectRepo"]:
         return [repo for repo in self.project.repos if repo.full_name != self.full_name]
 
+    @property
     def effective_profile(self) -> dict[str, Any]:
         # {} until the repo profiler has run — an unprofiled repo is a normal state.
         return self.profile.get("effective") or {}

--- a/backend/druks/contrib/ship/routes.py
+++ b/backend/druks/contrib/ship/routes.py
@@ -31,7 +31,7 @@ projects_router = APIRouter(prefix="/projects", tags=["projects"])
 @projects_router.get("", response_model=ProjectsResponse, response_model_by_alias=True)
 async def list_projects() -> ProjectsResponse:
     rows = list(db_session().scalars(select(Project).order_by(Project.name)))
-    return ProjectsResponse(projects=[ProjectSummary.from_project(p) for p in rows])
+    return ProjectsResponse(projects=[ProjectSummary.model_validate(p) for p in rows])
 
 
 @projects_router.post(
@@ -45,7 +45,7 @@ async def create_project(body: CreateProjectRequest) -> ProjectSummary:
     if not name:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "name is required")
     project = Project.create(name=name)
-    return ProjectSummary.from_project(project)
+    return ProjectSummary.model_validate(project)
 
 
 # GitHub repo typeahead source. Declared BEFORE the ``/{project_id}``
@@ -99,7 +99,7 @@ async def get_project(project_id: int) -> ProjectSummary:
     project = Project.get(project_id)
     if not project:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "project not found")
-    return ProjectSummary.from_project(project)
+    return ProjectSummary.model_validate(project)
 
 
 @projects_router.patch(
@@ -120,7 +120,7 @@ async def update_project(
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "name cannot be empty")
         project.name = name
         db_session().flush()
-    return ProjectSummary.from_project(project)
+    return ProjectSummary.model_validate(project)
 
 
 @projects_router.delete("/{project_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -178,7 +178,7 @@ async def add_project_repo(
         .values(project_id=project.id)
     )
     await Profile.dispatch(repo)
-    return ProjectRepoSummary.from_repo(repo)
+    return ProjectRepoSummary.model_validate(repo)
 
 
 @projects_router.patch(
@@ -197,7 +197,7 @@ async def update_project_repo(
     if purpose is not None:
         row.purpose = purpose.strip() or None
         db_session().flush()
-    return ProjectRepoSummary.from_repo(row)
+    return ProjectRepoSummary.model_validate(row)
 
 
 @projects_router.post(
@@ -212,7 +212,7 @@ async def profile_project_repo(project_id: int, repo_id: int) -> ProjectRepoSumm
     # Profile is subject-unique: dispatch() returns the live run when one is already
     # active for this repo, so the route just dispatches and lets the lock dedup.
     await Profile.dispatch(row)
-    return ProjectRepoSummary.from_repo(row)
+    return ProjectRepoSummary.model_validate(row)
 
 
 @projects_router.delete(

--- a/backend/druks/contrib/ship/schemas.py
+++ b/backend/druks/contrib/ship/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pydantic import AliasPath, BaseModel, ConfigDict, Field, computed_field
 
@@ -8,62 +8,26 @@ from druks.workflows import SubjectSummary
 
 from .enums import HandoffStatus
 
-if TYPE_CHECKING:
-    from druks.contrib.ship.models import Project, ProjectRepo
 
-ProfileState = Literal["unprofiled", "running", "ready", "failed"]
-
-
-class ProjectRepoSummary(BaseResponse):
-    id: int
+class ProjectRepoSummary(SubjectSummary):
+    # The repo, wherever it is read: nested in its project, and as the header of its
+    # own board. Where its profiling run stands is the platform's to say — the repo
+    # is a subject, so that answer is its ``SubjectStatus``.
     full_name: str
     purpose: str | None = None
-    # The stored effective profile as-is; {} until the repo profiler has run.
-    profile: dict[str, Any] = Field(default_factory=dict)
-    profile_status: ProfileState
-    profiler_run_failure: str | None = None
+    # The profiler's findings as stored; {} until it has run.
+    profile: dict[str, Any] = Field(default_factory=dict, validation_alias="effective_profile")
     created_at: datetime
-
-    @classmethod
-    def from_repo(cls, repo: "ProjectRepo") -> "ProjectRepoSummary":
-        # "ready" outranks a later failed re-profile: a stored profile stays usable.
-        status = repo.get_status()
-        profile = repo.effective_profile()
-        if status.is_running:
-            profile_status, failure = "running", None
-        elif profile:
-            profile_status, failure = "ready", None
-        elif status.is_failed:
-            profile_status, failure = "failed", status.failure
-        else:
-            profile_status, failure = "unprofiled", None
-        return cls(
-            id=repo.id,
-            full_name=repo.full_name,
-            purpose=repo.purpose,
-            profile=profile,
-            profile_status=profile_status,
-            profiler_run_failure=failure,
-            created_at=repo.created_at,
-        )
 
 
 class ProjectSummary(BaseResponse):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     name: str
     created_at: datetime
     updated_at: datetime
     repos: list[ProjectRepoSummary] = Field(default_factory=list)
-
-    @classmethod
-    def from_project(cls, project: "Project") -> "ProjectSummary":
-        return cls(
-            id=project.id,
-            name=project.name,
-            created_at=project.created_at,
-            updated_at=project.updated_at,
-            repos=[ProjectRepoSummary.from_repo(repo) for repo in project.repos],
-        )
 
 
 class ProjectsResponse(BaseResponse):

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -231,7 +231,7 @@ class Build(Workflow):
         target = ProjectRepo.get_for_repo(self.input.repo, raise_on_missing=True)
         return {
             "policy": policy.model_dump(mode="json"),
-            "profile": target.effective_profile(),
+            "profile": target.effective_profile,
         }
 
     @step

--- a/backend/druks/durable/datastructures.py
+++ b/backend/druks/durable/datastructures.py
@@ -2,11 +2,10 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Self
 
-from druks.durable.schemas import SubjectSummary
 from druks.models import snake_name
 
 if TYPE_CHECKING:
-    from druks.durable.schemas import RunResponse, SubjectStatus
+    from druks.durable.schemas import RunResponse, SubjectStatus, SubjectSummary
     from druks.workflows import Workflow
 
 
@@ -45,13 +44,15 @@ class Subject:
         so override to return None for a shape this subject could never wear."""
         return cls(id=subject_id)
 
-    def get_summary(self) -> SubjectSummary:
-        """The header its board and page show it under. Its id and label already say
-        what it is; override to add the fields only this extension knows."""
-        return SubjectSummary.model_validate(self)
+    def get_summary(self) -> "SubjectSummary":
+        """The header its board and page show it under — the extension's own fields;
+        the read side composes it with the platform's status and timeline."""
+        raise NotImplementedError(
+            f"a workflow declares {type(self).__name__}, so it needs a get_summary()"
+        )
 
     @classmethod
-    def list_summaries(cls) -> Sequence[SubjectSummary]:
+    def list_summaries(cls) -> "Sequence[SubjectSummary]":
         """The subjects on this class's board, newest-movement first, each as its domain
         summary. Returns a covariant ``Sequence`` so an extension can return a ``list``
         of its own ``SubjectSummary`` subclass. Required once a workflow declares it."""

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -170,14 +170,12 @@ SubjectId = Annotated[str, BeforeValidator(str)]
 
 
 class SubjectSummary(BaseResponse):
-    # Every subject's header: ``id`` keys its status, timeline and detail URL, and
-    # ``label`` is the one line it shows itself as — read live off the subject, unlike
-    # the copy an event snapshots. A subject with more to say subclasses this, and
-    # ``from_attributes`` builds any of them straight off the subject.
+    # The base an extension's subject header subclasses; ``id`` keys the subject's
+    # status, timeline and detail URL, and ``from_attributes`` builds the header
+    # straight off the subject.
     model_config = ConfigDict(from_attributes=True)
 
     id: SubjectId
-    label: str
 
 
 class SubjectStatus(BaseResponse):

--- a/backend/druks/models.py
+++ b/backend/druks/models.py
@@ -87,13 +87,11 @@ class StoredSubject(Base):
         return db_session().get(cls, key)
 
     def get_summary(self) -> "SubjectSummary":
-        """The header its board and page show it under. Its id and label already say
-        what it is; override to add the fields only this extension knows."""
-        # ``druks.durable`` imports the ORM models this module defines the base for,
-        # so nothing under it can be imported here at module scope.
-        from druks.durable.schemas import SubjectSummary
-
-        return SubjectSummary.model_validate(self)
+        """The header its board and page show it under — the extension's own fields;
+        the read side composes it with the platform's status and timeline."""
+        raise NotImplementedError(
+            f"a workflow declares {type(self).__name__}, so it needs a get_summary()"
+        )
 
     @classmethod
     def list_summaries(cls) -> "Sequence[SubjectSummary]":

--- a/backend/tests/ship/test_profiling.py
+++ b/backend/tests/ship/test_profiling.py
@@ -112,7 +112,7 @@ class TestProfileRun:
         repo = ProjectRepo.get(repo.id)
 
         assert repo.profile["baseline"]["languages"] == ["python"]
-        assert repo.effective_profile()["verification"]["lint_commands"] == ["ruff check ."]
+        assert repo.effective_profile["verification"]["lint_commands"] == ["ruff check ."]
 
     async def test_drops_skills_that_are_not_enabled(self, druks_db, monkeypatch):
         _seed_skills("django-patterns", "retired-skill", disabled=("retired-skill",))
@@ -148,8 +148,8 @@ class TestProfileRun:
         repo = ProjectRepo.get(repo.id)
 
         # The pin replaces the whole verification section on the effective profile...
-        assert repo.effective_profile()["verification"]["test_commands"] == ["make test"]
-        assert repo.effective_profile()["verification"]["lint_commands"] == []
+        assert repo.effective_profile["verification"]["test_commands"] == ["make test"]
+        assert repo.effective_profile["verification"]["lint_commands"] == []
         # ...but the detected baseline is preserved underneath it.
         assert repo.profile["baseline"]["verification"]["lint_commands"] == ["ruff check ."]
 
@@ -174,54 +174,4 @@ class TestRefreshOnly:
 
         # Baseline untouched — only the pin re-applies.
         assert repo.profile["baseline"]["verification"]["test_commands"] == ["pytest"]
-        assert repo.effective_profile()["verification"]["test_commands"] == ["make test"]
-
-
-class TestProfileStatus:
-    """ProjectRepoSummary derives profile lifecycle state from the profiler's
-    runs on every read — a repo with a profile is ready even if a later refresh
-    failed, so there's no separate 'ready but stale' state."""
-
-    def _summary(self, repo):
-        from druks.contrib.ship.schemas import ProjectRepoSummary
-
-        return ProjectRepoSummary.from_repo(repo)
-
-    def _seed_run(self, druks_db, repo, *, state, failure=None):
-        from druks.durable import Run
-        from druks.testing import seed_dbos_status
-        from uuid_utils import uuid7
-
-        run = Run(id=str(uuid7()), kind="ship.profile", failure=failure)
-        druks_db.add(run)
-        druks_db.flush()
-        seed_dbos_status(druks_db, run.id, state, subject={"type": "project_repo", "id": repo.id})
-        return run
-
-    def test_unprofiled_when_no_run_and_no_profile(self, druks_db):
-        assert self._summary(_seed_repo()).profile_status == "unprofiled"
-
-    def test_ready_when_profiled(self, druks_db):
-        repo = _seed_repo()
-        repo.set_profile(baseline=_profiled(), effective=_profiled())
-        assert self._summary(repo).profile_status == "ready"
-
-    def test_ready_even_when_a_later_run_failed(self, druks_db):
-        repo = _seed_repo()
-        repo.set_profile(baseline=_profiled(), effective=_profiled())
-        self._seed_run(druks_db, repo, state="failed", failure="refresh boom")
-        assert self._summary(repo).profile_status == "ready"
-
-    def test_failed_when_run_failed_and_no_profile(self, druks_db):
-        repo = _seed_repo()
-        self._seed_run(druks_db, repo, state="failed", failure="boom")
-        summary = self._summary(repo)
-        assert summary.profile_status == "failed"
-        assert summary.profiler_run_failure == "boom"
-
-    def test_running_when_the_profiler_is_in_flight(self, druks_db):
-        repo = _seed_repo()
-        self._seed_run(druks_db, repo, state="running")
-        summary = self._summary(repo)
-        assert summary.profile_status == "running"
-        assert summary.profiler_run_failure is None
+        assert repo.effective_profile["verification"]["test_commands"] == ["make test"]

--- a/backend/tests/ship/test_project_repo_routes.py
+++ b/backend/tests/ship/test_project_repo_routes.py
@@ -40,11 +40,11 @@ def test_adding_a_repo_dispatches_a_profile_run(client: TestClient, monkeypatch)
 
     assert calls == [
         {
-            "repo_id": repo["id"],
+            "repo_id": int(repo["id"]),
             "refresh_only": False,
         }
     ]
-    assert repo["profileStatus"] == "unprofiled"
+    assert repo["profile"] == {}
 
 
 def test_profile_endpoint_dispatches(client: TestClient, monkeypatch):
@@ -106,9 +106,10 @@ def test_the_repo_subject_read_side_mounts(client: TestClient, druks_db):
     seed_run(druks_db, kind=Profile.kind, subject=repo, state="running")
 
     (row,) = client.get("/api/ship/project_repo").json()["rows"]
-    assert row["summary"] == {"id": str(repo.id), "label": "acme/widget"}
+    assert row["summary"]["id"] == str(repo.id)
+    assert row["summary"]["fullName"] == "acme/widget"
     assert row["status"]["state"] == "running"
 
     detail = client.get(f"/api/ship/project_repo/{repo.id}").json()
-    assert detail["summary"]["label"] == "acme/widget"
+    assert detail["summary"]["fullName"] == "acme/widget"
     assert [entry["kind"] for entry in detail["timeline"]] == [Profile.kind]

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -26,7 +26,7 @@ class Thing(StoredSubject):
     __tablename__ = "faketest_things"
 
     def get_summary(self) -> _ThingSummary:
-        return _ThingSummary(id=self.id, label=self.label, title=TITLES[self.id])
+        return _ThingSummary(id=self.id, title=TITLES[self.id])
 
     @classmethod
     def list_summaries(cls) -> list[_ThingSummary]:
@@ -43,10 +43,11 @@ class Ticket(Subject):
             return cls(id=subject_id)
         return
 
+    def get_summary(self) -> _ThingSummary:
+        return _ThingSummary(id=self.id, title=self.id.rpartition("#")[2])
+
     @classmethod
-    def list_summaries(cls) -> list[SubjectSummary]:
-        # No get_summary() of its own: a subject with nothing to add is named by
-        # the header every subject already has.
+    def list_summaries(cls) -> list[_ThingSummary]:
         return [ticket.get_summary() for ticket in cls.list_open()]
 
 
@@ -122,13 +123,12 @@ def test_a_subject_id_is_a_string_whatever_the_row_is_keyed_by(druks_db):
     # A row is keyed by an integer and every read of a subject id is a string — the
     # URL segment, the DBOS attribute, the dedup key. The header takes either and is
     # always the string, so no summary hand-stringifies a primary key.
-    summary = SubjectSummary.model_validate(Thing(id=7))
-    assert summary.id == "7"
+    assert SubjectSummary.model_validate(Thing(id=7)).id == "7"
     assert SubjectSummary.model_validate(Ticket(id="owner/repo#7")).id == "owner/repo#7"
 
-    # Only the id widens: a label that arrives as a number is still a mistake.
+    # Only the id widens: a title that arrives as a number is still a mistake.
     with pytest.raises(ValidationError):
-        SubjectSummary(id=7, label=7)
+        _ThingSummary(id=7, title=7)
 
 
 def test_status_aggregates_across_runs_and_timeline_spans_them(client: TestClient, druks_db):
@@ -141,7 +141,7 @@ def test_status_aggregates_across_runs_and_timeline_spans_them(client: TestClien
     _seed_call(druks_db, live, agent="implement", status="running")
 
     detail = client.get("/api/faketest/thing/1").json()
-    assert detail["summary"] == {"id": "1", "label": "thing 1", "title": "First"}
+    assert detail["summary"] == {"id": "1", "title": "First"}
     assert detail["status"]["state"] == "running"
     assert [entry["kind"] for entry in detail["timeline"]] == ["faketest.prepare", "faketest.flow"]
     # Calls group under their own run, not the subject at large.
@@ -232,7 +232,7 @@ def test_an_id_spanning_separators_reaches_the_board_and_its_page(client: TestCl
     assert [row["summary"]["id"] for row in board["rows"]] == ["owner/repo#7"]
 
     detail = client.get("/api/faketest/ticket/owner/repo%237").json()
-    assert detail["summary"] == {"id": "owner/repo#7", "label": "owner/repo#7"}
+    assert detail["summary"] == {"id": "owner/repo#7", "title": "7"}
     assert detail["status"]["state"] == "parked"
     assert [entry["kind"] for entry in detail["timeline"]] == ["faketest.flow"]
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -29,12 +29,10 @@ export type RunState =
   // The run's DBOS workflow row is gone; it will never start.
   | 'orphaned'
 
-// Every subject's header: ``id`` keys its status, timeline and detail URL, and
-// ``label`` is the one line it shows itself as — a work item's ticket key, a repo's
-// full name, a pull request's handle.
+// The base every extension's subject summary satisfies; ``id`` keys its status,
+// timeline, and detail URL.
 export interface SubjectSummary {
   id: string
-  label: string
 }
 
 export interface SubjectStatus {

--- a/frontend/src/components/RepoCell.tsx
+++ b/frontend/src/components/RepoCell.tsx
@@ -1,15 +1,16 @@
 interface Props {
-  repoBare?: string | null
+  repo?: string | null
   project?: string | null
 }
 
 /**
- * Repo column — bare repo name as plain text, with the Druks Project as a
- * hover tooltip when bound. Items without a repo (e.g. scope rows pre-target)
- * render an em-dash.
+ * Repo column — an ``owner/name`` shown by its bare name, with the Druks Project
+ * as a hover tooltip when bound. Items without a repo (e.g. scope rows
+ * pre-target) render an em-dash.
  */
-export function RepoCell({ repoBare, project }: Props) {
-  if (!repoBare) return <span className="mono dim">—</span>
+export function RepoCell({ repo, project }: Props) {
+  if (!repo) return <span className="mono dim">—</span>
+  const repoBare = repo.slice(repo.indexOf('/') + 1)
   const title = project ? `${project} · ${repoBare}` : repoBare
   return (
     <span className="row-repo mono" title={title}>

--- a/frontend/src/extensions/review/ReviewsPage.tsx
+++ b/frontend/src/extensions/review/ReviewsPage.tsx
@@ -75,7 +75,7 @@ function ReviewRowView({ row }: { row: ReviewRow }) {
   return (
     <div className={`row row-review${failed ? ' row-failed' : ''}`}>
       <StatusGlyph state={status.state} pulse={live} />
-      <RepoCell repoBare={bareName(summary.repo)} />
+      <RepoCell repo={summary.repo} />
       <PRCell prNumber={summary.prNumber} prUrl={summary.pullRequestUrl} />
       <span className="review-line mono dim">
         {live ? `${reviewLine(status)}…` : reviewLine(status)}
@@ -88,6 +88,3 @@ function ReviewRowView({ row }: { row: ReviewRow }) {
   )
 }
 
-function bareName(repo: string): string {
-  return repo.includes('/') ? repo.slice(repo.indexOf('/') + 1) : repo
-}

--- a/frontend/src/extensions/ship/HistoryPage.tsx
+++ b/frontend/src/extensions/ship/HistoryPage.tsx
@@ -17,10 +17,6 @@ import { dashboardItemPath } from './slug'
 
 type StatusFilter = 'all' | HandoffStatus
 
-function repoBareName(repo: string | null | undefined): string | null {
-  if (!repo) return null
-  return repo.includes('/') ? repo.slice(repo.indexOf('/') + 1) : repo
-}
 
 export function HistoryPage() {
   const historyQuery = useQuery({
@@ -129,7 +125,7 @@ export function HistoryPage() {
               <span className="row-title" title={item.title}>
                 {item.title}
               </span>
-              <RepoCell repoBare={repoBareName(item.repo)} project={item.projectName} />
+              <RepoCell repo={item.repo} project={item.projectName} />
               <PRCell prNumber={item.prNumber} prUrl={null} />
               <span className="row-fin-what mono">{item.status}</span>
               <span className="row-fin-dur mono dim">

--- a/frontend/src/extensions/ship/WorkItemsPage.tsx
+++ b/frontend/src/extensions/ship/WorkItemsPage.tsx
@@ -15,12 +15,6 @@ import { relTime, secondsSince, updatedAtSortKey } from '../../lib/format'
 import { statusLine } from './statusLine'
 import { workItemPathFromSummary } from './slug'
 
-/** ``owner/name`` -> ``name`` for the repo column. */
-function repoBareName(repo: string): string | null {
-  if (!repo) return null
-  const slash = repo.indexOf('/')
-  return slash >= 0 ? repo.slice(slash + 1) : repo
-}
 
 function matchesQuery(row: WorkItemRow, q: string): boolean {
   if (!q.trim()) return true
@@ -53,7 +47,7 @@ function WorkItemRowView({
         {wi.title}
       </span>
       <span />
-      <RepoCell repoBare={repoBareName(wi.repo)} project={wi.projectName} />
+      <RepoCell repo={wi.repo} project={wi.projectName} />
       <PRCell prNumber={wi.prNumber} prUrl={wi.links.pr} />
       {/* The line is the ask ("Review plan"), the live step ("Implementing…"),
           or the timeout hint — build's copy over the platform's status facts. */}

--- a/frontend/src/extensions/ship/api.ts
+++ b/frontend/src/extensions/ship/api.ts
@@ -13,6 +13,7 @@ import type { SubjectResponse, SubjectRow, SubjectSummary } from '../../api/type
 // generic shell reads the extension name off the registry, never hardcodes it.
 export const SHIP = 'ship'
 export const WORK_ITEM = 'work_item'
+export const PROJECT_REPO = 'project_repo'
 
 // build's read-side, specialised from the platform's generic subject endpoints.
 export const buildApi = {

--- a/frontend/src/extensions/ship/projects/ProjectsPage.tsx
+++ b/frontend/src/extensions/ship/projects/ProjectsPage.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { EmptyState } from '../../../components/EmptyState'
 import { Page } from '../../../components/Page'
 import { projectsApi } from './api'
+import { repoProfiling, useRepoRuns, type RepoProfiling } from './profiling'
 import type { Project, ProjectRepo } from './types'
 
 function splitRepo(full: string): { org: string; short: string } {
@@ -14,17 +15,14 @@ function splitRepo(full: string): { org: string; short: string } {
 
 export function ProjectsPage() {
   const queryClient = useQueryClient()
+  const runs = useRepoRuns()
+  const anyProfiling = [...runs.values()].some((status) => status.state === 'running')
   const { data, isLoading, isError } = useQuery({
     queryKey: ['projects'],
     queryFn: projectsApi.list,
-    // Poll fast while a profiler run is in flight so its chip settles without a reload.
-    refetchInterval: (query) => {
-      const projects = query.state.data?.projects ?? []
-      const profiling = projects.some((p) =>
-        p.repos.some((r) => r.profileStatus === 'running'),
-      )
-      return profiling ? 3_000 : 30_000
-    },
+    // A finished profiler run changes what a repo stores, so refresh alongside
+    // the board that reports the run.
+    refetchInterval: anyProfiling ? 3_000 : 30_000,
   })
 
   const [draft, setDraft] = useState('')
@@ -275,6 +273,8 @@ function RepoRow({
   onChange: () => void
 }) {
   const { org, short } = splitRepo(repo.fullName)
+  const runs = useRepoRuns()
+  const profiling = repoProfiling(repo.profile, runs.get(repo.id))
   const [editing, setEditing] = useState(false)
   const [purpose, setPurpose] = useState(repo.purpose ?? '')
   const [open, setOpen] = useState(false)
@@ -337,7 +337,7 @@ function RepoRow({
           </span>
         )}
         <ProfileChip
-          repo={repo}
+          profiling={profiling}
           open={open}
           pending={profile.isPending}
           onToggle={() => setOpen((o) => !o)}
@@ -357,6 +357,7 @@ function RepoRow({
       {open && (
         <ProfilePanel
           repo={repo}
+          profiling={profiling}
           pending={profile.isPending}
           onProfile={() => profile.mutate()}
         />
@@ -367,13 +368,13 @@ function RepoRow({
 }
 
 function ProfileChip({
-  repo,
+  profiling,
   open,
   pending,
   onToggle,
   onProfile,
 }: {
-  repo: ProjectRepo
+  profiling: RepoProfiling
   open: boolean
   pending: boolean
   onToggle: () => void
@@ -381,22 +382,22 @@ function ProfileChip({
 }) {
   // The chip is the whole profile affordance: unprofiled → trigger profiling;
   // running → progress; ready/failed → toggle the details panel.
-  if (repo.profileStatus === 'unprofiled') {
+  if (profiling.state === 'unprofiled') {
     return (
       <button type="button" className="pj-profile-chip mono" disabled={pending} onClick={onProfile}>
         {pending ? 'profiling…' : 'profile'}
       </button>
     )
   }
-  if (repo.profileStatus === 'running' || pending) {
+  if (profiling.state === 'running' || pending) {
     return <span className="pj-profile-chip pj-profile-running mono">profiling…</span>
   }
-  const failed = repo.profileStatus === 'failed'
+  const failed = profiling.state === 'failed'
   return (
     <button
       type="button"
       className={`pj-profile-chip mono ${failed ? 'pj-profile-failed' : 'pj-profile-ready'}`}
-      title={failed ? (repo.profilerRunFailure ?? 'profiler run failed') : 'view profile'}
+      title={failed ? (profiling.failure ?? 'profiler run failed') : 'view profile'}
       onClick={onToggle}
     >
       {failed ? 'profile failed' : 'profiled'} {open ? '▴' : '▾'}
@@ -406,10 +407,12 @@ function ProfileChip({
 
 function ProfilePanel({
   repo,
+  profiling,
   pending,
   onProfile,
 }: {
   repo: ProjectRepo
+  profiling: RepoProfiling
   pending: boolean
   onProfile: () => void
 }) {
@@ -426,8 +429,8 @@ function ProfilePanel({
   ]
   return (
     <div className="pj-profile-panel">
-      {repo.profileStatus === 'failed' && (
-        <div className="pj-profile-failure mono">{repo.profilerRunFailure ?? 'profiler run failed'}</div>
+      {profiling.state === 'failed' && (
+        <div className="pj-profile-failure mono">{profiling.failure ?? 'profiler run failed'}</div>
       )}
       {found.stack_summary && <p className="pj-profile-summary">{found.stack_summary}</p>}
       {stack.length > 0 && (

--- a/frontend/src/extensions/ship/projects/api.ts
+++ b/frontend/src/extensions/ship/projects/api.ts
@@ -4,6 +4,7 @@ import {
   patchJSON,
   postJSON,
 } from '../../../api/client'
+import type { SubjectRow } from '../../../api/types'
 import type {
   AddProjectRepoRequest,
   CreateProjectRequest,
@@ -14,13 +15,17 @@ import type {
   UpdateProjectRepoRequest,
   UpdateProjectRequest,
 } from './types'
-import { SHIP } from '../api'
+import { PROJECT_REPO, SHIP } from '../api'
 
 // Projects are Ship-owned, under its own ``/api/ship/projects`` namespace.
 const root = `/api/${SHIP}/projects`
 
 export const projectsApi = {
   list: () => getJSON<ProjectsResponse>(root),
+  // Where each repo's profiling stands — the platform's board for the subject
+  // Profile runs are about, keyed by the same repo id the projects list carries.
+  repoBoard: () =>
+    getJSON<{ rows: SubjectRow<ProjectRepo>[] }>(`/api/${SHIP}/${PROJECT_REPO}`),
   get: (id: number) => getJSON<Project>(`${root}/${id}`),
   create: (body: CreateProjectRequest) => postJSON<Project>(root, body),
   update: (id: number, body: UpdateProjectRequest) =>
@@ -29,12 +34,12 @@ export const projectsApi = {
   addRepo: (projectId: number, body: AddProjectRepoRequest) =>
     postJSON<ProjectRepo>(`${root}/${projectId}/repos`, body),
   updateRepo: (
-    projectId: number, repoId: number, body: UpdateProjectRepoRequest,
+    projectId: number, repoId: string, body: UpdateProjectRepoRequest,
   ) =>
     patchJSON<ProjectRepo>(`${root}/${projectId}/repos/${repoId}`, body),
-  deleteRepo: (projectId: number, repoId: number) =>
+  deleteRepo: (projectId: number, repoId: string) =>
     deleteRequest(`${root}/${projectId}/repos/${repoId}`),
-  profileRepo: (projectId: number, repoId: number) =>
+  profileRepo: (projectId: number, repoId: string) =>
     postJSON<ProjectRepo>(`${root}/${projectId}/repos/${repoId}/profile`, {}),
   listGithubRepos: (owner?: string) => {
     const qs = owner ? `?owner=${encodeURIComponent(owner)}` : ''

--- a/frontend/src/extensions/ship/projects/profiling.test.ts
+++ b/frontend/src/extensions/ship/projects/profiling.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SubjectStatus } from '../../../api/types'
+import { repoProfiling } from './profiling'
+import type { RepoProfile } from './types'
+
+const profiled: RepoProfile = { stack_summary: 'python' }
+const run = (state: SubjectStatus['state'], failure: string | null = null) =>
+  ({ state, kind: null, agent: null, gate: null, failure, reason: null }) as SubjectStatus
+
+describe('repoProfiling', () => {
+  it('is unprofiled with nothing stored and no run', () => {
+    expect(repoProfiling({}, undefined)).toEqual({ state: 'unprofiled', failure: null })
+  })
+
+  it('is ready once the repo has a profile', () => {
+    expect(repoProfiling(profiled, undefined)).toEqual({ state: 'ready', failure: null })
+  })
+
+  it('stays ready when a later refresh failed — a stored profile is still usable', () => {
+    expect(repoProfiling(profiled, run('failed', 'refresh boom'))).toEqual({
+      state: 'ready',
+      failure: null,
+    })
+  })
+
+  it('is failed when the run failed and nothing is stored, and carries why', () => {
+    expect(repoProfiling({}, run('failed', 'boom'))).toEqual({ state: 'failed', failure: 'boom' })
+  })
+
+  it('is running while the profiler is in flight, whatever is stored', () => {
+    expect(repoProfiling(profiled, run('running'))).toEqual({ state: 'running', failure: null })
+  })
+})

--- a/frontend/src/extensions/ship/projects/profiling.ts
+++ b/frontend/src/extensions/ship/projects/profiling.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query'
+
+import type { SubjectStatus } from '../../../api/types'
+import { projectsApi } from './api'
+import type { RepoProfile, RepoProfileStatus } from './types'
+
+export interface RepoProfiling {
+  state: RepoProfileStatus
+  failure: string | null
+}
+
+/**
+ * Where a repo's profiling stands: what it has stored, and what its profiler run
+ * says. A repo with a profile is ready even if a later refresh failed, so there is
+ * no separate "ready but stale" state.
+ */
+export function repoProfiling(
+  profile: RepoProfile,
+  run: SubjectStatus | undefined,
+): RepoProfiling {
+  if (run?.state === 'running') return { state: 'running', failure: null }
+  if (Object.keys(profile).length > 0) return { state: 'ready', failure: null }
+  if (run?.state === 'failed') return { state: 'failed', failure: run.failure ?? null }
+  return { state: 'unprofiled', failure: null }
+}
+
+/**
+ * The repo board — the platform's read-side for the subject Profile runs are about.
+ * Every repo row asks for it under one key, so they share a single request, and it
+ * polls fast only while a profiler is in flight.
+ */
+export function useRepoRuns() {
+  const { data } = useQuery({
+    queryKey: ['project-repo-board'],
+    queryFn: projectsApi.repoBoard,
+    refetchInterval: (query) =>
+      query.state.data?.rows.some((row) => row.status.state === 'running') ? 3_000 : 30_000,
+  })
+  return new Map((data?.rows ?? []).map((row) => [row.summary.id, row.status]))
+}

--- a/frontend/src/extensions/ship/projects/types.ts
+++ b/frontend/src/extensions/ship/projects/types.ts
@@ -1,3 +1,5 @@
+import type { SubjectSummary } from '../../../api/types'
+
 // The profiler agent's stored findings — a raw JSON dict, so keys stay snake_case.
 // Empty ({}) until the repo has been profiled.
 export interface RepoProfile {
@@ -13,15 +15,14 @@ export interface RepoProfile {
   recommended_skills?: string[]
 }
 
+// Where a repo's profiling stands. Derived here from what the repo carries and
+// what its runs say — the platform answers the run half on the repo's own board.
 export type RepoProfileStatus = 'unprofiled' | 'running' | 'ready' | 'failed'
 
-export interface ProjectRepo {
-  id: number
+export interface ProjectRepo extends SubjectSummary {
   fullName: string
   purpose: string | null
   profile: RepoProfile
-  profileStatus: RepoProfileStatus
-  profilerRunFailure: string | null
   createdAt: string
 }
 


### PR DESCRIPTION
`ProjectRepoSummary` asked every repo for its latest run to derive a profile lifecycle, from inside what reads as a field copy:

```python
status = repo.get_status()          # one query, per repo
```

Measured on `GET /api/ship/projects` with three projects of four repos: **19 statements, 12 of them run lookups**. It scales with the operator's whole estate, and the list endpoint has no limit.

## A repo is a subject, so its run state is already answered

Where a profiler run stands is a `SubjectStatus`, on the board the platform mounts for `ProjectRepo` because `Profile` declares it. The summary drops `profile_status` and `profiler_run_failure`, becomes the repo's own columns, and serves both the project pane and its board:

```python
class ProjectRepoSummary(SubjectSummary):
    full_name: str
    purpose: str | None = None
    profile: dict[str, Any] = Field(default_factory=dict, validation_alias="effective_profile")
    created_at: datetime
```

Same measurement after: **7 statements, 0 run lookups.** `from_repo` and `from_project` both go — the shapes are columns and `model_validate` reads them.

The page asks for the board alongside the projects list, under one query key so every repo row shares a single request, and derives the chip from what the repo stores and what its run says. That derivation is now five unit tests instead of a hidden query, and it keeps the rule it always had: a repo with a profile is ready even if a later refresh failed.

## The header drops `label`

It was carried on every board and read by none. On work items it repeated `ticketKey`, which has ten consumers including URL slugs; on reviews it repeated `id`. It was added to give `ProjectRepo` a board with no schema — and that repo now has a summary of its own, so the last reason for it is gone.

`get_summary()` goes back to being required, symmetric with `list_summaries()`: declaring a subject means saying what its board shows.

## Three copies of one slice

`owner/name` → `name` was implemented in `ReviewsPage`, `HistoryPage` and `WorkItemsPage`, all feeding the same `RepoCell`. The cell now takes the repo it is given and shows the bare half.

Kept in the frontend deliberately: the backend owns `acme/app`, which is identity — showing only `app` is a display choice, and a different surface may want the owner. Putting `repo_bare` on three wire shapes would ship a rendering decision to the server.
