### PR TITLE
ENG-796 - Durable in-run retry for transient harness failures

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -1,6 +1,9 @@
+import asyncio
 import contextlib
+import random
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -13,6 +16,7 @@ from druks.durable.engine import _step_engine, step_session
 from druks.durable.exceptions import WorkflowError
 from druks.durable.models import AgentCall, Artifact
 from druks.extensions.registry import agents
+from druks.harnesses.exceptions import HarnessError, Retry
 from druks.harnesses.models import HarnessConnection
 from druks.harnesses.registry import get_harness_for_model
 from druks.prompts import render_prompt
@@ -20,6 +24,7 @@ from druks.sandbox import gate as sandbox_gate
 from druks.sandbox.client import sandbox_client
 from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
 from druks.settings import load_settings
+from druks.usage.models import UsageScrape
 from druks.user_settings.models import SettingsOverride
 from druks.workflows import _in_step, current_workflow
 
@@ -28,6 +33,10 @@ if TYPE_CHECKING:
     from druks.workflows import Workflow
 
 __all__ = ["Agent", "AgentOutput"]
+
+_QUOTA_FALLBACK_WAIT_SECONDS = 30 * 60
+_QUOTA_MAX_WAIT_SECONDS = 6 * 60 * 60
+_REAP_BEFORE_WAIT_SECONDS = 120
 
 
 @contextlib.asynccontextmanager
@@ -151,19 +160,97 @@ class Agent:
             return await self._run(workflow_id=workflow.workflow_id, **context)
 
         if _in_step.get():
-            return await _invoke()  # the enclosing @step owns the session + memoizes it
+            transient_retry_index = 0
+            while True:
+                try:
+                    return await _invoke()  # the enclosing @step owns the session + memoizes it
+                except HarnessError as error:
+                    # Transient only, on the error's own schedule. Quota waits
+                    # are hours; nothing that long belongs inside a held step,
+                    # so those fail here instead of sleeping.
+                    if error.retry is not Retry.TRANSIENT or transient_retry_index >= len(
+                        error.retry_delays
+                    ):
+                        raise
+                    delay = error.retry_delays[transient_retry_index]
+                    transient_retry_index += 1
+                    # Plain sleep: nothing checkpoints inside a step — a crash
+                    # re-runs the whole enclosing step from attempt one anyway.
+                    await asyncio.sleep(delay * random.uniform(0.9, 1.1))
 
         async def _do() -> Any:  # a standalone run is its own memoized step + session
             async with step_session():
                 return await _invoke()
 
