### PR TITLE
druks.toml is the deployment; .env is its render

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ explains the exact boundary.
 
 ## Install
 
-The installer supports three sandbox profiles backed by
+The installer supports three deployment shapes backed by
 [Drukbox](https://github.com/czpython/drukbox):
 
-- `exe` (default) and `aws`: remote sandbox VMs, with Druks and Drukbox in Compose
+- `exe` (default): exe.dev sandbox VMs over a tailnet
+- any provider name other than `exe` or `docker`: the generic remote shape
 - `docker`: local sandbox containers, with Drukbox running on the host
 
 For a remote install:
@@ -41,9 +42,10 @@ That command follows the edge channel while Druks has no stable release. Once
 versioned releases exist, install the script and image from the same tag as
 described in [the release process](https://github.com/czpython/druks/blob/main/docs/releasing.md#install-an-immutable-version).
 
-The first run creates `~/druks/.env`, generates secrets, and prints any values
-still required. Re-run the same command after filling them; it pulls images,
-runs migrations, and starts the stack. Re-running is also the upgrade path.
+The first run creates `~/druks/druks.toml`, generates secrets, renders `.env`,
+and prints any values still required. Edit `druks.toml`, then re-run the same
+command; it renders the complete `.env` artifact, pulls images, runs migrations,
+and starts the stack. Re-running is also the upgrade path.
 See the [deployment runbook](https://github.com/czpython/druks/blob/main/deploy/README.md) for prerequisites, access
 control, verification, and rollback.
 

--- a/backend/druks/cli.py
+++ b/backend/druks/cli.py
@@ -35,15 +35,17 @@ def main() -> None:
     setup_parser = subparsers.add_parser(
         "setup",
         help=(
-            "Write/complete the install .env interactively. Idempotent: an "
-            "existing file is preserved and only blank required values are "
-            "prompted for. Exits 0 when boot-ready, 3 when gaps remain."
+            "Create or update druks.toml and render the install .env. "
+            "Exits 0 when boot-ready, 3 when gaps remain, and 4 when an "
+            "existing pre-TOML .env needs hand migration."
         ),
     )
-    setup_parser.add_argument("env_path", help="Path to the .env to write/patch.")
-    # No enumeration here — setup owns the provider names and lists the
-    # valid ones itself when handed an unknown one.
-    setup_parser.add_argument("--provider", default="exe", help="Sandbox provider.")
+    setup_parser.add_argument("env_path", help="Path to the rendered .env.")
+    setup_parser.add_argument(
+        "--provider",
+        default="exe",
+        help="Fresh-install sandbox provider; ignored when druks.toml exists.",
+    )
     setup_parser.add_argument(
         "--install-dir",
         required=True,
@@ -58,6 +60,14 @@ def main() -> None:
         "--non-interactive",
         action="store_true",
         help="Never prompt: write the template, report gaps, exit.",
+    )
+    setup_parser.add_argument(
+        "--set",
+        action="append",
+        default=[],
+        dest="set_values",
+        metavar="KEY.PATH=VALUE",
+        help="Set a druks.toml value before rendering; repeat for multiple values.",
     )
     create_parser = subparsers.add_parser("create", help="Scaffold a new druks artifact.")
     create_subparsers = create_parser.add_subparsers(dest="artifact", required=True)
@@ -99,6 +109,7 @@ def main() -> None:
                 install_dir=args.install_dir,
                 home=args.home,
                 interactive=not args.non_interactive and sys.stdin.isatty(),
+                set_values=tuple(args.set_values),
             )
         )
 

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -258,7 +258,11 @@ def check_database(settings: Settings) -> CheckResult:
 
 def check_drukbox(settings: Settings) -> CheckResult:
     if not settings.sandbox_service_url:
-        return CheckResult(name="drukbox", ok=True, detail="not configured")
+        return CheckResult(
+            name="drukbox",
+            ok=True,
+            detail="not configured (deployments: [sandbox].service_url in druks.toml)",
+        )
     try:
         report = asyncio.run(_drukbox_doctor(settings))
     except Exception as error:  # noqa: BLE001 — surface any SDK/transport failure as fail

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -401,9 +401,10 @@ def _canonical_config(raw: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(table, dict):
             _require_scalar("", table_name, table)
             continue
-        known = _KNOWN_TOML_KEYS.get(table_name)
         for key, value in table.items():
-            if known is not None and (key in known or (table_name, key) == ("sandbox", "env")):
+            if table_name in _KNOWN_TOML_KEYS and (
+                key in _KNOWN_TOML_KEYS[table_name] or (table_name, key) == ("sandbox", "env")
+            ):
                 continue
             _require_scalar(f"{table_name}.", key, value)
     return config

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -96,11 +96,6 @@ _SECTIONS = (
                 is_required=True,
             ),
             Entry("DRUKS_WEBHOOK_SECRET", ("secrets", "webhook_secret"), is_required=True),
-            Entry(
-                "ANNOUNCE_TOKEN_SECRET",
-                ("secrets", "announce_token_secret"),
-                is_required=True,
-            ),
             Entry("DRUKS_SECRETS_KEY", ("secrets", "secrets_key"), is_required=True),
         ),
     ),
