### PR TITLE
Every agent call names the model that ran it

### DIFF
--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -316,10 +316,10 @@ class AgentCall(Base, Uuid7Pk):
         Index("agent_calls_account_finished_idx", "account_id", "finished_at"),
     )
 
-    # Which model ran this row, snapshotted at dispatch; cost analysis and the
-    # transcript layout both read it. Nullable — a call may be recorded before
-    # its model is resolved.
-    model: Mapped[str | None] = mapped_column(String, default=None)
+    # Which model ran this row, snapshotted at dispatch — the model is resolved
+    # before the harness is chosen, so a call always knows what ran it. Cost
+    # analysis reads it; the id may name no current harness once ids churn.
+    model: Mapped[str] = mapped_column(String)
     # The run this LLM call ran in. ON DELETE CASCADE, so a call never outlives it.
     run_id: Mapped[str] = mapped_column(ForeignKey("durable_runs.id", ondelete="CASCADE"))
     run: Mapped["Run"] = relationship()
@@ -371,8 +371,7 @@ class AgentCall(Base, Uuid7Pk):
     @property
     def artifact_layout(self) -> RunArtifactLayout:
         # The sandbox runner streams every run's stdout to stdout.jsonl no matter
-        # which harness runs it, so the layout never needs the model (which may
-        # still be unresolved on this row).
+        # which harness runs it, so the layout never needs the model.
         sub = self.call_dir
         return RunArtifactLayout(
             transcript=sub / "stdout.jsonl",
@@ -404,7 +403,7 @@ class AgentCall(Base, Uuid7Pk):
         *,
         call_id: str,
         run_id: str,
-        model: str | None,
+        model: str,
         agent: str,
         host_id: str,
         account_id: str,

--- a/backend/druks/testing.py
+++ b/backend/druks/testing.py
@@ -360,7 +360,7 @@ def seed_call(
     agent: str,
     *,
     status: str = "succeeded",
-    model: str | None = "gpt-5.5",
+    model: str = "gpt-5.5",
     last_error: str | None = None,
 ) -> AgentCall:
     """An agent call on a run, stamped with the id of the agent that made it."""

--- a/backend/druks/usage/routes.py
+++ b/backend/druks/usage/routes.py
@@ -97,7 +97,7 @@ async def get_usage_today(account: Account = Depends(current_account)) -> UsageT
     timezone_name = str(timezone)
 
     # Every call counts, even one whose model no picker list claims (pinned
-    # outside the list, or never resolved): money spent must not vanish from
+    # outside the list, or an id that churned): money spent must not vanish from
     # the display, and the strip's total_run_spend_between counts them too.
     # Unclaimed calls land in an extra "unattributed" entry — the panel's
     # per-harness cards look up by name and skip it, its grand total sums the

--- a/backend/migrations/versions/c71b3d95e802_every_agent_call_names_its_model.py
+++ b/backend/migrations/versions/c71b3d95e802_every_agent_call_names_its_model.py
@@ -1,0 +1,29 @@
+"""every agent call names its model
+
+Revision ID: c71b3d95e802
+Revises: a4e1f60c2b95
+Create Date: 2026-07-28 19:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c71b3d95e802"
+down_revision: str | Sequence[str] | None = "a4e1f60c2b95"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # No backfill, for the reason the agent column had none: the model is resolved
+    # before the harness is chosen, so a null would name a writer nobody knows about
+    # and a guessed model would land in the cost breakdown.
+    op.alter_column("agent_calls", "model", existing_type=sa.String(), nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("agent_calls", "model", existing_type=sa.String(), nullable=True)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -231,7 +231,7 @@ def seed_note_run(session, *, note=None, state: str = "running", **kwargs):
     return seed_run(session, kind=Summarize.kind, subject=subject, state=state, **kwargs)
 
 
-def seed_note_agent_run(*, agent: str = "implement", model: str | None = "gpt-5.5", **kwargs):
+def seed_note_agent_run(*, agent: str = "implement", model: str = "gpt-5.5", **kwargs):
     """A run on a fresh note with one agent call on it — the call is what the caller wants."""
     from druks.database import db_session
     from druks.testing import seed_call

--- a/backend/tests/test_api_runs.py
+++ b/backend/tests/test_api_runs.py
@@ -228,11 +228,11 @@ def test_get_file_missing_returns_404(
 
 
 def test_agent_call_artifact_layout(druks_db, tmp_path):
-    # Layout sub-dir is the call id; the sandbox runner streams every run's
-    # stdout to stdout.jsonl, so the layout holds with the model unresolved.
+    # Layout sub-dir is the call id; the sandbox runner streams every run's stdout
+    # to stdout.jsonl, so the layout is the same whichever harness ran the call.
     note = Note.create(body="artifact layout")
     run = seed_run(druks_db, kind=Summarize.kind, subject=note)
-    call = seed_call(druks_db, run, "summarize", model=None, status="running")
+    call = seed_call(druks_db, run, "summarize", model="claude-opus-4-7", status="running")
     sub = Path(call.artifact_dir) / call.id
     assert call.artifact_layout.transcript == sub / "stdout.jsonl"
     assert call.artifact_layout.stderr == sub / "stderr.log"

--- a/backend/tests/test_api_usage.py
+++ b/backend/tests/test_api_usage.py
@@ -47,7 +47,7 @@ def _harness(body: dict, name: str) -> dict:
     return next(entry for entry in body["harnesses"] if entry["name"] == name)
 
 
-def _seed_agent_call(druks_db, *, model: str | None = "gpt-5.5"):
+def _seed_agent_call(druks_db, *, model: str = "gpt-5.5"):
     note = Note.create(body="usage accounting")
     run = seed_run(druks_db, kind=Summarize.kind, subject=note)
     return seed_call(druks_db, run, "summarize", status="running", model=model)
@@ -57,19 +57,18 @@ def test_usage_today_counts_calls_whose_model_isnt_a_current_harness(client, dru
     # Model ids churn on deploys (opus-4-7 → 4-8), so a call finished earlier today
     # can carry an id no harness claims any more. Money spent must not vanish from
     # the display — the sys-strip's total_run_spend_between counts every call, and
-    # the two surfaces must quote the same number. Unclaimed and unresolved models
-    # land in the "unattributed" bucket the panel's grand total sums.
-    for model in ("claude-opus-4-5", None):
-        call = _seed_agent_call(druks_db, model=model)
-        call.account_id = _account_id()
-        call.finished_at = datetime.now(UTC)
-        call.cost_usd = 2.5
+    # the two surfaces must quote the same number. Unclaimed models land in the
+    # "unattributed" bucket the panel's grand total sums.
+    call = _seed_agent_call(druks_db, model="claude-opus-4-5")
+    call.account_id = _account_id()
+    call.finished_at = datetime.now(UTC)
+    call.cost_usd = 2.5
     druks_db.flush()
 
     body = client.get("/api/usage/today").json()
     bucket = _harness(body, "unattributed")
-    assert bucket["runs"] == 2
-    assert bucket["spendUsd"] == 5.0
+    assert bucket["runs"] == 1
+    assert bucket["spendUsd"] == 2.5
 
 
 def test_get_usage_empty_returns_available_false(client) -> None:

--- a/backend/tests/test_artifacts.py
+++ b/backend/tests/test_artifacts.py
@@ -12,7 +12,9 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 def _seed_call(druks_db) -> AgentCall:
     druks_db.add(Run(id="run-1", kind="build"))
-    call = AgentCall(id="call-1", run_id="run-1", agent="summarize", sandbox_host_id="host-1")
+    call = AgentCall(
+        id="call-1", run_id="run-1", agent="summarize", model="m", sandbox_host_id="host-1"
+    )
     druks_db.add(call)
     druks_db.flush()
     return call
@@ -64,7 +66,9 @@ def test_get_latest_for_run_returns_the_newest_calls_artifact(druks_db, tmp_path
     druks_db.add(Run(id="run-1", kind="build"))
     for call_id, title in (("call-1", "First plan"), ("call-2", "Revised plan")):
         druks_db.add(
-            AgentCall(id=call_id, run_id="run-1", agent="summarize", sandbox_host_id="host-1")
+            AgentCall(
+                id=call_id, run_id="run-1", agent="summarize", model="m", sandbox_host_id="host-1"
+            )
         )
         druks_db.flush()
         Artifact.record(
@@ -89,7 +93,9 @@ def test_get_ask_resolves_the_review_artifact(druks_db, tmp_path):
     )
     druks_db.add(run)
     druks_db.add(
-        AgentCall(id="call-1", run_id="run-1", agent="summarize", sandbox_host_id="host-1")
+        AgentCall(
+            id="call-1", run_id="run-1", agent="summarize", model="m", sandbox_host_id="host-1"
+        )
     )
     druks_db.flush()
     Artifact.record(call_dir=tmp_path, call_id="call-1", kind="markdown", title="Plan", content="x")
@@ -128,7 +134,9 @@ async def test_get_artifact_returns_recorded_content(druks_db, tmp_path, monkeyp
     # call_dir resolves through load_settings().artifacts_dir, so point it at tmp.
     monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
     druks_db.add(Run(id="run-1", kind="build"))
-    call = AgentCall(id="call-1", run_id="run-1", agent="summarize", sandbox_host_id="host-1")
+    call = AgentCall(
+        id="call-1", run_id="run-1", agent="summarize", model="m", sandbox_host_id="host-1"
+    )
     druks_db.add(call)
     druks_db.flush()
     Artifact.record(
@@ -158,7 +166,9 @@ async def test_get_artifact_404_when_content_gone(druks_db, tmp_path, monkeypatc
     monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
     druks_db.add(Run(id="run-1", kind="build"))
     druks_db.add(
-        AgentCall(id="call-1", run_id="run-1", agent="summarize", sandbox_host_id="host-1")
+        AgentCall(
+            id="call-1", run_id="run-1", agent="summarize", model="m", sandbox_host_id="host-1"
+        )
     )
     druks_db.flush()
     druks_db.execute(

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -82,7 +82,7 @@ def _seed_run(
 
 
 def _seed_call(session, run, *, agent, status="succeeded"):
-    call = AgentCall(run_id=run.id, agent=agent, status=status, sandbox_host_id="h")
+    call = AgentCall(run_id=run.id, agent=agent, model="m", status=status, sandbox_host_id="h")
     session.add(call)
     session.flush()
     return call


### PR DESCRIPTION
The sibling of #144. `AgentCall.model` was nullable on stated grounds:

```python
# Nullable — a call may be recorded before its model is resolved.
model: Mapped[str | None] = mapped_column(String, default=None)
```

It can't be. `_run` resolves `model = self.get_model_name()` — typed `-> str` —
and the next line picks the harness from it, which would raise on an empty one.
`AgentCall.start(model=model)` is fifty lines further on, past provisioning. So
the row is only ever written once the model is known, and `Agent.model` is a
required field with no default.

- `model: Mapped[str]`, and `AgentCall.start(model: str)`
- migration `c71b3d95e802`, no backfill for the same reason `agent` had none:
  a guessed model would land in the cost breakdown
- `seed_call` and `seed_note_agent_run` take `model: str`

## Two tests pinned the case that can't happen

`test_usage_today_counts_calls_whose_model_isnt_a_current_harness` seeded both
`"claude-opus-4-5"` and `None`. Its own comment states the real requirement —
model ids churn on deploys, so a call finished earlier today can carry an id no
harness claims any more — and that half stays, along with the `unattributed`
bucket it lands in. The `None` half went.

`test_agent_call_artifact_layout` seeded `model=None` to show "the layout holds
with the model unresolved". The layout's actual rule is that it is the same
whichever harness ran the call, which is what it now says.

The usage panel keeps its `unattributed` bucket either way: a pinned or churned
id that no picker list claims is a real case, and money spent must not vanish
from the display.
