### PR TITLE
ENG-797 - retry_run: fork-based recovery verb for failed runs

### DIFF
--- a/backend/druks/durable/dbos_state.py
+++ b/backend/druks/durable/dbos_state.py
@@ -26,6 +26,7 @@ workflow_status = sa.Table(
     sa.Column("status", sa.String),
     sa.Column("updated_at", sa.BigInteger),
     sa.Column("attributes", JSONB),
+    sa.Column("forked_from", sa.String),
 )
 
 

--- a/backend/druks/durable/dbos_state.py
+++ b/backend/druks/durable/dbos_state.py
@@ -26,7 +26,6 @@ workflow_status = sa.Table(
     sa.Column("status", sa.String),
     sa.Column("updated_at", sa.BigInteger),
     sa.Column("attributes", JSONB),
-    sa.Column("forked_from", sa.String),
 )
 
 

--- a/backend/druks/durable/enums.py
+++ b/backend/druks/durable/enums.py
@@ -30,6 +30,7 @@ class WorkflowEvent(StrEnum):
     FINISHED = "workflow.finished"
     FAILED = "workflow.failed"
     CANCELLED = "workflow.cancelled"
+    RETRIED = "workflow.retried"
 
     @classmethod
     def for_state(cls, state: RunState) -> "WorkflowEvent":

--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -69,12 +69,6 @@ class Run(Base):
     # How the subject showed itself when this run started — read with the row, so
     # every event the run writes names it without a second lookup.
     subject_label: Mapped[str | None] = column_property(subject_label_expression(id))
-    forked_from: Mapped[str | None] = column_property(
-        select(workflow_status.c.forked_from)
-        .where(workflow_status.c.workflow_uuid == id)
-        .correlate_except(workflow_status)
-        .scalar_subquery()
-    )
     # Who asked; the system account when nobody did (crons, background work).
     account_id: Mapped[str] = mapped_column(
         ForeignKey("accounts.id", ondelete="RESTRICT"), default=SYSTEM_ACCOUNT_ID

--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -20,6 +20,7 @@ from druks.durable.dbos_state import (
     updated_at_expression,
     workflow_status,
 )
+from druks.durable.engine import _step_engine, run_queue
 from druks.durable.enums import (
     ACTIVE_STATES,
     OPEN_STATES,
@@ -68,6 +69,12 @@ class Run(Base):
     # How the subject showed itself when this run started — read with the row, so
     # every event the run writes names it without a second lookup.
     subject_label: Mapped[str | None] = column_property(subject_label_expression(id))
+    forked_from: Mapped[str | None] = column_property(
+        select(workflow_status.c.forked_from)
+        .where(workflow_status.c.workflow_uuid == id)
+        .correlate_except(workflow_status)
+        .scalar_subquery()
+    )
     # Who asked; the system account when nobody did (crons, background work).
     account_id: Mapped[str] = mapped_column(
         ForeignKey("accounts.id", ondelete="RESTRICT"), default=SYSTEM_ACCOUNT_ID
@@ -289,6 +296,34 @@ class Run(Base):
                 kind=self.kind,
                 failure=failure,
             )
+
+    async def retry(self) -> str:
+        steps = await DBOS.list_workflow_steps_async(self.id)
+        start_step = max(
+            (step["function_id"] for step in steps if step["error"]),
+            default=1,
+        )
+        handle = await DBOS.fork_workflow_async(
+            self.id,
+            start_step,
+            queue_name=run_queue.name,
+        )
+        workflow_id = handle.workflow_id
+        Run.create_row(
+            _step_engine(),
+            workflow_id=workflow_id,
+            kind=self.kind,
+            account_id=self.account_id,
+        )
+        subject = self.subject
+        if subject:
+            await publish(
+                WorkflowEvent.RETRIED,
+                subject=subject,
+                kind=self.kind,
+                run=workflow_id,
+            )
+        return workflow_id
 
 
 @dataclass(frozen=True)

--- a/backend/druks/mcp/app.py
+++ b/backend/druks/mcp/app.py
@@ -24,9 +24,9 @@ chunk, and parkedAt; answer_gate must echo that parkedAt unchanged — it
 names the exact question being answered, and a repeat answer reports
 already_answered. get_agent_call returns bounded transcript and stderr
 tails, never full payloads. cancel_run records its reason as the run's
-failure. get_usage is the caller's quota and today's spend. There is no
-push channel; poll. Tool failures embed {code, message, retryable} from the
-HTTP surface.
+failure. retry_run forks a failed run from its failed step. get_usage is the
+caller's quota and today's spend. There is no push channel; poll.
+Tool failures embed {code, message, retryable} from the HTTP surface.
 """
 
 # FastMCP logs component-fn errors instead of raising, so the tools/list
@@ -36,6 +36,7 @@ _TOOL_ANNOTATIONS = {
     "answer_gate": ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
     "get_agent_call": ToolAnnotations(readOnlyHint=True),
     "cancel_run": ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True),
+    "retry_run": ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
     "get_usage": ToolAnnotations(readOnlyHint=True),
 }
 

--- a/backend/druks/mcp/app.py
+++ b/backend/druks/mcp/app.py
@@ -24,9 +24,9 @@ chunk, and parkedAt; answer_gate must echo that parkedAt unchanged — it
 names the exact question being answered, and a repeat answer reports
 already_answered. get_agent_call returns bounded transcript and stderr
 tails, never full payloads. cancel_run records its reason as the run's
-failure. retry_run forks a failed run from its failed step. get_usage is the
-caller's quota and today's spend. There is no push channel; poll.
-Tool failures embed {code, message, retryable} from the HTTP surface.
+failure. retry_run reruns a failed run from the step that killed it.
+get_usage is the caller's quota and today's spend. There is no push channel;
+poll. Tool failures embed {code, message, retryable} from the HTTP surface.
 """
 
 # FastMCP logs component-fn errors instead of raising, so the tools/list
@@ -36,7 +36,7 @@ _TOOL_ANNOTATIONS = {
     "answer_gate": ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
     "get_agent_call": ToolAnnotations(readOnlyHint=True),
     "cancel_run": ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True),
-    "retry_run": ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
+    "retry_run": ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False),
     "get_usage": ToolAnnotations(readOnlyHint=True),
 }
 

