### PR TITLE
A work item holds no run id

### DIFF
--- a/backend/druks/contrib/ship/models.py
+++ b/backend/druks/contrib/ship/models.py
@@ -216,16 +216,10 @@ class WorkItem(StoredSubject):
     repo: Mapped[str]
     pr_number: Mapped[int | None]
     branch: Mapped[str | None]
-    # The item's latest durable build id. Build owns this historical link, so the
-    # platform timeline stays oblivious to extensions. SET NULL lets pruning leave
-    # the item without a stale attempt id.
-    build_run_id: Mapped[str | None] = mapped_column(
-        ForeignKey("durable_runs.id", ondelete="SET NULL"), default=None
-    )
-    # GitHub's verdict on the PR above, verbatim: "merged" or "closed". Unset while
-    # the work is still druks's — Board reads the absence, History reads the fact.
+    # GitHub's word, verbatim: "merged" or "closed". Unset while the work is
+    # still druks's, which is what the board reads.
     resolution: Mapped[str | None] = mapped_column(default=None)
-    # When GitHub resolved it, by GitHub's clock — History's order.
+    # GitHub's clock, not druks's receipt time.
     resolved_at: Mapped[datetime | None] = mapped_column(default=None)
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
@@ -238,9 +232,8 @@ class WorkItem(StoredSubject):
 
     @classmethod
     def list_summaries(cls) -> list[WorkItemSummary]:
-        # The active board: work GitHub hasn't answered yet. Where its run stands
-        # colours the row; it never decides whether the row is here. The 500
-        # most-recent cover it; paginate if a board outgrows it.
+        # Where a run stands colours the row; it never decides whether the row is
+        # here. The 500 most-recent cover it; paginate if a board outgrows it.
         stmt = (
             select(cls).where(cls.resolution.is_(None)).order_by(cls.updated_at.desc()).limit(500)
         )
@@ -302,10 +295,7 @@ class WorkItem(StoredSubject):
         )
         return db_session().scalars(stmt).first()
 
-    def start_attempt(self, run_id: str) -> None:
-        """A fresh build owns the item: the branch, PR and verdict left by the
-        previous attempt describe work this one has not done yet."""
-        self.build_run_id = run_id
+    def start_attempt(self) -> None:
         self.branch = None
         self.pr_number = None
         self.resolution = None
@@ -314,8 +304,6 @@ class WorkItem(StoredSubject):
         db_session().flush()
 
     def resolve(self, *, merged: bool, at: datetime) -> None:
-        """GitHub's verdict on this item's PR, stored once and announced as the
-        milestone of the same name."""
         # cycle: the extension imports this module at file scope.
         import druks.contrib.ship.extension as ship_extension
 
@@ -371,7 +359,6 @@ class WorkItem(StoredSubject):
 
     @classmethod
     def list_handoff(cls, *, limit: int = 10) -> list["WorkItem"]:
-        # The history list: PRs GitHub has resolved, its verdict newest first.
         stmt = (
             select(cls)
             .where(cls.resolved_at.is_not(None))
@@ -415,7 +402,6 @@ class WorkItem(StoredSubject):
         ticket_url: str | None = _KEEP,
         pr_number: int | None = _KEEP,
         branch: str | None = _KEEP,
-        build_run_id: str | None = _KEEP,
         project_id: int = _KEEP,
     ) -> None:
         if title is not _KEEP:
@@ -426,8 +412,6 @@ class WorkItem(StoredSubject):
             self.pr_number = pr_number
         if branch is not _KEEP:
             self.branch = branch
-        if build_run_id is not _KEEP:
-            self.build_run_id = build_run_id
         if project_id is not _KEEP:
             self.project_id = project_id
         self.updated_at = Base.utc_now()

--- a/backend/druks/contrib/ship/subscribers.py
+++ b/backend/druks/contrib/ship/subscribers.py
@@ -7,6 +7,11 @@ from druks.ticketing.enums import TicketStatus
 from druks.workflows import WorkflowEvent
 
 
