### PR TITLE
A workflow's subject is one word, read off the class or off the run

### DIFF
--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -344,13 +344,20 @@ class AgentCall(Base, Uuid7Pk):
     # and treat 404 as the host being gone.
     sandbox_host_id: Mapped[str]
 
-    def get_live_status(self) -> str:
-        # Unfinished: "running" while the run is live, "abandoned" once it's terminal.
+    @property
+    def live_status(self) -> AgentCallStatus:
+        # Unfinished: running while the run is live, abandoned once it's terminal.
         if self.finished_at:
-            return AgentCallStatus(self.status).value
+            return AgentCallStatus(self.status)
         if self.run.is_active:
-            return "running"
-        return "abandoned"
+            return AgentCallStatus.RUNNING
+        return AgentCallStatus.ABANDONED
+
+    @property
+    def token_usage(self) -> dict[str, int] | None:
+        # Each harness reports tokens its own way; this is the one shape, and None
+        # once a call reported nothing countable.
+        return normalize_token_usage(self.cost_metadata)
 
     @property
     def artifact_dir(self) -> str:

--- a/backend/druks/durable/reads.py
+++ b/backend/druks/durable/reads.py
@@ -198,7 +198,7 @@ async def stream_transcript(
         with session_scope(engine):
             call = AgentCall.get(call_id)
             path = call.get_stream_path(stream) if call else None
-            summary = AgentCallResponse.from_call(call) if call else None
+            summary = AgentCallResponse.model_validate(call) if call else None
 
         if not summary:
             # Unknown (or deleted) call: nothing will ever arrive — close the

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -2,12 +2,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from pydantic import BeforeValidator, ConfigDict, Field, SerializeAsAny
+from pydantic import AliasPath, BeforeValidator, ConfigDict, Field, SerializeAsAny, computed_field
 
-from druks.harnesses.artifacts import normalize_token_usage
 from druks.schemas import BaseResponse
 
-from .enums import RunState
+from .enums import AgentCallStatus, RunState
 
 if TYPE_CHECKING:
     from .models import AgentCall, Artifact, Run
@@ -22,46 +21,32 @@ class TokenUsage(BaseResponse):
     total_tokens: int
 
 
-def _token_usage(cost_metadata: dict | None) -> TokenUsage | None:
-    canonical = normalize_token_usage(cost_metadata)
-    return TokenUsage(**canonical) if canonical else None
-
-
 def get_display_label(kind: str) -> str:
     # "ship.build" → "Build"; "implement" → "Implement".
     return kind.rsplit(".", 1)[-1].replace("_", " ").capitalize()
 
 
 class AgentCallResponse(BaseResponse):
+    model_config = ConfigDict(from_attributes=True)
+
     id: str
     # Which agent made this call ("scope", "implement") — the timeline's row label.
     agent: str | None = None
-    label: str = ""
     # The account charged — differs from the run's on fallback.
-    account_username: str
-    status: Literal["running", "succeeded", "failed", "abandoned"]
+    account_username: str = Field(validation_alias=AliasPath("account", "username"))
+    status: AgentCallStatus = Field(validation_alias="live_status")
     # started_at + finished_at are the facts; the client derives elapsed (a live
     # tick off started_at while running), so nothing here churns between polls.
     started_at: datetime
     finished_at: datetime | None = None
     last_error: str | None = None
     cost_usd: float | None = None
-    tokens: TokenUsage | None = None
+    tokens: TokenUsage | None = Field(default=None, validation_alias="token_usage")
 
-    @classmethod
-    def from_call(cls, call: "AgentCall") -> "AgentCallResponse":
-        return cls(
-            id=call.id,
-            agent=call.agent,
-            label=get_display_label(call.agent) if call.agent else "Agent",
-            account_username=call.account.username,
-            status=call.get_live_status(),  # type: ignore[arg-type]
-            started_at=call.started_at,
-            finished_at=call.finished_at,
-            last_error=call.last_error,
-            cost_usd=call.cost_usd,
-            tokens=_token_usage(call.cost_metadata),
-        )
+    @computed_field
+    @property
+    def label(self) -> str:
+        return get_display_label(self.agent) if self.agent else "Agent"
 
 
 class ArtifactFile(BaseResponse):
@@ -159,7 +144,7 @@ class RunResponse(BaseResponse):
             created_at=run.created_at,
             updated_at=run.updated_at,
             account_username=run.account.username,
-            agent_calls=[AgentCallResponse.from_call(c) for c in calls],
+            agent_calls=[AgentCallResponse.model_validate(call) for call in calls],
         )
 
 