--- a/backend/druks/mcp/gateway/exceptions.py
+++ b/backend/druks/mcp/gateway/exceptions.py
@@ -65,3 +65,20 @@ class RunNotActive(AgentApiError):
 
     def __init__(self, run_id: str) -> None:
         super().__init__(f"Run {run_id} already ended.")
+
+
+class RunNotFailed(AgentApiError):
+    status_code = 409
+    code = "RUN_NOT_FAILED"
+
+    def __init__(self, run_id: str) -> None:
+        super().__init__(f"Run {run_id} did not fail.")
+
+
+class SubjectBusy(AgentApiError):
+    status_code = 409
+    code = "SUBJECT_BUSY"
+    retryable = True
+
+    def __init__(self, run_id: str) -> None:
+        super().__init__(f"The subject already has active run {run_id}.")

--- a/backend/druks/mcp/gateway/routes.py
+++ b/backend/druks/mcp/gateway/routes.py
@@ -75,8 +75,8 @@ async def cancel_run(
     response_model_by_alias=True,
 )
 async def retry_run(run_id: str) -> schemas.RetryRunResponse:
-    """Retry a failed run from its failed step; a repeat reports the active
-    fork as already_retried."""
+    """Rerun a failed run from the step that killed it, reusing every
+    completed step."""
     return await services.retry_run(run_id)
 
 

