### PR TITLE
ENG-795 - A harness failure carries its code and retry class

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -10,7 +10,6 @@ from pydantic import BaseModel, ConfigDict
 from druks.database import db_session
 from druks.durable.activity import set_run_phase
 from druks.durable.engine import _step_engine, step_session
-from druks.durable.enums import AgentCallStatus
 from druks.durable.exceptions import WorkflowError
 from druks.durable.models import AgentCall, Artifact
 from druks.extensions.registry import agents
@@ -222,12 +221,12 @@ class Agent:
                         runner, model, prompt, artifact_dir, call_id, connection_id
                     )
                 except BaseException as error:
-                    AgentCall.fail(engine, call_id=call_id, error=str(error))
+                    AgentCall.fail(engine, call_id=call_id, error=error)
                     raise
                 AgentCall.finish(engine, call_id=call_id, result=result)
 
-        if result.status is AgentCallStatus.FAILED:
-            raise WorkflowError(result.last_error or f"agent {self.id!r} failed")
+        if result.error:
+            raise result.error
 
         output = self.contract.model_validate(result.output)
         if spec := output.get_artifact():

--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -55,9 +55,9 @@ class Run(Base):
     # The receipt: the input_requested_at stamp an answer last resumed.
     answer_parked_at: Mapped[datetime | None] = mapped_column(default=None)
     failure: Mapped[str | None] = mapped_column(default=None)
-    # The FatalError subtype's code when the run stopped on a deliberate domain
-    # error, so read-sides tell e.g. a gate timeout from a crash without parsing
-    # `failure`. Empty/None for a crash.
+    # The stopping error's stable code — FatalError's or a classified harness
+    # failure's — so read-sides tell a gate timeout or a provider outage from
+    # a crash without parsing `failure`. Empty/None for a crash.
     failure_code: Mapped[str | None] = mapped_column(default=None)
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
     # Derived, never stored: DBOS owns whether the workflow is live — every
@@ -339,6 +339,8 @@ class AgentCall(Base, Uuid7Pk):
     status: Mapped[str] = mapped_column(default=AgentCallStatus.RUNNING.value)
     finished_at: Mapped[datetime | None]
     last_error: Mapped[str | None]
+    # The classified failure's code, mirroring the run's failure_code.
+    failure_code: Mapped[str | None] = mapped_column(default=None)
     cost_usd: Mapped[float | None]
     cost_metadata: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     # The VM this run executed on. Resolve via the sandbox service when needed
@@ -442,19 +444,20 @@ class AgentCall(Base, Uuid7Pk):
             call.started_at = result.started_at
             call.finished_at = Base.utc_now()
             call.last_error = result.last_error
+            call.failure_code = result.error.code if result.error else ""
             call.cost_usd = result.cost_usd
             call.cost_metadata = result.cost_metadata
             session.commit()
 
     @classmethod
-    def fail(cls, engine, *, call_id: str, error: str) -> None:
+    def fail(cls, engine, *, call_id: str, error: BaseException) -> None:
         # The run raised after the call started (a cancel, or a crash past the
         # agent body) — close the row so it doesn't linger as a phantom step.
         with get_session(engine) as session:
             call = session.get(cls, call_id)
             call.status = AgentCallStatus.FAILED.value
             call.finished_at = Base.utc_now()
-            call.last_error = error
+            call.last_error = str(error)
             session.commit()
 
     @classmethod

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -21,6 +21,7 @@ from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
 from druks.skills.models import Skill
 from druks.usage.models import UsageScrape
 
