### PR TITLE
A fallback credential is a fact on the call, not a row in the feed

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -12,8 +12,7 @@ from druks.durable.activity import set_run_phase
 from druks.durable.engine import _step_engine, step_session
 from druks.durable.enums import AgentCallStatus
 from druks.durable.exceptions import WorkflowError
-from druks.durable.models import AgentCall, Artifact, Run
-from druks.events.models import Event
+from druks.durable.models import AgentCall, Artifact
 from druks.extensions.registry import agents
 from druks.harnesses.models import HarnessConnection
 from druks.harnesses.registry import get_harness_for_model
@@ -180,15 +179,6 @@ class Agent:
         connection = HarnessConnection.lookup(harness.name, workflow.account_id)
         # Plain snapshots: the commits below expire the ORM row mid-flight.
         connection_id, charged_account_id = connection.id, connection.account_id
-        if charged_account_id != workflow.account_id:
-            # The visible nudge: this call charged the fallback account.
-            Event.emit(
-                type="credential.fallback",
-                subject=workflow._subject,
-                label=Run.get(workflow_id).subject_label,
-                payload={"run_id": workflow_id, "harness": harness.name},
-                extension=type(workflow).extension,
-            )
         # An agent call is a durability boundary — its effects don't roll back —
         # so commit here rather than hold the step's connection idle through the
         # minutes of provisioning and the run.

--- a/frontend/src/lib/feed.test.ts
+++ b/frontend/src/lib/feed.test.ts
@@ -85,12 +85,4 @@ describe('eventLine', () => {
     expect(line.subject).toBe('note 7')
     expect(line.path).toBeUndefined()
   })
-
-  it('reads a core event with no subject at all', () => {
-    const line = eventLine(event({ kind: 'credential.fallback' }))
-
-    expect(line.label).toBe('credential.fallback')
-    expect(line.subject).toBe('')
-    expect(line.source).toBe('druks')
-  })
 })


### PR DESCRIPTION
Every agent call emitted a `credential.fallback` event when its login came
from the fallback account rather than the run's own. A run makes one such
call per agent, so a single run wrote a column of identical rows into the
feed — same subject, same harness, same run id — and the feed had no
renderer for the type, so each row read as the raw dotted identifier.

The fact those rows carried is already recorded: `agent_calls.account_id`
holds the subscription actually charged, on the row that paid it, and it is
already on the wire. The event is dropped; the account snapshot that stamps
the call stays.

The feed test that used this type as its fixture keeps it — logged rows from
before this change still carry the kind, and rendering an unrecognised kind
as itself is what keeps them readable.