--- a/backend/druks/mcp/gateway/routes.py
+++ b/backend/druks/mcp/gateway/routes.py
@@ -68,6 +68,18 @@ async def cancel_run(
     return await services.cancel_run(run_id, reason=reason)
 
 
+@router.post(
+    "/runs/{run_id}/retry",
+    operation_id="retry_run",
+    response_model=schemas.RetryRunResponse,
+    response_model_by_alias=True,
+)
+async def retry_run(run_id: str) -> schemas.RetryRunResponse:
+    """Retry a failed run from its failed step; a repeat reports the active
+    fork as already_retried."""
+    return await services.retry_run(run_id)
+
+
 @router.get(
     "/usage/summary",
     operation_id="get_usage",

--- a/backend/druks/mcp/gateway/schemas.py
+++ b/backend/druks/mcp/gateway/schemas.py
@@ -53,6 +53,11 @@ class CancelRunResponse(BaseResponse):
     result: Literal["cancelled", "already_cancelled"]
 
 
+class RetryRunResponse(BaseResponse):
+    run_id: str
+    result: Literal["retried", "already_retried"]
+
+
 class AgentHarnessUsage(BaseResponse):
     # *_history: percent-left trend samples, oldest first.
     name: str

--- a/backend/druks/mcp/gateway/schemas.py
+++ b/backend/druks/mcp/gateway/schemas.py
@@ -55,7 +55,6 @@ class CancelRunResponse(BaseResponse):
 
 class RetryRunResponse(BaseResponse):
     run_id: str
-    result: Literal["retried", "already_retried"]
 
 
 class AgentHarnessUsage(BaseResponse):

--- a/backend/druks/mcp/gateway/services.py
+++ b/backend/druks/mcp/gateway/services.py
@@ -108,12 +108,9 @@ async def retry_run(run_id: str) -> schemas.RetryRunResponse:
     if subject:
         latest = Run.get_latest_for_subject(subject["type"], subject["id"])
         if latest and latest.is_active:
-            if latest.forked_from == run.id:
-                return schemas.RetryRunResponse(run_id=latest.id, result="already_retried")
             raise exceptions.SubjectBusy(latest.id)
 
-    retried_run_id = await run.retry()
-    return schemas.RetryRunResponse(run_id=retried_run_id, result="retried")
+    return schemas.RetryRunResponse(run_id=await run.retry())
 
 
 def _artifact_content(artifact: Artifact | None) -> schemas.ArtifactContent | None:

--- a/backend/druks/mcp/gateway/services.py
+++ b/backend/druks/mcp/gateway/services.py
@@ -97,6 +97,25 @@ async def cancel_run(run_id: str, *, reason: str) -> schemas.CancelRunResponse:
     return schemas.CancelRunResponse(run_id=run.id, result="cancelled")
 
 
+async def retry_run(run_id: str) -> schemas.RetryRunResponse:
+    run = Run.get(run_id)
+    if not run:
+        raise exceptions.RunNotFound(run_id)
+    if run.state != RunState.FAILED.value:
+        raise exceptions.RunNotFailed(run_id)
+
+    subject = run.subject
+    if subject:
+        latest = Run.get_latest_for_subject(subject["type"], subject["id"])
+        if latest and latest.is_active:
+            if latest.forked_from == run.id:
+                return schemas.RetryRunResponse(run_id=latest.id, result="already_retried")
+            raise exceptions.SubjectBusy(latest.id)
+
+    retried_run_id = await run.retry()
+    return schemas.RetryRunResponse(run_id=retried_run_id, result="retried")
+
+
 def _artifact_content(artifact: Artifact | None) -> schemas.ArtifactContent | None:
     if not artifact:
         return

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -23,6 +23,7 @@ _MCP_ROUTES = {
     ("post", "/api/gates/{run_id}/answer"): "answer_gate",
     ("get", "/api/agent-calls/{call_id}"): "get_agent_call",
     ("post", "/api/runs/{run_id}/cancel"): "cancel_run",
+    ("post", "/api/runs/{run_id}/retry"): "retry_run",
     ("get", "/api/usage/summary"): "get_usage",
 }
 
@@ -66,7 +67,7 @@ def _park(druks_db, note):
     return run
 
 
-def test_openapi_pins_the_five_agent_routes(client: TestClient):
+def test_openapi_pins_the_six_agent_routes(client: TestClient):
     schema = app.openapi()
     found = {
         (method, path): operation

--- a/backend/tests/test_agent_services.py
+++ b/backend/tests/test_agent_services.py
@@ -1,13 +1,18 @@
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 from conftest import make_test_note, seed_note_run
 from druks.accounts.models import Account
+from druks.durable.dbos_state import workflow_status
+from druks.durable.engine import run_queue
+from druks.durable.enums import WorkflowEvent
 from druks.durable.models import Artifact, Run
 from druks.durable.reads import read_slice
 from druks.mcp.gateway import exceptions, services
-from druks.testing import seed_call
+from druks.testing import seed_call, seed_dbos_status
 from druks.usage.models import UsageScrape
 
 pytestmark = pytest.mark.usefixtures("_data_dir")
@@ -259,6 +264,140 @@ async def test_cancel_run_paths(druks_db):
 
     with pytest.raises(exceptions.RunNotFound):
         await services.cancel_run("no-such-run", reason="x")
+
+
+async def test_run_retry_forks_from_the_failed_step(druks_db, monkeypatch):
+    item = make_test_note()
+    run = seed_note_run(druks_db, note=item, state="failed")
+    retried_run_id = "retried-run"
+    steps = [
+        {"function_id": 2, "error": None},
+        {"function_id": 6, "error": RuntimeError("first failure")},
+        {"function_id": 8, "error": RuntimeError("final failure")},
+    ]
+    list_steps = mock.AsyncMock(return_value=steps)
+    events = []
+
+    async def _fork(workflow_id, start_step, *, queue_name):
+        seed_dbos_status(
+            druks_db,
+            retried_run_id,
+            "scheduled",
+            subject=item.identity,
+        )
+        druks_db.execute(
+            workflow_status.update()
+            .where(workflow_status.c.workflow_uuid == retried_run_id)
+            .values(forked_from=workflow_id)
+        )
+        return SimpleNamespace(workflow_id=retried_run_id)
+
+    async def _publish(event, **facts):
+        events.append((event, facts))
+
+    fork = mock.AsyncMock(side_effect=_fork)
+    monkeypatch.setattr("dbos.DBOS.list_workflow_steps_async", list_steps)
+    monkeypatch.setattr("dbos.DBOS.fork_workflow_async", fork)
+    monkeypatch.setattr("druks.durable.models.publish", _publish)
+
+    result = await run.retry()
+
+    assert result == retried_run_id
+    list_steps.assert_awaited_once_with(run.id)
+    fork.assert_awaited_once_with(run.id, 8, queue_name=run_queue.name)
+    druks_db.expire_all()
+    retried = Run.get(retried_run_id)
+    assert retried.kind == run.kind
+    assert retried.account_id == run.account_id
+    assert retried.state == "scheduled"
+    assert retried.forked_from == run.id
+    assert events == [
+        (
+            WorkflowEvent.RETRIED,
+            {"subject": item.identity, "kind": run.kind, "run": retried_run_id},
+        )
+    ]
+
+
+async def test_run_retry_restarts_at_step_one_without_a_failed_checkpoint(druks_db, monkeypatch):
+    run = seed_note_run(druks_db, state="failed")
+    list_steps = mock.AsyncMock(return_value=[{"function_id": 2, "error": None}])
+    fork = mock.AsyncMock(return_value=SimpleNamespace(workflow_id="clean-retry"))
+    monkeypatch.setattr("dbos.DBOS.list_workflow_steps_async", list_steps)
+    monkeypatch.setattr("dbos.DBOS.fork_workflow_async", fork)
+    monkeypatch.setattr("druks.durable.models.publish", mock.AsyncMock())
+
+    await run.retry()
+
+    fork.assert_awaited_once_with(run.id, 1, queue_name=run_queue.name)
+
+
+async def test_retry_run_refuses_a_non_failed_run(druks_db, monkeypatch):
+    run = seed_note_run(druks_db, state="finished")
+    retry = mock.AsyncMock()
+    monkeypatch.setattr(Run, "retry", retry)
+
+    with pytest.raises(exceptions.RunNotFailed) as error:
+        await services.retry_run(run.id)
+
+    assert error.value.code == "RUN_NOT_FAILED"
+    assert error.value.retryable is False
+    retry.assert_not_awaited()
+
+
+async def test_retry_run_refuses_a_busy_subject(druks_db, monkeypatch):
+    item = make_test_note()
+    failed = seed_note_run(druks_db, note=item, state="failed")
+    active = seed_note_run(druks_db, note=item, state="running")
+    retry = mock.AsyncMock()
+    monkeypatch.setattr(Run, "retry", retry)
+
+    with pytest.raises(exceptions.SubjectBusy) as error:
+        await services.retry_run(failed.id)
+
+    assert str(error.value) == f"The subject already has active run {active.id}."
+    assert error.value.retryable is True
+    retry.assert_not_awaited()
+
+
+async def test_retry_run_returns_the_active_fork_on_replay(druks_db, monkeypatch):
+    item = make_test_note()
+    failed = seed_note_run(druks_db, note=item, state="failed")
+    retried = seed_note_run(druks_db, note=item, state="running")
+    druks_db.execute(
+        workflow_status.update()
+        .where(workflow_status.c.workflow_uuid == retried.id)
+        .values(forked_from=failed.id)
+    )
+    druks_db.expire_all()
+    retry = mock.AsyncMock()
+    monkeypatch.setattr(Run, "retry", retry)
+
+    result = await services.retry_run(failed.id)
+
+    assert result.run_id == retried.id
+    assert result.result == "already_retried"
+    retry.assert_not_awaited()
+
+
+async def test_retry_run_retries_a_failed_run(druks_db, monkeypatch):
+    run = seed_note_run(druks_db, state="failed")
+    retry = mock.AsyncMock(return_value="retried-run")
+    monkeypatch.setattr(Run, "retry", retry)
+
+    result = await services.retry_run(run.id)
+
+    assert result.run_id == "retried-run"
+    assert result.result == "retried"
+    retry.assert_awaited_once_with()
+
+
+async def test_retry_run_refuses_a_missing_run(druks_db):
+    with pytest.raises(exceptions.RunNotFound) as error:
+        await services.retry_run("no-such-run")
+
+    assert error.value.code == "RUN_NOT_FOUND"
+    assert error.value.retryable is False
 
 
 # ---- usage ----------------------------------------------------------------

--- a/backend/tests/test_agent_services.py
+++ b/backend/tests/test_agent_services.py
@@ -6,7 +6,6 @@ from unittest import mock
 import pytest
 from conftest import make_test_note, seed_note_run
 from druks.accounts.models import Account
-from druks.durable.dbos_state import workflow_status
 from druks.durable.engine import run_queue
 from druks.durable.enums import WorkflowEvent
 from druks.durable.models import Artifact, Run
@@ -285,11 +284,6 @@ async def test_run_retry_forks_from_the_failed_step(druks_db, monkeypatch):
             "scheduled",
             subject=item.identity,
         )
-        druks_db.execute(
-            workflow_status.update()
-            .where(workflow_status.c.workflow_uuid == retried_run_id)
-            .values(forked_from=workflow_id)
-        )
         return SimpleNamespace(workflow_id=retried_run_id)
 
     async def _publish(event, **facts):
@@ -310,11 +304,16 @@ async def test_run_retry_forks_from_the_failed_step(druks_db, monkeypatch):
     assert retried.kind == run.kind
     assert retried.account_id == run.account_id
     assert retried.state == "scheduled"
-    assert retried.forked_from == run.id
     assert events == [
         (
             WorkflowEvent.RETRIED,
-            {"subject": item.identity, "kind": run.kind, "run": retried_run_id},
+            # Subject ids ride the DBOS attributes as strings — the one shape
+            # every reader compares.
+            {
+                "subject": {"type": "note", "id": str(item.id)},
+                "kind": run.kind,
+                "run": retried_run_id,
+            },
         )
     ]
 
@@ -360,26 +359,6 @@ async def test_retry_run_refuses_a_busy_subject(druks_db, monkeypatch):
     retry.assert_not_awaited()
 
 
-async def test_retry_run_returns_the_active_fork_on_replay(druks_db, monkeypatch):
-    item = make_test_note()
-    failed = seed_note_run(druks_db, note=item, state="failed")
-    retried = seed_note_run(druks_db, note=item, state="running")
-    druks_db.execute(
-        workflow_status.update()
-        .where(workflow_status.c.workflow_uuid == retried.id)
-        .values(forked_from=failed.id)
-    )
-    druks_db.expire_all()
-    retry = mock.AsyncMock()
-    monkeypatch.setattr(Run, "retry", retry)
-
-    result = await services.retry_run(failed.id)
-
-    assert result.run_id == retried.id
-    assert result.result == "already_retried"
-    retry.assert_not_awaited()
-
-
 async def test_retry_run_retries_a_failed_run(druks_db, monkeypatch):
     run = seed_note_run(druks_db, state="failed")
     retry = mock.AsyncMock(return_value="retried-run")
@@ -388,7 +367,6 @@ async def test_retry_run_retries_a_failed_run(druks_db, monkeypatch):
     result = await services.retry_run(run.id)
 
     assert result.run_id == "retried-run"
-    assert result.result == "retried"
     retry.assert_awaited_once_with()
 
 

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -37,7 +37,14 @@ _WIRE_HEADERS = {
 }
 
 # tools/list order is the gateway router's declaration order.
-_TOOL_NAMES = ["get_gate", "answer_gate", "get_agent_call", "cancel_run", "get_usage"]
+_TOOL_NAMES = [
+    "get_gate",
+    "answer_gate",
+    "get_agent_call",
+    "cancel_run",
+    "retry_run",
+    "get_usage",
+]
 
 
 @pytest.fixture
@@ -156,7 +163,7 @@ async def test_mcp_subpaths_never_reach_the_spa(app):
             assert stray.headers["content-type"].startswith("application/json")
 
 
-async def test_tools_list_pins_the_five_derived_from_agent_routes(app, pat_token):
+async def test_tools_list_pins_the_six_derived_from_agent_routes(app, pat_token):
     async with live(app), _client(app, pat_token) as client:
         assert "parkedAt" in (client.initialize_result.instructions or "")
         tools = {tool.name: tool for tool in await client.list_tools()}

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -174,7 +174,8 @@ async def test_tools_list_pins_the_six_derived_from_agent_routes(app, pat_token)
         annotations = tool.annotations
         assert annotations.readOnlyHint == (name in read_only)
         assert annotations.destructiveHint == (None if name in read_only else name == "cancel_run")
-        assert annotations.idempotentHint == (None if name in read_only else True)
+        # A repeat retry answers SUBJECT_BUSY, so it alone is not idempotent.
+        assert annotations.idempotentHint == (None if name in read_only else name != "retry_run")
         assert tool.description, name
 
     # Derived schemas keep the routes' own shapes and constraints.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -177,7 +177,7 @@ export const api = {
   cancelRun: (runId: string, reason: string) =>
     postJSON<{ runId: string; result: string }>(`/api/runs/${runId}/cancel`, { reason }),
   retryRun: (runId: string) =>
-    postJSON<{ runId: string; result: string }>(`/api/runs/${runId}/retry`, undefined),
+    postJSON<{ runId: string }>(`/api/runs/${runId}/retry`, undefined),
   listEvents: (params: { limit?: number; before?: string; extension?: string } = {}) => {
     const query = new URLSearchParams()
     if (params.limit !== undefined) query.set('limit', String(params.limit))

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -176,6 +176,8 @@ export const api = {
   // Cancel is a run-level action, not a review verdict — it ends any active run.
   cancelRun: (runId: string, reason: string) =>
     postJSON<{ runId: string; result: string }>(`/api/runs/${runId}/cancel`, { reason }),
+  retryRun: (runId: string) =>
+    postJSON<{ runId: string; result: string }>(`/api/runs/${runId}/retry`, undefined),
   listEvents: (params: { limit?: number; before?: string; extension?: string } = {}) => {
     const query = new URLSearchParams()
     if (params.limit !== undefined) query.set('limit', String(params.limit))

--- a/frontend/src/extensions/ship/WorkItemPage.tsx
+++ b/frontend/src/extensions/ship/WorkItemPage.tsx
@@ -535,6 +535,9 @@ function RunHeader({
       </span>
       <span className="ins-sh-actions">
         {isActiveRun(run) && <CancelRun runId={run.id} />}
+        {run.state === 'failed' && data.timeline.at(-1)?.id === run.id && (
+          <RetryRun runId={run.id} />
+        )}
         {call && (
           <button
             type="button"
@@ -600,6 +603,31 @@ function CancelRun({ runId }: { runId: string }) {
       </button>
       {error && <span className="review-error">{error}</span>}
     </span>
+  )
+}
+
+function RetryRun({ runId }: { runId: string }) {
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function retry() {
+    setPending(true)
+    setError(null)
+    try {
+      await api.retryRun(runId)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'could not retry')
+      setPending(false)
+    }
+  }
+
+  return (
+    <>
+      <button type="button" className="ins-run-link" disabled={pending} onClick={retry}>
+        {pending ? 'retrying…' : 'retry run'}
+      </button>
+      {error && <span className="review-error">{error}</span>}
+    </>
   )
 }
 


### PR DESCRIPTION
**Linear ticket:** [ENG-797](https://linear.app/fellaworks/issue/ENG-797/retry-run-fork-based-recovery-verb-for-failed-runs)

## What changed

A terminal-ERROR workflow was unrecoverable: DBOS resume silently excludes terminal statuses, same-id replay re-raises the recorded step error, and a fresh dispatch wipes the item's PR pointer and re-burns every checkpointed dollar. This adds the run-addressed retry verb on DBOS fork — the SDK's own rewind primitive:

- `Run.retry()` is pure mechanics, mirroring `Run.cancel()`: find the failed step (max recorded `function_id` with an error; a body-level failure with no failed checkpoint restarts from step 1), fork with `queue_name` pinned to the shared run queue (fork otherwise lands on DBOS's internal queue), mirror `start()`'s visible-early Run row, and publish `workflow.retried` carrying the new run id.
- `retry_run` in the gateway owns every guard, exactly like `cancel_run`: not-found, `RUN_NOT_FAILED` (409), and the subject check — an active run that was forked from this one answers `already_retried` idempotently (via a `forked_from` projection of DBOS's lineage column); any other active run raises `SUBJECT_BUSY` (409, retryable), since forks carry no dedup slot.
- One route declaration serves HTTP and the MCP tool (`operation_id="retry_run"`, annotated non-destructive + idempotent beside `cancel_run`).
- Frontend: `api.retryRun` and a Retry control on a failed run's header, rendered only while that run is the subject's newest — once the fork appears on the timeline the control disappears with it.

Fork semantics that make this resume-in-place: attributes copy so the new run joins the subject timeline automatically; no SCHEDULED event fires, so `start_attempt()` does not wipe pr_number/branch; the journal rebuilds from the copied checkpoints. Pre-fork AgentCall rows stay on the old run — its history stays honest. A `DBOSUnexpectedStepError` on a post-deploy body-shape drift simply fails the retried run.

## Risk

Low. Additive surface; no migration (`forked_from` maps a column DBOS already owns). The one semantic to know: a retried run reuses checkpoints recorded by the old code if a deploy happened in between — that failure mode is loud, not silent.

## Verification

- `uv run ruff check` / `ruff format --check` — clean on all touched files.
- `uv run pyright` on touched files — error count identical to main's baseline, no new kinds.
- `uv run pytest backend/tests --collect-only -q` — no import errors (the 19 `druks_field_notes` errors are the known local-venv gap).
- Tests pin: fork arguments (start_step from the failed checkpoint, queue pinning), step-1 fallback, the visible-early row and its lineage, the retried event payload, all three guards with their codes, and the idempotent replay answer. The suite gates in CI (conftest needs the shared Postgres).