--- a/backend/druks/events/builder.py
+++ b/backend/druks/events/builder.py
@@ -14,7 +14,7 @@ def build_feed(
     before: int | None = None,
     limit: int = _PAGE_LIMIT_DEFAULT,
 ) -> tuple[list[FeedItem], str | None]:
-    items = [FeedItem.from_event(event) for event in _events(extension, before)]
+    items = [FeedItem.model_validate(event) for event in _events(extension, before)]
     items.sort(key=lambda item: item.seq, reverse=True)
     page = items[:limit]
     next_cursor = str(page[-1].seq) if len(page) == limit and page else None

--- a/backend/druks/events/feed.py
+++ b/backend/druks/events/feed.py
@@ -1,38 +1,31 @@
 from datetime import datetime
 
-from druks.events.models import Event
+from pydantic import AliasPath, ConfigDict, Field, computed_field
+
 from druks.schemas import BaseResponse
 
 
 class FeedItem(BaseResponse):
-    id: str
+    model_config = ConfigDict(from_attributes=True)
+
     # The event's monotonic log position (its pk) — the feed's ordering and
     # pagination key. ``at`` is whole-second and ties constantly; this never does.
-    seq: int
-    at: datetime
+    seq: int = Field(validation_alias="id")
+    at: datetime = Field(validation_alias="created_at")
     # The event type verbatim: a lifecycle topic ("workflow.finished") or the
     # milestone an extension recorded ("shipped"). The words are the client's.
-    kind: str
+    kind: str = Field(validation_alias="type")
     extension: str | None = None
     # The durable kind of the workflow a lifecycle row is about ("ship.build").
-    workflow: str | None = None
+    workflow: str | None = Field(default=None, validation_alias=AliasPath("payload", "kind"))
     subject_type: str | None = None
     subject_id: str | None = None
     subject_label: str | None = None
 
-    @classmethod
-    def from_event(cls, event: Event) -> "FeedItem":
-        return cls(
-            id=f"event:{event.id}",
-            seq=event.id,
-            at=event.created_at,
-            kind=event.type,
-            extension=event.extension,
-            workflow=event.payload.get("kind"),
-            subject_type=event.subject_type,
-            subject_id=event.subject_id,
-            subject_label=event.subject_label,
-        )
+    @computed_field
+    @property
+    def id(self) -> str:
+        return f"event:{self.seq}"
 
 
 class FeedResponse(BaseResponse):

--- a/backend/druks/extensions/base.py
+++ b/backend/druks/extensions/base.py
@@ -158,7 +158,7 @@ class Extension:
         """What this extension's runs are about, read off the workflows that declare
         them — each one gets a board and a page, ordered by subject type so the routes
         it mounts are stable."""