@@ -171,7 +166,6 @@ _KNOWN_TOML_KEYS = {
     "secrets": (
         "postgres_password",
         "webhook_secret",
-        "announce_token_secret",
         "secrets_key",
         "sandbox_service_token",
     ),
@@ -193,10 +187,6 @@ _TOML_TABLE_COMMENTS = {
 
 def _hex_secret() -> str:
     return secrets.token_hex(32)
-
-
-def _announce_secret() -> str:
-    return secrets.token_urlsafe(32)
 
 
 def _secrets_key() -> str:
@@ -344,7 +334,6 @@ def _fresh_config(*, provider: str, home: str) -> dict[str, object]:
         "secrets": {
             "postgres_password": _hex_secret(),
             "webhook_secret": _hex_secret(),
-            "announce_token_secret": _announce_secret(),
             "secrets_key": _secrets_key(),
             "sandbox_service_token": sandbox_token,
         },
@@ -892,7 +881,6 @@ def _print_migration_recipe(
     print_fn("  - DRUKS_POSTGRES_PASSWORD → [secrets].postgres_password")
     print_fn("  - DRUKS_SECRETS_KEY → [secrets].secrets_key")
     print_fn("  - DRUKS_WEBHOOK_SECRET → [secrets].webhook_secret")
-    print_fn("  - ANNOUNCE_TOKEN_SECRET → [secrets].announce_token_secret")
     print_fn("  - DRUKS_SANDBOX_SERVICE_TOKEN → [secrets].sandbox_service_token")
     print_fn("  - GITHUB_*_APP_ID → [github]")
     print_fn("  - provider and its credentials → [sandbox] and [sandbox.env]")

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -4,10 +4,12 @@ import os
 import re
 import secrets
 import tomllib
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, MutableMapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+import tomlkit
 
 GAPS_EXIT_CODE = 3
 MIGRATION_EXIT_CODE = 4
@@ -20,7 +22,6 @@ _COMPOSE_ENV_KEYS = (
     "COMPOSE_PROFILES",
 )
 _ENV_KEY_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
-_TOML_KEY_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
 
 
 @dataclass(frozen=True)
@@ -171,16 +172,6 @@ _KNOWN_TOML_KEYS = {
     "sandbox": ("provider", "service_url", "image", "service_tokens"),
     "env": (),
 }
-_TOML_TABLE_COMMENTS = {
-    "identity": '# Browser identity: "header", "jwt", or "none".',
-    "github": "# GitHub Apps may also be provisioned with install.sh --apps.",
-    "ticketing": "# Optional ticketing integration.",
-    "urls": "# Public dashboard and webhook ingress addresses.",
-    "secrets": "# Generated on first write. Do not regenerate a deployed secret.",
-    "paths": "# Host paths. Relative PEM paths are resolved against the install directory.",
-    "sandbox": "# Any drukbox provider name; docker and exe select install shapes.",
-    "env": "# Additional deployment settings; keys render verbatim unless owned above.",
-}
 
 
 def _hex_secret() -> str:
@@ -226,23 +217,25 @@ def run_setup(
             provider = answer or provider
         if not provider:
             raise ValueError("sandbox provider cannot be blank")
-        config = _fresh_config(provider=provider, home=home)
+        document = tomlkit.parse(_TOML_TEMPLATE)
+        for value_path, value in _fresh_values(provider=provider, home=home):
+            _set_value(document, value_path, value)
     else:
-        config = _read_toml(toml_path)
+        document = tomlkit.parse(toml_path.read_text())
 
     is_changed = is_fresh
     for assignment in set_values:
-        path, value = _parse_assignment(assignment)
-        _set_value(config, path, value)
+        value_path, value = _parse_assignment(assignment)
+        _set_value(document, value_path, value)
         is_changed = True
 
-    provider = _get_string(config, ("sandbox", "provider"))
+    provider = _get_string(document, ("sandbox", "provider"))
     print_fn(_shape_message(provider))
 
     if interactive:
         is_changed = (
             _prompt_values(
-                config,
+                document,
                 is_fresh=is_fresh,
                 input_fn=input_fn,
             )
@@ -250,8 +243,8 @@ def run_setup(
         )
 
     if is_changed:
-        _write_toml(toml_path, config)
-        config = _read_toml(toml_path)
+        _write_toml(toml_path, document)
+    config = _read_toml(toml_path)
     if is_fresh:
         _write_gitignore(env_path.parent / ".gitignore")
         (env_path.parent / "secrets").mkdir(mode=0o700, exist_ok=True)
@@ -269,87 +262,112 @@ def run_setup(
     return GAPS_EXIT_CODE if gaps else 0
 
 
-def _fresh_config(*, provider: str, home: str) -> dict[str, Any]:
+_TOML_TEMPLATE = """\
+# druks.toml — the deployment. Edit this file, then re-run the installer
+# to render and apply it. `druks setup` alone re-renders .env but does
+# not restart services.
+
+# Browser identity: "header", "jwt", or "none".
+[identity]
+mode = ""
+header = ""
+jwks_url = ""
+jwt_issuer = ""
+jwt_audience = ""
+jwt_identity_claim = "email"
+
+# GitHub Apps may also be provisioned with install.sh --apps.
+[github]
+operator_app_id = ""
+reviewer_app_id = ""
+operator_pem = "secrets/operator.pem"
+reviewer_pem = "secrets/reviewer.pem"
+
+# Optional ticketing integration.
+[ticketing]
+linear_api_key = ""
+linear_webhook_secret = ""
+
+# Public dashboard and webhook ingress addresses.
+[urls]
+endpoint = ""
+webhook_host = ""
+
+# Generated on first write. Do not regenerate a deployed secret.
+[secrets]
+postgres_password = ""
+webhook_secret = ""
+secrets_key = ""
+sandbox_service_token = ""
+
+# Host paths. Relative PEM paths are resolved against the install directory.
+[paths]
+data_dir = ""
+claude_home = ""
+codex_home = ""
+claude_json = ""
+
+# Any drukbox provider name; docker and exe select install shapes.
+[sandbox]
+provider = ""
+service_url = ""
+image = ""
+service_tokens = ""
+
+# Drukbox environment, passed through to the remote stack verbatim.
+# Local docker shape: host-run drukbox reads its own env, so this table
+# is not rendered. Provider reference: https://github.com/czpython/drukbox
+# (docs/deploy.md).
+[sandbox.env]
+
+# Additional deployment settings; keys render verbatim unless owned by druks.
+[env]
+"""
+
+
+def _fresh_values(*, provider: str, home: str) -> tuple[tuple[tuple[str, ...], str], ...]:
     if provider == "docker":
-        identity_mode = "none"
-        identity_header = ""
-        endpoint = "http://localhost:8001"
-        service_url = "http://127.0.0.1:8000"
-        sandbox_token = "dev-token"
-        sandbox_image = "ghcr.io/czpython/druks-sandbox:latest"
+        shape = (
+            (("identity", "mode"), "none"),
+            (("urls", "endpoint"), "http://localhost:8001"),
+            (("sandbox", "service_url"), "http://127.0.0.1:8000"),
+            (("secrets", "sandbox_service_token"), "dev-token"),
+            (("sandbox", "image"), "ghcr.io/czpython/druks-sandbox:latest"),
+        )
     elif provider == "exe":
-        identity_mode = "header"
-        identity_header = "X-ExeDev-Email"
-        endpoint = ""
-        service_url = "http://127.0.0.1:8780"
-        sandbox_token = _hex_secret()
-        sandbox_image = ""
+        shape = (
+            (("identity", "mode"), "header"),
+            (("identity", "header"), "X-ExeDev-Email"),
+            (("sandbox", "service_url"), "http://127.0.0.1:8780"),
+            (("secrets", "sandbox_service_token"), _hex_secret()),
+            (("sandbox", "env", "EXE_API_TOKEN"), ""),
+            (("sandbox", "env", "TAILSCALE_TAILNET"), ""),
+            (("sandbox", "env", "TAILSCALE_OAUTH_CLIENT_ID"), ""),
+            (("sandbox", "env", "TAILSCALE_OAUTH_CLIENT_SECRET"), ""),
+            (("sandbox", "env", "EXE_API_URL"), "https://exe.dev"),
+            (("sandbox", "env", "EXE_DEFAULT_IMAGE"), "ghcr.io/boldsoftware/exeuntu:latest"),
+            (("sandbox", "env", "TAILSCALE_ENABLED"), "true"),
+            (("sandbox", "env", "TAILSCALE_API_TIMEOUT"), "30"),
+            (("sandbox", "env", "TAILSCALE_AUTH_TAGS"), "tag:sandbox"),
+        )
     else:
-        identity_mode = "header"
-        identity_header = ""
-        endpoint = ""
-        service_url = "http://127.0.0.1:8780"
-        sandbox_token = _hex_secret()
-        sandbox_image = ""
+        shape = (
+            (("identity", "mode"), "header"),
+            (("sandbox", "service_url"), "http://127.0.0.1:8780"),
+            (("secrets", "sandbox_service_token"), _hex_secret()),
+        )
 
-    sandbox_env: dict[str, Any] = {}
-    if provider == "exe":
-        sandbox_env = {
-            "EXE_API_TOKEN": "",
-            "TAILSCALE_TAILNET": "",
-            "TAILSCALE_OAUTH_CLIENT_ID": "",
-            "TAILSCALE_OAUTH_CLIENT_SECRET": "",
-            "EXE_API_URL": "https://exe.dev",
-            "EXE_DEFAULT_IMAGE": "ghcr.io/boldsoftware/exeuntu:latest",
-            "TAILSCALE_ENABLED": "true",
-            "TAILSCALE_API_TIMEOUT": "30",
-            "TAILSCALE_AUTH_TAGS": "tag:sandbox",
-        }
-
-    return {
-        "identity": {
-            "mode": identity_mode,
-            "header": identity_header,
-            "jwks_url": "",
-            "jwt_issuer": "",
-            "jwt_audience": "",
-            "jwt_identity_claim": "email",
-        },
-        "github": {
-            "operator_app_id": "",
-            "reviewer_app_id": "",
-            "operator_pem": "secrets/operator.pem",
-            "reviewer_pem": "secrets/reviewer.pem",
-        },
-        "ticketing": {
-            "linear_api_key": "",
-            "linear_webhook_secret": "",
-        },
-        "urls": {
-            "endpoint": endpoint,
-            "webhook_host": "",
-        },
-        "secrets": {
-            "postgres_password": _hex_secret(),
-            "webhook_secret": _hex_secret(),
-            "secrets_key": _secrets_key(),
-            "sandbox_service_token": sandbox_token,
-        },
-        "paths": {
-            "data_dir": f"{home.rstrip('/')}/druks-data",
-            "claude_home": f"{home.rstrip('/')}/.claude",
-            "codex_home": f"{home.rstrip('/')}/.codex",
-            "claude_json": f"{home.rstrip('/')}/.claude.json",
-        },
-        "sandbox": {
-            "provider": provider,
-            "service_url": service_url,
-            "image": sandbox_image,
-            "service_tokens": "",
-            "env": sandbox_env,
-        },
-        "env": {},
-    }
+    return (
+        (("sandbox", "provider"), provider),
+        (("secrets", "postgres_password"), _hex_secret()),
+        (("secrets", "webhook_secret"), _hex_secret()),
+        (("secrets", "secrets_key"), _secrets_key()),
+        (("paths", "data_dir"), f"{home.rstrip('/')}/druks-data"),
+        (("paths", "claude_home"), f"{home.rstrip('/')}/.claude"),
+        (("paths", "codex_home"), f"{home.rstrip('/')}/.codex"),
+        (("paths", "claude_json"), f"{home.rstrip('/')}/.claude.json"),
+        *shape,
+    )
 
 
 def _read_toml(path: Path) -> dict[str, Any]:
@@ -398,22 +416,20 @@ def _require_scalar(prefix: str, key: str, value: Any) -> None:
         )
 
 
-def _get_string(config: dict[str, Any], path: tuple[str, ...]) -> str:
-    current: object = config
+def _get_string(source: Mapping[str, Any], path: tuple[str, ...]) -> str:
+    current: Any = source
     for part in path:
-        if not isinstance(current, dict):
-            raise ValueError(f"druks.toml: {'.'.join(path)} crosses a non-table value")
+        if not isinstance(current, Mapping):
+            return ""
         current = current.get(part, "")
-    if not isinstance(current, str):
-        raise ValueError(f"druks.toml: {'.'.join(path)} must be a string")
-    return current
+    return current if isinstance(current, str) else ""
 
 
-def _set_value(config: dict[str, Any], path: tuple[str, ...], value: str) -> None:
-    current = config
+def _set_value(target: MutableMapping[str, Any], path: tuple[str, ...], value: str) -> None:
+    current: MutableMapping[str, Any] = target
     for part in path[:-1]:
         child = current.setdefault(part, {})
-        if not isinstance(child, dict):
+        if not isinstance(child, MutableMapping):
             raise ValueError(f"druks.toml: {'.'.join(path)} crosses a non-table value")
         current = child
     current[path[-1]] = value
@@ -428,7 +444,7 @@ def _parse_assignment(assignment: str) -> tuple[tuple[str, ...], str]:
 
 
 def _prompt_values(
-    config: dict[str, Any],
+    document: tomlkit.TOMLDocument,
     *,
     is_fresh: bool,
     input_fn: Callable[[str], str],
@@ -439,7 +455,7 @@ def _prompt_values(
         for entry in section.entries
         if entry.source and entry.prompt
     ]
-    identity_mode = _get_string(config, ("identity", "mode"))
+    identity_mode = _get_string(document, ("identity", "mode"))
     if identity_mode in {"header", "jwt"}:
         prompts.append(
             (
@@ -458,7 +474,7 @@ def _prompt_values(
             )
         )
 
-    if _get_string(config, ("sandbox", "provider")) == "exe":
+    if _get_string(document, ("sandbox", "provider")) == "exe":
         prompts.extend(
             (
                 (("sandbox", "env", "EXE_API_TOKEN"), "exe.dev API token", True),
@@ -482,112 +498,19 @@ def _prompt_values(
 
     is_changed = False
     for path, prompt, is_required in prompts:
-        if _get_string(config, path) or (not is_required and not is_fresh):
+        if _get_string(document, path) or (not is_required and not is_fresh):
             continue
         answer = input_fn(f"{prompt}: ").strip()
         if answer:
-            _set_value(config, path, answer)
+            _set_value(document, path, answer)
             is_changed = True
     return is_changed
 
 
-def _write_toml(path: Path, config: dict[str, Any]) -> None:
-    canonical = _canonical_config(config)
-    text = _render_toml(canonical)
+def _write_toml(path: Path, document: tomlkit.TOMLDocument) -> None:
+    text = tomlkit.dumps(document)
+    _canonical_config(tomllib.loads(text))
     _write_secure_text(path, text)
-    parsed = _read_toml(path)
-    if parsed != canonical:
-        raise ValueError("druks.toml write verification failed: parsed values changed")
-
-
-def _render_toml(config: dict[str, Any]) -> str:
-    lines = [
-        "# druks.toml — the deployment. Edit this file, then re-run the installer",
-        "# to render and apply it. `druks setup` alone re-renders .env but does",
-        "# not restart services.",
-        "",
-    ]
-
-    root_values = {key: value for key, value in config.items() if not isinstance(value, dict)}
-    if root_values:
-        lines.append("# OPERATOR ADDITIONS")
-        for key, value in root_values.items():
-            lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
-        lines.append("")
-
-    for table_name, known_keys in _KNOWN_TOML_KEYS.items():
-        lines.append(_TOML_TABLE_COMMENTS[table_name])
-        lines.append(f"[{table_name}]")
-        table = config[table_name]
-        for key in known_keys:
-            lines.append(f"{key} = {_toml_value(table[key])}")
-        additions = {
-            key: value for key, value in table.items() if key not in known_keys and key != "env"
-        }
-        if additions:
-            if known_keys:
-                lines.append("# OPERATOR ADDITIONS")
-            for key, value in additions.items():
-                lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
-        lines.append("")
-
-        if table_name == "sandbox":
-            provider = table["provider"]
-            if provider == "docker":
-                lines.extend(
-                    (
-                        "# Host-run drukbox reads its own checkout's environment.",
-                        "# Values in this table are preserved but are not rendered to .env.",
-                    )
-                )
-            elif provider == "exe":
-                lines.append("# Drukbox environment passed through to the remote stack.")
-            else:
-                lines.extend(
-                    (
-                        "# Drukbox environment passed through to the remote stack.",
-                        "# Configuration reference: https://github.com/czpython/drukbox",
-                        "# See docs/deploy.md in that repository.",
-                    )
-                )
-            lines.append("[sandbox.env]")
-            for key, value in table["env"].items():
-                lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
-            lines.append("")
-
-    unknown_tables = {
-        key: value
-        for key, value in config.items()
-        if key not in _KNOWN_TOML_KEYS and isinstance(value, dict)
-    }
-    if unknown_tables:
-        lines.extend(("# " + "=" * 60, "# OPERATOR ADDITIONS", "# " + "=" * 60, ""))
-        for name, table in unknown_tables.items():
-            lines.append(f"[{_toml_key(name)}]")
-            lines.extend(f"{_toml_key(key)} = {_toml_value(value)}" for key, value in table.items())
-            lines.append("")
-
-    return "\n".join(lines).rstrip() + "\n"
-
-
-def _toml_key(value: str) -> str:
-    if _TOML_KEY_PATTERN.fullmatch(value):
-        return value
-    return f'"{_escape_toml_string(value)}"'
-
-
-def _toml_value(value: str | int | float | bool) -> str:
-    if isinstance(value, str):
-        return f'"{_escape_toml_string(value)}"'
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    return repr(value)
-
-
-def _escape_toml_string(value: str) -> str:
-    if any(ord(character) < 32 or ord(character) == 127 for character in value):
-        raise ValueError("druks.toml values may not contain newlines or control characters")
-    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _render_env(

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -1,30 +1,194 @@
 import base64
+import copy
+import math
+import os
+import re
 import secrets
+import tomllib
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import date, datetime, time
 from pathlib import Path
+from typing import TypeGuard, cast
 
 GAPS_EXIT_CODE = 3
+MIGRATION_EXIT_CODE = 4
+
+_COMPOSE_ENV_KEYS = (
+    "DRUKS_UID",
+    "DRUKS_GID",
+    "DRUKS_TAG",
+    "DRUKS_WEB_BIND_HOST",
+    "COMPOSE_PROFILES",
+)
+_ENV_KEY_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_TOML_KEY_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
 
 
 @dataclass(frozen=True)
 class Entry:
     key: str
-    # Static default, or a zero-arg callable evaluated once on first write
-    # (secrets). ``{install_dir}`` / ``{home}`` placeholders are expanded.
-    default: str | Callable[[], str] = ""
-    prompt: str | None = None
-    required: bool = False
-    comment: str | None = None
+    source: tuple[str, ...] = ()
+    fixed: str = ""
+    is_required: bool = False
+    prompt: str = ""
+    is_install_path: bool = False
+    is_remote_only: bool = False
 
 
 @dataclass(frozen=True)
 class Section:
     title: str
-    entries: tuple[Entry, ...] = ()
-    # Free-form commented lines appended after the entries (documented
-    # optional knobs the operator uncomments by hand).
-    trailer: str | None = None
+    entries: tuple[Entry, ...]
+
+
+_SECTIONS = (
+    Section(
+        "GITHUB AND TICKETING",
+        (
+            Entry(
+                "GITHUB_OPERATOR_APP_ID",
+                ("github", "operator_app_id"),
+                is_required=True,
+                prompt="Operator GitHub App id (or run install.sh --apps later)",
+            ),
+            Entry(
+                "GITHUB_OPERATOR_PRIVATE_KEY_PATH",
+                ("github", "operator_pem"),
+                is_install_path=True,
+            ),
+            Entry("GITHUB_OPERATOR_PEM", ("github", "operator_pem"), is_install_path=True),
+            Entry(
+                "GITHUB_REVIEWER_APP_ID",
+                ("github", "reviewer_app_id"),
+                is_required=True,
+                prompt="Reviewer GitHub App id (or run install.sh --apps later)",
+            ),
+            Entry(
+                "GITHUB_REVIEWER_PRIVATE_KEY_PATH",
+                ("github", "reviewer_pem"),
+                is_install_path=True,
+            ),
+            Entry("GITHUB_REVIEWER_PEM", ("github", "reviewer_pem"), is_install_path=True),
+            Entry(
+                "LINEAR_API_KEY",
+                ("ticketing", "linear_api_key"),
+                prompt="Linear API key (enter to skip Linear)",
+            ),
+            Entry(
+                "LINEAR_WEBHOOK_SECRET",
+                ("ticketing", "linear_webhook_secret"),
+                prompt="Linear webhook secret (enter to skip)",
+            ),
+            Entry(
+                "DRUKS_ENDPOINT",
+                ("urls", "endpoint"),
+                prompt="Base URL the operator's browser reaches druks at (enter to skip)",
+            ),
+        ),
+    ),
+    Section(
+        "GENERATED SECRETS",
+        (
+            Entry(
+                "DRUKS_POSTGRES_PASSWORD",
+                ("secrets", "postgres_password"),
+                is_required=True,
+            ),
+            Entry("DRUKS_WEBHOOK_SECRET", ("secrets", "webhook_secret"), is_required=True),
+            Entry(
+                "ANNOUNCE_TOKEN_SECRET",
+                ("secrets", "announce_token_secret"),
+                is_required=True,
+            ),
+            Entry("DRUKS_SECRETS_KEY", ("secrets", "secrets_key"), is_required=True),
+        ),
+    ),
+    Section(
+        "DEPLOYMENT DEFAULTS",
+        (
+            Entry("DRUKS_DATA_DIR", ("paths", "data_dir")),
+            Entry("DRUKS_UPSTREAM", fixed="127.0.0.1:8001"),
+            Entry("DRUKS_CLAUDE_HOME", ("paths", "claude_home")),
+            Entry("DRUKS_CODEX_HOME", ("paths", "codex_home")),
+            Entry("DRUKS_CLAUDE_JSON", ("paths", "claude_json")),
+            Entry("DRUKS_WEBHOOK_HOST", ("urls", "webhook_host")),
+            Entry("DATABASE_URL", fixed="sqlite+aiosqlite:////data/drukbox.db"),
+            Entry("REDIS_URL", fixed="redis://127.0.0.1:6379/2"),
+        ),
+    ),
+    Section(
+        "IDENTITY",
+        (
+            Entry("DRUKS_AUTH_MODE", ("identity", "mode"), is_required=True),
+            Entry("DRUKS_AUTH_HEADER", ("identity", "header")),
+            Entry("DRUKS_AUTH_JWKS_URL", ("identity", "jwks_url")),
+            Entry("DRUKS_AUTH_JWT_ISSUER", ("identity", "jwt_issuer")),
+            Entry("DRUKS_AUTH_JWT_AUDIENCE", ("identity", "jwt_audience")),
+            Entry(
+                "DRUKS_AUTH_JWT_IDENTITY_CLAIM",
+                ("identity", "jwt_identity_claim"),
+            ),
+        ),
+    ),
+    Section(
+        "SANDBOX",
+        (
+            Entry("DEFAULT_HOST_PROVIDER", ("sandbox", "provider"), is_required=True),
+            Entry(
+                "DRUKS_SANDBOX_SERVICE_URL",
+                ("sandbox", "service_url"),
+                is_required=True,
+            ),
+            Entry(
+                "DRUKS_SANDBOX_SERVICE_TOKEN",
+                ("secrets", "sandbox_service_token"),
+                is_required=True,
+            ),
+            Entry(
+                "SERVICE_TOKENS",
+                ("sandbox", "service_tokens"),
+                is_remote_only=True,
+            ),
+            Entry("DRUKS_SANDBOX_IMAGE", ("sandbox", "image")),
+        ),
+    ),
+)
+
+_OWNED_ENV_KEYS = frozenset(entry.key for section in _SECTIONS for entry in section.entries)
+_KNOWN_TOML_KEYS = {
+    "identity": (
+        "mode",
+        "header",
+        "jwks_url",
+        "jwt_issuer",
+        "jwt_audience",
+        "jwt_identity_claim",
+    ),
+    "github": ("operator_app_id", "reviewer_app_id", "operator_pem", "reviewer_pem"),
+    "ticketing": ("linear_api_key", "linear_webhook_secret"),
+    "urls": ("endpoint", "webhook_host"),
+    "secrets": (
+        "postgres_password",
+        "webhook_secret",
+        "announce_token_secret",
+        "secrets_key",
+        "sandbox_service_token",
+    ),
+    "paths": ("data_dir", "claude_home", "codex_home", "claude_json"),
+    "sandbox": ("provider", "service_url", "image", "service_tokens"),
+    "env": (),
+}
+_TOML_TABLE_COMMENTS = {
+    "identity": '# Browser identity: "header", "jwt", or "none".',
+    "github": "# GitHub Apps may also be provisioned with install.sh --apps.",
+    "ticketing": "# Optional ticketing integration.",
+    "urls": "# Public dashboard and webhook ingress addresses.",
+    "secrets": "# Generated on first write. Do not regenerate a deployed secret.",
+    "paths": "# Host paths. Relative PEM paths are resolved against the install directory.",
+    "sandbox": "# Any drukbox provider name; docker and exe select install shapes.",
+    "env": "# Additional deployment settings; keys render verbatim unless owned above.",
+}
 
 
 def _hex_secret() -> str:
@@ -32,246 +196,22 @@ def _hex_secret() -> str:
 
 
 def _announce_secret() -> str:
-    return secrets.token_urlsafe(40).replace("-", "").replace("_", "")[:43]
+    return secrets.token_urlsafe(32)
 
 
 def _secrets_key() -> str:
     return base64.b64encode(secrets.token_bytes(32)).decode()
 
 
-_COMMON_SECTIONS: tuple[Section, ...] = (
-    Section(
-        "EDIT THESE (the installer refuses to boot until they're filled in)",
-        (
-            # Where druks may act is NOT configured here — it's wherever the
-            # operator GitHub App is installed. Install/uninstall the App to
-            # grant/revoke; `druks doctor` shows the effective set.
-            Entry(
-                "GITHUB_OPERATOR_APP_ID",
-                prompt="Operator GitHub App id (or run install.sh --apps later)",
-                required=True,
-                comment=(
-                    "GitHub Apps — provision via ``install.sh --apps`` (manifest\n"
-                    "flow, fills these in) or create by hand and upload the PEMs."
-                ),
-            ),
-            Entry("GITHUB_OPERATOR_PRIVATE_KEY_PATH", "{install_dir}/secrets/operator.pem"),
-            Entry("GITHUB_OPERATOR_PEM", "{install_dir}/secrets/operator.pem"),
-            Entry(
-                "GITHUB_REVIEWER_APP_ID",
-                prompt="Reviewer GitHub App id (or run install.sh --apps later)",
-                required=True,
-            ),
-            Entry("GITHUB_REVIEWER_PRIVATE_KEY_PATH", "{install_dir}/secrets/reviewer.pem"),
-            Entry("GITHUB_REVIEWER_PEM", "{install_dir}/secrets/reviewer.pem"),
-            Entry(
-                "LINEAR_API_KEY",
-                prompt="Linear API key (enter to skip Linear)",
-                comment="Linear (optional — leave blank to skip)",
-            ),
-            Entry("LINEAR_WEBHOOK_SECRET", prompt="Linear webhook secret (enter to skip)"),
-            Entry(
-                "DRUKS_ENDPOINT",
-                prompt="Base URL the operator's browser reaches druks at (enter to skip)",
-                comment=(
-                    "Public base URL of the dashboard, e.g. https://druks.example.com —\n"
-                    "needed only to connect OAuth MCP servers (it hosts their callback)."
-                ),
-            ),
-        ),
-    ),
-    Section(
-        "AUTO-GENERATED — do not regenerate without redeploying the stack",
-        (
-            # Postgres reads it at initdb only — regenerating later means
-            # ALTER ROLE (or a fresh volume), not just a redeploy.
-            Entry("DRUKS_POSTGRES_PASSWORD", _hex_secret),
-            Entry("DRUKS_WEBHOOK_SECRET", _hex_secret),
-            Entry("ANNOUNCE_TOKEN_SECRET", _announce_secret),
-            # Encrypts stored secrets (MCP tokens, OAuth grants) at rest.
-            # Rotatable: comma-separated, first key encrypts, all decrypt —
-            # see docs/configuration.md.
-            Entry("DRUKS_SECRETS_KEY", _secrets_key),
-        ),
-    ),
-    Section(
-        "DEFAULTS (rarely changed)",
-        (
-            Entry("DRUKS_DATA_DIR", "{home}/druks-data"),
-            Entry("DRUKS_UPSTREAM", "127.0.0.1:8001"),
-            Entry("DRUKS_CLAUDE_HOME", "{home}/.claude"),
-            Entry("DRUKS_CODEX_HOME", "{home}/.codex"),
-            Entry("DRUKS_CLAUDE_JSON", "{home}/.claude.json"),
-            Entry(
-                "DRUKS_WEBHOOK_HOST",
-                comment=(
-                    "Public webhook hostname (e.g. druks.example.com). Point an\n"
-                    "A-record at this box and open 80/443; Caddy auto-provisions\n"
-                    "TLS and serves only /_external/*. Leave empty when the edge\n"
-                    "already carries webhooks (exe.dev port-share) or you bring\n"
-                    "your own ingress."
-                ),
-            ),
-            Entry(
-                "DATABASE_URL",
-                "sqlite+aiosqlite:////data/drukbox.db",
-                comment=(
-                    "Drukbox internals. DATABASE_URL is overridden by compose to the\n"
-                    "shared SQLite file; kept here only as a documented default for\n"
-                    "non-compose runs."
-                ),
-            ),
-            Entry("REDIS_URL", "redis://127.0.0.1:6379/2"),
-        ),
-    ),
-)
-
-# How each install shape resolves browser identity. Both Caddy and druks read
-# DRUKS_AUTH_HEADER: Caddy requires the edge's assertion, druks maps it to an
-# account.
-_EXE_IDENTITY_SECTION = Section(
-    "IDENTITY — exe.dev authenticates at the edge; druks maps the asserted email",
-    (
-        Entry("DRUKS_AUTH_MODE", "header"),
-        Entry("DRUKS_AUTH_HEADER", "X-ExeDev-Email"),
-    ),
-)
-
-_AWS_IDENTITY_SECTION = Section(
-    "IDENTITY — your edge proxy authenticates; druks maps the asserted email",
-    (
-        Entry("DRUKS_AUTH_MODE", "header"),
-        Entry(
-            "DRUKS_AUTH_HEADER",
-            prompt="Identity header your edge proxy injects (e.g. X-Forwarded-Email)",
-            required=True,
-            comment=(
-                "The header your identity proxy (Teleport, Cloudflare Access, …)\n"
-                "injects after authenticating. The proxy must strip any\n"
-                "client-supplied copy before inserting its own."
-            ),
-        ),
-    ),
-)
-
-_LOCAL_IDENTITY_SECTION = Section(
-    "IDENTITY — loopback dashboard, no authentication; one operator account",
-    (Entry("DRUKS_AUTH_MODE", "none"),),
-)
-
-_IDENTITY_SECTIONS = {
-    "exe": _EXE_IDENTITY_SECTION,
-    "aws": _AWS_IDENTITY_SECTION,
-    "docker": _LOCAL_IDENTITY_SECTION,
-}
-
-# How druks reaches drukbox. The remote shapes run drukbox itself from this
-# same .env (compose `remote` profile): container on :8780, generated token;
-# SERVICE_TOKENS is drukbox's accepted-token list, mirrored from the sandbox
-# token when blank.
-_REMOTE_DRUKBOX_ENTRIES: tuple[Entry, ...] = (
-    Entry("DRUKS_SANDBOX_SERVICE_URL", "http://127.0.0.1:8780"),
-    Entry("DRUKS_SANDBOX_SERVICE_TOKEN", _hex_secret),
-    Entry("SERVICE_TOKENS"),
-    Entry(
-        "DRUKS_SANDBOX_IMAGE",
-        comment="Leave empty so drukbox picks per-provider; set as override only.",
-    ),
-)
-
-_AWS_SECTION = Section(
-    "SANDBOX PROVIDER — AWS EC2 (drukbox)",
-    (
-        Entry(
-            "AWS_REGION",
-            prompt="AWS region (e.g. eu-central-1)",
-            required=True,
-            comment=(
-                "Control-plane credentials reach boto via the container env; an\n"
-                "IAM instance profile on this box works too — leave the key pair\n"
-                "blank and boto's default chain picks the role up automatically."
-            ),
-        ),
-        Entry("AWS_DEFAULT_IMAGE", prompt="AMI id for sandbox VMs", required=True),
-        Entry("AWS_ACCESS_KEY_ID", prompt="AWS access key id (enter to use instance profile)"),
-        Entry("AWS_SECRET_ACCESS_KEY", prompt="AWS secret access key (enter to skip)"),
-        Entry("DEFAULT_HOST_PROVIDER", "aws"),
-        Entry("TAILSCALE_ENABLED", "false"),
-        Entry("AWS_INSTANCE_TYPE", "t3.medium"),
-        *_REMOTE_DRUKBOX_ENTRIES,
-    ),
-    trailer=(
-        "# AWS_SUBNET_ID=          # default VPC subnet if unset\n"
-        "# AWS_SECURITY_GROUP_ID=  # drukbox manages one if unset\n"
-        "# AWS_SSH_USERNAME=ubuntu # override if the AMI uses a different user\n"
-        "# AWS_INSTANCE_PROFILE=   # IAM profile attached to the SANDBOX VMs\n"
-        "#                         # drukbox launches (not control-plane auth)"
-    ),
-)
-
-_EXE_SECTION = Section(
-    "SANDBOX PROVIDER — exe.dev + Tailscale (drukbox)",
-    (
-        Entry(
-            "TAILSCALE_TAILNET",
-            prompt='Tailscale magic-DNS suffix (e.g. "yourtail.ts.net")',
-            required=True,
-        ),
-        Entry("TAILSCALE_OAUTH_CLIENT_ID", prompt="Tailscale OAuth client id"),
-        Entry("TAILSCALE_OAUTH_CLIENT_SECRET", prompt="Tailscale OAuth client secret"),
-        Entry("EXE_API_TOKEN", prompt="exe.dev API token", required=True),
-        Entry("DEFAULT_HOST_PROVIDER", "exe"),
-        Entry("TAILSCALE_ENABLED", "true"),
-        Entry("EXE_API_URL", "https://exe.dev"),
-        Entry("EXE_DEFAULT_IMAGE", "ghcr.io/boldsoftware/exeuntu:latest"),
-        Entry("TAILSCALE_API_TIMEOUT", "30"),
-        Entry("TAILSCALE_AUTH_TAGS", "tag:sandbox"),
-        *_REMOTE_DRUKBOX_ENTRIES,
-    ),
-)
-
-_LOCAL_SECTION = Section(
-    "SANDBOX PROVIDER — local Docker containers (drukbox on the host)",
-    (
-        Entry("DEFAULT_HOST_PROVIDER", "docker"),
-        # drukbox runs on the host (`make dev`: port 8000, fixed dev-token)
-        # and reads its own env there — nothing in this file configures it.
-        Entry("DRUKS_SANDBOX_SERVICE_URL", "http://127.0.0.1:8000"),
-        Entry("DRUKS_SANDBOX_SERVICE_TOKEN", "dev-token"),
-        Entry("DRUKS_SANDBOX_IMAGE", "ghcr.io/czpython/druks-sandbox:latest"),
-    ),
-    trailer=(
-        "# Sandboxes are local Docker containers. Run drukbox on the host so\n"
-        "# its docker provider reaches your Docker daemon:\n"
-        "#   git clone https://github.com/czpython/drukbox\n"
-        "#   cd drukbox && DOCKER_SSH_USERNAME=druks make dev"
-    ),
-)
-
-_PROVIDER_SECTIONS = {"exe": _EXE_SECTION, "aws": _AWS_SECTION, "docker": _LOCAL_SECTION}
-
-
-def sections_for(provider: str) -> tuple[Section, ...]:
-    return (*_COMMON_SECTIONS, _IDENTITY_SECTIONS[provider], _PROVIDER_SECTIONS[provider])
-
-
 def read_env(path: Path) -> dict[str, str]:
-    """KEY=VALUE lines → dict. Comments/blank lines skipped; values kept raw
-    (quotes and all) so we round-trip exactly what the operator wrote."""
     values: dict[str, str] = {}
-    if not path.exists():
-        return values
-    for line in path.read_text().splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#") or "=" not in stripped:
-            continue
-        key, _, value = stripped.partition("=")
-        values[key.strip()] = value.strip()
+    if path.exists():
+        for line in path.read_text().splitlines():
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            values[key.strip()] = value
     return values
-
-
-def _is_blank(value: str | None) -> bool:
-    return value is None or value.strip().strip("\"'") == ""
 
 
 def run_setup(
@@ -281,128 +221,683 @@ def run_setup(
     install_dir: str,
     home: str,
     interactive: bool,
+    set_values: tuple[str, ...] = (),
     input_fn: Callable[[str], str] = input,
     print_fn: Callable[[str], None] = print,
 ) -> int:
-    fresh = not env_path.exists()
-    existing = read_env(env_path)
-    # A re-run keeps the provider the .env was written with; the flag only
-    # decides the very first write.
-    provider = existing.get("DEFAULT_HOST_PROVIDER", "").strip() or provider
-    if provider not in _PROVIDER_SECTIONS:
-        print_fn(f"unknown provider {provider!r} (expected one of {', '.join(_PROVIDER_SECTIONS)})")
-        return 1
+    toml_path = env_path.parent / "druks.toml"
+    if env_path.exists() and not toml_path.exists():
+        _print_migration_recipe(print_fn, env_path, toml_path)
+        return MIGRATION_EXIT_CODE
 
-    sections = sections_for(provider)
-    placeholders = {"install_dir": install_dir.rstrip("/"), "home": home.rstrip("/")}
+    is_fresh = not toml_path.exists()
+    if is_fresh:
+        provider = provider.strip()
+        if interactive:
+            answer = input_fn(f"Sandbox provider [{provider}]: ").strip()
+            provider = answer or provider
+        if not provider:
+            raise ValueError("sandbox provider cannot be blank")
+        config = _fresh_config(provider=provider, home=home)
+    else:
+        config = _read_toml(toml_path)
 
-    values: dict[str, str] = {}
-    for section in sections:
-        for entry in section.entries:
-            current = existing.get(entry.key)
-            if not _is_blank(current):
-                values[entry.key] = current  # type: ignore[assignment]
-                continue
-            default = entry.default() if callable(entry.default) else entry.default
-            values[entry.key] = default.format(**placeholders)
-    # drukbox's accepted-token list mirrors the sandbox token (remote shapes
-    # only — the local shape's drukbox brings its own env).
-    if "SERVICE_TOKENS" in values and _is_blank(values["SERVICE_TOKENS"]):
-        values["SERVICE_TOKENS"] = values["DRUKS_SANDBOX_SERVICE_TOKEN"]
-    # A local install's dashboard sits at a fixed localhost port, so its
-    # OAuth-MCP callback base is knowable up front — default it so connecting
-    # an OAuth MCP server (e.g. Linear) works out of the box. Remote shapes
-    # reach the dashboard through their own edge, so they supply this.
-    if provider == "docker" and _is_blank(values.get("DRUKS_ENDPOINT")):
-        values["DRUKS_ENDPOINT"] = "http://localhost:8001"
+    is_changed = is_fresh
+    for assignment in set_values:
+        path, value = _parse_assignment(assignment)
+        _set_value(config, path, value)
+        is_changed = True
+
+    provider = _get_string(config, ("sandbox", "provider"))
+    print_fn(_shape_message(provider))
 
     if interactive:
-        for section in sections:
-            for entry in section.entries:
-                if not entry.prompt or not _is_blank(values.get(entry.key)):
-                    continue
-                # Optional values get one offer — on the fresh write. Re-runs
-                # only nag about what actually blocks the boot; a blank
-                # optional is a decision, not a gap.
-                if not entry.required and not fresh:
-                    continue
-                answer = input_fn(f"{entry.prompt}: ").strip()
-                if answer:
-                    values[entry.key] = answer
+        is_changed = (
+            _prompt_values(
+                config,
+                is_fresh=is_fresh,
+                input_fn=input_fn,
+            )
+            or is_changed
+        )
 
-    template_keys = {entry.key for section in sections for entry in section.entries}
-    extras = {key: value for key, value in existing.items() if key not in template_keys}
+    if is_changed:
+        _write_toml(toml_path, config)
+        config = _read_toml(toml_path)
+    if is_fresh:
+        _write_gitignore(env_path.parent / ".gitignore")
+        (env_path.parent / "secrets").mkdir(mode=0o700, exist_ok=True)
 
-    _write_env(env_path, sections, values, extras)
-    (env_path.parent / "secrets").mkdir(mode=0o700, exist_ok=True)
+    existing_env = env_path.read_text() if env_path.exists() else ""
+    extras = {key: value for key, value in read_env(env_path).items() if key in _COMPOSE_ENV_KEYS}
+    env_text = _render_env(config, install_dir=install_dir, extras=extras)
+    _write_secure_text(env_path, env_text)
 
-    gaps = _collect_gaps(sections, values, env_path=env_path, install_dir=install_dir)
-    aws_keys_blank = provider == "aws" and _is_blank(values.get("AWS_ACCESS_KEY_ID"))
-    _print_outcome(
-        print_fn,
-        env_path=env_path,
-        provider=provider,
-        gaps=gaps,
-        aws_keys_blank=aws_keys_blank,
-    )
-    return 0 if not gaps else GAPS_EXIT_CODE
+    if existing_env and existing_env != env_text:
+        print_fn("Rendered .env changed. Apply it with: docker compose up -d")
+
+    gaps = _collect_gaps(config, env_path=env_path, install_dir=install_dir)
+    _print_outcome(print_fn, env_path=env_path, provider=provider, gaps=gaps)
+    return GAPS_EXIT_CODE if gaps else 0
 
 
-def _write_env(
-    env_path: Path,
-    sections: tuple[Section, ...],
-    values: dict[str, str],
+def _fresh_config(*, provider: str, home: str) -> dict[str, object]:
+    if provider == "docker":
+        identity_mode = "none"
+        identity_header = ""
+        endpoint = "http://localhost:8001"
+        service_url = "http://127.0.0.1:8000"
+        sandbox_token = "dev-token"
+        sandbox_image = "ghcr.io/czpython/druks-sandbox:latest"
+    elif provider == "exe":
+        identity_mode = "header"
+        identity_header = "X-ExeDev-Email"
+        endpoint = ""
+        service_url = "http://127.0.0.1:8780"
+        sandbox_token = _hex_secret()
+        sandbox_image = ""
+    else:
+        identity_mode = "header"
+        identity_header = ""
+        endpoint = ""
+        service_url = "http://127.0.0.1:8780"
+        sandbox_token = _hex_secret()
+        sandbox_image = ""
+
+    sandbox_env: dict[str, object] = {}
+    if provider == "exe":
+        sandbox_env = {
+            "EXE_API_TOKEN": "",
+            "TAILSCALE_TAILNET": "",
+            "TAILSCALE_OAUTH_CLIENT_ID": "",
+            "TAILSCALE_OAUTH_CLIENT_SECRET": "",
+            "EXE_API_URL": "https://exe.dev",
+            "EXE_DEFAULT_IMAGE": "ghcr.io/boldsoftware/exeuntu:latest",
+            "TAILSCALE_ENABLED": "true",
+            "TAILSCALE_API_TIMEOUT": "30",
+            "TAILSCALE_AUTH_TAGS": "tag:sandbox",
+        }
+
+    return {
+        "identity": {
+            "mode": identity_mode,
+            "header": identity_header,
+            "jwks_url": "",
+            "jwt_issuer": "",
+            "jwt_audience": "",
+            "jwt_identity_claim": "email",
+        },
+        "github": {
+            "operator_app_id": "",
+            "reviewer_app_id": "",
+            "operator_pem": "secrets/operator.pem",
+            "reviewer_pem": "secrets/reviewer.pem",
+        },
+        "ticketing": {
+            "linear_api_key": "",
+            "linear_webhook_secret": "",
+        },
+        "urls": {
+            "endpoint": endpoint,
+            "webhook_host": "",
+        },
+        "secrets": {
+            "postgres_password": _hex_secret(),
+            "webhook_secret": _hex_secret(),
+            "announce_token_secret": _announce_secret(),
+            "secrets_key": _secrets_key(),
+            "sandbox_service_token": sandbox_token,
+        },
+        "paths": {
+            "data_dir": f"{home.rstrip('/')}/druks-data",
+            "claude_home": f"{home.rstrip('/')}/.claude",
+            "codex_home": f"{home.rstrip('/')}/.codex",
+            "claude_json": f"{home.rstrip('/')}/.claude.json",
+        },
+        "sandbox": {
+            "provider": provider,
+            "service_url": service_url,
+            "image": sandbox_image,
+            "service_tokens": "",
+            "env": sandbox_env,
+        },
+        "env": {},
+    }
+
+
+def _read_toml(path: Path) -> dict[str, object]:
+    with path.open("rb") as config_file:
+        config = tomllib.load(config_file)
+    return _canonical_config(config)
+
+
+def _validate_config(config: dict[str, object]) -> None:
+    for table_name, keys in _KNOWN_TOML_KEYS.items():
+        value = config.get(table_name, {})
+        if not isinstance(value, dict):
+            raise ValueError(f"druks.toml: [{table_name}] must be a table")
+        for key in keys:
+            configured = value.get(key, "")
+            if not isinstance(configured, str):
+                raise ValueError(f"druks.toml: {table_name}.{key} must be a string")
+
+    sandbox = config.get("sandbox", {})
+    if not isinstance(sandbox, dict):
+        raise ValueError("druks.toml: [sandbox] must be a table")
+    sandbox_env = sandbox.get("env", {})
+    if not isinstance(sandbox_env, dict):
+        raise ValueError("druks.toml: [sandbox.env] must be a table")
+    for key, value in sandbox_env.items():
+        if not isinstance(value, str):
+            raise ValueError(f"druks.toml: sandbox.env.{key} must be a string")
+
+    deployment_env = config.get("env", {})
+    if not isinstance(deployment_env, dict):
+        raise ValueError("druks.toml: [env] must be a table")
+    for key, value in deployment_env.items():
+        if not isinstance(value, str):
+            raise ValueError(f"druks.toml: env.{key} must be a string")
+
+
+def _canonical_config(config: dict[str, object]) -> dict[str, object]:
+    _validate_config(config)
+    canonical = copy.deepcopy(config)
+    for table_name, keys in _KNOWN_TOML_KEYS.items():
+        table = cast(dict[str, object], canonical.setdefault(table_name, {}))
+        for key in keys:
+            table.setdefault(key, "")
+    sandbox = cast(dict[str, object], canonical["sandbox"])
+    sandbox.setdefault("env", {})
+    if not sandbox["service_tokens"]:
+        del sandbox["service_tokens"]
+
+    identity = cast(dict[str, object], canonical["identity"])
+    if identity["mode"] != "jwt":
+        for key in ("jwks_url", "jwt_issuer", "jwt_audience", "jwt_identity_claim"):
+            if not identity[key] or key == "jwt_identity_claim" and identity[key] == "email":
+                del identity[key]
+    return canonical
+
+
+def _get_string(config: dict[str, object], path: tuple[str, ...]) -> str:
+    current: object = config
+    for part in path:
+        if not isinstance(current, dict):
+            raise ValueError(f"druks.toml: {'.'.join(path)} crosses a non-table value")
+        current = current.get(part, "")
+    if not isinstance(current, str):
+        raise ValueError(f"druks.toml: {'.'.join(path)} must be a string")
+    return current
+
+
+def _set_value(config: dict[str, object], path: tuple[str, ...], value: str) -> None:
+    current = config
+    for part in path[:-1]:
+        child = current.setdefault(part, {})
+        if not isinstance(child, dict):
+            raise ValueError(f"druks.toml: {'.'.join(path)} crosses a non-table value")
+        current = child
+    current[path[-1]] = value
+
+
+def _parse_assignment(assignment: str) -> tuple[tuple[str, ...], str]:
+    path_text, separator, value = assignment.partition("=")
+    path = tuple(path_text.split("."))
+    if not separator or len(path) < 2 or any(not part for part in path):
+        raise ValueError(f"invalid --set {assignment!r}; expected key.path=value")
+    return path, value
+
+
+def _prompt_values(
+    config: dict[str, object],
+    *,
+    is_fresh: bool,
+    input_fn: Callable[[str], str],
+) -> bool:
+    prompts = [
+        (entry.source, entry.prompt, entry.is_required)
+        for section in _SECTIONS
+        for entry in section.entries
+        if entry.source and entry.prompt
+    ]
+    identity_mode = _get_string(config, ("identity", "mode"))
+    if identity_mode in {"header", "jwt"}:
+        prompts.append(
+            (
+                ("identity", "header"),
+                "Identity header your edge injects (e.g. X-Forwarded-Email)",
+                True,
+            )
+        )
+    if identity_mode == "jwt":
+        prompts.extend(
+            (
+                (("identity", "jwks_url"), "Identity edge JWKS URL", True),
+                (("identity", "jwt_issuer"), "Identity token issuer", True),
+                (("identity", "jwt_audience"), "Identity token audience", True),
+                (("identity", "jwt_identity_claim"), "Identity claim containing the email", True),
+            )
+        )
+
+    if _get_string(config, ("sandbox", "provider")) == "exe":
+        prompts.extend(
+            (
+                (("sandbox", "env", "EXE_API_TOKEN"), "exe.dev API token", True),
+                (
+                    ("sandbox", "env", "TAILSCALE_TAILNET"),
+                    'Tailscale magic-DNS suffix (e.g. "yourtail.ts.net")',
+                    True,
+                ),
+                (
+                    ("sandbox", "env", "TAILSCALE_OAUTH_CLIENT_ID"),
+                    "Tailscale OAuth client id",
+                    False,
+                ),
+                (
+                    ("sandbox", "env", "TAILSCALE_OAUTH_CLIENT_SECRET"),
+                    "Tailscale OAuth client secret",
+                    False,
+                ),
+            )
+        )
+
+    is_changed = False
+    for path, prompt, is_required in prompts:
+        if _get_string(config, path) or (not is_required and not is_fresh):
+            continue
+        answer = input_fn(f"{prompt}: ").strip()
+        if answer:
+            _set_value(config, path, answer)
+            is_changed = True
+    return is_changed
+
+
+def _write_toml(path: Path, config: dict[str, object]) -> None:
+    canonical = _canonical_config(config)
+    text = _render_toml(canonical)
+    _write_secure_text(path, text)
+    parsed = _read_toml(path)
+    if parsed != canonical:
+        raise ValueError("druks.toml write verification failed: parsed values changed")
+
+
+def _render_toml(config: dict[str, object]) -> str:
+    lines = [
+        "# druks.toml — the deployment. Edit this file, then re-run the installer",
+        "# to render and apply it. `druks setup` alone re-renders .env but does",
+        "# not restart services.",
+        "",
+    ]
+
+    root_values = {
+        key: value
+        for key, value in config.items()
+        if not isinstance(value, dict) and not _is_table_array(value)
+    }
+    if root_values:
+        lines.append("# OPERATOR ADDITIONS")
+        for key, value in root_values.items():
+            lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
+        lines.append("")
+
+    for table_name, known_keys in _KNOWN_TOML_KEYS.items():
+        lines.append(_TOML_TABLE_COMMENTS[table_name])
+        lines.append(f"[{table_name}]")
+        table = cast(dict[str, object], config[table_name])
+        for key in known_keys:
+            if key in table:
+                lines.append(f"{key} = {_toml_value(table[key])}")
+            elif table_name == "identity":
+                lines.append(f'# {key} = "{"email" if key == "jwt_identity_claim" else ""}"')
+            else:
+                lines.append(f'# {key} = ""')
+        additions = {
+            key: value
+            for key, value in table.items()
+            if key not in known_keys
+            and key != "env"
+            and not isinstance(value, dict)
+            and not _is_table_array(value)
+        }
+        if additions:
+            if known_keys:
+                lines.append("# OPERATOR ADDITIONS")
+            for key, value in additions.items():
+                lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
+        lines.append("")
+
+        if table_name == "sandbox":
+            provider = table["provider"]
+            if provider == "docker":
+                lines.extend(
+                    (
+                        "# Host-run drukbox reads its own checkout's environment.",
+                        "# Values in this table are preserved but are not rendered to .env.",
+                    )
+                )
+            elif provider == "exe":
+                lines.append("# Drukbox environment passed through to the remote stack.")
+            else:
+                lines.extend(
+                    (
+                        "# Drukbox environment passed through to the remote stack.",
+                        "# Configuration reference: https://github.com/czpython/drukbox",
+                        "# See docs/deploy.md in that repository.",
+                    )
+                )
+            lines.append("[sandbox.env]")
+            sandbox_env = cast(dict[str, object], table["env"])
+            for key, value in sandbox_env.items():
+                lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
+            lines.append("")
+
+    unknown_tables: list[tuple[tuple[str, ...], dict[str, object], bool]] = []
+    for key, value in config.items():
+        if isinstance(value, dict) and key not in _KNOWN_TOML_KEYS:
+            unknown_tables.append(((key,), value, False))
+        elif _is_table_array(value):
+            for table in value:
+                unknown_tables.append(((key,), table, True))
+    for table_name in _KNOWN_TOML_KEYS:
+        table = cast(dict[str, object], config[table_name])
+        for key, value in table.items():
+            if isinstance(value, dict) and not (table_name == "sandbox" and key == "env"):
+                unknown_tables.append(((table_name, key), value, False))
+            elif _is_table_array(value):
+                for item in value:
+                    unknown_tables.append(((table_name, key), item, True))
+
+    if unknown_tables:
+        lines.extend(("# " + "=" * 60, "# OPERATOR ADDITIONS", "# " + "=" * 60, ""))
+        for path, table, is_array in unknown_tables:
+            lines.extend(_render_unknown_table(path, table, is_array=is_array))
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_unknown_table(
+    path: tuple[str, ...],
+    table: dict[str, object],
+    *,
+    is_array: bool,
+) -> list[str]:
+    path_text = ".".join(_toml_key(part) for part in path)
+    brackets = "[[" if is_array else "["
+    closing_brackets = "]]" if is_array else "]"
+    lines = [f"{brackets}{path_text}{closing_brackets}"]
+    nested: list[tuple[str, dict[str, object]]] = []
+    arrays: list[tuple[str, list[dict[str, object]]]] = []
+    for key, value in table.items():
+        if isinstance(value, dict):
+            nested.append((key, value))
+        elif _is_table_array(value):
+            arrays.append((key, value))
+        else:
+            lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
+    lines.append("")
+    for key, value in nested:
+        lines.extend(_render_unknown_table((*path, key), value, is_array=False))
+    for key, values in arrays:
+        for value in values:
+            lines.extend(_render_unknown_table((*path, key), value, is_array=True))
+    return lines
+
+
+def _is_table_array(value: object) -> TypeGuard[list[dict[str, object]]]:
+    return isinstance(value, list) and bool(value) and all(isinstance(item, dict) for item in value)
+
+
+def _toml_key(value: str) -> str:
+    if _TOML_KEY_PATTERN.fullmatch(value):
+        return value
+    return f'"{_escape_toml_string(value)}"'
+
+
+def _toml_value(value: object) -> str:
+    if isinstance(value, str):
+        return f'"{_escape_toml_string(value)}"'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("druks.toml: non-finite floats are unsupported")
+        return repr(value)
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    if isinstance(value, dict):
+        items = (f"{_toml_key(key)} = {_toml_value(item)}" for key, item in value.items())
+        return "{ " + ", ".join(items) + " }"
+    raise ValueError(f"druks.toml: unsupported operator value {value!r}")
+
+
+def _escape_toml_string(value: str) -> str:
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ValueError("druks.toml values may not contain newlines or control characters")
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _render_env(
+    config: dict[str, object],
+    *,
+    install_dir: str,
     extras: dict[str, str],
-) -> None:
+) -> str:
+    provider = _get_string(config, ("sandbox", "provider"))
     lines: list[str] = []
-    for section in sections:
-        lines.append("# " + "=" * 60)
-        lines.append(f"# {section.title}")
-        lines.append("# " + "=" * 60)
-        lines.append("")
+    for section in _SECTIONS:
+        section_lines: list[str] = []
         for entry in section.entries:
-            if entry.comment:
-                lines.extend(f"# {comment_line}" for comment_line in entry.comment.splitlines())
-            lines.append(f"{entry.key}={values.get(entry.key, '')}")
-        if section.trailer:
-            lines.append(section.trailer)
+            if entry.is_remote_only and provider == "docker":
+                continue
+            value = entry.fixed or _get_string(config, entry.source)
+            if entry.key == "SERVICE_TOKENS" and not value:
+                value = _get_string(config, ("secrets", "sandbox_service_token"))
+            if entry.is_install_path and value:
+                value = _resolve_install_path(value, install_dir)
+            if not value:
+                continue
+            section_lines.append(_env_line(entry.key, value))
+        if section_lines:
+            lines.extend(("# " + "=" * 60, f"# {section.title}", "# " + "=" * 60, ""))
+            lines.extend(section_lines)
+            lines.append("")
+
+    sandbox = cast(dict[str, object], config["sandbox"])
+    sandbox_env = cast(dict[str, str], sandbox["env"])
+    if provider != "docker":
+        pass_through = []
+        for key, value in sandbox_env.items():
+            if _is_reserved_env_key(key) or not value:
+                continue
+            if not _ENV_KEY_PATTERN.fullmatch(key):
+                raise ValueError(f"druks.toml: sandbox.env key {key!r} is not an env name")
+            pass_through.append(_env_line(key, value))
+        if pass_through:
+            lines.extend(
+                (
+                    "# " + "=" * 60,
+                    "# SANDBOX ENVIRONMENT",
+                    "# " + "=" * 60,
+                    "",
+                    *pass_through,
+                    "",
+                )
+            )
+
+    deployment_env = cast(dict[str, str], config["env"])
+    additions = []
+    for key, value in deployment_env.items():
+        if key in _OWNED_ENV_KEYS or not value:
+            continue
+        if not _ENV_KEY_PATTERN.fullmatch(key):
+            raise ValueError(f"druks.toml: env key {key!r} is not an env name")
+        additions.append(_env_line(key, value))
+    if additions:
+        lines.extend(
+            (
+                "# " + "=" * 60,
+                "# DEPLOYMENT ENVIRONMENT ADDITIONS",
+                "# " + "=" * 60,
+                "",
+                *additions,
+                "",
+            )
+        )
+
+    compose_extras = {key: value for key, value in extras.items() if key not in deployment_env}
+    if compose_extras:
+        lines.extend(
+            (
+                "# " + "=" * 60,
+                "# OPERATOR ADDITIONS (preserved verbatim by druks setup)",
+                "# " + "=" * 60,
+                "",
+            )
+        )
+        for key in _COMPOSE_ENV_KEYS:
+            if key in compose_extras:
+                lines.append(_env_line(key, compose_extras[key]))
         lines.append("")
-    if extras:
-        lines.append("# " + "=" * 60)
-        lines.append("# OPERATOR ADDITIONS (preserved verbatim by druks setup)")
-        lines.append("# " + "=" * 60)
-        lines.append("")
-        lines.extend(f"{key}={value}" for key, value in extras.items())
-        lines.append("")
-    env_path.write_text("\n".join(lines))
-    env_path.chmod(0o600)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _env_line(key: str, value: str) -> str:
+    if "\n" in value or "\r" in value:
+        raise ValueError(f".env value for {key} may not contain a newline")
+    return f"{key}={value}"
+
+
+def _resolve_install_path(value: str, install_dir: str) -> str:
+    path = Path(value)
+    if path.is_absolute():
+        return str(path)
+    return str(Path(install_dir.rstrip("/")) / path)
+
+
+def _is_reserved_env_key(key: str) -> bool:
+    return key.startswith("DRUKS_") or key in _OWNED_ENV_KEYS
 
 
 def _collect_gaps(
-    sections: tuple[Section, ...],
-    values: dict[str, str],
+    config: dict[str, object],
     *,
     env_path: Path,
     install_dir: str,
 ) -> list[str]:
     gaps = [
         f"{entry.key} is empty"
-        for section in sections
+        for section in _SECTIONS
         for entry in section.entries
-        if entry.required and _is_blank(values.get(entry.key))
+        if entry.is_required and not _get_string(config, entry.source)
     ]
-    # PEM files must exist to boot. The configured paths are HOST paths;
-    # when they live under the install dir we can check them through the
-    # bootstrap mount (env_path's directory IS the install dir).
-    prefix = install_dir.rstrip("/") + "/"
-    for key in ("GITHUB_OPERATOR_PEM", "GITHUB_REVIEWER_PEM"):
-        configured = values.get(key, "").strip()
-        if not configured.startswith(prefix):
-            continue  # custom location — doctor verifies it post-boot
-        local = env_path.parent / configured.removeprefix(prefix)
-        if not local.is_file():
-            gaps.append(f"{configured} is missing (upload the PEM, or run install.sh --apps)")
+
+    identity_mode = _get_string(config, ("identity", "mode"))
+    if identity_mode not in {"none", "header", "jwt"}:
+        gaps.append("identity.mode must be one of: header, jwt, none")
+    if identity_mode in {"header", "jwt"} and not _get_string(config, ("identity", "header")):
+        gaps.append("DRUKS_AUTH_HEADER is empty")
+    if identity_mode == "jwt":
+        for path, env_key in (
+            (("identity", "jwks_url"), "DRUKS_AUTH_JWKS_URL"),
+            (("identity", "jwt_issuer"), "DRUKS_AUTH_JWT_ISSUER"),
+            (("identity", "jwt_audience"), "DRUKS_AUTH_JWT_AUDIENCE"),
+            (("identity", "jwt_identity_claim"), "DRUKS_AUTH_JWT_IDENTITY_CLAIM"),
+        ):
+            if not _get_string(config, path):
+                gaps.append(f"{env_key} is empty")
+
+    provider = _get_string(config, ("sandbox", "provider"))
+    sandbox = cast(dict[str, object], config["sandbox"])
+    sandbox_env = cast(dict[str, str], sandbox["env"])
+    for key in sandbox_env:
+        if _is_reserved_env_key(key):
+            gaps.append(f"sandbox.env.{key} is reserved by druks")
+
+    deployment_env = cast(dict[str, str], config["env"])
+    for key in deployment_env:
+        if key in _OWNED_ENV_KEYS:
+            gaps.append(f"env.{key} is reserved by druks")
+
+    if provider == "exe":
+        for key in ("EXE_API_TOKEN", "TAILSCALE_TAILNET"):
+            if not _get_string(config, ("sandbox", "env", key)):
+                gaps.append(f"{key} is empty")
+    elif provider != "docker" and not any(
+        value for key, value in sandbox_env.items() if not _is_reserved_env_key(key)
+    ):
+        gaps.append(f"[sandbox.env] has no configured values for remote provider {provider!r}")
+
+    for key in ("operator_pem", "reviewer_pem"):
+        configured = _get_string(config, ("github", key))
+        if not configured:
+            gaps.append(f"github.{key} is empty")
+            continue
+        host_path = Path(_resolve_install_path(configured, install_dir))
+        install_path = Path(install_dir.rstrip("/"))
+        if host_path.is_relative_to(install_path):
+            local_path = env_path.parent / host_path.relative_to(install_path)
+        elif Path(configured).is_absolute():
+            continue
+        else:
+            local_path = env_path.parent / configured
+        if not local_path.is_file():
+            gaps.append(f"{host_path} is missing (upload the PEM, or run install.sh --apps)")
     return gaps
+
+
+def _write_secure_text(path: Path, text: str) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w") as output:
+            descriptor = -1
+            output.write(text)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _write_gitignore(path: Path) -> None:
+    existing = path.read_text().splitlines() if path.exists() else []
+    missing = [entry for entry in ("druks.toml", ".env", "secrets/") if entry not in existing]
+    if missing:
+        body = "\n".join((*existing, *missing)).lstrip("\n") + "\n"
+        path.write_text(body)
+
+
+def _shape_message(provider: str) -> str:
+    if not provider:
+        return "sandbox provider is not configured"
+    if provider == "docker":
+        return "provider 'docker' → local shape; host-run drukbox validates its configuration"
+    if provider == "exe":
+        return "provider 'exe' → exe shape; check `druks doctor` after boot"
+    return (
+        f"provider {provider!r} → remote shape; drukbox validates the name — "
+        "check `druks doctor` after boot"
+    )
+
+
+def _print_migration_recipe(
+    print_fn: Callable[[str], None],
+    env_path: Path,
+    toml_path: Path,
+) -> None:
+    print_fn(f"Refusing to replace existing {env_path}: {toml_path} does not exist.")
+    print_fn("Back up .env and hand-write druks.toml, copying values verbatim:")
+    print_fn("  - DRUKS_POSTGRES_PASSWORD → [secrets].postgres_password")
+    print_fn("  - DRUKS_SECRETS_KEY → [secrets].secrets_key")
+    print_fn("  - DRUKS_WEBHOOK_SECRET → [secrets].webhook_secret")
+    print_fn("  - ANNOUNCE_TOKEN_SECRET → [secrets].announce_token_secret")
+    print_fn("  - DRUKS_SANDBOX_SERVICE_TOKEN → [secrets].sandbox_service_token")
+    print_fn("  - GITHUB_*_APP_ID → [github]")
+    print_fn("  - provider and its credentials → [sandbox] and [sandbox.env]")
+    print_fn("  - other hand-added .env keys → [env]")
+    print_fn("Nothing was written.")
 
 
 def _print_outcome(
@@ -411,20 +906,15 @@ def _print_outcome(
     env_path: Path,
     provider: str,
     gaps: list[str],
-    aws_keys_blank: bool,
 ) -> None:
-    if not gaps:
+    if gaps:
+        print_fn(f"Wrote {env_path} (provider: {provider}). Still needed before boot:")
+        for gap in gaps:
+            print_fn(f"  - {gap}")
+        print_fn("")
+        if provider == "docker":
+            print_fn("Start host-run drukbox, then re-run the installer.")
+        else:
+            print_fn("Complete the remote shape values, then re-run the installer.")
+    else:
         print_fn(f"✓ {env_path} is complete (provider: {provider}).")
-        return
-    print_fn(f"Wrote {env_path} (provider: {provider}). Still needed before boot:")
-    for gap in gaps:
-        print_fn(f"  - {gap}")
-    print_fn("")
-    if aws_keys_blank:
-        print_fn("Outside this installer:")
-        print_fn("  - AWS auth: with the key pair blank, attach an EC2-launch")
-        print_fn("    IAM role to this box (or fill AWS_ACCESS_KEY_ID/SECRET).")
-    elif provider == "exe":
-        print_fn("Outside this installer:")
-        print_fn("  - Make sure tailscaled is up (`tailscale status`).")
-    print_fn("Then re-run the installer.")

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -1,15 +1,13 @@
 import base64
 import copy
-import math
 import os
 import re
 import secrets
 import tomllib
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import date, datetime, time
 from pathlib import Path
-from typing import TypeGuard, cast
+from typing import Any
 
 GAPS_EXIT_CODE = 3
 MIGRATION_EXIT_CODE = 4
@@ -271,7 +269,7 @@ def run_setup(
     return GAPS_EXIT_CODE if gaps else 0
 
 
-def _fresh_config(*, provider: str, home: str) -> dict[str, object]:
+def _fresh_config(*, provider: str, home: str) -> dict[str, Any]:
     if provider == "docker":
         identity_mode = "none"
         identity_header = ""
@@ -294,7 +292,7 @@ def _fresh_config(*, provider: str, home: str) -> dict[str, object]:
         sandbox_token = _hex_secret()
         sandbox_image = ""
 
-    sandbox_env: dict[str, object] = {}
+    sandbox_env: dict[str, Any] = {}
     if provider == "exe":
         sandbox_env = {
             "EXE_API_TOKEN": "",
@@ -354,61 +352,53 @@ def _fresh_config(*, provider: str, home: str) -> dict[str, object]:
     }
 
 
-def _read_toml(path: Path) -> dict[str, object]:
+def _read_toml(path: Path) -> dict[str, Any]:
     with path.open("rb") as config_file:
         config = tomllib.load(config_file)
     return _canonical_config(config)
 
 
-def _validate_config(config: dict[str, object]) -> None:
+def _canonical_config(raw: dict[str, Any]) -> dict[str, Any]:
+    """Validated copy with every known table and key present. Operator
+    additions are welcome as flat scalars, one table deep; anything more
+    structured is refused with its key named."""
+    config = copy.deepcopy(raw)
     for table_name, keys in _KNOWN_TOML_KEYS.items():
-        value = config.get(table_name, {})
-        if not isinstance(value, dict):
+        table = config.setdefault(table_name, {})
+        if not isinstance(table, dict):
             raise ValueError(f"druks.toml: [{table_name}] must be a table")
         for key in keys:
-            configured = value.get(key, "")
-            if not isinstance(configured, str):
+            if not isinstance(table.setdefault(key, ""), str):
                 raise ValueError(f"druks.toml: {table_name}.{key} must be a string")
 
-    sandbox = config.get("sandbox", {})
-    if not isinstance(sandbox, dict):
-        raise ValueError("druks.toml: [sandbox] must be a table")
-    sandbox_env = sandbox.get("env", {})
+    sandbox_env = config["sandbox"].setdefault("env", {})
     if not isinstance(sandbox_env, dict):
         raise ValueError("druks.toml: [sandbox.env] must be a table")
-    for key, value in sandbox_env.items():
-        if not isinstance(value, str):
-            raise ValueError(f"druks.toml: sandbox.env.{key} must be a string")
+    for env_name, env_table in (("sandbox.env", sandbox_env), ("env", config["env"])):
+        for key, value in env_table.items():
+            if not isinstance(value, str):
+                raise ValueError(f"druks.toml: {env_name}.{key} must be a string")
 
-    deployment_env = config.get("env", {})
-    if not isinstance(deployment_env, dict):
-        raise ValueError("druks.toml: [env] must be a table")
-    for key, value in deployment_env.items():
-        if not isinstance(value, str):
-            raise ValueError(f"druks.toml: env.{key} must be a string")
-
-
-def _canonical_config(config: dict[str, object]) -> dict[str, object]:
-    _validate_config(config)
-    canonical = copy.deepcopy(config)
-    for table_name, keys in _KNOWN_TOML_KEYS.items():
-        table = cast(dict[str, object], canonical.setdefault(table_name, {}))
-        for key in keys:
-            table.setdefault(key, "")
-    sandbox = cast(dict[str, object], canonical["sandbox"])
-    sandbox.setdefault("env", {})
-    if not sandbox["service_tokens"]:
-        del sandbox["service_tokens"]
-
-    identity = cast(dict[str, object], canonical["identity"])
-    if identity["mode"] != "jwt":
-        for key in ("jwks_url", "jwt_issuer", "jwt_audience", "jwt_identity_claim"):
-            if not identity[key] or key == "jwt_identity_claim" and identity[key] == "email":
-                del identity[key]
-    return canonical
+    for table_name, table in config.items():
+        if not isinstance(table, dict):
+            _require_scalar("", table_name, table)
+            continue
+        known = _KNOWN_TOML_KEYS.get(table_name)
+        for key, value in table.items():
+            if known is not None and (key in known or (table_name, key) == ("sandbox", "env")):
+                continue
+            _require_scalar(f"{table_name}.", key, value)
+    return config
 
 
-def _get_string(config: dict[str, object], path: tuple[str, ...]) -> str:
+def _require_scalar(prefix: str, key: str, value: Any) -> None:
+    if not isinstance(value, (str, int, float, bool)):
+        raise ValueError(
+            f"druks.toml: {prefix}{key} must be a plain value (string, number, or boolean)"
+        )
+
+
+def _get_string(config: dict[str, Any], path: tuple[str, ...]) -> str:
     current: object = config
     for part in path:
         if not isinstance(current, dict):
@@ -419,7 +409,7 @@ def _get_string(config: dict[str, object], path: tuple[str, ...]) -> str:
     return current
 
 
-def _set_value(config: dict[str, object], path: tuple[str, ...], value: str) -> None:
+def _set_value(config: dict[str, Any], path: tuple[str, ...], value: str) -> None:
     current = config
     for part in path[:-1]:
         child = current.setdefault(part, {})
@@ -438,7 +428,7 @@ def _parse_assignment(assignment: str) -> tuple[tuple[str, ...], str]:
 
 
 def _prompt_values(
-    config: dict[str, object],
+    config: dict[str, Any],
     *,
     is_fresh: bool,
     input_fn: Callable[[str], str],
@@ -501,7 +491,7 @@ def _prompt_values(
     return is_changed
 
 
-def _write_toml(path: Path, config: dict[str, object]) -> None:
+def _write_toml(path: Path, config: dict[str, Any]) -> None:
     canonical = _canonical_config(config)
     text = _render_toml(canonical)
     _write_secure_text(path, text)
@@ -510,7 +500,7 @@ def _write_toml(path: Path, config: dict[str, object]) -> None:
         raise ValueError("druks.toml write verification failed: parsed values changed")
 
 
-def _render_toml(config: dict[str, object]) -> str:
+def _render_toml(config: dict[str, Any]) -> str:
     lines = [
         "# druks.toml — the deployment. Edit this file, then re-run the installer",
         "# to render and apply it. `druks setup` alone re-renders .env but does",
@@ -518,11 +508,7 @@ def _render_toml(config: dict[str, object]) -> str:
         "",
     ]
 
-    root_values = {
-        key: value
-        for key, value in config.items()
-        if not isinstance(value, dict) and not _is_table_array(value)
-    }
+    root_values = {key: value for key, value in config.items() if not isinstance(value, dict)}
     if root_values:
         lines.append("# OPERATOR ADDITIONS")
         for key, value in root_values.items():
@@ -532,21 +518,11 @@ def _render_toml(config: dict[str, object]) -> str:
     for table_name, known_keys in _KNOWN_TOML_KEYS.items():
         lines.append(_TOML_TABLE_COMMENTS[table_name])
         lines.append(f"[{table_name}]")
-        table = cast(dict[str, object], config[table_name])
+        table = config[table_name]
         for key in known_keys:
-            if key in table:
-                lines.append(f"{key} = {_toml_value(table[key])}")
-            elif table_name == "identity":
-                lines.append(f'# {key} = "{"email" if key == "jwt_identity_claim" else ""}"')
-            else:
-                lines.append(f'# {key} = ""')
+            lines.append(f"{key} = {_toml_value(table[key])}")
         additions = {
-            key: value
-            for key, value in table.items()
-            if key not in known_keys
-            and key != "env"
-            and not isinstance(value, dict)
-            and not _is_table_array(value)
+            key: value for key, value in table.items() if key not in known_keys and key != "env"
         }
         if additions:
             if known_keys:
@@ -575,65 +551,23 @@ def _render_toml(config: dict[str, object]) -> str:
                     )
                 )
             lines.append("[sandbox.env]")
-            sandbox_env = cast(dict[str, object], table["env"])
-            for key, value in sandbox_env.items():
+            for key, value in table["env"].items():
                 lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
             lines.append("")
 
-    unknown_tables: list[tuple[tuple[str, ...], dict[str, object], bool]] = []
-    for key, value in config.items():
-        if isinstance(value, dict) and key not in _KNOWN_TOML_KEYS:
-            unknown_tables.append(((key,), value, False))
-        elif _is_table_array(value):
-            for table in value:
-                unknown_tables.append(((key,), table, True))
-    for table_name in _KNOWN_TOML_KEYS:
-        table = cast(dict[str, object], config[table_name])
-        for key, value in table.items():
-            if isinstance(value, dict) and not (table_name == "sandbox" and key == "env"):
-                unknown_tables.append(((table_name, key), value, False))
-            elif _is_table_array(value):
-                for item in value:
-                    unknown_tables.append(((table_name, key), item, True))
-
+    unknown_tables = {
+        key: value
+        for key, value in config.items()
+        if key not in _KNOWN_TOML_KEYS and isinstance(value, dict)
+    }
     if unknown_tables:
         lines.extend(("# " + "=" * 60, "# OPERATOR ADDITIONS", "# " + "=" * 60, ""))
-        for path, table, is_array in unknown_tables:
-            lines.extend(_render_unknown_table(path, table, is_array=is_array))
+        for name, table in unknown_tables.items():
+            lines.append(f"[{_toml_key(name)}]")
+            lines.extend(f"{_toml_key(key)} = {_toml_value(value)}" for key, value in table.items())
+            lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"
-
-
-def _render_unknown_table(
-    path: tuple[str, ...],
-    table: dict[str, object],
-    *,
-    is_array: bool,
-) -> list[str]:
-    path_text = ".".join(_toml_key(part) for part in path)
-    brackets = "[[" if is_array else "["
-    closing_brackets = "]]" if is_array else "]"
-    lines = [f"{brackets}{path_text}{closing_brackets}"]
-    nested: list[tuple[str, dict[str, object]]] = []
-    arrays: list[tuple[str, list[dict[str, object]]]] = []
-    for key, value in table.items():
-        if isinstance(value, dict):
-            nested.append((key, value))
-        elif _is_table_array(value):
-            arrays.append((key, value))
-        else:
-            lines.append(f"{_toml_key(key)} = {_toml_value(value)}")
-    lines.append("")
-    for key, value in nested:
-        lines.extend(_render_unknown_table((*path, key), value, is_array=False))
-    for key, values in arrays:
-        for value in values:
-            lines.extend(_render_unknown_table((*path, key), value, is_array=True))
-    return lines
-
-
-def _is_table_array(value: object) -> TypeGuard[list[dict[str, object]]]:
-    return isinstance(value, list) and bool(value) and all(isinstance(item, dict) for item in value)
 
 
 def _toml_key(value: str) -> str:
@@ -642,25 +576,12 @@ def _toml_key(value: str) -> str:
     return f'"{_escape_toml_string(value)}"'
 
 
-def _toml_value(value: object) -> str:
+def _toml_value(value: str | int | float | bool) -> str:
     if isinstance(value, str):
         return f'"{_escape_toml_string(value)}"'
     if isinstance(value, bool):
         return "true" if value else "false"
-    if isinstance(value, int):
-        return str(value)
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise ValueError("druks.toml: non-finite floats are unsupported")
-        return repr(value)
-    if isinstance(value, (datetime, date, time)):
-        return value.isoformat()
-    if isinstance(value, list):
-        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
-    if isinstance(value, dict):
-        items = (f"{_toml_key(key)} = {_toml_value(item)}" for key, item in value.items())
-        return "{ " + ", ".join(items) + " }"
-    raise ValueError(f"druks.toml: unsupported operator value {value!r}")
+    return repr(value)
 
 
 def _escape_toml_string(value: str) -> str:
@@ -670,7 +591,7 @@ def _escape_toml_string(value: str) -> str:
 
 
 def _render_env(
-    config: dict[str, object],
+    config: dict[str, Any],
     *,
     install_dir: str,
     extras: dict[str, str],
@@ -695,8 +616,7 @@ def _render_env(
             lines.extend(section_lines)
             lines.append("")
 
-    sandbox = cast(dict[str, object], config["sandbox"])
-    sandbox_env = cast(dict[str, str], sandbox["env"])
+    sandbox_env: dict[str, str] = config["sandbox"]["env"]
     if provider != "docker":
         pass_through = []
         for key, value in sandbox_env.items():
@@ -717,7 +637,7 @@ def _render_env(
                 )
             )
 
-    deployment_env = cast(dict[str, str], config["env"])
+    deployment_env: dict[str, str] = config["env"]
     additions = []
     for key, value in deployment_env.items():
         if key in _OWNED_ENV_KEYS or not value:
@@ -772,7 +692,7 @@ def _is_reserved_env_key(key: str) -> bool:
 
 
 def _collect_gaps(
-    config: dict[str, object],
+    config: dict[str, Any],
     *,
     env_path: Path,
     install_dir: str,
@@ -800,13 +720,12 @@ def _collect_gaps(
                 gaps.append(f"{env_key} is empty")
 
     provider = _get_string(config, ("sandbox", "provider"))
-    sandbox = cast(dict[str, object], config["sandbox"])
-    sandbox_env = cast(dict[str, str], sandbox["env"])
+    sandbox_env: dict[str, str] = config["sandbox"]["env"]
     for key in sandbox_env:
         if _is_reserved_env_key(key):
             gaps.append(f"sandbox.env.{key} is reserved by druks")
 
-    deployment_env = cast(dict[str, str], config["env"])
+    deployment_env: dict[str, str] = config["env"]
     for key in deployment_env:
         if key in _OWNED_ENV_KEYS:
             gaps.append(f"env.{key} is reserved by druks")

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -1,6 +1,8 @@
+import stat
+import tomllib
 from pathlib import Path
 
-from druks.setup_env import GAPS_EXIT_CODE, read_env, run_setup
+from druks.setup_env import GAPS_EXIT_CODE, MIGRATION_EXIT_CODE, read_env, run_setup
 
 
 def _run(env_path: Path, **overrides):
@@ -15,170 +17,333 @@ def _run(env_path: Path, **overrides):
     return run_setup(env_path, **kwargs)
 
 
-def test_fresh_run_writes_template_with_secrets_and_reports_gaps(tmp_path):
+def _read_toml(path: Path) -> dict:
+    with path.open("rb") as config_file:
+        return tomllib.load(config_file)
+
+
+def test_fresh_exe_render_matches_the_deployment_contract(tmp_path):
     env_path = tmp_path / ".env"
 
-    rc = _run(env_path)
+    assert _run(env_path) == GAPS_EXIT_CODE
 
-    assert rc == GAPS_EXIT_CODE  # required values are blank on a fresh box
     values = read_env(env_path)
-    # Secrets generated, not blank, and drukbox's token list mirrors ours.
-    assert len(values["DRUKS_WEBHOOK_SECRET"]) == 64
-    assert values["SERVICE_TOKENS"] == values["DRUKS_SANDBOX_SERVICE_TOKEN"]
-    # Path defaults rendered against the HOST install dir / home.
-    assert values["GITHUB_OPERATOR_PEM"] == "/home/op/druks/secrets/operator.pem"
-    assert values["DRUKS_DATA_DIR"] == "/home/op/druks-data"
-    # Provider block present.
+    config = _read_toml(tmp_path / "druks.toml")
     assert values["DEFAULT_HOST_PROVIDER"] == "exe"
     assert values["TAILSCALE_ENABLED"] == "true"
-    # exe.dev is the identity edge; druks maps its asserted email header.
+    assert values["EXE_API_URL"] == "https://exe.dev"
+    assert values["EXE_DEFAULT_IMAGE"] == "ghcr.io/boldsoftware/exeuntu:latest"
     assert values["DRUKS_AUTH_MODE"] == "header"
     assert values["DRUKS_AUTH_HEADER"] == "X-ExeDev-Email"
-    # The secrets dir is created alongside.
+    assert values["SERVICE_TOKENS"] == values["DRUKS_SANDBOX_SERVICE_TOKEN"]
+    assert values["GITHUB_OPERATOR_PEM"] == "/home/op/druks/secrets/operator.pem"
+    assert values["DRUKS_DATA_DIR"] == "/home/op/druks-data"
+    assert "EXE_API_TOKEN" not in values
+    assert "TAILSCALE_TAILNET" not in values
+    assert len(config["secrets"]["postgres_password"]) == 64
+    assert len(config["secrets"]["webhook_secret"]) == 64
+    assert len(config["secrets"]["announce_token_secret"]) == 43
+    assert len(config["secrets"]["sandbox_service_token"]) == 64
     assert (tmp_path / "secrets").is_dir()
+    assert (tmp_path / ".gitignore").read_text().splitlines() == [
+        "druks.toml",
+        ".env",
+        "secrets/",
+    ]
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE((tmp_path / "druks.toml").stat().st_mode) == 0o600
 
 
-def test_aws_provider_block(tmp_path):
+def test_generic_remote_passes_provider_environment_without_enumeration(tmp_path):
     env_path = tmp_path / ".env"
 
-    _run(env_path, provider="aws")
+    def answer(prompt):
+        if prompt.startswith("Identity header"):
+            return "X-Forwarded-Email"
+        return ""
+
+    _run(
+        env_path,
+        provider="exoscale",
+        interactive=True,
+        input_fn=answer,
+        set_values=("sandbox.env.EXOSCALE_API_KEY=key",),
+    )
 
     values = read_env(env_path)
-    assert values["DEFAULT_HOST_PROVIDER"] == "aws"
-    # A remote shape reaches the dashboard through its own edge — no localhost
-    # default leaks in; the operator supplies the real public URL.
-    assert values["DRUKS_ENDPOINT"] == ""
-    assert values["TAILSCALE_ENABLED"] == "false"
-    assert "AWS_REGION" in values
-    # Bring-your-own-edge: header mode, and the operator must name the header
-    # their proxy injects — a required gap, never a guessed default.
-    assert values["DRUKS_AUTH_MODE"] == "header"
-    assert values["DRUKS_AUTH_HEADER"] == ""
-    # The sandbox-VM instance profile stays a documented, commented knob.
-    assert "# AWS_INSTANCE_PROFILE=" in env_path.read_text()
+    assert values["DEFAULT_HOST_PROVIDER"] == "exoscale"
+    assert values["DRUKS_AUTH_HEADER"] == "X-Forwarded-Email"
+    assert values["EXOSCALE_API_KEY"] == "key"
+    assert "AWS_REGION" not in values
+    assert "EXE_API_TOKEN" not in values
+    assert "TAILSCALE_ENABLED" not in values
 
 
-def test_docker_provider_wires_drukbox_on_host(tmp_path):
-    """The provider choice selects the drukbox wiring block, nothing else —
-    required values and PEMs gate the boot the same as any provider."""
+def test_docker_shape_matches_local_wiring_and_ignores_sandbox_env(tmp_path):
     env_path = tmp_path / ".env"
 
-    rc = _run(env_path, provider="docker")
+    assert (
+        _run(
+            env_path,
+            provider="docker",
+            set_values=("sandbox.env.DOCKER_HOST=tcp://elsewhere",),
+        )
+        == GAPS_EXIT_CODE
+    )
 
-    assert rc == GAPS_EXIT_CODE  # same GitHub/PEM gaps as every shape
     values = read_env(env_path)
     assert values["DEFAULT_HOST_PROVIDER"] == "docker"
-    # Pointed at drukbox on the host (`make dev`), not a drukbox container.
     assert values["DRUKS_SANDBOX_SERVICE_URL"] == "http://127.0.0.1:8000"
     assert values["DRUKS_SANDBOX_SERVICE_TOKEN"] == "dev-token"
-    assert values["DRUKS_SANDBOX_IMAGE"].endswith("druks-sandbox:latest")
-    assert "TAILSCALE_TAILNET" not in values and "AWS_REGION" not in values
-    # The local dashboard's URL is fixed, so the OAuth-MCP callback base is
-    # defaulted — connecting an OAuth MCP server works without a manual edit.
+    assert values["DRUKS_SANDBOX_IMAGE"] == "ghcr.io/czpython/druks-sandbox:latest"
     assert values["DRUKS_ENDPOINT"] == "http://localhost:8001"
-    # Loopback dashboard, no edge: identity mode none.
     assert values["DRUKS_AUTH_MODE"] == "none"
     assert "DRUKS_AUTH_HEADER" not in values
+    assert "SERVICE_TOKENS" not in values
+    assert "DOCKER_HOST" not in values
 
 
-def test_rerun_preserves_values_secrets_and_operator_additions(tmp_path):
+def test_pre_toml_guard_refuses_without_writing(tmp_path):
     env_path = tmp_path / ".env"
-    _run(env_path)
-    first = read_env(env_path)
-    # Operator fills a value and adds a custom var by hand.
-    env_path.write_text(
-        env_path.read_text().replace("GITHUB_OPERATOR_APP_ID=", "GITHUB_OPERATOR_APP_ID=111")
-        + "\nMY_CUSTOM_FLAG=on\n"
+    env_path.write_text("DRUKS_POSTGRES_PASSWORD=keep\n")
+    before = env_path.read_bytes()
+    printed = []
+
+    rc = _run(env_path, print_fn=printed.append)
+
+    assert rc == MIGRATION_EXIT_CODE
+    assert env_path.read_bytes() == before
+    assert {path.name for path in tmp_path.iterdir()} == {".env"}
+    output = "\n".join(printed)
+    for key in (
+        "DRUKS_POSTGRES_PASSWORD",
+        "DRUKS_SECRETS_KEY",
+        "DRUKS_WEBHOOK_SECRET",
+        "ANNOUNCE_TOKEN_SECRET",
+        "DRUKS_SANDBOX_SERVICE_TOKEN",
+        "GITHUB_*_APP_ID",
+        "[sandbox.env]",
+        "other hand-added .env keys → [env]",
+    ):
+        assert key in output
+
+
+def test_set_updates_toml_and_rerender_preserves_the_values(tmp_path):
+    env_path = tmp_path / ".env"
+    _run(
+        env_path,
+        provider="docker",
+        set_values=(
+            "github.operator_app_id=101",
+            "secrets.webhook_secret=github-secret",
+        ),
     )
 
-    _run(env_path)
+    printed = []
+    _run(
+        env_path,
+        provider="exoscale",
+        set_values=("secrets.webhook_secret=rotated-secret",),
+        print_fn=printed.append,
+    )
 
+    config = _read_toml(tmp_path / "druks.toml")
     values = read_env(env_path)
-    assert values["GITHUB_OPERATOR_APP_ID"] == "111"
-    assert values["DRUKS_WEBHOOK_SECRET"] == first["DRUKS_WEBHOOK_SECRET"]  # not regenerated
-    assert values["MY_CUSTOM_FLAG"] == "on"  # hand edits survive
+    assert config["github"]["operator_app_id"] == "101"
+    assert config["secrets"]["webhook_secret"] == "rotated-secret"
+    assert config["sandbox"]["provider"] == "docker"
+    assert values["GITHUB_OPERATOR_APP_ID"] == "101"
+    assert values["DRUKS_WEBHOOK_SECRET"] == "rotated-secret"
+    assert "docker compose up -d" in "\n".join(printed)
 
 
-def test_rerun_preserves_the_identity_header_choice(tmp_path):
+def test_generated_secrets_never_regenerate_on_rerun(tmp_path):
     env_path = tmp_path / ".env"
     _run(env_path)
-    env_path.write_text(
-        env_path.read_text().replace(
-            "DRUKS_AUTH_HEADER=X-ExeDev-Email", "DRUKS_AUTH_HEADER=X-Custom-Email"
-        )
+    first = _read_toml(tmp_path / "druks.toml")["secrets"]
+
+    _run(env_path, set_values=("github.operator_app_id=101",))
+
+    assert _read_toml(tmp_path / "druks.toml")["secrets"] == first
+
+
+def test_blank_toml_value_is_omitted_from_env(tmp_path):
+    env_path = tmp_path / ".env"
+
+    _run(env_path, set_values=("ticketing.linear_api_key=",))
+
+    assert "LINEAR_API_KEY" not in read_env(env_path)
+    assert "LINEAR_API_KEY=" not in env_path.read_text()
+
+
+def test_deployment_env_addition_renders_verbatim_and_survives_rerender(tmp_path):
+    env_path = tmp_path / ".env"
+    _run(
+        env_path,
+        provider="docker",
+        set_values=(
+            "env.SLACK_SIGNING_SECRET=slack-secret",
+            "env.DRUKS_SANDBOX_SERVICE_TIMEOUT=45",
+        ),
     )
 
     _run(env_path)
 
-    assert read_env(env_path)["DRUKS_AUTH_HEADER"] == "X-Custom-Email"
+    config = _read_toml(tmp_path / "druks.toml")
+    assert config["env"]["SLACK_SIGNING_SECRET"] == "slack-secret"
+    assert read_env(env_path)["SLACK_SIGNING_SECRET"] == "slack-secret"
+    assert read_env(env_path)["DRUKS_SANDBOX_SERVICE_TIMEOUT"] == "45"
+    assert "# DEPLOYMENT ENVIRONMENT ADDITIONS" in env_path.read_text()
 
 
-def test_rerun_keeps_the_provider_the_env_was_written_with(tmp_path):
+def test_blank_deployment_env_addition_is_omitted(tmp_path):
     env_path = tmp_path / ".env"
-    _run(env_path, provider="aws")
 
-    _run(env_path, provider="exe")  # flag ignored on re-run
+    _run(env_path, provider="docker", set_values=("env.JIRA_API_TOKEN=",))
 
-    assert read_env(env_path)["DEFAULT_HOST_PROVIDER"] == "aws"
+    assert "JIRA_API_TOKEN" not in read_env(env_path)
+    assert "JIRA_API_TOKEN=" not in env_path.read_text()
 
 
-def test_interactive_prompts_fill_only_blanks(tmp_path):
+def test_owned_deployment_env_key_is_a_named_gap_and_is_not_rendered(tmp_path):
     env_path = tmp_path / ".env"
-    answers = iter(
-        [
-            "111",  # operator app id
-            "222",  # reviewer app id
-            "",  # linear api key — skipped
-            "",  # linear webhook secret — skipped
-            "",  # druks endpoint — skipped
-            "tail.ts.net",  # tailnet
-            "",  # ts oauth client id
-            "",  # ts oauth client secret
-            "exe-token",  # exe api token
-        ]
+    printed = []
+
+    rc = _run(
+        env_path,
+        provider="docker",
+        set_values=("env.DRUKS_ENDPOINT=wrong",),
+        print_fn=printed.append,
     )
 
-    rc = _run(env_path, interactive=True, input_fn=lambda _prompt: next(answers))
-
-    values = read_env(env_path)
-    assert values["GITHUB_OPERATOR_APP_ID"] == "111"
-    assert values["GITHUB_REVIEWER_APP_ID"] == "222"
-    assert values["EXE_API_TOKEN"] == "exe-token"
-    # Required values all present — only the PEM files gate the boot now.
     assert rc == GAPS_EXIT_CODE
-    gaps_cleared = _run(env_path, interactive=False)
-    assert gaps_cleared == GAPS_EXIT_CODE  # still missing PEM files
-
-    # Drop the PEMs in → boot-ready.
-    (tmp_path / "secrets" / "operator.pem").write_text("pem")
-    (tmp_path / "secrets" / "reviewer.pem").write_text("pem")
-    assert _run(env_path) == 0
+    assert "env.DRUKS_ENDPOINT is reserved by druks" in "\n".join(printed)
+    assert read_env(env_path)["DRUKS_ENDPOINT"] == "http://localhost:8001"
 
 
-def test_rerun_with_complete_env_prompts_nothing(tmp_path):
+def test_reserved_sandbox_env_key_is_a_named_gap_and_is_not_rendered(tmp_path):
     env_path = tmp_path / ".env"
-    answers = iter(["111", "222", "", "", "", "t.ts.net", "", "", "tok"])
-    _run(env_path, interactive=True, input_fn=lambda _p: next(answers))
-    (tmp_path / "secrets" / "operator.pem").write_text("pem")
-    (tmp_path / "secrets" / "reviewer.pem").write_text("pem")
+    printed = []
 
-    def explode(_prompt):
-        raise AssertionError("prompted despite complete .env")
-
-    assert _run(env_path, interactive=True, input_fn=explode) == 0
-
-
-def test_custom_pem_location_is_not_boot_gated(tmp_path):
-    """A PEM outside the install dir can't be checked pre-boot — doctor owns
-    that post-boot; setup must not block on it."""
-    env_path = tmp_path / ".env"
-    answers = iter(["111", "222", "", "", "", "t.ts.net", "", "", "tok"])
-    _run(env_path, interactive=True, input_fn=lambda _p: next(answers))
-    body = env_path.read_text().replace(
-        "GITHUB_OPERATOR_PEM=/home/op/druks/secrets/operator.pem",
-        "GITHUB_OPERATOR_PEM=/etc/keys/operator.pem",
+    rc = _run(
+        env_path,
+        provider="exoscale",
+        set_values=(
+            "sandbox.env.EXOSCALE_API_KEY=key",
+            "sandbox.env.DATABASE_URL=wrong",
+        ),
+        print_fn=printed.append,
     )
-    env_path.write_text(body)
+
+    assert rc == GAPS_EXIT_CODE
+    assert "sandbox.env.DATABASE_URL is reserved by druks" in "\n".join(printed)
+    assert read_env(env_path)["DATABASE_URL"] == "sqlite+aiosqlite:////data/drukbox.db"
+
+
+def test_deleted_env_is_regenerated_byte_identically(tmp_path):
+    env_path = tmp_path / ".env"
+    _run(env_path)
+    expected = env_path.read_bytes()
+    env_path.unlink()
+
+    _run(env_path)
+
+    assert env_path.read_bytes() == expected
+
+
+def test_compose_plane_env_additions_survive_rerender(tmp_path):
+    env_path = tmp_path / ".env"
+    _run(env_path, provider="docker")
+    env_path.write_text(env_path.read_text() + "DRUKS_UID=1000\nCOMPOSE_PROFILES=\n")
+
+    _run(env_path)
+
+    values = read_env(env_path)
+    assert values["DRUKS_UID"] == "1000"
+    assert "COMPOSE_PROFILES" in values
+    assert values["COMPOSE_PROFILES"] == ""
+    assert "# OPERATOR ADDITIONS" in env_path.read_text()
+
+
+def test_unknown_toml_values_survive_a_writer_pass(tmp_path):
+    env_path = tmp_path / ".env"
+    _run(env_path, provider="docker")
+    toml_path = tmp_path / "druks.toml"
+    body = toml_path.read_text()
+    body = body.replace(
+        'operator_app_id = ""',
+        'operator_app_id = ""\ncustom_label = "blue"',
+    )
+    body += "\n[operator]\nretries = 4\nenabled = true\n"
+    toml_path.write_text(body)
+
+    _run(env_path, set_values=("github.operator_app_id=101",))
+
+    config = _read_toml(toml_path)
+    assert config["github"]["custom_label"] == "blue"
+    assert config["operator"] == {"retries": 4, "enabled": True}
+    assert "# OPERATOR ADDITIONS" in toml_path.read_text()
+
+
+def test_missing_known_tables_are_canonicalized_before_rerender(tmp_path):
+    env_path = tmp_path / ".env"
+    _run(env_path, provider="docker")
+    toml_path = tmp_path / "druks.toml"
+    body = toml_path.read_text()
+    body = body.replace("[ticketing]", "[ticketing-renamed]")
+    body = body.replace("[sandbox.env]\n", "")
+    body = body.replace('provider = "docker"\n', "")
+    toml_path.write_text(body)
+    printed = []
+
+    rc = _run(
+        env_path,
+        set_values=("github.operator_app_id=101",),
+        print_fn=printed.append,
+    )
+
+    config = _read_toml(toml_path)
+    assert rc == GAPS_EXIT_CODE
+    assert "DEFAULT_HOST_PROVIDER is empty" in "\n".join(printed)
+    assert "GITHUB_REVIEWER_APP_ID is empty" in "\n".join(printed)
+    assert config["ticketing"] == {"linear_api_key": "", "linear_webhook_secret": ""}
+    assert "ticketing-renamed" in config
+    assert config["sandbox"]["env"] == {}
+
+
+def test_interactive_rerun_prompts_only_for_required_blanks(tmp_path):
+    env_path = tmp_path / ".env"
+
+    def answer(prompt):
+        answers = {
+            "Operator GitHub App": "101",
+            "Reviewer GitHub App": "202",
+            "exe.dev API token": "exe-token",
+            "Tailscale magic-DNS": "tail.ts.net",
+        }
+        return next((value for label, value in answers.items() if label in prompt), "")
+
+    _run(env_path, interactive=True, input_fn=answer)
+    (tmp_path / "secrets" / "operator.pem").write_text("pem")
     (tmp_path / "secrets" / "reviewer.pem").write_text("pem")
 
-    assert _run(env_path) == 0
+    def fail_on_prompt(prompt):
+        raise AssertionError(f"unexpected prompt: {prompt}")
+
+    assert _run(env_path, interactive=True, input_fn=fail_on_prompt) == 0
+
+
+def test_fresh_interactive_run_prompts_for_provider_first(tmp_path):
+    env_path = tmp_path / ".env"
+    prompts = []
+
+    def answer(prompt):
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            return "docker"
+        return ""
+
+    _run(env_path, provider="exe", interactive=True, input_fn=answer)
+
+    assert prompts[0] == "Sandbox provider [exe]: "
+    assert _read_toml(tmp_path / "druks.toml")["sandbox"]["provider"] == "docker"

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -285,7 +285,9 @@ def test_operator_edits_survive_a_writer_pass(tmp_path):
     assert "# our app, registered 2026-07 by ops" in written
 
 
-def test_missing_known_tables_are_canonicalized_before_rerender(tmp_path):
+def test_missing_known_tables_gap_without_rewriting_the_operators_file(tmp_path):
+    """Canonicalization fills missing tables in memory for the render; the
+    operator's file keeps exactly the shape they wrote."""
     env_path = tmp_path / ".env"
     _run(env_path, provider="docker")
     toml_path = tmp_path / "druks.toml"
@@ -306,9 +308,11 @@ def test_missing_known_tables_are_canonicalized_before_rerender(tmp_path):
     assert rc == GAPS_EXIT_CODE
     assert "DEFAULT_HOST_PROVIDER is empty" in "\n".join(printed)
     assert "GITHUB_REVIEWER_APP_ID is empty" in "\n".join(printed)
-    assert config["ticketing"] == {"linear_api_key": "", "linear_webhook_secret": ""}
+    assert "ticketing" not in config
     assert "ticketing-renamed" in config
-    assert config["sandbox"]["env"] == {}
+    assert "env" not in config["sandbox"]
+    assert config["github"]["operator_app_id"] == "101"
+    assert read_env(env_path)["GITHUB_OPERATOR_APP_ID"] == "101"
 
 
 def test_nested_operator_content_is_refused(tmp_path):

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -264,14 +264,14 @@ def test_compose_plane_env_additions_survive_rerender(tmp_path):
     assert "# OPERATOR ADDITIONS" in env_path.read_text()
 
 
-def test_unknown_toml_values_survive_a_writer_pass(tmp_path):
+def test_operator_edits_survive_a_writer_pass(tmp_path):
     env_path = tmp_path / ".env"
     _run(env_path, provider="docker")
     toml_path = tmp_path / "druks.toml"
     body = toml_path.read_text()
     body = body.replace(
         'operator_app_id = ""',
-        'operator_app_id = ""\ncustom_label = "blue"',
+        '# our app, registered 2026-07 by ops\noperator_app_id = ""\ncustom_label = "blue"',
     )
     body += "\n[operator]\nretries = 4\nenabled = true\n"
     toml_path.write_text(body)
@@ -279,9 +279,10 @@ def test_unknown_toml_values_survive_a_writer_pass(tmp_path):
     _run(env_path, set_values=("github.operator_app_id=101",))
 
     config = _read_toml(toml_path)
+    written = toml_path.read_text()
     assert config["github"]["custom_label"] == "blue"
     assert config["operator"] == {"retries": 4, "enabled": True}
-    assert "# OPERATOR ADDITIONS" in toml_path.read_text()
+    assert "# our app, registered 2026-07 by ops" in written
 
 
 def test_missing_known_tables_are_canonicalized_before_rerender(tmp_path):

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -2,6 +2,7 @@ import stat
 import tomllib
 from pathlib import Path
 
+import pytest
 from druks.setup_env import GAPS_EXIT_CODE, MIGRATION_EXIT_CODE, read_env, run_setup
 
 
@@ -307,6 +308,19 @@ def test_missing_known_tables_are_canonicalized_before_rerender(tmp_path):
     assert config["ticketing"] == {"linear_api_key": "", "linear_webhook_secret": ""}
     assert "ticketing-renamed" in config
     assert config["sandbox"]["env"] == {}
+
+
+def test_nested_operator_content_is_refused(tmp_path):
+    """Operator additions are flat scalars, one table deep — druks.toml is
+    druks' file, and structure it can't own round-trip is refused, not
+    silently re-rendered."""
+    env_path = tmp_path / ".env"
+    _run(env_path, provider="docker")
+    toml_path = tmp_path / "druks.toml"
+    toml_path.write_text(toml_path.read_text() + "\n[operator.nested]\nvalue = 1\n")
+
+    with pytest.raises(ValueError, match="operator.nested"):
+        _run(env_path)
 
 
 def test_interactive_rerun_prompts_only_for_required_blanks(tmp_path):

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -42,7 +42,6 @@ def test_fresh_exe_render_matches_the_deployment_contract(tmp_path):
     assert "TAILSCALE_TAILNET" not in values
     assert len(config["secrets"]["postgres_password"]) == 64
     assert len(config["secrets"]["webhook_secret"]) == 64
-    assert len(config["secrets"]["announce_token_secret"]) == 43
     assert len(config["secrets"]["sandbox_service_token"]) == 64
     assert (tmp_path / "secrets").is_dir()
     assert (tmp_path / ".gitignore").read_text().splitlines() == [
@@ -119,7 +118,6 @@ def test_pre_toml_guard_refuses_without_writing(tmp_path):
         "DRUKS_POSTGRES_PASSWORD",
         "DRUKS_SECRETS_KEY",
         "DRUKS_WEBHOOK_SECRET",
-        "ANNOUNCE_TOKEN_SECRET",
         "DRUKS_SANDBOX_SERVICE_TOKEN",
         "GITHUB_*_APP_ID",
         "[sandbox.env]",

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,11 +2,12 @@
 
 The whole stack runs in Docker Compose: Druks (`web`, which embeds the DBOS
 durable engine and serves the dashboard SPA), Postgres, and Redis. A
-**remote** install (`DRUKS_PROVIDER=exe`/`aws`) also brings up stock Caddy
-(identity edge + proxy, Caddyfile bind-mounted) and the Drukbox sandbox control
-plane (`sandbox-service`, `sandbox-janitor`). Those three live in the compose
-`remote` profile, which `install.sh` selects by writing `COMPOSE_PROFILES` to
-`.env`, so plain `docker compose` commands in the install dir pick it up.
+**remote** install (any `DRUKS_PROVIDER` except `docker`) also brings up stock
+Caddy (identity edge + proxy, Caddyfile bind-mounted) and the Drukbox sandbox
+control plane (`sandbox-service`, `sandbox-janitor`). Those three live in the
+Compose `remote` profile, which `install.sh` selects by writing
+`COMPOSE_PROFILES` to `.env`, so plain `docker compose` commands in the install
+dir pick it up.
 
 A **local** install (`DRUKS_PROVIDER=docker`) runs neither: the dashboard is
 reached directly on `127.0.0.1:8001` and sandboxes are local Docker
@@ -15,23 +16,24 @@ containers with drukbox on the host — see
 
 The Druks services use the **host network** so they can reach Postgres, Redis,
 Drukbox, and provider-specific sandbox addresses from the host network
-namespace. The default exe.dev profile reaches VMs over the host's tailnet;
+namespace. The default exe.dev shape reaches VMs over the host's tailnet;
 other providers may return directly reachable SSH addresses.
 
 ## First-time setup on a fresh box
 
-Prerequisites: Docker with the Compose plugin. The default exe.dev profile also
+Prerequisites: Docker with the Compose plugin. The default exe.dev shape also
 needs `tailscaled` joined to the intended tailnet (`tailscale status` shows
-peers). AWS uses its own network and credential block; the local Docker profile
-is covered in [Full local](../docs/full-local.md).
+peers). Other remote providers have their own network and credential
+requirements; the local Docker shape is covered in
+[Full local](../docs/full-local.md).
 
 The Druks application and sandbox images are published for both `linux/amd64`
 and `linux/arm64`.
 
-Everything else — `compose.yaml`, the Caddyfile, `.env`, image pulls,
-DB init — is handled by `install.sh`. (While the ghcr.io images
-require auth, export `GHCR_TOKEN` — a PAT with `read:packages` — and
-the installer logs in with it.)
+Everything else — `compose.yaml`, the Caddyfile, `druks.toml`, the rendered
+`.env`, image pulls, and DB init — is handled by `install.sh`. (While the
+ghcr.io images require auth, export `GHCR_TOKEN` — a PAT with `read:packages`
+— and the installer logs in with it.)
 
 ### 1. Run the installer
 
@@ -39,24 +41,28 @@ the installer logs in with it.)
 bash <(curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh)
 ```
 
-First pass writes `~/druks/.env` with random secrets pre-filled,
-creates `~/druks/secrets/`, and exits. It tells you exactly what to do
-next:
+First pass writes `~/druks/druks.toml` with random secrets pre-filled, creates
+`~/druks/secrets/`, renders `~/druks/.env`, and exits when required values are
+missing. It tells you exactly what to do next:
 
-- Fill in the blanks at the top of `.env` (the sandbox provider block).
+- Edit `druks.toml`. For a generic remote shape, fill `[sandbox.env]` from
+  Drukbox's [configuration reference](https://github.com/czpython/drukbox).
 - Provision the two GitHub Apps: re-run the installer with `--apps`.
   It registers each app via GitHub's manifest flow — it prints a link
   per app, you open it, click Create, then paste the `?code=...` from
   the redirect back into the SSH session. App ids, PEMs, and the
-  webhook secret are written in place. (Manual fallback: create the
+  webhook secret are applied through `druks setup`, the single
+  `druks.toml` writer. (Manual fallback: create the
   apps by hand per the permission tables in
-  [`docs/configuration.md`](../docs/configuration.md) and upload the
-  PEMs to `~/druks/secrets/{operator,reviewer}.pem`.)
+  [`docs/configuration.md`](../docs/configuration.md), enter their ids under
+  `[github]`, and upload the PEMs to
+  `~/druks/secrets/{operator,reviewer}.pem`.)
+
 The sandbox backend defaults to exe.dev + Tailscale. Pass `DRUKS_PROVIDER`
-on the first run to choose another: `aws` (EC2 — the `.env` carries the
-`AWS_*` block of region, AMI, and credentials instead) or `docker` (local
-sandboxes, drukbox on the host; see [Full local](../docs/full-local.md)).
-Re-runs read the choice back from `.env`, so you only set it once.
+on the first run to choose another. `docker` selects the local shape; any other
+Drukbox provider name selects the generic remote shape and is passed through
+without a Druks provider registry. Re-runs read `[sandbox].provider` from
+`druks.toml`, so the environment flag is only a fresh-install seed.
 
 Override the install dir with `DRUKS_INSTALL_DIR=/srv/druks` if you
 want it elsewhere.
@@ -67,8 +73,8 @@ want it elsewhere.
 bash <(curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh)
 ```
 
-Second pass validates that the required `.env` keys and PEMs are present,
-then: `docker compose pull` → migrate the databases out of band
+Second pass renders `.env` from `druks.toml`, validates the required values and
+PEMs, then: `docker compose pull` → migrate the databases out of band
 (`docker compose run --rm web druks init-db`, plus drukbox's schema on a
 remote install) → `docker compose up -d`. Nothing migrates on boot.
 
@@ -111,8 +117,8 @@ Public URLs: `https://<host>/_external/{github,linear,jira}/events/`
 (exe.dev authenticates at the edge; druks maps its asserted email to your
 account).
 
-**Elsewhere (e.g. AWS + Teleport)**, the dashboard goes through your
-identity proxy (set `DRUKS_AUTH_HEADER` to the header it injects), but
+**On another remote provider**, the dashboard goes through your identity proxy
+(set `[identity].header` in `druks.toml` to the header it injects), but
 webhook senders can't authenticate through SSO — they need their own
 public HTTPS path. The stack's Caddy provides it:
 
@@ -122,8 +128,8 @@ Druks' shipped Caddy dashboard listener is loopback HTTP behind that edge.
 
 1. Point an A-record (e.g. `druks.example.com`) at the box and open
    inbound 80 + 443.
-2. Set `DRUKS_WEBHOOK_HOST=druks.example.com` in `.env` and
-   `docker compose up -d caddy`.
+2. Set `[urls].webhook_host = "druks.example.com"` in `druks.toml` and re-run
+   the installer.
 
 Caddy auto-provisions Let's Encrypt for that hostname and serves **only**
 `POST /_external/*` and the PAT-authenticated `/mcp` endpoint on it — no
@@ -132,12 +138,12 @@ the public side. Webhook URLs become
 `https://druks.example.com/_external/<provider>/events/`; agents connect at
 `https://druks.example.com/mcp`
 ([Connect your agent](../docs/connect-your-agent.md)). Leave
-`DRUKS_WEBHOOK_HOST` unset to bring your own ingress instead.
+`[urls].webhook_host` blank to bring your own ingress instead.
 
 ## Update / redeploy
 
-Re-run the installer from the same version you intend to deploy. It always
-refreshes `compose.yaml` and the Caddyfile
+Edit `druks.toml`, then re-run the installer from the same version you intend
+to deploy. It renders `.env`, refreshes `compose.yaml` and the Caddyfile
 from the repo, applies any new migrations out of band
 (`docker compose run --rm web druks init-db`, plus drukbox's on a remote
 install), then runs `docker compose pull && up -d`, so it is the upgrade

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -142,7 +142,7 @@ These terms describe different ownership layers:
 | Harness | Platform adapter that invokes the Claude or Codex CLI for a model |
 | Workspace | Extension customization of what a call receives, such as a cloned repository |
 | Sandbox | Drukbox-provisioned isolated host where the harness process runs |
-| Provider | Drukbox backend that supplies the host; installer profiles are `exe`, `aws`, and `docker` |
+| Provider | Any Drukbox backend name that supplies the host; `docker` and `exe` select install shapes |
 
 Every agent call validates a strict Pydantic output contract, records model and
 cost metadata, and stores transcript, stderr, prompt, output, and a secret-free
@@ -179,7 +179,7 @@ extension or integration owns the provider payload and domain reaction.
 
 Configuration has two planes:
 
-- environment variables configure the process and deployment
+- `druks.toml` configures the deployment and renders the process environment
 - Postgres-backed settings configure operator profile, harness defaults,
   extension/workflow knobs, per-agent overrides, notifications, MCP servers,
   and skills

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,18 +1,61 @@
 # Configuration
 
-Druks has two configuration planes. Use environment variables for process and
+Druks has two authored configuration planes. Use `druks.toml` for process and
 deployment topology. Use the dashboard for operator choices that should change
 without replacing the process.
 
 | Plane | Examples | Stored in |
 | --- | --- | --- |
-| Environment | database, Redis, ingress, GitHub App keys, Drukbox, encryption key | `.env` / process environment |
+| Deployment | database, Redis, ingress, GitHub App keys, Drukbox, encryption key | `~/druks/druks.toml` |
 | Dashboard | timezone, harness connections/defaults, workflow and agent overrides, notifications, MCP servers, skills | Postgres |
 
-The [`Settings` model](../backend/druks/settings.py) is the authority for
-environment variables. [`.env.example`](../.env.example) is a development
-template; `druks setup` writes the larger deployment `.env` used by Compose and
+The installer renders the complete deployment `.env` from `druks.toml`; `.env`
+is a build artifact consumed by Compose, Druks, and Drukbox, not an authored
+configuration file. Edit `druks.toml` and re-run the installer to render and
+apply changes. Running `druks setup` alone re-renders `.env` but does not
+restart services.
+
+Format follows habitat: repository-committed files such as ship's
+`.druks/ship/config.yml` are YAML like the rest of the repository-dotfile
+world; box-resident operator files are TOML because they render to env
+byte-exact. The two files share no keys and no reader.
+
+The [`Settings` model](../backend/druks/settings.py) remains the authority for
+process environment variables. [`.env.example`](../.env.example) is only the
+host-run development template.
+
+## Deployment file
+
+`druks.toml` has one table per operator concern:
+
+| Table | Purpose |
+| --- | --- |
+| `[identity]` | Browser identity mode and header or JWT verification inputs |
+| `[github]` | Operator and reviewer App ids and host PEM paths |
+| `[ticketing]` | Linear credentials |
+| `[urls]` | Dashboard callback base URL and public webhook hostname |
+| `[secrets]` | Generated deployment secrets |
+| `[paths]` | Host data and harness configuration paths |
+| `[sandbox]` | Drukbox provider, service URL, token behavior, and image override |
+| `[sandbox.env]` | Provider environment passed through to the remote stack |
+| `[env]` | Additional deployment environment settings rendered verbatim |
+
+A blank string is unset and is omitted from `.env`. Use `[env]` for settings
+without another `druks.toml` home, including additional `DRUKS_*` settings. A
+key already owned by the renderer is reported as a configuration gap instead
+of overriding its canonical value. On a remote shape,
+`[sandbox.env]` accepts the variables documented by
+[Drukbox](https://github.com/czpython/drukbox); Druks does not enumerate
+providers. `docker` and `exe` select shape-specific first-write templates.
+Every other provider name selects the generic remote shape and is validated by
 Drukbox.
+The local `docker` shape does not render `[sandbox.env]` because host-run
+Drukbox reads its own checkout's environment.
+
+Secrets are generated only when the TOML is first created. Preserve
+`[secrets]` when moving or recovering an installation. Use repeatable
+`druks setup ... --set key.path=value` arguments for explicit scripted writes;
+this is the same single-writer path used by `install.sh --apps`.
 
 ## Core process settings
 
@@ -138,7 +181,7 @@ bash <(curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/
 
 This uses the GitHub manifest files under
 [`scripts/manifests/`](../scripts/manifests) and writes the returned App ids,
-PEMs, and webhook secret into the install.
+PEMs, and webhook secret into the install through `druks setup`.
 
 ### Operator app
 
@@ -230,10 +273,12 @@ connected.
 | `DRUKS_SANDBOX_IMAGE` | Optional provider image override |
 | `DRUKS_SANDBOX_KEYS_DIR` | Per-host SSH private-key directory |
 
-`druks setup` also writes the selected Drukbox provider settings. The installer
-profiles are `exe`, `aws`, and `docker`; provider-specific credentials and host
-options are interpreted by Drukbox. See [deployment](../deploy/README.md) or
-[full local setup](full-local.md) for the topology.
+`[sandbox].provider` accepts any Drukbox provider name. `docker` selects the
+local install shape, `exe` selects the exe.dev + tailnet shape, and every other
+name selects the generic remote shape. Provider-specific credentials and host
+options live in `[sandbox.env]` and are interpreted by Drukbox. See
+[deployment](../deploy/README.md) or [full local setup](full-local.md) for the
+topology.
 
 ## Notifications
 
@@ -300,10 +345,11 @@ python3 -c 'import base64, os; print(base64.b64encode(os.urandom(32)).decode())'
 ```
 
 The first key encrypts new values; every listed key may decrypt. To rotate,
-prepend a new key:
+prepend a new key in `druks.toml`, then re-run the installer:
 
-```dotenv
-DRUKS_SECRETS_KEY=<new>,<old>
+```toml
+[secrets]
+secrets_key = "<new>,<old>"
 ```
 
 Keep the old key until no stored row depends on it. Losing every key used for a

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -32,7 +32,8 @@ DRUKS_PROVIDER=docker bash <(curl -fsSL https://raw.githubusercontent.com/czpyth
 
 The first run:
 
-- writes `~/druks/.env` with `DEFAULT_HOST_PROVIDER=docker`
+- writes `~/druks/druks.toml` with `[sandbox].provider = "docker"`
+- renders `~/druks/.env` with `DEFAULT_HOST_PROVIDER=docker`
 - generates the database, webhook, notification, and stored-secret keys
 - points Druks at Drukbox on `127.0.0.1:8000`
 - prints blank required fields and exits without booting if setup is incomplete
@@ -62,12 +63,12 @@ Tailscale disabled, and the `dev-token` expected by the local Druks setup.
 `DOCKER_SSH_USERNAME=druks` matches the non-root user in the shipped sandbox
 image.
 
-If port 8000 is already occupied, run Drukbox on another port and update
-`DRUKS_SANDBOX_SERVICE_URL` in `~/druks/.env`, then recreate the web service:
+If port 8000 is already occupied, run Drukbox on another port, set its URL in
+`~/druks/druks.toml`, then re-run the installer:
 
-```bash
-cd ~/druks
-docker compose up -d --force-recreate web
+```toml
+[sandbox]
+service_url = "http://127.0.0.1:8100"
 ```
 
 ## 3. Verify the first working system
@@ -140,9 +141,15 @@ Build it from the repository when changing the sandbox:
 docker build -t druks-sandbox deploy/sandbox
 ```
 
-Set `DRUKS_SANDBOX_IMAGE=druks-sandbox` in `~/druks/.env` and recreate the web
-service. Existing hosts keep their original image; new acquisitions use the
-updated value.
+Set the image in `~/druks/druks.toml`, then re-run the installer:
+
+```toml
+[sandbox]
+image = "druks-sandbox"
+```
+
+Existing hosts keep their original image; new acquisitions use the updated
+value.
 
 ## Webhook caveat
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,10 +15,10 @@ with the route that matches what you are doing.
 
 - [Full local setup](full-local.md) — Druks and sandbox containers on one
   machine.
-- [Deployment runbook](../deploy/README.md) — remote `exe` or `aws` install,
-  upgrades, rollback, logs, and public ingress.
-- [Configuration](configuration.md) — environment settings, dashboard settings,
-  integrations, MCP, skills, and stored-secret handling.
+- [Deployment runbook](../deploy/README.md) — any Drukbox provider, install
+  shapes, upgrades, rollback, logs, and public ingress.
+- [Configuration](configuration.md) — `druks.toml`, process settings, dashboard
+  settings, integrations, MCP, skills, and stored-secret handling.
 - [Connect your agent](connect-your-agent.md) — the `/mcp` endpoint, personal
   access tokens, and client configuration.
 - [Troubleshooting](troubleshooting.md) — symptom-driven diagnosis for boot,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,11 +32,11 @@ Read the named field in the error. Common causes:
 
 - `DRUKS_SECRETS_KEY` is empty, not valid base64, or does not decode to 32 bytes
 - a mounted PEM path differs from the path visible inside the container
-- a hand-edited `.env` contains a malformed value
+- a `druks.toml` value renders an invalid process setting
 
-Re-running `install.sh` preserves existing values, fills generated values, and
-prints remaining prerequisites. It does not overwrite a nonblank broken value;
-fix that value in `~/druks/.env`.
+Re-running `install.sh` renders `.env` from `druks.toml` and prints remaining
+prerequisites. It does not replace a nonblank broken value; fix that value in
+`~/druks/druks.toml` and re-run the installer.
 
 ### Postgres or Redis is unreachable
 
@@ -234,12 +234,12 @@ migration namespaces. See [writing an extension](writing-an-extension.md).
 Record:
 
 - Druks image tag and `git` revision if running from a checkout
-- provider profile (`exe`, `aws`, or `docker`)
+- sandbox provider name and install shape (`exe`, `docker`, or generic remote)
 - affected workflow id, subject, state, and last agent-call id
 - `druks doctor` output
 - relevant web and Drukbox logs with secret values removed
 - whether the failure happened before a step completed, during a gate, or after
   a deploy
 
-Do not include `.env`, PEM files, OAuth grants, sandbox credential files, or
-raw MCP tokens.
+Do not include `druks.toml`, `.env`, PEM files, OAuth grants, sandbox credential
+files, or raw MCP tokens.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "dbos>=2.26",
     "croniter>=6.2.2",
     "redis>=8",
+    "tomlkit>=0.13",
     "blinker>=1.9",
     "apprise>=1.9",
     "cryptography>=48.0.1",

--- a/scripts/_github_app_setup.py
+++ b/scripts/_github_app_setup.py
@@ -1,18 +1,33 @@
 import base64
 import json
+import os
+import subprocess
 import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
 
 ENV_PATH = Path(".env")
+TOML_PATH = Path("druks.toml")
 MANIFEST_DIR = Path(__file__).parent / "manifests"
 SETUP_PAGE = "https://druks.ai/app-setup/"
 
-# (role, env key, pem path, default app name)
+# (role, env key, TOML path, PEM path, default app name)
 ROLES = (
-    ("operator", "GITHUB_OPERATOR_APP_ID", Path("secrets/operator.pem"), "druks-operator"),
-    ("reviewer", "GITHUB_REVIEWER_APP_ID", Path("secrets/reviewer.pem"), "druks-critic"),
+    (
+        "operator",
+        "GITHUB_OPERATOR_APP_ID",
+        "github.operator_app_id",
+        Path("secrets/operator.pem"),
+        "druks-operator",
+    ),
+    (
+        "reviewer",
+        "GITHUB_REVIEWER_APP_ID",
+        "github.reviewer_app_id",
+        Path("secrets/reviewer.pem"),
+        "druks-critic",
+    ),
 )
 
 
@@ -25,15 +40,32 @@ def read_env() -> dict[str, str]:
     return values
 
 
-def patch_env(updates: dict[str, str]) -> None:
-    lines = ENV_PATH.read_text().splitlines()
-    pending = dict(updates)
-    for i, line in enumerate(lines):
-        key = line.partition("=")[0]
-        if key in pending:
-            lines[i] = f"{key}={pending.pop(key)}"
-    lines.extend(f"{key}={value}" for key, value in pending.items())
-    ENV_PATH.write_text("\n".join(lines) + "\n")
+def apply_values(updates: dict[str, str]) -> None:
+    install_dir = Path.cwd()
+    command = [
+        "docker",
+        "run",
+        "--rm",
+        "--user",
+        f"{os.getuid()}:{os.getgid()}",
+        "-v",
+        f"{install_dir}:/bootstrap",
+        os.environ["DRUKS_BACKEND_IMAGE"],
+        "druks",
+        "setup",
+        "/bootstrap/.env",
+        "--install-dir",
+        str(install_dir),
+        "--home",
+        str(Path.home()),
+        "--non-interactive",
+    ]
+    for path, value in updates.items():
+        command.extend(("--set", f"{path}={value}"))
+
+    completed = subprocess.run(command, check=False)
+    if completed.returncode not in {0, 3}:
+        raise subprocess.CalledProcessError(completed.returncode, command)
 
 
 def create_link(manifest: str, org: str) -> str:
@@ -67,6 +99,7 @@ def prompt_code(role: str) -> str:
 def provision(
     role: str,
     env_key: str,
+    toml_path: str,
     pem_path: Path,
     default_name: str,
     public_url: str,
@@ -106,12 +139,12 @@ def provision(
 
     pem_path.write_text(converted["pem"])
     pem_path.chmod(0o600)
-    updates = {env_key: str(converted["id"])}
+    updates = {toml_path: str(converted["id"])}
     if role == "operator":
         # Druks verifies inbound webhooks against this; GitHub generated it
-        # during the conversion, so the pre-seeded random value is replaced.
-        updates["DRUKS_WEBHOOK_SECRET"] = converted["webhook_secret"]
-    patch_env(updates)
+        # during the conversion, so this explicit operator write replaces it.
+        updates["secrets.webhook_secret"] = converted["webhook_secret"]
+    apply_values(updates)
 
     print(f"\n✓ {role} app created: id={converted['id']} slug={converted['slug']}")
     print(f"  PEM → {pem_path}")
@@ -119,20 +152,21 @@ def provision(
 
 
 def main() -> int:
-    if not ENV_PATH.exists():
-        print("No .env here — run install.sh first, then re-run with --apps.")
+    if not TOML_PATH.exists():
+        print("No druks.toml here — run install.sh first, then re-run with --apps.")
         return 1
 
-    public_url = read_env().get("DRUKS_PUBLIC_URL") or input(
+    apply_values({})
+    public_url = read_env().get("DRUKS_ENDPOINT") or input(
         "Public base URL druks will be reachable on (e.g. https://druks.example.com): "
     ).strip().rstrip("/")
     org = input("GitHub org slug (empty for a personal account): ").strip()
 
-    for role, env_key, pem_path, base_name in ROLES:
+    for role, env_key, toml_path, pem_path, base_name in ROLES:
         # App names are globally unique across GitHub; the org prefix gives
         # every deployment its own namespace.
         default_name = f"{org}-{base_name}" if org else base_name
-        provision(role, env_key, pem_path, default_name, public_url, org)
+        provision(role, env_key, toml_path, pem_path, default_name, public_url, org)
     return 0
 
 

--- a/scripts/_github_app_setup.py
+++ b/scripts/_github_app_setup.py
@@ -12,7 +12,7 @@ TOML_PATH = Path("druks.toml")
 MANIFEST_DIR = Path(__file__).parent / "manifests"
 SETUP_PAGE = "https://druks.ai/app-setup/"
 
-# (role, env key, TOML path, PEM path, default app name)
+# (role, env key, setting path, PEM path, default app name)
 ROLES = (
     (
         "operator",
@@ -99,7 +99,7 @@ def prompt_code(role: str) -> str:
 def provision(
     role: str,
     env_key: str,
-    toml_path: str,
+    setting_path: str,
     pem_path: Path,
     default_name: str,
     public_url: str,
@@ -137,9 +137,10 @@ def provision(
             print(f"✗ exchange failed ({error.code}) — codes are single-use and expire in ~1h.")
             print("  Re-open the HTML page to mint a fresh code, then paste it again.")
 
-    pem_path.write_text(converted["pem"])
-    pem_path.chmod(0o600)
-    updates = {toml_path: str(converted["id"])}
+    pem_descriptor = os.open(pem_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(pem_descriptor, "w") as pem_file:
+        pem_file.write(converted["pem"])
+    updates = {setting_path: str(converted["id"])}
     if role == "operator":
         # Druks verifies inbound webhooks against this; GitHub generated it
         # during the conversion, so this explicit operator write replaces it.
@@ -156,17 +157,19 @@ def main() -> int:
         print("No druks.toml here — run install.sh first, then re-run with --apps.")
         return 1
 
+    # An empty apply still renders .env from druks.toml, so the endpoint
+    # read below sees the operator's current value.
     apply_values({})
     public_url = read_env().get("DRUKS_ENDPOINT") or input(
         "Public base URL druks will be reachable on (e.g. https://druks.example.com): "
     ).strip().rstrip("/")
     org = input("GitHub org slug (empty for a personal account): ").strip()
 
-    for role, env_key, toml_path, pem_path, base_name in ROLES:
+    for role, env_key, setting_path, pem_path, base_name in ROLES:
         # App names are globally unique across GitHub; the org prefix gives
         # every deployment its own namespace.
         default_name = f"{org}-{base_name}" if org else base_name
-        provision(role, env_key, toml_path, pem_path, default_name, public_url, org)
+        provision(role, env_key, setting_path, pem_path, default_name, public_url, org)
     return 0
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,18 +2,18 @@
 # Druks installer — the only thing you fetch on a fresh box.
 #
 # Idempotent: re-run any time to pull a fresh compose.yaml + new images.
-# Configuration lives in ``druks setup`` (run from the backend image): it
-# writes the .env, prompts interactively for any blank required values,
-# and preserves hand edits on re-runs. When everything needed to boot is
-# present the same run migrates the DB (out of band, once — never on boot)
-# and brings the stack up; otherwise it prints the remaining checklist
-# (PEMs / provider auth) and exits — do those, then re-run. Claude/Codex
-# subscription auth is NOT a prerequisite: connect them from the dashboard
-# after boot.
+# Deployment configuration lives in druks.toml. ``druks setup`` (run from
+# the backend image) creates it on a fresh box, prompts for required values,
+# and renders the complete .env artifact. Edit druks.toml and re-run this
+# installer to render and apply it. When everything needed to boot is present
+# the same run migrates the DB (out of band, once — never on boot) and brings
+# the stack up; otherwise it prints the remaining checklist and exits.
+# Claude/Codex subscription auth is NOT a prerequisite: connect them from the
+# dashboard after boot.
 #
-# Two install shapes, chosen by DRUKS_PROVIDER (below): `exe`/`aws` run the
-# full stack in containers against a remote VM provider; `docker` runs a
-# local stack whose sandboxes are local containers, with drukbox on the host.
+# Three install shapes are selected from DRUKS_PROVIDER: `docker` is local,
+# `exe` pre-seeds exe.dev + tailnet configuration, and every other drukbox
+# provider name uses the generic remote shape.
 #
 # Usage:
 #
@@ -26,16 +26,16 @@
 #   DRUKS_REF             default main — tag or full SHA to fetch deploy files from
 #   DRUKS_TAG             image tag to pull/run; defaults to the v* DRUKS_REF,
 #                         sha-<DRUKS_REF> for a full SHA, or latest for main
-#   DRUKS_PROVIDER        default exe — install shape / sandbox backend:
-#                         `exe` or `aws` (remote VMs, drukbox in containers)
-#                         or `docker` (local: sandboxes as local containers,
-#                         drukbox on the host).
-#                         Only read on first run (when the .env is written).
+#   DRUKS_PROVIDER        default exe — sandbox provider on the first run.
+#                         `docker` selects the local shape, `exe` selects the
+#                         exe.dev shape, and any other name selects the generic
+#                         remote shape. Drukbox validates provider names.
+#                         Ignored after druks.toml exists.
 #
 # Flags:
 #   --apps                provision the operator + reviewer GitHub Apps via
 #                         the manifest flow and exit. Run between
-#                         the first run (.env written) and the boot run.
+#                         the first run (druks.toml written) and the boot run.
 
 set -euo pipefail
 
@@ -85,20 +85,6 @@ mkdir -p caddy
 fetch_from_repo deploy/caddy/Caddyfile caddy/Caddyfile
 
 # ---------------------------------------------------------------------------
-# --apps — provision the GitHub Apps via the manifest flow
-# ---------------------------------------------------------------------------
-if [ "${1:-}" = "--apps" ]; then
-  [ -f .env ] || { echo "no .env yet — run the installer once first" >&2; exit 1; }
-  need python3
-  echo "→ fetching app-setup script + manifests from $REPO@$REF"
-  mkdir -p manifests
-  fetch_from_repo scripts/_github_app_setup.py _github_app_setup.py
-  fetch_from_repo scripts/manifests/operator.json manifests/operator.json
-  fetch_from_repo scripts/manifests/reviewer.json manifests/reviewer.json
-  exec python3 _github_app_setup.py
-fi
-
-# ---------------------------------------------------------------------------
 # 2. ghcr login + backend image — ``druks setup`` runs from the image
 # ---------------------------------------------------------------------------
 if [ -n "${GHCR_TOKEN:-}" ]; then
@@ -111,8 +97,25 @@ echo "→ pulling $BACKEND_IMAGE"
 docker pull -q "$BACKEND_IMAGE" >/dev/null
 
 # ---------------------------------------------------------------------------
-# 3. .env setup — the template + required-values brain is ``druks setup``
-#    (idempotent: prompts only for blanks; exit 0 = boot-ready, 3 = gaps)
+# --apps — provision the GitHub Apps through the single TOML writer
+# ---------------------------------------------------------------------------
+if [ "${1:-}" = "--apps" ]; then
+  [ -f druks.toml ] || {
+    echo "no druks.toml yet — run the installer once first" >&2
+    exit 1
+  }
+  need python3
+  echo "→ fetching app-setup script + manifests from $REPO@$REF"
+  mkdir -p manifests
+  fetch_from_repo scripts/_github_app_setup.py _github_app_setup.py
+  fetch_from_repo scripts/manifests/operator.json manifests/operator.json
+  fetch_from_repo scripts/manifests/reviewer.json manifests/reviewer.json
+  DRUKS_BACKEND_IMAGE="$BACKEND_IMAGE" exec python3 _github_app_setup.py
+fi
+
+# ---------------------------------------------------------------------------
+# 3. TOML setup + .env render — the required-values brain is ``druks setup``
+#    (exit 0 = boot-ready, 3 = gaps, 4 = pre-TOML hand migration required)
 # ---------------------------------------------------------------------------
 TTY_FLAGS=(-i)
 SETUP_ARGS=(--provider "$PROVIDER" --install-dir "$INSTALL_DIR" --home "$HOME")
@@ -133,9 +136,8 @@ case "$setup_rc" in
   *) echo "druks setup failed (exit $setup_rc)" >&2; exit "$setup_rc" ;;
 esac
 
-# setup persisted the provider (first run: the flag; re-runs: whatever the
-# .env already had) — read it back so the shape branches below follow the
-# .env, not a flag that a re-run didn't pass.
+# setup rendered the provider from druks.toml — read the artifact so the
+# shape branches below follow the authored configuration.
 PROVIDER=$(sed -n 's/^DEFAULT_HOST_PROVIDER=//p' .env)
 DATA_HOST_DIR=$(sed -n 's/^DRUKS_DATA_HOST_DIR=//p' .env)
 if [ -z "$DATA_HOST_DIR" ]; then
@@ -242,12 +244,19 @@ Sandboxes run as local Docker containers — start drukbox on the host:
   cd drukbox && DOCKER_SSH_USERNAME=druks make dev
 ------------------------------------------------------------
 MSG
-else
+elif [ "$PROVIDER" = "exe" ]; then
   cat <<MSG
 
 Public URLs (once exe.dev port-share is configured):
   https://<your-host>/webhooks/{github,linear}
   https://<your-host>/
+------------------------------------------------------------
+MSG
+else
+  cat <<MSG
+
+Remote shape ($PROVIDER): configure public ingress and identity per:
+  https://github.com/czpython/druks/tree/main/deploy
 ------------------------------------------------------------
 MSG
 fi

--- a/uv.lock
+++ b/uv.lock
@@ -556,6 +556,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "redis" },
     { name = "sqlalchemy" },
+    { name = "tomlkit" },
     { name = "uuid-utils" },
     { name = "uvicorn" },
 ]
@@ -591,6 +592,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "redis", specifier = ">=8" },
     { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "tomlkit", specifier = ">=0.13" },
     { name = "uuid-utils", specifier = ">=0.16.0" },
     { name = "uvicorn", specifier = ">=0.38.0" },
 ]
@@ -2148,6 +2150,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The installer stops enumerating drukbox providers. `druks.toml` in the install dir becomes the single authored deployment config; `.env` survives as a rendered artifact consumed by compose, druks, and drukbox exactly as before — deletable and regenerated losslessly, since every rendered key has a TOML home or a fixed-value entry in the key map.

**Shapes, not providers.** `[sandbox].provider` accepts any drukbox provider name: `docker` selects the local shape, `exe` the exe.dev + tailnet shape (its template pre-seeds the credential prompts), and every other name the generic remote shape — a prompted identity header and a `[sandbox.env]` table passed through verbatim. Drukbox's registry and `/doctor` (already relayed by `druks doctor`) own provider truth, so `exoscale`, `hetzner`, or any future provider installs with zero druks changes.

**One writer.** `druks setup` creates the TOML on a fresh box (provider question first; the shape seeds identity and sandbox defaults), applies repeatable `--set key.path=value` writes, renders `.env`, and parse-verifies every TOML write. `install.sh --apps` provisions the GitHub Apps and applies ids and GitHub's minted webhook secret through that same path.

**Guard rails**, each from an adversarially-verified design finding:
- `.env` present without `druks.toml` → exit 4 with the hand-migration recipe, before anything is written; `--apps` gates on the TOML. Protects every existing deploy's secrets on the documented re-run-to-upgrade path.
- Blank TOML values are omitted from the render — an empty env var shadows drukbox's pydantic defaults rather than clearing them.
- `[sandbox.env]` and `[env]` reject keys the render map owns as named gaps; `[env]` carries deployment settings knobs (`SLACK_SIGNING_SECRET`, `JIRA_*`, …) that have no dedicated key.
- The docker shape never renders `[sandbox.env]` — host-run drukbox reads its own env — while its service URL and sandbox image are TOML keys, keeping the full-local override flows expressible.
- Hand-edited TOMLs with missing tables surface gaps, not tracebacks; TOML and `.env` are written 0600 with no world-readable window; the first write drops a `.gitignore` covering `druks.toml`, `.env`, and `secrets/`.
- Re-renders that change an existing `.env` print the apply command; compose-plane keys `install.sh` writes into `.env` survive re-renders.

Format rule, now in docs/configuration.md: format follows habitat — repo-committed files (ship's `.druks/ship/config.yml`) stay YAML with the rest of the repo-dotfile world; box-resident operator files are TOML because they render to env byte-exact and parse with stdlib `tomllib`.

Existing installs migrate by hand on release (recipe printed by the guard); there is no old-format code path.

Closes ENG-793.