-        result = await DBOS.run_step_async(
-            StepOptions(name=f"{workflow.kind}.agent.{self.id}"), _do
-        )
-        # Body-level only, on both passes: in-step calls hit the early return
-        # live and are skipped with their step on replay.
-        workflow.journal.add(result)
-        return result
+        async def _quota_retry_wait() -> float:
+            # Runs as its own step: the body does no IO, and replay reuses the
+            # recorded wait instead of re-reading the scrape.
+            async with step_session():
+                harness = get_harness_for_model(self.get_model_name())
+                # The scrape belongs to the charged connection — its account
+                # differs from the run's on fallback.
+                connection = HarnessConnection.lookup(harness.name, workflow.account_id)
+                scrape = UsageScrape.latest_for(harness.name, connection.account_id)
+                if scrape:
+                    now = datetime.now(UTC)
+                    # The nearest window still ahead: the five-hour one usually
+                    # turns first; an exhausted week is what the caller caps on.
+                    reset = scrape.five_hour_resets_at
+                    if reset and reset > now:
+                        return (reset - now).total_seconds()
+                    reset = scrape.week_resets_at
+                    if reset and reset > now:
+                        return (reset - now).total_seconds()
+                # No scrape yet, or nothing ahead of now: a blind half hour.
+                return _QUOTA_FALLBACK_WAIT_SECONDS
+
+        transient_retry_index = 0
+        quota_retried = False
+        while True:
+            try:
+                result = await DBOS.run_step_async(
+                    StepOptions(name=f"{workflow.kind}.agent.{self.id}"), _do
+                )
+            except HarnessError as error:
+                if error.retry is Retry.TRANSIENT:
+                    # One retry per delay on the error's own schedule; past it,
+                    # the failure stands.
+                    if transient_retry_index >= len(error.retry_delays):
+                        raise
+                    delay = error.retry_delays[transient_retry_index]
+                    transient_retry_index += 1
+                    # Jitter, so a provider outage doesn't wake every run at once.
+                    wait_seconds = delay * random.uniform(0.9, 1.1)
+                elif error.retry is Retry.QUOTA:
+                    # One shot: sleep until the provider's window turns, read
+                    # off the latest usage scrape.
+                    if quota_retried:
+                        raise
+                    quota_retried = True
+                    wait_seconds = await DBOS.run_step_async(
+                        StepOptions(name=f"{workflow.kind}.agent.{self.id}.retry_wait"),
+                        _quota_retry_wait,
+                    )
+                    # A far-off reset (an exhausted weekly window) isn't worth
+                    # sleeping into — fail now.
+                    if wait_seconds > _QUOTA_MAX_WAIT_SECONDS:
+                        raise
+                    wait_seconds += random.uniform(60, 120)
+                else:
+                    # Permanent or unclassified — never retried.
+                    raise
+                # A long sleep shouldn't hold a VM; the next attempt rebuilds
+                # its workspace from git, like a gate park.
+                if wait_seconds >= _REAP_BEFORE_WAIT_SECONDS:
+                    await workflow._reap_run()
+                # Durable: the end time checkpoints now, so a restart resumes
+                # with the remaining wait, and replay skips it entirely.
+                await DBOS.sleep_async(wait_seconds)
+            else:
+                # Body-level only, on both passes: in-step calls hit the early return
+                # live and are skipped with their step on replay.
+                workflow.journal.add(result)
+                return result
 
     async def _run(self, *, workflow_id: str, **context: Any) -> Any:
         """The raw execution: provision or attach a host, record the AgentCall, run

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -63,6 +63,7 @@ class ClaudeHarness(Harness):
         "rate_limit": exceptions.HarnessRateLimitError,
         "api error: 401": exceptions.HarnessAuthError,
         "authentication_error": exceptions.HarnessAuthError,
+        "failed to authenticate": exceptions.HarnessAuthError,
         "oauth token": exceptions.HarnessAuthError,
         "invalid api key": exceptions.HarnessAuthError,
         "overloaded": exceptions.HarnessOverloadedError,

--- a/backend/druks/harnesses/exceptions.py
+++ b/backend/druks/harnesses/exceptions.py
@@ -14,6 +14,7 @@ class HarnessError(Exception):
     # unclassified, which is never retried.
     code: ClassVar[str] = ""
     retry: ClassVar[Retry] = Retry.NEVER
+    retry_delays: ClassVar[tuple[int, ...]] = ()
 
 
 class StreamJsonError(ValueError):
@@ -31,6 +32,7 @@ class HarnessTimeoutError(HarnessError):
 class HarnessOverloadedError(HarnessError):
     code = "overloaded"
     retry = Retry.TRANSIENT
+    retry_delays = (300, 900)
 
 
 class HarnessRateLimitError(HarnessError):
@@ -57,6 +59,7 @@ class HarnessSandboxError(HarnessError):
 
     code = "sandbox"
     retry = Retry.TRANSIENT
+    retry_delays = (60, 300)
 
 
 class OAuthTokenError(Exception):
@@ -114,3 +117,6 @@ class HarnessFirstByteTimeoutError(HarnessError):
 
     code = "first_byte"
     retry = Retry.TRANSIENT
+    # Two immediate retries: the failed attempt cost 90 seconds, not minutes,
+    # and the wedge is CLI-local — waiting buys nothing.
+    retry_delays = (0, 0)

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -1,4 +1,6 @@
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -95,9 +97,27 @@ def current_run():
     # An agent call reads its workflow from current_workflow; set it like the run engine does.
     from druks.workflows import Workflow, current_workflow
 
-    token = current_workflow.set(Workflow())
-    yield
+    workflow = Workflow()
+    workflow._workflow_id = "wf-9"
+    workflow.kind = "test"
+    token = current_workflow.set(workflow)
+    yield workflow
     current_workflow.reset(token)
+
+
+@pytest.fixture
+def _inline_agent_steps(monkeypatch):
+    # Run agent attempts and quota lookups inline while retaining their DBOS step boundaries.
+    checkpoints = []
+
+    async def run_inline(options, function):
+        checkpoints.append(options)
+        return await function()
+
+    sleep = AsyncMock()
+    monkeypatch.setattr(agents.DBOS, "run_step_async", run_inline)
+    monkeypatch.setattr(agents.DBOS, "sleep_async", sleep)
+    return checkpoints, sleep
 
 
 async def test_run_outside_workflow_raises():
@@ -305,6 +325,242 @@ async def test_a_carried_failure_is_raised_with_its_code(
     assert call.last_error == (
         "dummy: HarnessOverloadedError: claude exited with 1. API Error: 529 Overloaded."
     )
+
+
+async def test_body_level_overload_retries_as_separate_durable_attempts(
+    druks_db, tmp_path, monkeypatch, current_run, _inline_agent_steps
+):
+    from druks.harnesses.exceptions import HarnessOverloadedError
+
+    failures = [
+        HarnessOverloadedError("overloaded once"),
+        HarnessOverloadedError("overloaded twice"),
+    ]
+    sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
+    sandbox.run_agent = AsyncMock(
+        side_effect=[
+            make_agent_result(None, agent="dummy", error=failures[0]),
+            make_agent_result(None, agent="dummy", error=failures[1]),
+            make_agent_result({"ok": True}, agent="dummy"),
+        ]
+    )
+    _patch_ephemeral(monkeypatch, sandbox)
+    monkeypatch.setattr(agents.random, "uniform", MagicMock(side_effect=[0.95, 1.05]))
+    current_run._reap_run = AsyncMock()
+    checkpoints, sleep = _inline_agent_steps
+
+    result = await DUMMY_AGENT()
+
+    assert result == DummyOutput(ok=True)
+    assert [awaited.args[0] for awaited in sleep.await_args_list] == [285.0, 945.0]
+    assert [options["name"] for options in checkpoints] == ["test.agent.dummy"] * 3
+    assert current_run._reap_run.await_count == 2
+    calls = AgentCall.list_for_run("wf-9")
+    assert len(calls) == 3
+    assert sum(call.status == "failed" for call in calls) == 2
+    assert sum(call.status == "succeeded" for call in calls) == 1
+    assert {call.failure_code for call in calls if call.status == "failed"} == {"overloaded"}
+    assert current_run.journal.filter(DummyOutput) == [result]
+
+
+async def test_body_level_first_byte_retries_immediately_then_reraises(
+    druks_db, tmp_path, monkeypatch, current_run, _inline_agent_steps
+):
+    from druks.harnesses.exceptions import HarnessFirstByteTimeoutError
+
+    failures = [HarnessFirstByteTimeoutError(f"wedged {attempt}") for attempt in range(3)]
+    sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
+    sandbox.run_agent = AsyncMock(
+        side_effect=[make_agent_result(None, agent="dummy", error=failure) for failure in failures]
+    )
+    _patch_ephemeral(monkeypatch, sandbox)
+    monkeypatch.setattr(agents.random, "uniform", lambda _low, _high: 1.0)
+    current_run._reap_run = AsyncMock()
+    _, sleep = _inline_agent_steps
+
+    with pytest.raises(HarnessFirstByteTimeoutError) as excinfo:
+        await DUMMY_AGENT()
+
+    assert excinfo.value is failures[-1]
+    assert excinfo.value.code == "first_byte"
+    assert [awaited.args[0] for awaited in sleep.await_args_list] == [0.0, 0.0]
+    current_run._reap_run.assert_not_awaited()
+    calls = AgentCall.list_for_run("wf-9")
+    assert len(calls) == 3
+    assert all(call.status == "failed" for call in calls)
+
+
+async def test_body_level_quota_waits_for_the_reset_once(
+    druks_db, tmp_path, monkeypatch, current_run, _inline_agent_steps
+):
+    from druks.harnesses.exceptions import HarnessRateLimitError
+
+    now = datetime(2026, 8, 1, 10, tzinfo=UTC)
+    failures = [HarnessRateLimitError(f"quota {attempt}") for attempt in range(2)]
+    sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
+    sandbox.run_agent = AsyncMock(
+        side_effect=[make_agent_result(None, agent="dummy", error=failure) for failure in failures]
+    )
+    _patch_ephemeral(monkeypatch, sandbox)
+    clock = MagicMock()
+    clock.now.return_value = now
+    monkeypatch.setattr(agents, "datetime", clock)
+    monkeypatch.setattr(
+        agents.UsageScrape,
+        "latest_for",
+        classmethod(
+            lambda _cls, _harness, _account_id: SimpleNamespace(
+                five_hour_resets_at=now + timedelta(hours=1),
+                week_resets_at=now + timedelta(days=1),
+            )
+        ),
+    )
+    jitter = MagicMock(return_value=90.0)
+    monkeypatch.setattr(agents.random, "uniform", jitter)
+    current_run._reap_run = AsyncMock()
+    checkpoints, sleep = _inline_agent_steps
+
+    with pytest.raises(HarnessRateLimitError) as excinfo:
+        await DUMMY_AGENT()
+
+    assert excinfo.value is failures[-1]
+    sleep.assert_awaited_once_with(60 * 60 + 90.0)
+    jitter.assert_called_once_with(60.0, 120.0)
+    current_run._reap_run.assert_awaited_once()
+    assert [options["name"] for options in checkpoints] == [
+        "test.agent.dummy",
+        "test.agent.dummy.retry_wait",
+        "test.agent.dummy",
+    ]
+    calls = AgentCall.list_for_run("wf-9")
+    assert len(calls) == 2
+    assert all(call.failure_code == "rate_limited" for call in calls)
+
+
+async def test_body_level_quota_reset_over_six_hours_reraises_without_sleeping(
+    druks_db, tmp_path, monkeypatch, current_run, _inline_agent_steps
+):
+    from druks.harnesses.exceptions import HarnessUsageLimitError
+
+    now = datetime(2026, 8, 1, 10, tzinfo=UTC)
+    failure = HarnessUsageLimitError("weekly quota")
+    sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
+    sandbox.run_agent = AsyncMock(
+        return_value=make_agent_result(None, agent="dummy", error=failure)
+    )
+    _patch_ephemeral(monkeypatch, sandbox)
+    clock = MagicMock()
+    clock.now.return_value = now
+    monkeypatch.setattr(agents, "datetime", clock)
+    monkeypatch.setattr(
+        agents.UsageScrape,
+        "latest_for",
+        classmethod(
+            lambda _cls, _harness, _account_id: SimpleNamespace(
+                five_hour_resets_at=now + timedelta(hours=7),
+                week_resets_at=now + timedelta(days=1),
+            )
+        ),
+    )
+    jitter = MagicMock()
+    monkeypatch.setattr(agents.random, "uniform", jitter)
+    current_run._reap_run = AsyncMock()
+    _, sleep = _inline_agent_steps
+
+    with pytest.raises(HarnessUsageLimitError) as excinfo:
+        await DUMMY_AGENT()
+
+    assert excinfo.value is failure
+    sleep.assert_not_awaited()
+    jitter.assert_not_called()
+    current_run._reap_run.assert_not_awaited()
+    [call] = AgentCall.list_for_run("wf-9")
+    assert call.failure_code == "usage_limit"
+
+
+@pytest.mark.parametrize("error_name", [pytest.param("bare"), pytest.param("auth")])
+async def test_body_level_never_retry_errors_run_once(
+    error_name, druks_db, tmp_path, monkeypatch, current_run, _inline_agent_steps
+):
+    from druks.harnesses.exceptions import HarnessAuthError, HarnessError, Retry
+
+    failures = {"bare": HarnessError, "auth": HarnessAuthError}
+    failure = failures[error_name]("terminal")
+    sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
+    sandbox.run_agent = AsyncMock(
+        return_value=make_agent_result(None, agent="dummy", error=failure)
+    )
+    _patch_ephemeral(monkeypatch, sandbox)
+    current_run._reap_run = AsyncMock()
+    checkpoints, sleep = _inline_agent_steps
+
+    with pytest.raises(type(failure)) as excinfo:
+        await DUMMY_AGENT()
+
+    assert excinfo.value is failure
+    assert failure.retry is Retry.NEVER
+    assert [options["name"] for options in checkpoints] == ["test.agent.dummy"]
+    sleep.assert_not_awaited()
+    current_run._reap_run.assert_not_awaited()
+    sandbox.run_agent.assert_awaited_once()
+    assert len(AgentCall.list_for_run("wf-9")) == 1
+
+
+async def test_in_step_transient_retry_uses_asyncio_sleep(monkeypatch, current_run):
+    from druks.harnesses.exceptions import HarnessOverloadedError
+    from druks.workflows import _in_step
+
+    attempts = 0
+
+    async def run_agent(_self, **_context):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise HarnessOverloadedError("overloaded")
+        return DummyOutput(ok=True)
+
+    monkeypatch.setattr(agents.Agent, "_run", run_agent)
+    monkeypatch.setattr(agents.random, "uniform", lambda _low, _high: 1.0)
+    memory_sleep = AsyncMock()
+    durable_sleep = AsyncMock()
+    monkeypatch.setattr(agents.asyncio, "sleep", memory_sleep)
+    monkeypatch.setattr(agents.DBOS, "sleep_async", durable_sleep)
+    token = _in_step.set(True)
+    try:
+        result = await DUMMY_AGENT()
+    finally:
+        _in_step.reset(token)
+
+    assert result == DummyOutput(ok=True)
+    assert attempts == 2
+    memory_sleep.assert_awaited_once_with(300.0)
+    durable_sleep.assert_not_awaited()
+
+
+async def test_in_step_quota_reraises_without_sleeping(monkeypatch, current_run):
+    from druks.harnesses.exceptions import HarnessRateLimitError
+    from druks.workflows import _in_step
+
+    failure = HarnessRateLimitError("quota")
+
+    async def run_agent(_self, **_context):
+        raise failure
+
+    monkeypatch.setattr(agents.Agent, "_run", run_agent)
+    memory_sleep = AsyncMock()
+    durable_sleep = AsyncMock()
+    monkeypatch.setattr(agents.asyncio, "sleep", memory_sleep)
+    monkeypatch.setattr(agents.DBOS, "sleep_async", durable_sleep)
+    token = _in_step.set(True)
+    try:
+        with pytest.raises(HarnessRateLimitError) as excinfo:
+            await DUMMY_AGENT()
+    finally:
+        _in_step.reset(token)
+
+    assert excinfo.value is failure
+    memory_sleep.assert_not_awaited()
+    durable_sleep.assert_not_awaited()
 
 
 async def test_recovery_supersedes_the_orphaned_running_call(druks_db):

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -431,6 +431,14 @@ def _claude_result_event(text: str) -> bytes:
         (
             ClaudeHarness,
             _claude_result_event(
+                "Failed to authenticate: OAuth session expired and could not be refreshed"
+            ),
+            HarnessAuthError,
+            "auth",
+        ),
+        (
+            ClaudeHarness,
+            _claude_result_event(
                 'API Error: 503 {"type":"error","error":'
                 '{"type":"api_error","message":"Internal server error"}}'
             ),


### PR DESCRIPTION
**Linear ticket:** [ENG-796](https://linear.app/fellaworks/issue/ENG-796/durable-in-run-retry-for-transient-harness-failures)

## What changed

A transient provider error that outlasts the CLI's internal retries no longer kills the run. `Agent.__call__` grew a platform-level retry loop over both dispatch paths — extension code is untouched:

- Retry policy lives on the exception classes: transient failures declare `retry_delays` (`HarnessOverloadedError` (300, 900) — spaced in minutes deliberately, since the CLI already burned its fast retries before dying; `HarnessSandboxError` (60, 300); `HarnessFirstByteTimeoutError` (0, 0)). Each body-level attempt is its own DBOS step, so a re-invocation runs live while failed attempts stay checkpointed as their own AgentCall rows; the sleeps are `DBOS.sleep_async` — durable, resumed with remaining time after a crash. Jitter (±10%) feeds only the sleep, which checkpoints its absolute end, so replay stays deterministic.
- Quota failures (429, usage windows) retry once: a checkpointed `retry_wait` step reads the charged connection's latest `UsageScrape` reset and returns pure seconds-until-reset; the caller applies all policy — resets more than 6h away re-raise instead of sleeping, otherwise the run durably sleeps until reset plus 60–120s of jitter. In-step agent calls (auto-stepped `run()` bodies) get the same transient policy with in-memory sleeps, and re-raise quota failures immediately rather than holding an executor slot on a non-durable multi-hour sleep.
- The warm host is released (`_reap_run`) before any sleep of 120s or more — the same reasoning as gate parks; the next attempt re-provisions and rebuilds its workspace from git.
- Exhaustion re-raises the last typed error: the run fails with its classified code exactly as before, just after honest retries. `Retry.NEVER` and unclassified failures never loop.
- One evidence-backed marker fix from production transcripts: claude's only real auth death ("Failed to authenticate: OAuth session expired…") matched no auth marker; `"failed to authenticate"` now classifies it.

## Risk

Low. No body-shape change for runs that don't fail (the happy path is one step invocation, as before). In-flight runs replay unaffected. During a provider outage, runs now sleep-and-outlast instead of dying together; worst case they fail with the same classified code ~20 minutes later than they would have.

## Verification

- `uv run ruff check` / `ruff format --check` — clean on all touched files.
- `uv run pytest backend/tests --collect-only -q` — no import errors (the 19 `druks_field_notes` errors are a known local-venv gap; CI has the package).
- `uv run pyright` on touched files — no new error kinds vs HEAD.
- New tests pin: per-attempt durable steps and AgentCall rows, sleep sequencing with jitter, quota reset waits and the 6h cap, never-retry classes, in-step `asyncio.sleep` vs durable sleep, and the production auth transcript string. The full suite gates in CI (conftest needs the shared Postgres).