-        declared = {wf._subject_class for wf in cls.workflows() if wf._subject_class}
+        declared = {wf.subject for wf in cls.workflows() if wf.subject}
         for subject_class in declared:
             if subject_class.subject_type == "transcripts":
                 raise TypeError(
@@ -335,7 +335,7 @@ class Extension:
             call = AgentCall.get(call_id)
             if not call:
                 raise HTTPException(status.HTTP_404_NOT_FOUND, "Run not found.")
-            if call.get_live_status() == AgentCallStatus.RUNNING:
+            if call.live_status == AgentCallStatus.RUNNING:
                 response.headers["Cache-Control"] = "no-store"
             else:
                 response.headers["Cache-Control"] = settled_cache

--- a/backend/druks/mcp/gateway/services.py
+++ b/backend/druks/mcp/gateway/services.py
@@ -76,7 +76,7 @@ def get_agent_call(call_id: str) -> schemas.AgentCallDetailResponse:
     layout = call.artifact_layout
     return schemas.AgentCallDetailResponse(
         run_id=call.run_id,
-        call=AgentCallResponse.from_call(call),
+        call=AgentCallResponse.model_validate(call),
         transcript=read_slice(
             layout.transcript, offset=-_TRANSCRIPT_TAIL_BYTES, limit=_TRANSCRIPT_TAIL_BYTES
         ).text,

--- a/backend/druks/signals.py
+++ b/backend/druks/signals.py
@@ -46,7 +46,7 @@ def subscribe(name: str, **filters: Any) -> Callable[[Subscriber], Subscriber]:
             )
         if workflow_class:
             filters["kind"] = workflow_class.kind
-            subject_class = workflow_class._subject_class
+            subject_class = workflow_class.subject
         if subject_class:
             if not (
                 isinstance(subject_class, type)

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -132,11 +132,29 @@ def _resolve_body_method(cls: type["Workflow"]) -> str:
     )
 
 
-def _resolve_subject_class(cls: type["Workflow"]) -> "type[Subject] | type[StoredSubject] | None":
-    # The declaration and the run's live subject are the same word, so the class
-    # attribute comes off and the property answers in its place.
+class _DeclaredSubject:
+    """``subject = WorkItem`` on a workflow: the kind of thing its runs are about, read
+    off the workflow, and the particular one a run is about, read off that run."""
+
+    def __init__(self, subject_class: "type[Subject] | type[StoredSubject] | None") -> None:
+        self.subject_class = subject_class
+
+    def __get__(self, run: "Workflow | None", owner: type) -> Any:
+        if run is None:
+            return self.subject_class
+        # Live, not a snapshot taken at dispatch: a long-parked run resumes against
+        # whatever the declared class says then, and finds nothing if it went away.
+        if not run._subject:
+            return
+        return self.subject_class.get_for_subject_id(str(run._subject["id"]))
+
+
+def _declare_subject(cls: type["Workflow"]) -> None:
+    # The author writes a plain class attribute; it becomes the descriptor above.
+    # Presence in ``cls.__dict__``, not the value: an explicit ``subject = None`` is a
+    # declaration of nothing, which the error below names rather than passing over.
     if "subject" not in cls.__dict__:
-        return cls._subject_class
+        return
     declared = cls.__dict__["subject"]
     if not (isinstance(declared, type) and issubclass(declared, Subject | StoredSubject)):
         raise WorkflowError(
@@ -144,8 +162,7 @@ def _resolve_subject_class(cls: type["Workflow"]) -> "type[Subject] | type[Store
             f"is about a kind of thing, not {declared!r}. A workflow about nothing "
             "declares no subject at all."
         )
-    del cls.subject
-    return declared
+    cls.subject = _DeclaredSubject(declared)
 
 
 def _input_model_from_signature(cls: type["Workflow"]) -> type[BaseModel] | None:
@@ -483,10 +500,9 @@ class Workflow:
     # the loader's package registrations at definition time and namespacing
     # ``kind``. Never supplied or stored per run.
     extension: ClassVar[str | None] = None
-    # The subject class this workflow's runs are about, written ``subject = WorkItem``
-    # on the subclass and lifted off it in __init_subclass__ so the instance property
-    # below keeps the name. None for a workflow about nothing, which says so by silence.
-    _subject_class: ClassVar[type[Subject] | type[StoredSubject] | None] = None
+    # What this workflow's runs are about, written ``subject = WorkItem`` on the
+    # subclass. None for a workflow about nothing, which says so by silence.
+    subject = _DeclaredSubject(None)
     # When set to a cron string, the workflow also registers a schedule that
     # fires its run() on that cadence (no subject — a framework cron).
     every: ClassVar[str | None] = None
@@ -532,7 +548,7 @@ class Workflow:
                 "the declaring extension supplies the namespace"
             )
         cls.kind = f"{cls.extension}.{local_kind}" if cls.extension else local_kind
-        cls._subject_class = _resolve_subject_class(cls)
+        _declare_subject(cls)
         validate_settings_declaration(cls.Settings)
         cls._body_method = _resolve_body_method(cls)
         # Before _wrap_steps: run()'s wrapper signature is (*args, **kwargs).
@@ -564,14 +580,6 @@ class Workflow:
         # The run's warm VM, provisioned lazily and reaped at segment boundaries;
         # its lease expiry decides when it must rotate.
         self._host: Sandbox | None = None
