### PR TITLE
Every agent call names the agent that made it

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -134,6 +134,14 @@ class Agent:
         this picks which step does it: its own, or the @step it's already inside.
         workflow_id comes from the workflow context, not the caller; everything
         else (repo, …) is prompt context."""
+        if not self.id:
+            # Built loose — never assigned to an Extension, never given an explicit
+            # id — so its settings, its registry entry and the call it would record
+            # all key on nothing.
+            raise WorkflowError(
+                "an agent runs under its own id — declare it on an Extension, or "
+                "pass id= for a standalone one"
+            )
         workflow = current_workflow.get(None)
         if not workflow:
             raise WorkflowError(

--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -324,8 +324,9 @@ class AgentCall(Base, Uuid7Pk):
     run_id: Mapped[str] = mapped_column(ForeignKey("durable_runs.id", ondelete="CASCADE"))
     run: Mapped["Run"] = relationship()
     # Which agent (registry id: "scope", "implement", …) made this call — the
-    # timeline's grouping label. Nullable — not every call is agent-attributed.
-    agent: Mapped[str | None] = mapped_column(String, default=None)
+    # timeline's grouping label. An agent is what makes a call, so there is no
+    # unattributed one: the row is written from the registered agent's own id.
+    agent: Mapped[str] = mapped_column(String)
     # The subscription actually charged — differs from the run's account on
     # fallback.
     account_id: Mapped[str] = mapped_column(
@@ -404,7 +405,7 @@ class AgentCall(Base, Uuid7Pk):
         call_id: str,
         run_id: str,
         model: str | None,
-        agent: str | None,
+        agent: str,
         host_id: str,
         account_id: str,
     ) -> None:

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -31,7 +31,7 @@ class AgentCallResponse(BaseResponse):
 
     id: str
     # Which agent made this call ("scope", "implement") — the timeline's row label.
-    agent: str | None = None
+    agent: str
     # The account charged — differs from the run's on fallback.
     account_username: str = Field(validation_alias=AliasPath("account", "username"))
     status: AgentCallStatus = Field(validation_alias="live_status")
@@ -46,7 +46,7 @@ class AgentCallResponse(BaseResponse):
     @computed_field
     @property
     def label(self) -> str:
-        return get_display_label(self.agent) if self.agent else "Agent"
+        return get_display_label(self.agent)
 
 
 class ArtifactFile(BaseResponse):

--- a/backend/migrations/versions/a4e1f60c2b95_every_agent_call_names_its_agent.py
+++ b/backend/migrations/versions/a4e1f60c2b95_every_agent_call_names_its_agent.py
@@ -1,0 +1,29 @@
+"""every agent call names its agent
+
+Revision ID: a4e1f60c2b95
+Revises: f2c8b81a9d4e
+Create Date: 2026-07-28 18:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a4e1f60c2b95"
+down_revision: str | Sequence[str] | None = "f2c8b81a9d4e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # No backfill: a call is written from the registered agent's own id, so a null
+    # here would mean a writer nobody knows about. Inventing an attribution would
+    # put it in the cost table — let the constraint find it instead.
+    op.alter_column("agent_calls", "agent", existing_type=sa.String(), nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("agent_calls", "agent", existing_type=sa.String(), nullable=True)

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -253,6 +253,7 @@ def test_usage_agent_route_matches_the_service(client: TestClient, druks_db, acc
     druks_db.add(
         AgentCall(
             run_id=run.id,
+            agent="summarize",
             account_id=account.id,
             sandbox_host_id="host",
             model="gpt-5.5",

--- a/backend/tests/test_agent_services.py
+++ b/backend/tests/test_agent_services.py
@@ -275,6 +275,7 @@ def test_get_usage_is_a_bounded_pure_read(druks_db, account):
         druks_db.add(
             AgentCall(
                 run_id=run.id,
+                agent="summarize",
                 account_id=account.id,
                 sandbox_host_id="host",
                 model="gpt-5.5",
@@ -321,6 +322,7 @@ def test_get_usage_only_counts_the_callers_spend(druks_db, account):
     druks_db.add(
         AgentCall(
             run_id=run.id,
+            agent="summarize",
             account_id=other.id,
             sandbox_host_id="host",
             model="gpt-5.5",

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -277,10 +277,22 @@ async def test_recovery_supersedes_the_orphaned_running_call(druks_db):
 
     engine = _step_engine()
     AgentCall.start(
-        engine, call_id="a", run_id="wf-9", model="m", agent=None, host_id="h", account_id="system"
+        engine,
+        call_id="a",
+        run_id="wf-9",
+        model="m",
+        agent="summarize",
+        host_id="h",
+        account_id="system",
     )
     AgentCall.start(
-        engine, call_id="b", run_id="wf-9", model="m", agent=None, host_id="h", account_id="system"
+        engine,
+        call_id="b",
+        run_id="wf-9",
+        model="m",
+        agent="summarize",
+        host_id="h",
+        account_id="system",
     )
 
     by_id = {call.id: call for call in AgentCall.list_for_run("wf-9")}

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -106,6 +106,14 @@ async def test_run_outside_workflow_raises():
         await DUMMY_AGENT(repo="acme/widget")
 
 
+async def test_run_refuses_an_agent_with_no_id():
+    # Built loose — never assigned to an Extension, never given an explicit id — so
+    # the call it would record would name nobody.
+    loose = agents.Agent(prompt="dummy/agent.md", contract=DummyOutput, model="claude")
+    with pytest.raises(WorkflowError, match="runs under its own id"):
+        await loose(repo="acme/widget")
+
+
 async def test_run_refuses_unconnected_harness(druks_db, tmp_path, monkeypatch, current_run):
     # The precondition fires where the harness is resolved — before any VM work.
     from druks.accounts.models import Account

--- a/backend/tests/test_artifacts.py
+++ b/backend/tests/test_artifacts.py
@@ -12,7 +12,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 def _seed_call(druks_db) -> AgentCall:
     druks_db.add(Run(id="run-1", kind="build"))
-    call = AgentCall(id="call-1", run_id="run-1", sandbox_host_id="host-1")
+    call = AgentCall(id="call-1", run_id="run-1", agent="summarize", sandbox_host_id="host-1")
     druks_db.add(call)
     druks_db.flush()
     return call
@@ -63,7 +63,9 @@ def test_get_latest_for_run_returns_the_newest_calls_artifact(druks_db, tmp_path
     # the second call's plan wins.
     druks_db.add(Run(id="run-1", kind="build"))
     for call_id, title in (("call-1", "First plan"), ("call-2", "Revised plan")):
-        druks_db.add(AgentCall(id=call_id, run_id="run-1", sandbox_host_id="host-1"))
+        druks_db.add(
+            AgentCall(id=call_id, run_id="run-1", agent="summarize", sandbox_host_id="host-1")
+        )
         druks_db.flush()
         Artifact.record(
             call_dir=tmp_path / call_id,
@@ -86,7 +88,9 @@ def test_get_ask_resolves_the_review_artifact(druks_db, tmp_path):
         input_request={"presentation": "in_app", "controls": ["approve"]},
     )
     druks_db.add(run)
-    druks_db.add(AgentCall(id="call-1", run_id="run-1", sandbox_host_id="host-1"))
+    druks_db.add(
+        AgentCall(id="call-1", run_id="run-1", agent="summarize", sandbox_host_id="host-1")
+    )
     druks_db.flush()
     Artifact.record(call_dir=tmp_path, call_id="call-1", kind="markdown", title="Plan", content="x")
 
@@ -124,7 +128,7 @@ async def test_get_artifact_returns_recorded_content(druks_db, tmp_path, monkeyp
     # call_dir resolves through load_settings().artifacts_dir, so point it at tmp.
     monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
     druks_db.add(Run(id="run-1", kind="build"))
-    call = AgentCall(id="call-1", run_id="run-1", sandbox_host_id="host-1")
+    call = AgentCall(id="call-1", run_id="run-1", agent="summarize", sandbox_host_id="host-1")
     druks_db.add(call)
     druks_db.flush()
     Artifact.record(
@@ -153,7 +157,9 @@ async def test_get_artifact_404_when_content_gone(druks_db, tmp_path, monkeypatc
     # not a 500.
     monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
     druks_db.add(Run(id="run-1", kind="build"))
-    druks_db.add(AgentCall(id="call-1", run_id="run-1", sandbox_host_id="host-1"))
+    druks_db.add(
+        AgentCall(id="call-1", run_id="run-1", agent="summarize", sandbox_host_id="host-1")
+    )
     druks_db.flush()
     druks_db.execute(
         pg_insert(Artifact).values(

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -72,7 +72,7 @@ export interface TokenUsage {
 export interface AgentCallSummary {
   id: string
   // Which agent made this call ("scope", "implement"); label is its display name.
-  agent?: string | null
+  agent: string
   label: string
   /** The account charged for this call — differs from the run's on fallback. */
   accountUsername: string


### PR DESCRIPTION
`AgentCall.agent` was nullable, `AgentCallResponse.agent` optional, and the
response's `label` fell back to the string `"Agent"` when it was missing.
Nothing could produce that row.

The one production writer is `AgentCall.start(..., agent=self.id)`
([agents.py](backend/druks/agents.py)), where `self` is an `Agent`. An
explicit id registers in `__post_init__`; otherwise `__set_name__` stamps it
from the attribute name. Even `seed_call` takes `agent` as a required
positional. So the `| None`, the nullable column and the `"Agent"` fallback
modelled an absence with no producer — and #142 turning `label` into a
computed field made that dead branch read like a deliberate rule rather than
a copied default.

- `agent: Mapped[str]`, and `AgentCall.start(agent: str)`
- `AgentCallResponse.agent: str`; `label` is `get_display_label(self.agent)`
- `AgentCallSummary.agent: string` on the wire mirror
- migration `a4e1f60c2b95`

The migration adds the constraint with no backfill. A null here would mean a
writer nobody knows about, and inventing an attribution would put it in the
cost table — the constraint should find it instead.

## The blank id the constraint would have taken

`Agent.id` defaults to `""` so `__set_name__` can fill it, and an `Agent`
built loose — a local, never assigned to an `Extension`, never given an
explicit `id=` — keeps that default. `__set_name__` never runs, so it never
registers, but nothing stopped it running: it would have written `agent=""`,
which satisfies `NOT NULL` and displays as a blank timeline label.

An agent with no id has no durable key — its settings overrides, its registry
entry and its calls all key on nothing — so `__call__` refuses it, beside the
check that it is inside a workflow.

## Not changing

`SubjectStatus.agent` stays `str | None`. Its None means "no live agent call"
— the driving run is parked, or has none yet — not "an unattributed call".