+@subscribe(WorkflowEvent.SCHEDULED, workflow=Build)
+async def new_build_claims_the_item(*, subject: WorkItem, **_: object) -> None:
+    subject.start_attempt()
+
+
 @subscribe("pr.opened", workflow=Build)
 async def pr_open_mirrors_onto_item(
     *, subject: WorkItem, pr_number: int, branch: str, **_: object

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -116,7 +116,7 @@ class Build(Workflow):
                 return
         email = ticket["assignee_email"]
         assignee = Account.get_for_username(email.strip()) if email else None
-        run_id = await cls.start(
+        return await cls.start(
             subject=item,
             account_id=assignee.id if assignee else None,
             repo=item.repo,
@@ -124,12 +124,6 @@ class Build(Workflow):
             task_owner_email=email,
             task_owner_name=ticket["assignee_name"],
         )
-        # A duplicate dispatch gets the live run back and leaves it alone; only a
-        # genuinely new run takes the item over, so a late close for the prior PR
-        # can't resolve this item onto the new run and cancel it.
-        if item.build_run_id != run_id:
-            item.start_attempt(run_id)
-        return run_id
 
     async def run_multistep(
         self,

--- a/backend/druks/durable/enums.py
+++ b/backend/druks/durable/enums.py
@@ -24,6 +24,7 @@ class WorkflowEvent(StrEnum):
     # Each state's signal topic, and what the feed stores. Naming them makes a
     # subscriber's topic typo-proof — a bare string can silently subscribe to a
     # topic nobody publishes.
+    SCHEDULED = "workflow.scheduled"
     RUNNING = "workflow.running"
     PARKED = "workflow.parked"
     FINISHED = "workflow.finished"
@@ -32,7 +33,7 @@ class WorkflowEvent(StrEnum):
 
     @classmethod
     def for_state(cls, state: RunState) -> "WorkflowEvent":
-        # A derived state (scheduled, orphaned) announces nothing, so asking raises.
+        # A derived state (orphaned) announces nothing, so asking raises.
         return cls(f"workflow.{state.value}")
 
 

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -805,6 +805,8 @@ class Workflow:
         Run.create_row(
             _step_engine(), workflow_id=workflow_id, kind=cls.kind, account_id=account_id
         )
+        if subject:
+            await publish(WorkflowEvent.SCHEDULED, subject=subject.identity, kind=cls.kind)
         return workflow_id
 
 

--- a/backend/migrations/versions/b8d1e4a70c93_an_item_holds_no_run_id.py
+++ b/backend/migrations/versions/b8d1e4a70c93_an_item_holds_no_run_id.py
@@ -1,0 +1,34 @@
+"""an item holds no run id
+
+Revision ID: b8d1e4a70c93
+Revises: a4c9e2f7b1d6
+Create Date: 2026-07-29 10:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b8d1e4a70c93"
+down_revision: str | Sequence[str] | None = "a4c9e2f7b1d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("work_items", "build_run_id")
+
+
+def downgrade() -> None:
+    op.add_column("work_items", sa.Column("build_run_id", sa.String(), nullable=True))
+    op.create_foreign_key(
+        "work_items_build_run_id_fkey",
+        "work_items",
+        "durable_runs",
+        ["build_run_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )

--- a/backend/tests/ship/factories.py
+++ b/backend/tests/ship/factories.py
@@ -25,8 +25,8 @@ def seed_build_run(
     failure: str | None = None,
     account_id: str | None = None,
 ):
-    """Seed a build Run for a work item and bind it via ``item.build_run_id``. The run
-    and its calls are the item's timeline."""
+    """Seed a build Run for a work item. The run and its calls are the item's
+    timeline; it finds the item through the subject it was started for."""
     if state == "parked" and not input_gate:
         input_gate = "review"  # a parked run always has a gate; derivation needs it
     item = WorkItem.get(work_item_id)
@@ -40,6 +40,5 @@ def seed_build_run(
         failure=failure,
         account_id=account_id or "system",
     )
-    item.build_run_id = run.id
     session.flush()
     return run

--- a/backend/tests/ship/test_api_work_items.py
+++ b/backend/tests/ship/test_api_work_items.py
@@ -40,7 +40,7 @@ _GATE_REQUESTS = {
 def _seed_op(druks_db, work_item_id, *, kind="implement", state, input_gate=None):
     """A build run on the item in ``state`` whose latest agent call is ``kind``.
     When a run already exists, advance it (re-trigger = a fresh round on the same
-    item), rebinding ``build_run_id`` to the newest run."""
+    item)."""
     if state == "running" and input_gate:
         run = seed_build_run(
             druks_db,
@@ -224,17 +224,6 @@ def test_repeated_runs_on_one_subject_each_surface_separately(druks_db):
     entries = item.get_timeline()
     assert [entry.kind for entry in entries] == ["ship.build"] * 3
     assert len({entry.id for entry in entries}) == 3
-
-
-def test_update_stamps_build_run_id(druks_db):
-    # build intake stamps the owning run via update(build_run_id=...); the kwarg
-    # was missing, so every "Ready for Agent" transition threw a TypeError.
-    from druks.contrib.ship.models import WorkItem
-
-    item = make_test_work_item(repo="ClawHaven/acme-app", title="x")
-    run = seed_build_run(druks_db, work_item_id=item.id, state="running")
-    item.update(build_run_id=run.id)
-    assert WorkItem.get(item.id).build_run_id == run.id
 
 
 def test_timeline_shows_every_build_attempt(druks_db):

--- a/backend/tests/ship/test_build_board_membership.py
+++ b/backend/tests/ship/test_build_board_membership.py
@@ -20,8 +20,6 @@ def _resolve(item, *, merged=True, at=None):
     "state", ["scheduled", "running", "parked", "failed", "finished", "cancelled"]
 )
 def test_an_unresolved_item_holds_the_board(druks_db, state):
-    # Until GitHub answers, the work is still druks's — whatever its run is doing.
-    # Where the run stands colours the row; it never decides whether the row is here.
     item = make_test_work_item(repo="ClawHaven/acme-app", title=f"build {state}")
     seed_build_run(druks_db, work_item_id=item.id, state=state)
     assert str(item.id) in _board_ids(druks_db)
@@ -29,8 +27,6 @@ def test_an_unresolved_item_holds_the_board(druks_db, state):
 
 @pytest.mark.parametrize("state", ["running", "failed", "finished"])
 def test_a_resolved_pr_leaves_the_board_whatever_its_run_says(druks_db, state):
-    # The strand this fixes: membership read druks's own opinion, which a manual
-    # merge after a failed run never changed, so the item lingered forever.
     item = make_test_work_item(repo="ClawHaven/acme-app", title=f"resolved {state}")
     seed_build_run(druks_db, work_item_id=item.id, state=state)
     _resolve(item)
@@ -38,21 +34,15 @@ def test_a_resolved_pr_leaves_the_board_whatever_its_run_says(druks_db, state):
 
 
 def test_a_redispatched_item_returns_to_the_board(druks_db):
-    # Its newest run drives it, and starting a build drops the previous PR's
-    # verdict along with the branch and number it belonged to.
     item = make_test_work_item(repo="ClawHaven/acme-app", title="rebuilt")
-    seed_build_run(druks_db, work_item_id=item.id, state="finished")
     _resolve(item, merged=False)
-    run = seed_build_run(druks_db, work_item_id=item.id, state="running")
-    item.start_attempt(run.id)
 
-    assert item.resolution is None
+    item.start_attempt()
+
     assert str(item.id) in _board_ids(druks_db)
 
 
 def test_the_board_does_not_ask_about_runs(druks_db):
-    # Dispatch creates the item and starts its run in one transaction, so a
-    # run-less item is not a production shape — and the board no longer asks.
     item = make_test_work_item(repo="ClawHaven/acme-app", title="never dispatched")
     assert str(item.id) in _board_ids(druks_db)
 

--- a/backend/tests/ship/test_build_dispatch.py
+++ b/backend/tests/ship/test_build_dispatch.py
@@ -6,15 +6,14 @@ from druks.testing import seed_run
 from ship.factories import make_test_work_item
 
 
-async def test_redispatch_to_a_new_run_clears_the_prior_attempts_pr(druks_db, monkeypatch) -> None:
-    """A genuinely new run is a fresh attempt: dispatch points the item at it and
-    drops the prior attempt's branch, PR and verdict — so a late close for the old
-    PR can't resolve this item onto the new run, and a closed item comes back onto
-    the board instead of resting in History with a live run."""
+async def test_dispatch_leaves_the_item_alone(druks_db, monkeypatch) -> None:
+    """Dispatch starts the build and touches nothing else — clearing the previous
+    attempt is the scheduled reaction's (test_lane_reactions), and a duplicate
+    dispatch never makes that announcement."""
     seed_run(druks_db, kind=Build.kind, run_id="run-old")
     seed_run(druks_db, kind=Build.kind, run_id="run-new")
     item = make_test_work_item(repo="o/r", title="t", ticket_key="ACME-2")
-    item.update(build_run_id="run-old", pr_number=7, branch="agent/old")
+    item.update(pr_number=7, branch="agent/old")
     item.resolve(merged=False, at=datetime.now(UTC))
 
     async def fake_start(cls, **kwargs):
@@ -35,41 +34,9 @@ async def test_redispatch_to_a_new_run_clears_the_prior_attempts_pr(druks_db, mo
         }
     )
 
-    assert item.build_run_id == "run-new"
-    assert item.pr_number is None
-    assert item.branch is None
-    assert item.resolution is None
-    assert item.resolved_at is None
-
-
-async def test_duplicate_dispatch_keeps_the_live_attempt_routing(druks_db, monkeypatch) -> None:
-    """A duplicate dispatch dedups to the live run — start() hands back its id —
-    so the item's branch/PR must survive, or PR routing and board links break."""
-    seed_run(druks_db, kind=Build.kind, run_id="run-live")
-    item = make_test_work_item(repo="o/r", title="t", ticket_key="ACME-3")
-    item.update(build_run_id="run-live", pr_number=7, branch="agent/live")
-
-    async def dedup_start(cls, **kwargs):
-        return "run-live"
-
-    monkeypatch.setattr(Build, "start", classmethod(dedup_start))
-    await Build.dispatch(
-        ticket={
-            "source": item.source,
-            "identifier": item.ticket_key,
-            "status": "Ready",
-            "title": item.title,
-            "url": "https://tracker.test/ACME-3",
-            "project_name": "r",
-            "labels": [],
-            "assignee_email": None,
-            "assignee_name": None,
-        }
-    )
-
-    assert item.build_run_id == "run-live"
     assert item.pr_number == 7
-    assert item.branch == "agent/live"
+    assert item.branch == "agent/old"
+    assert item.resolution == "closed"
 
 
 def test_update_clears_nullable_with_none_and_skips_omitted(druks_db) -> None:

--- a/backend/tests/ship/test_build_durable.py
+++ b/backend/tests/ship/test_build_durable.py
@@ -1,11 +1,12 @@
 import asyncio
 import os
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import psycopg
 import pytest
 from druks.contrib.ship.models import Project, WorkItem
-from druks.database import configure_session, get_session
+from druks.database import configure_session, db_session, get_session
 from druks.durable import Run, RunState
 from druks.durable.engine import configure_engine, init_dbos, launch, shutdown
 from druks.testing import init_db
@@ -219,6 +220,9 @@ def _stub(
 
 async def _start_to_work_gate(rt, item):
     workflow_id = await rt.flow.start(repo=item.repo, subject=item)
+    # The claim rides the dispatcher's transaction, so its row lock releases at
+    # the request boundary — which the harness has to stand in for.
+    db_session().commit()
     parked = await _wait(
         rt.engine,
         workflow_id,
@@ -312,3 +316,36 @@ async def test_auto_mode_machine_review_replaces_the_plan_gate(rt, monkeypatch):
     await parked.resume(action="approve")
     done = await _wait(rt.engine, workflow_id, lambda run: run.state == RunState.FINISHED)
     assert not done.failure
+
+
+async def test_the_attempt_claims_the_item_once(rt, monkeypatch):
+    """A gate resume replays the body from the top; the claim must not run again
+    and wipe the PR this attempt already opened."""
+    _stub(monkeypatch, rt)
+
+    item = _seed_work_item(rt.engine, repo="acme/claims")
+    # What a previous attempt left behind, and GitHub's verdict on its PR.
+    with Session(rt.engine) as session:
+        stale = session.get(WorkItem, item.id)
+        stale.branch = "agent/previous"
+        stale.pr_number = 7
+        stale.resolution = "closed"
+        stale.resolved_at = datetime.now(UTC)
+        session.commit()
+
+    workflow_id, parked = await _start_to_work_gate(rt, item)
+
+    # The claim cleared what the previous attempt left...
+    with Session(rt.engine) as session:
+        claimed = session.get(WorkItem, item.id)
+        assert claimed.resolution is None
+        assert claimed.resolved_at is None
+        # ...and this attempt's own delivery then mirrored onto it.
+        assert (claimed.pr_number, claimed.branch) == (42, "agent/acme-1")
+
+    await parked.resume(action="approve")
+    await _wait(rt.engine, workflow_id, lambda run: run.state == RunState.FINISHED)
+
+    with Session(rt.engine) as session:
+        after = session.get(WorkItem, item.id)
+        assert (after.pr_number, after.branch) == (42, "agent/acme-1")

--- a/backend/tests/ship/test_lane_reactions.py
+++ b/backend/tests/ship/test_lane_reactions.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 import druks.contrib.ship.subscribers  # noqa: F401 — registers the lane reactions
 import pytest
 from druks.contrib.ship.contracts import ReviewWork
@@ -13,6 +15,20 @@ from uuid_utils import uuid7
 from ship.factories import make_test_work_item
 
 pytestmark = pytest.mark.asyncio
+
+
+async def test_new_build_claims_the_item(druks_db):
+    # A resume replays the body without passing through start(), so this topic —
+    # not RUNNING — is the one that fires once per attempt.
+    item = make_test_work_item(repo="acme/widget", title="t", source="linear", ticket_key="ACME-1")
+    item.update(pr_number=7, branch="agent/old")
+    item.resolve(merged=False, at=datetime.now(UTC))
+
+    await publish(WorkflowEvent.SCHEDULED, subject=item.identity, kind=Build.kind)
+
+    refreshed = WorkItem.get(item.id)
+    assert (refreshed.branch, refreshed.pr_number) == (None, None)
+    assert (refreshed.resolution, refreshed.resolved_at) == (None, None)
 
 
 async def test_build_lifecycle_reaches_the_tracker(druks_db, monkeypatch):
@@ -51,7 +67,6 @@ async def test_pr_review_answers_through_the_review_gate(druks_db, monkeypatch):
         "parked",
         subject=item.identity,
     )
-    item.update(build_run_id=run.id)
     answers = []
 
     async def answer(subject, **reply):

--- a/backend/tests/ship/test_webhooks_jira.py
+++ b/backend/tests/ship/test_webhooks_jira.py
@@ -183,7 +183,6 @@ async def test_trigger_status_routes_a_new_ticket_by_label(tmp_path, druks_db, m
     )
 
     item = WorkItem.get_for_ticket_key(source="jira", ticket_key="SHRP-1")
-    assert item.build_run_id == "run-new"
     assert item.repo == "octo/alfred"
     assert item.project_id == project.id
 

--- a/backend/tests/ship/test_webhooks_pull_request.py
+++ b/backend/tests/ship/test_webhooks_pull_request.py
@@ -62,7 +62,7 @@ async def _fire_closed(*, repo, pr_number, branch, tmp_path, merged=True, at=_RE
 
 def _park_work_item(*, repo, pr_number, branch, state="parked", input_gate="review_work"):
     """A work item with a build run paused on the operator (review_work) — the
-    haunting case. Returns (work_item_id, build_run_id)."""
+    haunting case. Returns (work_item_id, run_id)."""
     from druks.database import db_session
 
     item = make_test_work_item(repo=repo, title="Externally merged")
@@ -217,8 +217,8 @@ async def test_a_remerge_after_redispatch_records_a_fresh_verdict(druks_db, tmp_
     work_item_id, _ = _park_work_item(repo=repo, pr_number=pr_number, branch=branch)
     await _fire_closed(repo=repo, pr_number=pr_number, branch=branch, tmp_path=tmp_path)
     # Redispatched: a newer build run owns the item, and its PR is a fresh one.
-    new_run = seed_build_run(ds(), work_item_id=work_item_id, state="running")
-    WorkItem.get(work_item_id).start_attempt(new_run.id)
+    seed_build_run(ds(), work_item_id=work_item_id, state="running")
+    WorkItem.get(work_item_id).start_attempt()
     WorkItem.get(work_item_id).update(pr_number=pr_number, branch=branch)
 
     await _fire_closed(repo=repo, pr_number=pr_number, branch=branch, tmp_path=tmp_path)
@@ -372,16 +372,16 @@ async def test_external_close_survives_policy_resolution_failure(druks_db, tmp_p
 @pytest.mark.asyncio
 async def test_stale_close_after_redispatch_spares_the_new_run(druks_db, tmp_path):
     """A delayed pr.closed for a superseded attempt's PR must not touch the new
-    run: re-dispatch cleared the item's branch/PR, so the stale close no longer
-    resolves the item."""
+    run: the new attempt claimed the item, so the stale close no longer resolves
+    it."""
     from druks.database import db_session as ds
 
     repo, pr_a, branch_a = "ClawHaven/acme-app", 61, "agent/eng-old"
     item = make_test_work_item(repo=repo, title="Re-dispatched")
     item.update(pr_number=pr_a, branch=branch_a)
-    # Re-dispatch: a new run takes over and the prior attempt's branch/PR clear.
+    # Re-dispatch: a new run takes over and claims the item.
     new_run = seed_build_run(ds(), work_item_id=item.id, state="running")
-    item.start_attempt(new_run.id)
+    item.start_attempt()
 
     await _fire_closed(repo=repo, pr_number=pr_a, branch=branch_a, tmp_path=tmp_path, merged=False)
 

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -360,15 +360,28 @@ async def test_browser_origin_start_inherits_the_ambient_account(rt):
 
 async def test_duplicate_start_shares_the_run_across_accounts(rt):
     # Attribution is NEVER part of the dedup id: two accounts starting the same
-    # subject share the one active run.
+    # subject share the one active run — and only the mint announces
+    # workflow.scheduled; the deduped start stays silent.
+    from druks.durable.enums import WorkflowEvent
+    from druks.signals import subscribe
+
+    scheduled = []
+
+    @subscribe(WorkflowEvent.SCHEDULED)
+    async def saw(*, subject=None, **_: object) -> None:
+        scheduled.append(subject)
+
     first = _account_id(rt.engine, "op@example.com")
     second = _account_id(rt.engine, "peer@example.com")
     subject = Widget(id=909090)
     wfid = await rt.SampleFlow.start(subject=subject, account_id=first, repo="owner/app")
     parked = await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.PARKED)
+    minted = [s for s in scheduled if s and s.get("id") == 909090]
+    assert len(minted) == 1
 
     dup = await rt.SampleFlow.start(subject=subject, account_id=second, repo="owner/app")
     assert dup == wfid
+    assert len([s for s in scheduled if s and s.get("id") == 909090]) == 1
 
     await parked.resume(action="merge")
     await _wait_for(rt.engine, wfid, lambda r: r.state == RunState.FINISHED)


### PR DESCRIPTION
## The problem

`work_items.build_run_id` pointed at the item's latest build so `Build.dispatch` could ask one question — did `start()` mint a run, or hand back the live one it deduped to — and clear the previous attempt's branch, PR and verdict only in the first case.

That is a foreign key from ship's table into the durable schema, and a run id sitting in an extension's columns, for a boolean DBOS had already decided inside `start()`. It had exactly one read in the repo. Nothing else used it: `Build.cancel` resolves the run through `Run.list_for_subject`, and the column appears in no route, wire shape, or frontend.

## The change

`start()` announces the boolean instead of hiding it. A minted run publishes `workflow.scheduled` — the one lifecycle topic that was silent, because until now nothing read it — and a deduped start stays quiet, so the announcement fires exactly once per run by construction. Ship reacts the way it reacts to everything else:

```python
@subscribe(WorkflowEvent.SCHEDULED, workflow=Build)
async def build_scheduled_claims_the_item(*, subject: WorkItem, **_: object) -> None:
    subject.start_attempt()
```

It sits next to `pr_open_mirrors_onto_item`, which is the other half of the same mirror: `pr.opened` writes it, `workflow.scheduled` clears it.

`Build.dispatch` becomes `return await cls.start(...)` and touches nothing — the shape `Profile.dispatch` and `Review.dispatch` already had. Subscribers run inline with `publish`, so the claim commits with the dispatch request: the clearing stays synchronous, with no queue-hop window. A gate resume replays the body without ever passing through `start()`, so nothing can wipe the PR a live attempt opened — the once-per-run property is structural, not a memoized step.

Gone: the column, its `ondelete="SET NULL"` FK — ship's last structural link to the durable schema — the `update(build_run_id=…)` parameter, and the comparison in dispatch.

## Verification

- `test_the_attempt_claims_the_item_once` runs a real build against a live DBOS engine: mint → announcement clears the stale verdict → `pr.opened` mirrors this attempt's PR → gate resume replays the body → the PR survives.
- `test_duplicate_start_shares_the_run_across_accounts` now also asserts the platform contract: one `workflow.scheduled` on the mint, none on the dedup.
- `test_build_scheduled_claims_the_item` pins the ship reaction at signal granularity — the resurrected shape of the subscriber test deleted in #141, at the correct topic this time.
- Full backend suite passes with no skips (durable modules included, against the dev Postgres).
- Migration exercised up, down and up again on a fresh database; the downgrade restores the column with its foreign key.

The claim's write joins the dispatcher's transaction and its row lock is held until that request commits — in production, milliseconds. The durable-test harness has no request boundary, so `_start_to_work_gate` now commits where the request would have; the lock-starvation this fixes was caught live in `pg_locks` during a hung run.

## Deploy ordering

Old workers select `build_run_id` and will error on any work-item read once it is dropped. Migrations run off-boot, so deploy the code first and migrate after — the new code ignores the column while it is still present.