+from . import exceptions
 from .constants import CONNECT_PENDING_PREFIX, REFRESH_LOCK_PREFIX
 from .datastructures import (
     AgentInvocation,
@@ -32,13 +33,6 @@ from .datastructures import (
     ParsedUsage,
     RotationResult,
     SandboxSettings,
-)
-from .exceptions import (
-    ConnectError,
-    GrantError,
-    HarnessError,
-    HarnessNotConnectedError,
-    OAuthTokenError,
 )
 from .models import HarnessConnection
 
@@ -76,6 +70,11 @@ class Harness(ABC):
     default_model: ClassVar[str]
     # The provider's model-list endpoint the picker refresh fetches.
     model_discovery_url: ClassVar[str]
+    # This CLI's terminal-error vocabulary: phrase → the failure it names, the
+    # first phrase found in a death's text winning in declaration order; no
+    # match stays a bare, never-retried HarnessError. The terminal event has no
+    # structured error subtype, so words are the only signal.
+    failure_markers: ClassVar[dict[str, type[exceptions.HarnessError]]] = {}
     default_effort: ClassVar[str] = "high"
     default_timeout: ClassVar[int] = 1800
     # Per-CLI OAuth refresh config (set by subclasses).
@@ -108,6 +107,17 @@ class Harness(ABC):
     def parse(self, result: HarnessRunResult, *, artifact_dir: Path, run_id: str) -> object:
         """Turn a finished run into the structured payload (and write the
         cost/output sidecars under ``artifact_dir / run_id``)."""
+
+    @classmethod
+    def check_returncode(cls, result: HarnessRunResult) -> None:
+        if result.returncode != 0:
+            detail = _terminal_detail(result.stdout)
+            message = f"{cls.name} exited with {result.returncode}.{detail}"
+            lowered = detail.lower()
+            for marker, error in cls.failure_markers.items():
+                if marker in lowered:
+                    raise error(message)
+            raise exceptions.HarnessError(message)
 
     def get_manifest(
         self,
@@ -189,7 +199,7 @@ class Harness(ABC):
         data = dict(row.payload) if row else None
         if data:
             return data
-        raise HarnessNotConnectedError(
+        raise exceptions.HarnessNotConnectedError(
             f"{cls.name} is not connected — connect it in Settings → Harnesses."
         )
 
@@ -202,7 +212,7 @@ class Harness(ABC):
         row = HarnessConnection.get(connection_id)
         if row:
             return json.dumps(dict(row.payload))
-        raise HarnessNotConnectedError(
+        raise exceptions.HarnessNotConnectedError(
             f"the selected {cls.name} connection was removed — reconnect it in "
             "Settings → Harnesses."
         )
@@ -234,18 +244,20 @@ class Harness(ABC):
         so a retry re-starts cleanly."""
         pending = await get_client().getdel(f"{CONNECT_PENDING_PREFIX}{flow_id}")  # single-use
         if not pending:
-            raise ConnectError("This connect attempt expired — start it again.")
+            raise exceptions.ConnectError("This connect attempt expired — start it again.")
         expected = json.loads(pending)
 
         code, pasted_state = _parse_pasted(pasted)
         if not code:
-            raise ConnectError("Couldn't find an authorization code in what you pasted.")
+            raise exceptions.ConnectError("Couldn't find an authorization code in what you pasted.")
         if pasted_state and pasted_state != expected["state"]:
-            raise ConnectError("That code is from a different connect attempt — start it again.")
+            raise exceptions.ConnectError(
+                "That code is from a different connect attempt — start it again."
+            )
 
         payload, provider_email = await cls.exchange(code=code, verifier=expected["verifier"])
         if not provider_email:
-            raise ConnectError(
+            raise exceptions.ConnectError(
                 "The provider returned no account email — authorize with an account "
                 "that has one and try again."
             )
@@ -277,7 +289,7 @@ class Harness(ABC):
         token = cls._token_from_credentials(dict(connection.payload))
         moment = now or _utc_now()
         if token.expires_at and token.expires_at <= moment:
-            raise OAuthTokenError(
+            raise exceptions.OAuthTokenError(
                 "token_expired", f"access token expired at {token.expires_at.isoformat()}"
             )
         return token
@@ -343,7 +355,7 @@ class Harness(ABC):
             try:
                 grant = await _post_grant(cls._TOKEN_URL, cls._grant_body(refresh_token))
                 new_expiry = cls._apply_refresh(data, grant, moment)
-            except GrantError as exc:
+            except exceptions.GrantError as exc:
                 if exc.tag == "invalid_grant":
                     # The provider revoked this row's refresh lineage;
                     # presenting it again can never succeed. Drop only this
@@ -390,7 +402,7 @@ class Harness(ABC):
         or expired reads False: nothing live to protect, rotate ungated."""
         try:
             token = cls._token_from_credentials(dict(connection.payload))
-        except OAuthTokenError:
+        except exceptions.OAuthTokenError:
             return False
         if not token.expires_at:
             return False
@@ -425,7 +437,7 @@ class Harness(ABC):
         '0 metrics'."""
         try:
             token = cls.load_token(connection, now=now)
-        except OAuthTokenError as exc:
+        except exceptions.OAuthTokenError as exc:
             return ParsedUsage(ok=False, error=exc.tag)
 
         url, headers = cls._usage_request(token)
@@ -515,7 +527,7 @@ class Harness(ABC):
         only ever advances, it is never wiped by a bad fetch."""
         try:
             token = cls.load_token(connection)
-        except OAuthTokenError as exc:
+        except exceptions.OAuthTokenError as exc:
             return ParsedModels(ok=False, error=exc.tag)
 
         headers = cls.get_model_discovery_headers(token)
@@ -602,7 +614,7 @@ async def _post_grant(url: str, body: dict) -> dict:
             response = await client.post(url, json=body)
     except httpx.HTTPError as exc:
         logger.warning("token refresh request failed (%s): %s", url, exc, exc_info=True)
-        raise GrantError("network") from exc
+        raise exceptions.GrantError("network") from exc
     if response.status_code != 200:
         logger.warning(
             "token refresh returned %s (%s): %s",
@@ -614,11 +626,11 @@ async def _post_grant(url: str, body: dict) -> dict:
             tag = "invalid_grant"
         else:
             tag = f"http_{response.status_code}"
-        raise GrantError(tag)
+        raise exceptions.GrantError(tag)
     try:
         return response.json()
     except ValueError as exc:
-        raise GrantError("bad_response") from exc
+        raise exceptions.GrantError("bad_response") from exc
 
 
 def _b64url(raw: bytes) -> str:
@@ -655,7 +667,7 @@ async def post_token(url: str, body: dict, *, form: bool) -> dict:
                 response = await client.post(url, json=body)
     except httpx.HTTPError as exc:
         logger.warning("token exchange request failed (%s): %s", url, exc, exc_info=True)
-        raise ConnectError("The request to the provider failed — try again.") from exc
+        raise exceptions.ConnectError("The request to the provider failed — try again.") from exc
     if response.status_code != 200:
         logger.warning(
             "token exchange returned %s (%s): %s",
@@ -664,17 +676,11 @@ async def post_token(url: str, body: dict, *, form: bool) -> dict:
             response.text[:300],
         )
         detail = response.text.strip()[:300] or f"HTTP {response.status_code}"
-        raise ConnectError(f"The provider rejected the connect: {detail}")
+        raise exceptions.ConnectError(f"The provider rejected the connect: {detail}")
     try:
         return response.json()
     except ValueError as exc:
-        raise ConnectError("The provider returned an unreadable response.") from exc
-
-
-def check_returncode(result: HarnessRunResult, *, name: str) -> None:
-    if result.returncode != 0:
-        detail = _terminal_detail(result.stdout)
-        raise HarnessError(f"{name} exited with {result.returncode}.{detail}")
+        raise exceptions.ConnectError("The provider returned an unreadable response.") from exc
 
 
 def _terminal_detail(stdout: bytes) -> str:
@@ -690,6 +696,9 @@ def _terminal_detail(stdout: bytes) -> str:
             continue
         if event.get("is_error") and isinstance(event.get("result"), str):
             return f" {event['result'][:300]}"
+        message = event.get("message")
+        if event.get("type") == "error" and isinstance(message, str) and message:
+            return f" {message[:300]}"
         error = event.get("error")
         if isinstance(error, dict):
             error = error.get("message")

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -17,10 +17,10 @@ from druks.sandbox.datastructures import (
 from druks.sandbox.layout import get_runs_root
 from druks.skills.models import Skill
 
+from . import exceptions
 from .artifacts import call_dir, write_cost
-from .base import Harness, check_returncode, parse_epoch_expiry, post_token
+from .base import Harness, parse_epoch_expiry, post_token
 from .datastructures import OAuthToken, ParsedMetric, ParsedModels, ParsedUsage, SandboxSettings
-from .exceptions import HarnessError, OAuthTokenError, StreamJsonError
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +52,23 @@ class ClaudeHarness(Harness):
     # body.
     redirect_uri = "https://console.anthropic.com/oauth/code/callback"
 
+    # The CLI dies with the raw API error in the result text ("API Error: 529
+    # {…overloaded_error…}"), so "api error: 5" covers 529 and every 5xx; 429
+    # and 401 are their own families.
+    failure_markers = {
+        "session limit": exceptions.HarnessUsageLimitError,
+        "usage limit": exceptions.HarnessUsageLimitError,
+        "api error: 429": exceptions.HarnessRateLimitError,
+        "rate limit": exceptions.HarnessRateLimitError,
+        "rate_limit": exceptions.HarnessRateLimitError,
+        "api error: 401": exceptions.HarnessAuthError,
+        "authentication_error": exceptions.HarnessAuthError,
+        "oauth token": exceptions.HarnessAuthError,
+        "invalid api key": exceptions.HarnessAuthError,
+        "overloaded": exceptions.HarnessOverloadedError,
+        "api error: 5": exceptions.HarnessOverloadedError,
+    }
+
     def build_invocation(
         self,
         *,
@@ -68,7 +85,7 @@ class ClaudeHarness(Harness):
         connection_id: str | None = None,
     ) -> AgentInvocation:
         if not self.sandbox:
-            raise HarnessError(
+            raise exceptions.HarnessError(
                 "claude harness requires sandbox settings — set DRUKS_SANDBOX_SERVICE_URL et al.",
             )
 
@@ -129,13 +146,13 @@ class ClaudeHarness(Harness):
         )
 
     def parse(self, result: HarnessRunResult, *, artifact_dir: Path, run_id: str) -> Any:
-        check_returncode(result, name="claude")
+        self.check_returncode(result)
 
         try:
             envelope = collapse_claude_stream(result.stdout)
-        except StreamJsonError as error:
+        except exceptions.StreamJsonError as error:
             transcript = artifact_dir / run_id / "stdout.jsonl"
-            raise HarnessError(
+            raise exceptions.HarnessInvalidOutputError(
                 f"claude wrote invalid stream-json. See {transcript}",
             ) from error
 
@@ -193,7 +210,7 @@ class ClaudeHarness(Harness):
         block = _oauth_block(data)
         access = block.get("accessToken") or block.get("access_token")
         if not access:
-            raise OAuthTokenError("no_token", "credentials file has no access token")
+            raise exceptions.OAuthTokenError("no_token", "credentials file has no access token")
         return OAuthToken(
             access_token=access,
             expires_at=parse_epoch_expiry(block.get("expiresAt")),
@@ -442,9 +459,9 @@ def collapse_claude_stream(stdout: bytes) -> dict[str, Any]:
                 envelope[key] = value
             result_seen = True
     if not parsed_any:
-        raise StreamJsonError("claude stream-json contained no parseable events")
+        raise exceptions.StreamJsonError("claude stream-json contained no parseable events")
     if not result_seen:
-        raise StreamJsonError("claude stream-json had no 'result' event")
+        raise exceptions.StreamJsonError("claude stream-json had no 'result' event")
     return envelope
 
 

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -21,9 +21,16 @@ from druks.sandbox.layout import get_runs_root, get_work_root
 from druks.skills.models import Skill
 
 from .artifacts import write_cost
-from .base import Harness, check_returncode, jwt_claims, jwt_expiry, post_token
+from .base import Harness, jwt_claims, jwt_expiry, post_token
 from .datastructures import CodexToken, ParsedMetric, ParsedModels, ParsedUsage
-from .exceptions import HarnessError, OAuthTokenError
+from .exceptions import (
+    HarnessAuthError,
+    HarnessError,
+    HarnessOverloadedError,
+    HarnessRateLimitError,
+    HarnessUsageLimitError,
+    OAuthTokenError,
+)
 from .subprocess import read_result_json
 
 logger = logging.getLogger(__name__)
@@ -279,6 +286,20 @@ class CodexHarness(Harness):
     # catches it if the server ever starts rejecting unknown versions.
     model_discovery_url = "https://chatgpt.com/backend-api/codex/models?client_version=99.99.99"
     command = "codex"
+
+    # The CLI's terminal {"type":"error"} event carries prose, not status
+    # shapes: stream drops after its internal retries, usage windows, 429s.
+    failure_markers = {
+        "usage limit": HarnessUsageLimitError,
+        "rate limit": HarnessRateLimitError,
+        "429": HarnessRateLimitError,
+        "401": HarnessAuthError,
+        "unauthorized": HarnessAuthError,
+        "stream disconnected": HarnessOverloadedError,
+        "stream error": HarnessOverloadedError,
+        "overloaded": HarnessOverloadedError,
+        "internal server error": HarnessOverloadedError,
+    }
 
     # OAuth refresh config (consumed by the Harness templates).
     REFRESH_MARGIN = timedelta(hours=24)
@@ -580,7 +601,7 @@ class CodexHarness(Harness):
         )
 
     def parse(self, result: HarnessRunResult, *, artifact_dir: Path, run_id: str) -> Any:
-        check_returncode(result, name=self.name)
+        self.check_returncode(result)
 
         call_dir = artifact_dir / run_id
         payload = read_result_json(

--- a/backend/druks/harnesses/exceptions.py
+++ b/backend/druks/harnesses/exceptions.py
@@ -1,5 +1,19 @@
+from enum import StrEnum
+from typing import ClassVar
+
+
+class Retry(StrEnum):
+    # Spaced attempts now, once the quota window resets, or not at all.
+    TRANSIENT = "transient"
+    QUOTA = "quota"
+    NEVER = "never"
+
+
 class HarnessError(Exception):
-    pass
+    # Recorded beside the message on the failed call and its run; "" means
+    # unclassified, which is never retried.
+    code: ClassVar[str] = ""
+    retry: ClassVar[Retry] = Retry.NEVER
 
 
 class StreamJsonError(ValueError):
@@ -7,7 +21,42 @@ class StreamJsonError(ValueError):
 
 
 class HarnessTimeoutError(HarnessError):
-    pass
+    """The full per-operation budget elapsed. Never auto-retried: the spend
+    was real and a rerun may just spend it again — that's the operator's
+    call."""
+
+    code = "timeout"
+
+
+class HarnessOverloadedError(HarnessError):
+    code = "overloaded"
+    retry = Retry.TRANSIENT
+
+
+class HarnessRateLimitError(HarnessError):
+    code = "rate_limited"
+    retry = Retry.QUOTA
+
+
+class HarnessUsageLimitError(HarnessError):
+    code = "usage_limit"
+    retry = Retry.QUOTA
+
+
+class HarnessAuthError(HarnessError):
+    code = "auth"
+
+
+class HarnessInvalidOutputError(HarnessError):
+    code = "invalid_output"
+
+
+class HarnessSandboxError(HarnessError):
+    """Transient because every attempt provisions or re-attaches its host,
+    which covers both the unreachable and the gone-for-good VM."""
+
+    code = "sandbox"
+    retry = Retry.TRANSIENT
 
 
 class OAuthTokenError(Exception):
@@ -48,6 +97,8 @@ class HarnessNotConnectedError(HarnessError):
     path — there is no host-file or baked-API-key fallback — which is what
     makes "is this harness runnable" decidable before any VM work."""
 
+    code = "not_connected"
+
 
 class HarnessFirstByteTimeoutError(HarnessError):
     """A harness subprocess produced zero stdout bytes within the
@@ -60,3 +111,6 @@ class HarnessFirstByteTimeoutError(HarnessError):
     upstream HTTP stall the CLI didn't surface) rather than slow
     legitimate inference, so retries are usually safe.
     """
+
+    code = "first_byte"
+    retry = Retry.TRANSIENT

--- a/backend/druks/harnesses/subprocess.py
+++ b/backend/druks/harnesses/subprocess.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from .exceptions import HarnessError
+from .exceptions import HarnessInvalidOutputError
 
 
 def read_result_json(output_path: Path, *, name: str) -> dict[str, Any]:
@@ -14,7 +14,7 @@ def read_result_json(output_path: Path, *, name: str) -> dict[str, Any]:
     try:
         text = output_path.read_text().strip()
     except FileNotFoundError as error:
-        raise HarnessError(f"{name} did not write result JSON.") from error
+        raise HarnessInvalidOutputError(f"{name} did not write result JSON.") from error
 
     if text[:3] == "```":
         lines = text.splitlines()
@@ -27,9 +27,9 @@ def read_result_json(output_path: Path, *, name: str) -> dict[str, Any]:
     try:
         payload = json.loads(text)
     except json.JSONDecodeError as error:
-        raise HarnessError(f"{name} wrote invalid result JSON.") from error
+        raise HarnessInvalidOutputError(f"{name} wrote invalid result JSON.") from error
 
     if not isinstance(payload, dict):
-        raise HarnessError(f"{name} result JSON must be an object.")
+        raise HarnessInvalidOutputError(f"{name} result JSON must be an object.")
 
     return payload

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -16,6 +16,7 @@ from druks.mcp.helpers import get_bearer_token_env_var
 
 if TYPE_CHECKING:
     from druks.durable.enums import AgentCallStatus
+    from druks.harnesses.exceptions import HarnessError
 
     from .host import Sandbox
 
@@ -56,7 +57,13 @@ class AgentResult:
     started_at: datetime
     cost_usd: float | None = None
     cost_metadata: dict[str, Any] | None = None
-    last_error: str | None = None
+    error: "HarnessError | None" = None
+
+    @property
+    def last_error(self) -> str | None:
+        if self.error:
+            return f"{self.agent}: {type(self.error).__name__}: {self.error}"
+        return
 
 
 @dataclass

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -18,6 +18,7 @@ from druks.harnesses.artifacts import persist_manifest, persist_prompt, read_cos
 from druks.harnesses.exceptions import (
     HarnessError,
     HarnessFirstByteTimeoutError,
+    HarnessSandboxError,
     HarnessTimeoutError,
 )
 from druks.settings import load_settings
@@ -200,7 +201,8 @@ class Sandbox:
         connection_id: str | None = None,
     ) -> AgentResult:
         """Run the harness and return a pure ``AgentResult`` — no database write.
-        A failure is captured on the result (``status=FAILED``), not raised.
+        A failure is carried on the result's ``error``, not raised, so the call
+        still records what it cost before the agent call re-raises it.
 
         The repo is a *precondition*, not an input: callers that need one clone
         it into the VM first (see Ship's workspace). ``include_plugins=False`` (Claude only)
@@ -234,8 +236,7 @@ class Sandbox:
         # back to a fresh uuid for callers that record the call after the fact.
         run_id = harness.mint_run_id(call_id)
         started_at = datetime.now(UTC)
-        status = AgentCallStatus.SUCCEEDED
-        last_error: str | None = None
+        error: HarnessError | None = None
         output: Any = None
         try:
             output = await self.run_prompt(
@@ -253,9 +254,14 @@ class Sandbox:
                 call_id=run_id,
                 connection_id=connection_id,
             )
-        except Exception as exc:  # noqa: BLE001 — captured on the result, not raised
-            status = AgentCallStatus.FAILED
-            last_error = f"{agent}: {type(exc).__name__}: {exc}"
+        except HarnessError as exc:
+            error = exc
+        except Exception as exc:  # noqa: BLE001 — carried on the result, not raised
+            # A foreign failure rides as an unclassified HarnessError: the chain
+            # keeps the live traceback, and pickle drops the chain, so DBOS's
+            # step record stays loadable (asyncssh/httpx errors don't unpickle).
+            error = HarnessError(f"{type(exc).__name__}: {exc}")
+            error.__cause__ = exc
         cost_usd, cost_metadata = read_cost(artifact_dir / run_id)
         return AgentResult(
             output=output,
@@ -263,11 +269,11 @@ class Sandbox:
             sandbox_host_id=self.id,
             model=model,
             agent=agent,
-            status=status,
+            status=AgentCallStatus.FAILED if error else AgentCallStatus.SUCCEEDED,
             started_at=started_at,
             cost_usd=cost_usd,
             cost_metadata=cost_metadata,
-            last_error=last_error,
+            error=error,
         )
 
     async def run_prompt(
@@ -463,7 +469,7 @@ class Sandbox:
             # SSH unreachable, host gone, sandbox-service down. Translate
             # into the existing HarnessError taxonomy so callers don't
             # have to learn a new exception family.
-            raise HarnessError(f"{invocation.name} sandbox failure: {exc}") from exc
+            raise HarnessSandboxError(f"{invocation.name} sandbox failure: {exc}") from exc
 
         ended_at = datetime.now(UTC)
         elapsed = (ended_at - started_at).total_seconds()

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -39,6 +39,7 @@ from druks.extensions.settings import (
     validate_setting_override,
     validate_settings_declaration,
 )
+from druks.harnesses.exceptions import HarnessError
 from druks.models import StoredSubject, snake_name
 from druks.notifications.outbox import notifications_queue, send_notification
 from druks.sandbox.client import sandbox_client
@@ -474,21 +475,20 @@ async def _execute_run(
     # status, so it passes through untouched.
     Run.create_row(_step_engine(), workflow_id=workflow_id, kind=kind, account_id=account_id)
     await _emit_run_event(workflow_id, RunState.RUNNING, subject=subject)
+
+    async def record_failed(exc: BaseException, code: str) -> None:
+        facts = {**_GATE_CLEARED, "failure": str(exc), "failure_code": code}
+        await _emit_run_event(workflow_id, RunState.FAILED, subject=subject, facts=facts)
+
     try:
         result = await body()
     except (DBOSAwaitedWorkflowCancelledError, DBOSWorkflowCancelledError):
         raise
+    except (FatalError, HarnessError) as exc:
+        await record_failed(exc, exc.code)
+        raise
     except Exception as exc:
-        await _emit_run_event(
-            workflow_id,
-            RunState.FAILED,
-            subject=subject,
-            facts={
-                **_GATE_CLEARED,
-                "failure": str(exc),
-                "failure_code": exc.code if isinstance(exc, FatalError) else "",
-            },
-        )
+        await record_failed(exc, "")
         raise
     await _emit_run_event(workflow_id, RunState.FINISHED, subject=subject, result=result)
     return result

--- a/backend/migrations/versions/b9e4d21c7a03_agent_calls_carry_a_failure_code.py
+++ b/backend/migrations/versions/b9e4d21c7a03_agent_calls_carry_a_failure_code.py
@@ -1,0 +1,27 @@
+"""agent calls carry a failure code
+
+Revision ID: b9e4d21c7a03
+Revises: c2f6a9d8137e
+Create Date: 2026-07-30 21:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b9e4d21c7a03"
+down_revision: str | Sequence[str] | None = "c2f6a9d8137e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # No backfill: NULL already reads as unclassified.
+    op.add_column("agent_calls", sa.Column("failure_code", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("agent_calls", "failure_code")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -167,8 +167,9 @@ def connect_harness(harness_cls, payload: dict, *, provider_email: str = "op@exa
     )
 
 
-def make_agent_result(output, *, agent="agent", status=None, cost_usd=None, cost_metadata=None):
+def make_agent_result(output, *, agent="agent", error=None, cost_usd=None, cost_metadata=None):
     # An AgentResult to return from a faked run_agent, so the agent call records/parses it.
+    # Status follows the error, as the sandbox does it — a failed result always says why.
     from datetime import UTC, datetime
 
     from druks.durable.enums import AgentCallStatus
@@ -180,10 +181,11 @@ def make_agent_result(output, *, agent="agent", status=None, cost_usd=None, cost
         sandbox_host_id="host-test",
         model="claude-opus-4-7",
         agent=agent,
-        status=status or AgentCallStatus.SUCCEEDED,
+        status=AgentCallStatus.FAILED if error else AgentCallStatus.SUCCEEDED,
         started_at=datetime.now(UTC),
         cost_usd=cost_usd,
         cost_metadata=cost_metadata,
+        error=error,
     )
 
 

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -278,6 +278,35 @@ async def test_crash_after_start_fails_the_call(druks_db, tmp_path, monkeypatch,
     assert "kaboom" in call.last_error
 
 
+async def test_a_carried_failure_is_raised_with_its_code(
+    druks_db, tmp_path, monkeypatch, current_run
+):
+    """The sandbox captures a harness failure on the result so the call can
+    record its cost; the agent call then re-raises that same error, and the row
+    keeps the code a retry decides on."""
+    from druks.harnesses.exceptions import HarnessOverloadedError
+
+    sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
+    overloaded = HarnessOverloadedError("claude exited with 1. API Error: 529 Overloaded.")
+
+    async def _run_agent(**_kwargs):
+        return make_agent_result(None, agent="dummy", error=overloaded)
+
+    sandbox.run_agent = _run_agent
+    _patch_ephemeral(monkeypatch, sandbox)
+
+    with pytest.raises(HarnessOverloadedError) as excinfo:
+        await DUMMY_AGENT._run(workflow_id="wf-9")
+
+    assert excinfo.value is overloaded
+    [call] = AgentCall.list_for_run("wf-9")
+    assert call.status == "failed"
+    assert call.failure_code == "overloaded"
+    assert call.last_error == (
+        "dummy: HarnessOverloadedError: claude exited with 1. API Error: 529 Overloaded."
+    )
+
+
 async def test_recovery_supersedes_the_orphaned_running_call(druks_db):
     """A worker crash leaves a RUNNING row; the recovered step re-runs with a
     fresh id and abandons the orphan, so the timeline shows one live step."""

--- a/backend/tests/test_cost_capture.py
+++ b/backend/tests/test_cost_capture.py
@@ -8,10 +8,10 @@ from druks.harnesses.artifacts import (
     write_cost,
 )
 from druks.harnesses.claude import (
-    StreamJsonError,
     collapse_claude_stream,
     extract_claude_cost_from_envelope,
 )
+from druks.harnesses.exceptions import StreamJsonError
 from druks.testing import seed_call, seed_run
 from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize

--- a/backend/tests/test_run_state.py
+++ b/backend/tests/test_run_state.py
@@ -274,6 +274,40 @@ async def test_gate_timeout_stamps_its_failure_code(druks_db, _inline_steps):
 
 
 @pytest.mark.asyncio
+async def test_a_harness_failure_stamps_its_code(druks_db, _inline_steps):
+    from druks.harnesses.exceptions import HarnessOverloadedError
+
+    item, run = _item_and_run(druks_db, "running")
+
+    async def body() -> None:
+        raise HarnessOverloadedError("claude exited with 1. API Error: 529 Overloaded.")
+
+    with pytest.raises(HarnessOverloadedError):
+        await _execute_run(run.id, run.kind, {"type": "work_item", "id": item.id}, None, body)
+
+    ambient_session().expire_all()
+    assert Run.get(run.id).failure_code == "overloaded"
+
+
+@pytest.mark.asyncio
+async def test_a_foreign_code_never_becomes_the_failure_code(druks_db, _inline_steps):
+    """``code`` is a common attribute name — asyncssh's is an int — so only
+    the declaring families stamp the run; anything else records a crash."""
+    import asyncssh
+
+    item, run = _item_and_run(druks_db, "running")
+
+    async def body() -> None:
+        raise asyncssh.PermissionDenied("denied")
+
+    with pytest.raises(asyncssh.PermissionDenied):
+        await _execute_run(run.id, run.kind, {"type": "work_item", "id": item.id}, None, body)
+
+    ambient_session().expire_all()
+    assert Run.get(run.id).failure_code == ""
+
+
+@pytest.mark.asyncio
 async def test_announce_carries_the_runs_routing(druks_db):
     # The body states its facts; the platform injects what subscribers filter on,
     # and the publish rides its own named checkpoint — the boundary that keeps a

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -2,18 +2,33 @@ import asyncio
 import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from druks.harnesses.base import Harness, check_returncode
+from druks.durable.enums import AgentCallStatus
+from druks.harnesses.base import Harness
+from druks.harnesses.claude import ClaudeHarness
+from druks.harnesses.codex import CodexHarness
 from druks.harnesses.exceptions import (
+    HarnessAuthError,
     HarnessError,
     HarnessFirstByteTimeoutError,
+    HarnessOverloadedError,
+    HarnessRateLimitError,
+    HarnessSandboxError,
     HarnessTimeoutError,
+    HarnessUsageLimitError,
+    Retry,
 )
-from druks.sandbox.datastructures import AgentInvocation, Credentials, HarnessRunResult
+from druks.sandbox.datastructures import (
+    AgentInvocation,
+    AgentResult,
+    Credentials,
+    HarnessRunResult,
+)
 from druks.sandbox.exceptions import SandboxUnreachable
 from druks.sandbox.host import Sandbox
 
@@ -278,7 +293,7 @@ async def test_sandbox_unreachable_translates_to_harness_error(
     sandbox._start_instruction = boom
     sandbox._download_artifacts = _download_artifacts
 
-    with pytest.raises(HarnessError, match="sandbox failure"):
+    with pytest.raises(HarnessSandboxError, match="sandbox failure") as excinfo:
         await Sandbox._exec(
             sandbox,
             _inv(("claude",)),
@@ -287,6 +302,7 @@ async def test_sandbox_unreachable_translates_to_harness_error(
             timeout=60,
         )
 
+    assert excinfo.value.retry is Retry.TRANSIENT
     # Start never produced a run → nothing to download from.
     assert downloads == []
 
@@ -356,16 +372,180 @@ def test_check_returncode_surfaces_the_streams_terminal_error():
         b'"result":"You\'ve hit your session limit \xc2\xb7 resets 5:10pm (UTC)"}\n'
     )
     with pytest.raises(HarnessError, match="session limit"):
-        check_returncode(
-            HarnessRunResult(returncode=1, stdout=stdout, stderr=b""),
-            name="claude",
-        )
+        ClaudeHarness.check_returncode(HarnessRunResult(returncode=1, stdout=stdout, stderr=b""))
 
 
 def test_check_returncode_stays_bare_without_a_terminal_event():
 
-    with pytest.raises(HarnessError, match=r"claude exited with 2\.$"):
-        check_returncode(
-            HarnessRunResult(returncode=2, stdout=b"not json\n", stderr=b""),
-            name="claude",
+    with pytest.raises(HarnessError, match=r"claude exited with 2\.$") as excinfo:
+        ClaudeHarness.check_returncode(
+            HarnessRunResult(returncode=2, stdout=b"not json\n", stderr=b"")
         )
+
+    assert type(excinfo.value) is HarnessError
+    assert excinfo.value.code == ""
+    assert excinfo.value.retry is Retry.NEVER
+
+
+def _claude_result_event(text: str) -> bytes:
+    payload = {"type": "result", "subtype": "success", "is_error": True, "result": text}
+    return json.dumps(payload).encode() + b"\n"
+
+
+@pytest.mark.parametrize(
+    ("harness", "stdout", "expected", "code"),
+    [
+        (
+            ClaudeHarness,
+            _claude_result_event(
+                'API Error: 529 {"type":"error","error":'
+                '{"type":"overloaded_error","message":"Overloaded"}}'
+            ),
+            HarnessOverloadedError,
+            "overloaded",
+        ),
+        (
+            ClaudeHarness,
+            _claude_result_event(
+                'API Error: 429 {"type":"error","error":'
+                '{"type":"rate_limit_error","message":"Request rate limit exceeded"}}'
+            ),
+            HarnessRateLimitError,
+            "rate_limited",
+        ),
+        (
+            ClaudeHarness,
+            _claude_result_event("You've hit your session limit · resets 5:10pm (UTC)"),
+            HarnessUsageLimitError,
+            "usage_limit",
+        ),
+        (
+            ClaudeHarness,
+            _claude_result_event(
+                'API Error: 401 {"type":"error","error":'
+                '{"type":"authentication_error","message":"OAuth token has expired"}}'
+            ),
+            HarnessAuthError,
+            "auth",
+        ),
+        (
+            ClaudeHarness,
+            _claude_result_event(
+                'API Error: 503 {"type":"error","error":'
+                '{"type":"api_error","message":"Internal server error"}}'
+            ),
+            HarnessOverloadedError,
+            "overloaded",
+        ),
+        (
+            CodexHarness,
+            b'{"type":"error","message":"stream error: stream disconnected before completion"}\n',
+            HarnessOverloadedError,
+            "overloaded",
+        ),
+        (
+            CodexHarness,
+            b'{"type":"error","message":"You\'ve hit your usage limit."}\n',
+            HarnessUsageLimitError,
+            "usage_limit",
+        ),
+    ],
+)
+def test_check_returncode_classifies_the_terminal_error(
+    harness: type[Harness], stdout: bytes, expected: type[HarnessError], code: str
+):
+    with pytest.raises(expected) as excinfo:
+        harness.check_returncode(HarnessRunResult(returncode=1, stdout=stdout, stderr=b""))
+
+    assert type(excinfo.value) is expected
+    assert excinfo.value.code == code
+    assert str(excinfo.value).startswith(f"{harness.name} exited with 1. ")
+
+
+def test_agent_result_names_the_agent_in_its_failure():
+    result = AgentResult(
+        output=None,
+        run_id=_DEFAULT_RUN_ID,
+        sandbox_host_id="host-abc",
+        model="claude-opus-5",
+        agent="evaluate_implementation",
+        status=AgentCallStatus.FAILED,
+        started_at=datetime.now(UTC),
+        error=HarnessOverloadedError("claude exited with 1. API Error: 529"),
+    )
+
+    assert result.last_error == (
+        "evaluate_implementation: HarnessOverloadedError: claude exited with 1. API Error: 529"
+    )
+    assert result.error.code == "overloaded"
+
+
+def _patch_harness_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
+    # run_agent resolves the harness + its settings from the DB; these tests
+    # are about the failure boundary, not resolution.
+    from druks.harnesses.claude import ClaudeHarness
+
+    monkeypatch.setattr(
+        "druks.harnesses.registry.get_harness_for_model", lambda model: ClaudeHarness
+    )
+    monkeypatch.setattr(
+        "druks.user_settings.models.HarnessSettings.require",
+        staticmethod(lambda name: SimpleNamespace(effort="high", timeout=60, fast_mode=False)),
+    )
+
+
+async def test_run_agent_carries_foreign_failures_as_harness_errors(
+    ctx: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+):
+    """The result's error is always from the taxonomy: a foreign failure is
+    wrapped unclassified, keeps its traceback via the chain, and — unlike an
+    asyncssh or httpx error — survives DBOS's pickled step record."""
+    import pickle
+
+    _patch_harness_resolution(monkeypatch)
+    sandbox = SimpleNamespace(id="host-abc", ssh_username="root")
+    original = RuntimeError("kaboom")
+
+    async def run_prompt(harness: Any, **_kwargs: Any) -> Any:
+        raise original
+
+    sandbox.run_prompt = run_prompt
+    result = await Sandbox.run_agent(
+        sandbox,
+        model="claude-opus-4-7",
+        prompt="p",
+        schema={"type": "object"},
+        agent="evaluate",
+        artifact_dir=ctx.artifact_dir,
+    )
+
+    assert result.status is AgentCallStatus.FAILED
+    assert type(result.error) is HarnessError
+    assert result.error.code == ""
+    assert result.error.__cause__ is original
+    assert result.last_error == "evaluate: HarnessError: RuntimeError: kaboom"
+    revived = pickle.loads(pickle.dumps(result.error))
+    assert type(revived) is HarnessError and revived.__cause__ is None
+
+
+async def test_run_agent_carries_a_taxonomy_failure_as_itself(
+    ctx: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+):
+    _patch_harness_resolution(monkeypatch)
+    sandbox = SimpleNamespace(id="host-abc", ssh_username="root")
+    timeout = HarnessTimeoutError("claude timed out after 60s.")
+
+    async def run_prompt(harness: Any, **_kwargs: Any) -> Any:
+        raise timeout
+
+    sandbox.run_prompt = run_prompt
+    result = await Sandbox.run_agent(
+        sandbox,
+        model="claude-opus-4-7",
+        prompt="p",
+        schema={"type": "object"},
+        agent="evaluate",
+        artifact_dir=ctx.artifact_dir,
+    )
+
+    assert result.error is timeout


### PR DESCRIPTION
**Linear ticket:** [ENG-795](https://linear.app/fellaworks/issue/ENG-795/typed-harness-failures-tag-retry-class-on-terminal-errors)

## What changed

A harness death used to reach the workflow as a bare string — `Sandbox.run_agent` folds every exception into `AgentResult.last_error`, and the agent call re-raised it as `WorkflowError(text)`, so nothing downstream could tell a 529 from bad credentials without regexing strings. Codex deaths were worse: its terminal error event matched none of `_terminal_detail`'s shapes, so they persisted as a bare "codex exited with 1."

Now classification happens at the one place the CLI's terminal event exists as parsed JSON and rides the whole pipeline as data:

- `HarnessError` carries ClassVar `code` (stable short code) and `retry` (a `transient | quota | never` enum), with subclasses per failure family: `HarnessOverloadedError` (529/5xx/dropped stream), `HarnessRateLimitError` (429), `HarnessUsageLimitError` (session/weekly window), `HarnessAuthError`, `HarnessInvalidOutputError`, `HarnessSandboxError`, plus codes on the existing timeout/first-byte/not-connected classes.
- Each harness declares `failure_markers` — its own CLI's terminal-error vocabulary as a flat phrase → failure dict, first match winning in declaration order — and `Harness.check_returncode` classifies a death against the declaring class's table (claude's "api error: 5" covers 529 and every 5xx; codex's is stream-drop/usage-limit prose). One CLI's vocabulary can't misclassify another's output, a new harness ships its own markers or classifies nothing, and anything unmatched stays a bare, never-retried `HarnessError`. `_terminal_detail` additionally matches codex's `{"type":"error","message":…}` event.
- The sandbox boundary owns the taxonomy: `AgentResult` carries the exception itself (`error: HarnessError | None`), with foreign failures wrapped as unclassified `HarnessError` at capture (the chain keeps the live traceback; pickle drops it, so DBOS's step record always deserializes). The agent call re-raises it, `AgentCall.finish` reads `.code` straight off it, and `_execute_run` records the run's `failure_code` via except-clause dispatch over the two declaring families (`FatalError`, `HarnessError`) — no isinstance anywhere on the failure path.
- `agent_calls` gets a `failure_code` column (additive migration, no backfill — NULL already reads as unclassified).

No retry behavior changes; this is the classification layer ENG-796's durable retry dispatches on, and it independently makes every failure say what class it is.

## Risk

Low. The migration is additive and nullable. No workflow body shapes change, so in-flight runs replay unaffected; step errors recorded before the deploy deserialize as their old types and still just fail the run as before.

## Verification

- `uv run ruff check` / `ruff format --check` on every touched file — passed.
- `uv run pyright` on touched files — no new errors beyond the pre-existing `session.get` Optional family the added lines sit in.
- Classification, the foreign-failure wrap, and pickle round-trips (DBOS records step errors pickled; asyncssh/httpx errors don't survive unpickling, which is what the wrap prevents) exercised directly against the terminal-event fixtures — all pass; the pytest suite gates in CI (the conftest needs the shared Postgres).