-
-    @property
-    def subject(self) -> Any:
-        # Live, not a snapshot taken at dispatch: a long-parked run resumes against
-        # whatever the declared class says then, and finds nothing if it went away.
-        if not self._subject:
-            return
-        return self._subject_class.get_for_subject_id(str(self._subject["id"]))
 
     async def announce(self, topic: str, **facts: Any) -> None:
         # The workflow announcing a domain event in its extension's vocabulary
@@ -703,13 +711,11 @@ class Workflow:
     def _validate_subject(cls, subject: "Subject | StoredSubject | None") -> None:
         # The declaration is the contract — subscribers derive their subject class
         # from ``workflow=``, so it has to hold for every run.
-        if cls._subject_class:
-            if isinstance(subject, cls._subject_class):
+        if cls.subject:
+            if isinstance(subject, cls.subject):
                 return
             given = "nothing" if subject is None else type(subject).__name__
-            raise WorkflowError(
-                f"{cls.__name__} is about {cls._subject_class.__name__}, not {given}"
-            )
+            raise WorkflowError(f"{cls.__name__} is about {cls.subject.__name__}, not {given}")
         if subject is None:
             return
         raise WorkflowError(

--- a/backend/tests/druks-field_notes/druks_field_notes/contracts.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/contracts.py
@@ -1,6 +1,6 @@
 from druks.agents import AgentOutput
 
 
-class NoteSummary(AgentOutput):
-    # What the summarizer agent returns: a one-line distillation of the note it read.
-    summary: str
+class GistOutput(AgentOutput):
+    # What the summarizer agent returns: the note it read, in one line.
+    gist: str

--- a/backend/tests/druks-field_notes/druks_field_notes/extension.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/extension.py
@@ -6,7 +6,7 @@ from druks.doctor import CheckResult
 from druks.extensions import Extension
 from pydantic import BaseModel, Field, SecretStr, field_validator
 
-from druks_field_notes.contracts import NoteSummary
+from druks_field_notes.contracts import GistOutput
 
 if TYPE_CHECKING:
     from druks.settings import Settings
@@ -33,7 +33,7 @@ def check_summary_api_key(settings: "Settings") -> CheckResult:
 class FieldNotes(Extension):
     name = "field_notes"
     icon = "notebook"
-    description = "Turns a jotted observation into a one-line summary with an agent."
+    description = "Turns a jotted observation into a one-line gist with an agent."
 
     class Settings(BaseModel):
         # How many recent notes the board shows — an operator knob, so it lives here.
@@ -71,11 +71,11 @@ class FieldNotes(Extension):
                 raise ValueError(f"sync token {value.get_secret_value()!r} must start with 'sk-'")
             return value
 
-    # The one agent this extension runs: it reads a note and writes its summary.
+    # The one agent this extension runs: it reads a note and writes its gist.
     summarize = Agent(
-        description="reads a note and writes a one-line summary",
+        description="reads a note and writes its one-line gist",
         prompt="field_notes/summarize.md",
-        contract=NoteSummary,
+        contract=GistOutput,
         model="claude",
     )
 

--- a/backend/tests/druks-field_notes/druks_field_notes/migrations/versions/field_notes_0001_notes.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/migrations/versions/field_notes_0001_notes.py
@@ -22,7 +22,7 @@ def upgrade() -> None:
         "field_notes_notes",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("body", sa.String(), nullable=False),
-        sa.Column("summary", sa.String(), nullable=True),
+        sa.Column("gist", sa.String(), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/backend/tests/druks-field_notes/druks_field_notes/models.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/models.py
@@ -11,11 +11,10 @@ class Note(StoredSubject):
     __tablename__ = "field_notes_notes"
 
     # What the note is about — the raw observation an operator jotted down. A run's
-    # agent reads this and writes back a one-line summary.
+    # agent reads this and writes back its gist.
     body: Mapped[str]
-    # The agent's summary of ``body``, written when a Summarize run finishes. None
-    # until then.
-    summary: Mapped[str | None]
+    # ``body`` in one line, written when a Summarize run finishes. None until then.
+    gist: Mapped[str | None]
     created_at: Mapped[datetime] = mapped_column(default=StoredSubject.utc_now)
 
     @classmethod
@@ -35,8 +34,8 @@ class Note(StoredSubject):
         stmt = select(cls).order_by(cls.created_at.desc(), cls.id.desc()).limit(limit)
         return list(db_session().scalars(stmt))
 
-    def save_summary(self, summary: str) -> None:
-        self.summary = summary
+    def save_gist(self, gist: str) -> None:
+        self.gist = gist
         db_session().flush()
 
     def get_summary(self) -> NoteSummary:

--- a/backend/tests/druks-field_notes/druks_field_notes/schemas.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/schemas.py
@@ -7,5 +7,5 @@ class NoteSummary(SubjectSummary):
     # The note's domain header — what only field_notes knows. The platform's subject
     # read-side composes it with the generic status + timeline.
     body: str
-    summary: str | None = None
+    gist: str | None = None
     created_at: datetime

--- a/backend/tests/druks-field_notes/druks_field_notes/templates/prompts/field_notes/summarize.md
+++ b/backend/tests/druks-field_notes/druks_field_notes/templates/prompts/field_notes/summarize.md
@@ -1,8 +1,8 @@
-You are reading one field note and writing a single-sentence summary of it.
+You are reading one field note and writing its gist in a single sentence.
 
 The note:
 
 {{ note_body }}
 
-Write one clear sentence capturing the note's essence. Return it as the `summary`
+Write one clear sentence capturing the note's essence. Return it as the `gist`
 field of your structured output — nothing else.

--- a/backend/tests/druks-field_notes/druks_field_notes/workflows.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/workflows.py
@@ -5,17 +5,17 @@ from druks_field_notes.models import Note
 
 
 class Summarize(Workflow):
-    """Reads one note and writes its summary — a single durable operation: the
-    agent produces the summary prose, and the run stores it on the note."""
+    """Reads one note and writes its gist — a single durable operation: the agent
+    produces the line, and the run stores it on the note."""
 
     subject = Note
 
     async def run(self) -> None:
         note = self.subject
-        # The note body is the agent's prompt context; the summary it returns is the
+        # The note body is the agent's prompt context; the gist it returns is the
         # extension's own domain result, saved onto the note.
         result = await FieldNotes.summarize(note_body=note.body)
-        note.save_summary(result.summary)
+        note.save_gist(result.gist)
 
     @classmethod
     async def dispatch(cls, *, note: Note) -> str:

--- a/backend/tests/druks-field_notes/tests/test_models.py
+++ b/backend/tests/druks-field_notes/tests/test_models.py
@@ -1,13 +1,13 @@
 from druks_field_notes.models import Note
 
 
-def test_note_create_list_and_save_summary(druks_db):
+def test_note_create_list_and_save_gist(druks_db):
     first = Note.create(body="the pump ran hot")
     second = Note.create(body="the pressure held")
 
     assert Note.list_recent(limit=1) == [second]
 
-    first.save_summary("The pump ran hot.")
+    first.save_gist("The pump ran hot.")
 
     saved = Note.get(first.id)
-    assert saved.summary == "The pump ran hot."
+    assert saved.gist == "The pump ran hot."

--- a/backend/tests/druks-field_notes/tests/test_routes.py
+++ b/backend/tests/druks-field_notes/tests/test_routes.py
@@ -1,4 +1,3 @@
-
 from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
 
@@ -28,4 +27,4 @@ def test_notes_routes_create_and_list_notes(druks_client, monkeypatch):
 
     assert listed.status_code == 200
     assert listed.json()[0]["body"] == "the pump ran hot"
-    assert listed.json()[0]["summary"] is None
+    assert listed.json()[0]["gist"] is None

--- a/backend/tests/druks-field_notes/tests/test_workflows.py
+++ b/backend/tests/druks-field_notes/tests/test_workflows.py
@@ -1,23 +1,21 @@
 from unittest import mock
 
 from druks.testing import run_workflow
-from druks_field_notes.contracts import NoteSummary
+from druks_field_notes.contracts import GistOutput
 from druks_field_notes.extension import FieldNotes
 from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
 
 
-async def test_summarize_writes_the_summary(druks_db, monkeypatch):
+async def test_summarize_writes_the_gist(druks_db, monkeypatch):
     note = Note.create(body="the pump ran hot on the second pass")
-    summarize = mock.AsyncMock(
-        return_value=NoteSummary(summary="The pump ran hot on the second pass.")
-    )
+    summarize = mock.AsyncMock(return_value=GistOutput(gist="The pump ran hot on the second pass."))
     monkeypatch.setattr(FieldNotes, "summarize", staticmethod(summarize))
 
     await run_workflow(Summarize, subject=note)
 
     summarize.assert_awaited_once_with(note_body=note.body)
-    assert Note.get(note.id).summary == "The pump ran hot on the second pass."
+    assert Note.get(note.id).gist == "The pump ran hot on the second pass."
 
 
 async def test_dispatch_starts_the_workflow_for_the_note(monkeypatch):

--- a/backend/tests/test_agent_call_liveness.py
+++ b/backend/tests/test_agent_call_liveness.py
@@ -1,6 +1,5 @@
 from druks.durable.dbos_state import workflow_status
 from druks.durable.enums import AgentCallStatus
-from druks.durable.schemas import AgentCallResponse
 from druks.testing import seed_call, seed_run
 from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
@@ -13,12 +12,11 @@ def _running_call(druks_db):
     return seed_call(druks_db, run, "summarize", status="running")
 
 
-def test_from_call_derives_running_while_run_active(druks_db):
-    call = _running_call(druks_db)
-    assert AgentCallResponse.from_call(call).status == "running"
+def test_an_unfinished_call_reads_running_while_its_run_is_active(druks_db):
+    assert _running_call(druks_db).live_status == AgentCallStatus.RUNNING
 
 
-def test_from_call_derives_abandoned_when_run_terminal(druks_db):
+def test_an_unfinished_call_reads_abandoned_once_its_run_is_terminal(druks_db):
     call = _running_call(druks_db)
     druks_db.execute(
         update(workflow_status)
@@ -26,10 +24,10 @@ def test_from_call_derives_abandoned_when_run_terminal(druks_db):
         .values(status="ERROR")
     )
     druks_db.expire_all()
-    assert AgentCallResponse.from_call(call).status == "abandoned"
+    assert call.live_status == AgentCallStatus.ABANDONED
 
 
-def test_from_call_keeps_a_finished_calls_outcome(druks_db):
+def test_a_finished_call_keeps_its_outcome(druks_db):
     note = Note.create(body="finished agent call")
     run = seed_run(druks_db, kind=Summarize.kind, subject=note)
     call = seed_call(
@@ -39,4 +37,4 @@ def test_from_call_keeps_a_finished_calls_outcome(druks_db):
         status=AgentCallStatus.SUCCEEDED.value,
     )
     # A finished call keeps its outcome regardless of its run's state.
-    assert AgentCallResponse.from_call(call).status == "succeeded"
+    assert call.live_status == AgentCallStatus.SUCCEEDED

--- a/backend/tests/test_extensions.py
+++ b/backend/tests/test_extensions.py
@@ -185,7 +185,7 @@ def test_a_subject_cannot_take_the_transcripts_segment():
 
         @classmethod
         def workflows(cls):
-            return [SimpleNamespace(_subject_class=Transcripts)]
+            return [SimpleNamespace(subject=Transcripts)]
 
     with pytest.raises(TypeError, match="agent-call reads"):
         Colliding.subject_classes()

--- a/backend/tests/test_workflow_identity.py
+++ b/backend/tests/test_workflow_identity.py
@@ -147,21 +147,25 @@ def test_display_label_reads_the_local_kind():
     assert get_display_label("field_notes.summarize") == "Summarize"
 
 
-def test_a_declared_subject_is_lifted_off_the_class():
-    # The declaration and the run's live subject share the name, so the class
-    # attribute comes off and the instance property answers in its place.
+def test_a_declared_subject_answers_off_the_workflow_and_off_a_run():
+    # One word, two answers: the workflow says what kind of thing its runs are about,
+    # a run of it says which one.
     register_workflow_package("alpha_pkg", "alpha")
     flow = _workflow("Sweep", "alpha_pkg.workflows", subject=Note)
 
-    assert flow._subject_class is Note
-    assert "subject" not in flow.__dict__
+    assert flow.subject is Note
     assert flow().subject is None  # a run with no subject has none to resolve
+
+
+def test_a_workflow_about_nothing_says_so_by_silence():
+    register_workflow_package("alpha_pkg", "alpha")
+    assert _workflow("Sweep", "alpha_pkg.workflows").subject is None
 
 
 @pytest.mark.parametrize("declared", ["note", None])
 def test_a_subject_that_is_not_a_subject_class_is_rejected(declared):
-    # ``subject = None`` included: written out it would shadow the instance
-    # property with a permanent None, so a workflow about nothing writes nothing.
+    # ``subject = None`` included: written out it would shadow the declaration with a
+    # permanent None, so a workflow about nothing writes nothing.
     register_workflow_package("alpha_pkg", "alpha")
     with pytest.raises(WorkflowError, match="must be a Subject or StoredSubject"):
         _workflow("Sweep", "alpha_pkg.workflows", subject=declared)


### PR DESCRIPTION
Three things the subject arc left behind.

## `subject` is one word, answering twice

A workflow declares what its runs are about. The declaration and the run's live
subject share the name, so `__init_subclass__` moved the class attribute out of
the way and kept a private copy:

```python
del cls.subject
cls._subject_class = declared
```

Which left `Build.subject` answering `None` while `Build` is plainly about a
`WorkItem`, and two modules reaching across for the truth — `signals.py` and
`extensions/base.py` both read `workflow_class._subject_class` to derive a
subscriber's filter and an extension's mounted boards.

A descriptor is what the two readings were asking for. The declaration becomes
one, and the same word answers the workflow with the kind of thing and a run
with the particular one:

```python
class _DeclaredSubject:
    def __get__(self, run, owner):
        if run is None:
            return self.subject_class
        ...
```

`Build.subject is WorkItem` is true now, `_subject_class` is gone, and the two
cross-module private reads are `workflow.subject`.

Presence in `cls.__dict__` still decides, not the value: an explicit
`subject = None` is a declaration of nothing, and stays an error.

## The proof extension said "summary" three times

`field_notes` is what an extension author copies from, and it spelled one word
over three unrelated things: `Note.summary` (the agent's prose),
`Note.get_summary()` (the platform's board header), and two classes both named
`NoteSummary` — one an `AgentOutput`, one a `SubjectSummary`.

`get_summary()` / `list_summaries()` is the platform's pair and stays. The
domain word moves: a note has a `body`, and the agent writes its **gist**.

- `Note.summary` → `Note.gist`, `save_summary()` → `save_gist()`
- `contracts.NoteSummary(AgentOutput)` → `GistOutput`, returning `gist`
- `schemas.NoteSummary(SubjectSummary)` keeps its name — it is the platform summary
- the baseline migration, the prompt template and the agent's description follow

## Two more builders that were copying fields

Same reduction as #139: a builder that only reads attributes off one object is
`model_validate` and a few aliases.

`FeedItem.from_event` — `seq` / `at` / `kind` alias to the event's `id` /
`created_at` / `type`, `workflow` becomes `AliasPath("payload", "kind")`, and
`id` is the `f"event:{seq}"` computed field `DashboardItem.key` already models.

`AgentCallResponse.from_call` — `account_username` becomes
`AliasPath("account", "username")` and `label` a computed field. The two
derivations it reached for move onto the row that owns them:
`AgentCall.get_live_status()` is the `live_status` property, and
`normalize_token_usage(call.cost_metadata)` is `AgentCall.token_usage`, which
retires the `_token_usage` helper in `schemas.py`. `status` is typed
`AgentCallStatus` rather than a restated literal union, so the `# type: ignore`
the mismatch needed goes with it.

Both wire shapes are unchanged, field for field.

The `from_*` builders that stay are the ones that aren't field copies:
`AgentCallFiles.from_call` walks the filesystem, `RunResponse.from_run` takes a
second argument, `HarnessResponse.from_row` joins three sources,
`SettingsFieldResponse.from_field` reads a `FieldInfo` plus kwargs, and the four
`from_settings` are config constructors.
