### PR TITLE
ENG-794 - An MCP OAuth grant belongs to the account that connected it

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -305,7 +305,13 @@ class Agent:
                 )
                 try:
                     result = await self._execute(
-                        runner, model, prompt, artifact_dir, call_id, connection_id
+                        runner,
+                        model,
+                        prompt,
+                        artifact_dir,
+                        call_id,
+                        connection_id,
+                        account_id=workflow.account_id,
                     )
                 except BaseException as error:
                     AgentCall.fail(engine, call_id=call_id, error=error)
@@ -328,9 +334,12 @@ class Agent:
         artifact_dir: Path,
         call_id: str,
         connection_id: str,
+        *,
+        account_id: str | None,
     ) -> "AgentResult":
         schema = self.contract.model_json_schema()
         return await runner.run_agent(
+            account_id=account_id,
             model=model,
             prompt=prompt,
             schema=schema,

--- a/backend/druks/mcp/constants.py
+++ b/backend/druks/mcp/constants.py
@@ -32,7 +32,7 @@ OAUTH_TOKEN_TTL_SKEW_SECONDS = 60
 
 # Mint's mutual exclusion, in the Redis that fronts the token cache (the run
 # lock's SET NX idiom): a rotating grant tolerates exactly one refresher per
-# grant. The server name and account scope are part of both keys. The lock TTL
+# grant. The server name and the grant's account are part of both keys. The lock TTL
 # is a crash backstop at three times the HTTP client's timeout — a live refresh
 # cannot outlive it. Losers poll the cache on the interval for about one
 # token-endpoint round trip, then fail loudly.

--- a/backend/druks/mcp/constants.py
+++ b/backend/druks/mcp/constants.py
@@ -32,9 +32,10 @@ OAUTH_TOKEN_TTL_SKEW_SECONDS = 60
 
 # Mint's mutual exclusion, in the Redis that fronts the token cache (the run
 # lock's SET NX idiom): a rotating grant tolerates exactly one refresher per
-# server. The lock TTL is a crash backstop at three times the HTTP client's
-# timeout — a live refresh cannot outlive it. Losers poll the cache on the
-# interval for about one token-endpoint round trip, then fail loudly.
+# grant. The server name and account scope are part of both keys. The lock TTL
+# is a crash backstop at three times the HTTP client's timeout — a live refresh
+# cannot outlive it. Losers poll the cache on the interval for about one
+# token-endpoint round trip, then fail loudly.
 OAUTH_REFRESH_LOCK_PREFIX = "mcp:oauth:refresh_lock:"
 OAUTH_REFRESH_LOCK_TTL_SECONDS = 90
 OAUTH_MINT_WAIT_INTERVAL_SECONDS = 0.2

--- a/backend/druks/mcp/enums.py
+++ b/backend/druks/mcp/enums.py
@@ -1,6 +1,11 @@
 from enum import StrEnum
 
 
+class IdentityMode(StrEnum):
+    SHARED = "shared"
+    PER_USER = "per_user"
+
+
 class TokenSource(StrEnum):
     STATIC = "static"
     STATIC_FROM_ENV = "static_from_env"

--- a/backend/druks/mcp/exceptions.py
+++ b/backend/druks/mcp/exceptions.py
@@ -1,3 +1,6 @@
+from druks.mcp.enums import IdentityMode
+
+
 class McpServerError(Exception):
     pass
 
@@ -65,16 +68,28 @@ class OauthConnectError(McpServerError):
         self.reason = reason
 
 
+class InvalidGrantScopeError(McpServerError):
+    def __init__(self, identity_mode: str | None, account_id: str | None):
+        if identity_mode == IdentityMode.PER_USER:
+            reason = "per-user grants require an account"
+        else:
+            reason = f"identity mode {identity_mode!r} is not resolved"
+        super().__init__(f"Cannot resolve an MCP OAuth grant scope: {reason}.")
+        self.identity_mode = identity_mode
+        self.account_id = account_id
+
+
 class MissingGrantError(McpServerError):
     # An enabled OAuth server has no stored grant, so delivery can't mint a
     # token for it. Raised loudly at delivery — the operator must run the
     # connect flow (or disable the server), not discover a dead server mid-run.
-    def __init__(self, name: str):
+    def __init__(self, name: str, account_id: str):
         super().__init__(
-            f"Enabled MCP server {name!r} is not connected; complete its OAuth "
-            "connect flow or disable it."
+            f"Enabled MCP server {name!r} is not connected for account {account_id!r}; "
+            "complete its OAuth connect flow or disable it."
         )
         self.name = name
+        self.account_id = account_id
 
 
 class GrantRefreshError(McpServerError):

--- a/backend/druks/mcp/exceptions.py
+++ b/backend/druks/mcp/exceptions.py
@@ -68,13 +68,13 @@ class OauthConnectError(McpServerError):
         self.reason = reason
 
 
-class InvalidGrantScopeError(McpServerError):
+class UnresolvedGrantAccountError(McpServerError):
     def __init__(self, identity_mode: str | None, account_id: str | None):
         if identity_mode == IdentityMode.PER_USER:
             reason = "per-user grants require an account"
         else:
             reason = f"identity mode {identity_mode!r} is not resolved"
-        super().__init__(f"Cannot resolve an MCP OAuth grant scope: {reason}.")
+        super().__init__(f"Cannot resolve which account's grant to use: {reason}.")
         self.identity_mode = identity_mode
         self.account_id = account_id
 

--- a/backend/druks/mcp/models.py
+++ b/backend/druks/mcp/models.py
@@ -105,7 +105,7 @@ class McpServer(Base, Uuid7Pk):
             elif source == TokenSource.OAUTH:
                 server["has_token"] = False
                 if server["identity_mode"]:
-                    grant_account = McpOauthGrant.account_for(server["identity_mode"], account_id)
+                    grant_account = McpOauthGrant.grant_account(server["identity_mode"], account_id)
                     server["has_token"] = bool(
                         McpOauthGrant.get_for_account(server["name"], grant_account)
                     )
@@ -195,7 +195,7 @@ class McpOauthGrant(Base, Uuid7Pk):
     connected_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
     @staticmethod
-    def account_for(identity_mode: str | None, run_account_id: str | None) -> str:
+    def grant_account(identity_mode: str | None, run_account_id: str | None) -> str:
         # Whose grant serves this caller: a shared server's grant lives under
         # the system account whoever asks; a per-user server's under the asker.
         if identity_mode == IdentityMode.PER_USER and run_account_id:

--- a/backend/druks/mcp/models.py
+++ b/backend/druks/mcp/models.py
@@ -2,16 +2,18 @@ import os
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import Boolean, String, select
+from sqlalchemy import Boolean, ForeignKey, String, UniqueConstraint, select
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Mapped, mapped_column
 
+from druks.accounts.constants import SYSTEM_ACCOUNT_ID
 from druks.core.models import Uuid7Pk
 from druks.database import db_session
 from druks.extensions.registry import mcp_servers
 from druks.mcp.constants import NAME_PATTERN
-from druks.mcp.enums import TokenSource
-from druks.mcp.exceptions import InvalidServerNameError
+from druks.mcp.enums import IdentityMode, TokenSource
+from druks.mcp.exceptions import InvalidGrantScopeError, InvalidServerNameError
 from druks.models import Base
 from druks.secrets.fields import EncryptedJsonField, EncryptedTextField, Secret
 
@@ -36,11 +38,14 @@ class McpServer(Base, Uuid7Pk):
     headers: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict)
     secret_headers = EncryptedJsonField()
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+    # The first completed OAuth connect claims the credential-sharing policy.
+    # A registry install or enable overlay alone carries no such decision.
+    identity_mode: Mapped[str | None]
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
     @classmethod
     def list_all(cls) -> list["McpServer"]:
-        # The raw overlay rows — not the merged registry view (get_resolved).
+        # The raw overlay rows — not the merged registry view (_merged).
         return list(db_session().execute(select(cls).order_by(cls.name)).scalars())
 
     @classmethod
@@ -48,8 +53,8 @@ class McpServer(Base, Uuid7Pk):
         return db_session().execute(select(cls).where(cls.name == name)).scalar_one_or_none()
 
     @classmethod
-    def get_resolved(cls) -> dict[str, dict]:
-        # The full view the API reads and delivery resolves from, keyed by
+    def _merged(cls) -> dict[str, dict]:
+        # The full view the API and delivery build from, keyed by
         # name: each built-in definition (url + auth from the registry)
         # overlaid with its operator row's enable choice and secrets, then any
         # fully custom rows.
@@ -66,6 +71,7 @@ class McpServer(Base, Uuid7Pk):
                 "token": row.token if row else Secret(b"", ""),
                 "headers": row.headers if row else {},
                 "secret_headers": row.secret_headers if row else {},
+                "identity_mode": row.identity_mode if row else None,
                 "builtin": True,
             }
         for row in rows.values():
@@ -78,8 +84,14 @@ class McpServer(Base, Uuid7Pk):
                 "token": row.token,
                 "headers": row.headers,
                 "secret_headers": row.secret_headers,
+                "identity_mode": row.identity_mode,
                 "builtin": False,
             }
+        return servers
+
+    @classmethod
+    def get_resolved(cls, account_id: str | None) -> dict[str, dict]:
+        servers = cls._merged()
         # has_token = nothing blocks this server's auth at delivery, read from
         # wherever its source keeps the secret: druks' env for an env-sourced
         # server, a stored grant for a connected one, the stored token for a
@@ -91,7 +103,14 @@ class McpServer(Base, Uuid7Pk):
             elif source == TokenSource.STATIC_FROM_ENV:
                 server["has_token"] = bool(os.environ.get(server["source_env_var"]))
             elif source == TokenSource.OAUTH:
-                server["has_token"] = bool(McpOauthGrant.get_for_server(server["name"]))
+                server["has_token"] = False
+                if server["identity_mode"]:
+                    scope_account_id = McpOauthGrant.scope_account(
+                        server["identity_mode"], account_id
+                    )
+                    server["has_token"] = bool(
+                        McpOauthGrant.get_for_scope(server["name"], scope_account_id)
+                    )
             else:
                 server["has_token"] = bool(server["token"])
         return servers
@@ -99,7 +118,7 @@ class McpServer(Base, Uuid7Pk):
     @classmethod
     def list_enabled(cls) -> list[dict]:
         # The enabled subset — what a run delivers and the settings UI shows active.
-        return [server for server in cls.get_resolved().values() if server["is_enabled"]]
+        return [server for server in cls._merged().values() if server["is_enabled"]]
 
     @classmethod
     def set_enabled(cls, name: str, is_enabled: bool) -> bool:
@@ -151,13 +170,17 @@ class McpServer(Base, Uuid7Pk):
 
 class McpOauthGrant(Base, Uuid7Pk):
     __tablename__ = "mcp_oauth_grants"
+    __table_args__ = (UniqueConstraint("server_name", "account_id"),)
 
-    # One grant per server: the durable outcome of the operator's connect flow —
-    # exactly what mint needs to refresh an access token. Connect-time material
-    # (authorization endpoint, PKCE verifier, state) is transient and lives in
-    # Redis, never here. The refresh token never leaves the backend; the API
-    # exposes only that a grant exists.
-    server_name: Mapped[str] = mapped_column(String, unique=True)
+    # One grant per server and account scope: the durable outcome of an OAuth
+    # connect flow — exactly what mint needs to refresh an access token.
+    # Connect-time material (authorization endpoint, PKCE verifier, state) is
+    # transient and lives in Redis, never here. The refresh token never leaves
+    # the backend; the API exposes only that a grant exists.
+    server_name: Mapped[str] = mapped_column(String)
+    account_id: Mapped[str] = mapped_column(
+        ForeignKey("accounts.id", ondelete="RESTRICT"), default=SYSTEM_ACCOUNT_ID
+    )
     # Ciphertext at rest; decrypted only into the refresh request body.
     refresh_token = EncryptedTextField()
     token_endpoint: Mapped[str] = mapped_column(String)
@@ -173,40 +196,65 @@ class McpOauthGrant(Base, Uuid7Pk):
     # row is upserted on re-connect, so row-creation time would lie.
     connected_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
+    @staticmethod
+    def scope_account(identity_mode: str | None, run_account_id: str | None) -> str:
+        if identity_mode == IdentityMode.PER_USER and run_account_id:
+            return run_account_id
+        if identity_mode == IdentityMode.PER_USER:
+            raise InvalidGrantScopeError(identity_mode, run_account_id)
+        if identity_mode == IdentityMode.SHARED:
+            return SYSTEM_ACCOUNT_ID
+        raise InvalidGrantScopeError(identity_mode, run_account_id)
+
     @classmethod
-    def get_for_server(cls, server_name: str) -> "McpOauthGrant | None":
+    def get_for_scope(cls, server_name: str, account_id: str) -> "McpOauthGrant | None":
         return (
             db_session()
-            .execute(select(cls).where(cls.server_name == server_name))
+            .execute(
+                select(cls).where(cls.server_name == server_name, cls.account_id == account_id)
+            )
             .scalar_one_or_none()
         )
+
+    @classmethod
+    def list_for_server(cls, server_name: str) -> list["McpOauthGrant"]:
+        return list(db_session().scalars(select(cls).where(cls.server_name == server_name)))
 
     @classmethod
     def store(
         cls,
         *,
         server_name: str,
+        account_id: str,
         refresh_token: str,
         token_endpoint: str,
         resource: str,
         client_id: str,
         client_secret: str = "",
     ) -> "McpOauthGrant":
-        # Connecting again replaces the grant — the recovery path for a revoked
-        # or rotten refresh token.
         session = db_session()
-        grant = cls.get_for_server(server_name)
-        if not grant:
-            grant = cls(server_name=server_name)
-            session.add(grant)
-        grant.refresh_token = refresh_token
-        grant.token_endpoint = token_endpoint
-        grant.resource = resource
-        grant.client_id = client_id
-        grant.client_secret = client_secret
-        grant.connected_at = cls.utc_now()
-        session.flush()
-        return grant
+        statement = pg_insert(cls).values(
+            server_name=server_name,
+            account_id=account_id,
+            refresh_token=refresh_token,
+            token_endpoint=token_endpoint,
+            resource=resource,
+            client_id=client_id,
+            client_secret=client_secret,
+            connected_at=cls.utc_now(),
+        )
+        statement = statement.on_conflict_do_update(
+            index_elements=["server_name", "account_id"],
+            set_={
+                "refresh_token": statement.excluded.refresh_token,
+                "token_endpoint": statement.excluded.token_endpoint,
+                "resource": statement.excluded.resource,
+                "client_id": statement.excluded.client_id,
+                "client_secret": statement.excluded.client_secret,
+                "connected_at": statement.excluded.connected_at,
+            },
+        ).returning(cls)
+        return session.scalars(statement, execution_options={"populate_existing": True}).one()
 
     def delete(self) -> None:
         session = db_session()

--- a/backend/druks/mcp/models.py
+++ b/backend/druks/mcp/models.py
@@ -105,7 +105,9 @@ class McpServer(Base, Uuid7Pk):
             elif source == TokenSource.OAUTH:
                 server["has_token"] = False
                 if server["identity_mode"]:
-                    grant_account = McpOauthGrant.grant_account(server["identity_mode"], account_id)
+                    grant_account = McpOauthGrant.get_grant_account(
+                        server["identity_mode"], account_id
+                    )
                     server["has_token"] = bool(
                         McpOauthGrant.get_for_account(server["name"], grant_account)
                     )
@@ -195,7 +197,7 @@ class McpOauthGrant(Base, Uuid7Pk):
     connected_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
     @staticmethod
-    def grant_account(identity_mode: str | None, run_account_id: str | None) -> str:
+    def get_grant_account(identity_mode: str | None, run_account_id: str | None) -> str:
         # Whose grant serves this caller: a shared server's grant lives under
         # the system account whoever asks; a per-user server's under the asker.
         if identity_mode == IdentityMode.PER_USER and run_account_id:

--- a/backend/druks/mcp/models.py
+++ b/backend/druks/mcp/models.py
@@ -13,7 +13,7 @@ from druks.database import db_session
 from druks.extensions.registry import mcp_servers
 from druks.mcp.constants import NAME_PATTERN
 from druks.mcp.enums import IdentityMode, TokenSource
-from druks.mcp.exceptions import InvalidGrantScopeError, InvalidServerNameError
+from druks.mcp.exceptions import InvalidServerNameError, UnresolvedGrantAccountError
 from druks.models import Base
 from druks.secrets.fields import EncryptedJsonField, EncryptedTextField, Secret
 
@@ -105,11 +105,9 @@ class McpServer(Base, Uuid7Pk):
             elif source == TokenSource.OAUTH:
                 server["has_token"] = False
                 if server["identity_mode"]:
-                    scope_account_id = McpOauthGrant.scope_account(
-                        server["identity_mode"], account_id
-                    )
+                    grant_account = McpOauthGrant.account_for(server["identity_mode"], account_id)
                     server["has_token"] = bool(
-                        McpOauthGrant.get_for_scope(server["name"], scope_account_id)
+                        McpOauthGrant.get_for_account(server["name"], grant_account)
                     )
             else:
                 server["has_token"] = bool(server["token"])
@@ -172,7 +170,7 @@ class McpOauthGrant(Base, Uuid7Pk):
     __tablename__ = "mcp_oauth_grants"
     __table_args__ = (UniqueConstraint("server_name", "account_id"),)
 
-    # One grant per server and account scope: the durable outcome of an OAuth
+    # One grant per (server, account): the durable outcome of an OAuth
     # connect flow — exactly what mint needs to refresh an access token.
     # Connect-time material (authorization endpoint, PKCE verifier, state) is
     # transient and lives in Redis, never here. The refresh token never leaves
@@ -197,17 +195,19 @@ class McpOauthGrant(Base, Uuid7Pk):
     connected_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
     @staticmethod
-    def scope_account(identity_mode: str | None, run_account_id: str | None) -> str:
+    def account_for(identity_mode: str | None, run_account_id: str | None) -> str:
+        # Whose grant serves this caller: a shared server's grant lives under
+        # the system account whoever asks; a per-user server's under the asker.
         if identity_mode == IdentityMode.PER_USER and run_account_id:
             return run_account_id
         if identity_mode == IdentityMode.PER_USER:
-            raise InvalidGrantScopeError(identity_mode, run_account_id)
+            raise UnresolvedGrantAccountError(identity_mode, run_account_id)
         if identity_mode == IdentityMode.SHARED:
             return SYSTEM_ACCOUNT_ID
-        raise InvalidGrantScopeError(identity_mode, run_account_id)
+        raise UnresolvedGrantAccountError(identity_mode, run_account_id)
 
     @classmethod
-    def get_for_scope(cls, server_name: str, account_id: str) -> "McpOauthGrant | None":
+    def get_for_account(cls, server_name: str, account_id: str) -> "McpOauthGrant | None":
         return (
             db_session()
             .execute(

--- a/backend/druks/mcp/oauth.py
+++ b/backend/druks/mcp/oauth.py
@@ -240,6 +240,9 @@ async def complete_connect(*, state: str, code: str) -> str:
         raise OauthConnectError(
             name, "the authorization server granted no refresh token; druks needs offline access"
         )
+    # The first completed connect claims the mode: insert the row if absent,
+    # fill the mode if unclaimed. A concurrent claim wins the row lock; the
+    # select reads whichever choice landed, and the grant goes under it.
     session = db_session()
     session.execute(
         pg_insert(McpServer)
@@ -250,11 +253,10 @@ async def complete_connect(*, state: str, code: str) -> str:
         )
         .on_conflict_do_nothing(index_elements=["name"])
     )
-    session.scalar(
+    session.execute(
         update(McpServer)
         .where(McpServer.name == name, McpServer.identity_mode.is_(None))
         .values(identity_mode=pending["identity_mode"])
-        .returning(McpServer.identity_mode)
     )
     effective_identity_mode = session.scalar(
         select(McpServer.identity_mode).where(McpServer.name == name)

--- a/backend/druks/mcp/oauth.py
+++ b/backend/druks/mcp/oauth.py
@@ -3,9 +3,12 @@ import base64
 import hashlib
 import json
 import secrets
+from typing import cast
 from urllib.parse import urlencode, urlparse
 
 import httpx
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from druks.database import db_session
 from druks.mcp.constants import (
@@ -19,8 +22,9 @@ from druks.mcp.constants import (
     OAUTH_REFRESH_LOCK_TTL_SECONDS,
     OAUTH_TOKEN_TTL_SKEW_SECONDS,
 )
+from druks.mcp.enums import IdentityMode
 from druks.mcp.exceptions import GrantRefreshError, MissingGrantError, OauthConnectError
-from druks.mcp.models import McpOauthGrant
+from druks.mcp.models import McpOauthGrant, McpServer
 from druks.redis import get_client
 
 
@@ -139,7 +143,14 @@ async def _register_client(
     return registration
 
 
-async def begin_connect(name: str, server_url: str, endpoint: str) -> str:
+async def begin_connect(
+    name: str,
+    server_url: str,
+    endpoint: str,
+    *,
+    account_id: str | None,
+    identity_mode: IdentityMode,
+) -> str:
     """Start the operator's authorization-code + PKCE flow for one server:
     discover the authorization server, register druks as a public client, stash
     the pending exchange (verifier + endpoints) in Redis under the state, and
@@ -164,6 +175,8 @@ async def begin_connect(name: str, server_url: str, endpoint: str) -> str:
     pending = {
         "name": name,
         "server_url": server_url,
+        "account_id": account_id,
+        "identity_mode": identity_mode,
         "code_verifier": code_verifier,
         "token_endpoint": metadata["token_endpoint"],
         "client_id": registration["client_id"],
@@ -227,8 +240,29 @@ async def complete_connect(*, state: str, code: str) -> str:
         raise OauthConnectError(
             name, "the authorization server granted no refresh token; druks needs offline access"
         )
+    session = db_session()
+    session.execute(
+        pg_insert(McpServer)
+        .values(
+            name=name,
+            url=pending["server_url"],
+            identity_mode=pending["identity_mode"],
+        )
+        .on_conflict_do_nothing(index_elements=["name"])
+    )
+    session.scalar(
+        update(McpServer)
+        .where(McpServer.name == name, McpServer.identity_mode.is_(None))
+        .values(identity_mode=pending["identity_mode"])
+        .returning(McpServer.identity_mode)
+    )
+    effective_identity_mode = session.scalar(
+        select(McpServer.identity_mode).where(McpServer.name == name)
+    )
+    account_id = McpOauthGrant.scope_account(effective_identity_mode, pending["account_id"])
     McpOauthGrant.store(
         server_name=name,
+        account_id=account_id,
         refresh_token=tokens["refresh_token"],
         token_endpoint=pending["token_endpoint"],
         resource=pending["server_url"],
@@ -238,36 +272,36 @@ async def complete_connect(*, state: str, code: str) -> str:
     return name
 
 
-async def evict_access_token(name: str) -> None:
-    await get_client().delete(f"{OAUTH_ACCESS_TOKEN_PREFIX}{name}")
+async def evict_access_token(name: str, account_id: str) -> None:
+    await get_client().delete(f"{OAUTH_ACCESS_TOKEN_PREFIX}{name}:{account_id}")
 
 
-async def mint_access_token(name: str) -> str:
+async def mint_access_token(name: str, account_id: str) -> str:
     """The delivery-side token for a connected server: the cached access token
     while it lives, else one refreshed from the grant. The provider may rotate
     the refresh token on use — two concurrent refreshes trip its reuse
     detection and can revoke the whole grant — so the Redis that fronts the
-    cache also elects one refresher per server (the run lock's SET NX idiom;
+    cache also elects one refresher per grant (the run lock's SET NX idiom;
     the TTL is a crash backstop a live refresh cannot outlive). Losers poll
     for the winner's cache fill, for about one token-endpoint round trip, then
     fail loudly — delivery never ships a server the agent can't authenticate
     to."""
     redis = get_client()
-    token_key = f"{OAUTH_ACCESS_TOKEN_PREFIX}{name}"
-    lock_key = f"{OAUTH_REFRESH_LOCK_PREFIX}{name}"
+    token_key = f"{OAUTH_ACCESS_TOKEN_PREFIX}{name}:{account_id}"
+    lock_key = f"{OAUTH_REFRESH_LOCK_PREFIX}{name}:{account_id}"
     for _ in range(OAUTH_MINT_WAIT_ATTEMPTS):
         cached = await redis.get(token_key)
         if cached:
-            return cached.decode()
+            return cast(bytes, cached).decode()
         if await redis.set(lock_key, "1", nx=True, ex=OAUTH_REFRESH_LOCK_TTL_SECONDS):
             break
         await asyncio.sleep(OAUTH_MINT_WAIT_INTERVAL_SECONDS)
     else:
         raise GrantRefreshError(name, "timed out waiting for a concurrent refresh to finish")
     try:
-        grant = McpOauthGrant.get_for_server(name)
+        grant = McpOauthGrant.get_for_scope(name, account_id)
         if not grant:
-            raise MissingGrantError(name)
+            raise MissingGrantError(name, account_id)
         # The grant's secret halves are ciphertext at rest; the plaintext
         # exists only in this request body.
         data = {
@@ -286,7 +320,7 @@ async def mint_access_token(name: str) -> str:
             except httpx.HTTPError as error:
                 raise GrantRefreshError(name, str(error)) from error
         if response.status_code != 200:
-            await evict_access_token(name)
+            await evict_access_token(name, account_id)
             raise GrantRefreshError(name, f"HTTP {response.status_code} from the token endpoint")
         try:
             tokens = response.json()

--- a/backend/druks/mcp/oauth.py
+++ b/backend/druks/mcp/oauth.py
@@ -261,7 +261,7 @@ async def complete_connect(*, state: str, code: str) -> str:
     effective_identity_mode = session.scalar(
         select(McpServer.identity_mode).where(McpServer.name == name)
     )
-    account_id = McpOauthGrant.account_for(effective_identity_mode, pending["account_id"])
+    account_id = McpOauthGrant.grant_account(effective_identity_mode, pending["account_id"])
     McpOauthGrant.store(
         server_name=name,
         account_id=account_id,

--- a/backend/druks/mcp/oauth.py
+++ b/backend/druks/mcp/oauth.py
@@ -259,7 +259,7 @@ async def complete_connect(*, state: str, code: str) -> str:
     effective_identity_mode = session.scalar(
         select(McpServer.identity_mode).where(McpServer.name == name)
     )
-    account_id = McpOauthGrant.scope_account(effective_identity_mode, pending["account_id"])
+    account_id = McpOauthGrant.account_for(effective_identity_mode, pending["account_id"])
     McpOauthGrant.store(
         server_name=name,
         account_id=account_id,
@@ -299,7 +299,7 @@ async def mint_access_token(name: str, account_id: str) -> str:
     else:
         raise GrantRefreshError(name, "timed out waiting for a concurrent refresh to finish")
     try:
-        grant = McpOauthGrant.get_for_scope(name, account_id)
+        grant = McpOauthGrant.get_for_account(name, account_id)
         if not grant:
             raise MissingGrantError(name, account_id)
         # The grant's secret halves are ciphertext at rest; the plaintext

--- a/backend/druks/mcp/oauth.py
+++ b/backend/druks/mcp/oauth.py
@@ -261,7 +261,7 @@ async def complete_connect(*, state: str, code: str) -> str:
     effective_identity_mode = session.scalar(
         select(McpServer.identity_mode).where(McpServer.name == name)
     )
-    account_id = McpOauthGrant.grant_account(effective_identity_mode, pending["account_id"])
+    account_id = McpOauthGrant.get_grant_account(effective_identity_mode, pending["account_id"])
     McpOauthGrant.store(
         server_name=name,
         account_id=account_id,

--- a/backend/druks/mcp/routes.py
+++ b/backend/druks/mcp/routes.py
@@ -240,7 +240,7 @@ async def disconnect_mcp_server(name: str) -> None:
         raise HTTPException(status_code=404, detail=f"MCP server {name!r} is not an OAuth server.")
     if not server["identity_mode"]:
         raise HTTPException(status_code=404, detail=f"MCP server {name!r} has no grant.")
-    account_id = McpOauthGrant.account_for(server["identity_mode"], current_account_id.get())
+    account_id = McpOauthGrant.grant_account(server["identity_mode"], current_account_id.get())
     grant = McpOauthGrant.get_for_account(name, account_id)
     if not grant:
         raise HTTPException(

--- a/backend/druks/mcp/routes.py
+++ b/backend/druks/mcp/routes.py
@@ -1,11 +1,13 @@
 import json
+from typing import Annotated
 
 from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
+from druks.accounts.context import current_account_id
 from druks.extensions.registry import mcp_servers
 from druks.mcp import oauth, registry
-from druks.mcp.enums import TokenSource
+from druks.mcp.enums import IdentityMode, TokenSource
 from druks.mcp.exceptions import (
     InvalidServerNameError,
     OauthConnectError,
@@ -24,13 +26,14 @@ router = APIRouter(prefix="/api/mcp-servers", tags=["mcp-servers"])
 
 
 def _response(name: str) -> McpServerResponse:
-    return McpServerResponse.model_validate(McpServer.get_resolved()[name])
+    return McpServerResponse.model_validate(McpServer.get_resolved(current_account_id.get())[name])
 
 
 @router.get("", response_model=list[McpServerResponse])
 async def list_mcp_servers() -> list[McpServerResponse]:
     return [
-        McpServerResponse.model_validate(server) for server in McpServer.get_resolved().values()
+        McpServerResponse.model_validate(server)
+        for server in McpServer.get_resolved(current_account_id.get()).values()
     ]
 
 
@@ -158,18 +161,27 @@ async def remove_mcp_server(name: str) -> None:
     server = McpServer.get_for_name(name)
     if not server:
         raise HTTPException(status_code=404, detail=f"MCP server {name!r} not found")
+    grants = McpOauthGrant.list_for_server(name)
     server.delete()
-    if grant := McpOauthGrant.get_for_server(name):
-        # An orphan grant would revive as this name's credential on re-add.
+    for grant in grants:
         grant.delete()
-        await oauth.evict_access_token(name)
+        await oauth.evict_access_token(name, grant.account_id)
 
 
 @router.post("/{name}/connect", response_model=ConnectMcpServerResponse)
-async def connect_mcp_server(name: str, request: Request) -> ConnectMcpServerResponse:
-    server = McpServer.get_resolved().get(name)
+async def connect_mcp_server(
+    name: str,
+    request: Request,
+    identity_mode: Annotated[IdentityMode, Body(embed=True)],
+) -> ConnectMcpServerResponse:
+    server = McpServer.get_resolved(current_account_id.get()).get(name)
     if not server or server["token_source"] != TokenSource.OAUTH:
         raise HTTPException(status_code=404, detail=f"MCP server {name!r} is not an OAuth server.")
+    if McpOauthGrant.list_for_server(name) and server["identity_mode"] != identity_mode:
+        raise HTTPException(
+            status_code=409,
+            detail=f"MCP server {name!r} already uses {server['identity_mode']!r} identity.",
+        )
     endpoint = request.app.state.settings.endpoint
     if not endpoint:
         # The authorization server redirects the operator's browser back to
@@ -180,7 +192,13 @@ async def connect_mcp_server(name: str, request: Request) -> ConnectMcpServerRes
             "at, to connect OAuth MCP servers.",
         )
     try:
-        authorization_url = await oauth.begin_connect(name, server["url"], endpoint)
+        authorization_url = await oauth.begin_connect(
+            name,
+            server["url"],
+            endpoint,
+            account_id=current_account_id.get(),
+            identity_mode=identity_mode,
+        )
     except OauthConnectError as error:
         raise HTTPException(status_code=502, detail=str(error)) from error
     return ConnectMcpServerResponse(authorization_url=authorization_url)
@@ -217,11 +235,26 @@ async def oauth_callback(state: str = "", code: str = "", error: str = "") -> HT
 
 @router.delete("/{name}/grant", status_code=204)
 async def disconnect_mcp_server(name: str) -> None:
-    grant = McpOauthGrant.get_for_server(name)
+    server = McpServer.get_resolved(current_account_id.get()).get(name)
+    if not server or server["token_source"] != TokenSource.OAUTH:
+        raise HTTPException(status_code=404, detail=f"MCP server {name!r} is not an OAuth server.")
+    account_id = current_account_id.get()
+    grant = None
+    if server["identity_mode"]:
+        account_id = McpOauthGrant.scope_account(server["identity_mode"], account_id)
+        grant = McpOauthGrant.get_for_scope(name, account_id)
     if not grant:
-        raise HTTPException(status_code=404, detail=f"MCP server {name!r} has no grant.")
+        raise HTTPException(
+            status_code=404,
+            detail=f"MCP server {name!r} has no grant for account {account_id!r}.",
+        )
+    await oauth.evict_access_token(name, grant.account_id)
     grant.delete()
-    await oauth.evict_access_token(name)
-    # The mirror of connect-enables: a disconnected OAuth server can't serve
-    # a single call, so leaving it enabled just ships a dead entry to VMs.
-    McpServer.set_enabled(name, False)
+    if not McpOauthGrant.list_for_server(name):
+        # The last grant leaving reopens the mode choice: the next connect is
+        # a first connect again.
+        server_row = McpServer.get_for_name(name)
+        if server_row:
+            server_row.identity_mode = None
+    if server["identity_mode"] == IdentityMode.SHARED:
+        McpServer.set_enabled(name, False)

--- a/backend/druks/mcp/routes.py
+++ b/backend/druks/mcp/routes.py
@@ -221,7 +221,7 @@ async def oauth_callback(state: str = "", code: str = "", error: str = "") -> HT
         raise HTTPException(status_code=400, detail=str(exchange_error)) from exchange_error
     # Connecting is the operator's explicit "use this server" — a
     # connected-but-disabled server is a dead end nobody asks for.
-    McpServer.set_enabled(name, True)
+    McpServer.set_enabled(name, is_enabled=True)
     # druks opened this tab via window.open, so the page may close itself; the
     # broadcast tells the settings modal to refetch before the tab goes. The
     # text stays for browsers that refuse the close.
@@ -241,8 +241,8 @@ async def disconnect_mcp_server(name: str) -> None:
     account_id = current_account_id.get()
     grant = None
     if server["identity_mode"]:
-        account_id = McpOauthGrant.scope_account(server["identity_mode"], account_id)
-        grant = McpOauthGrant.get_for_scope(name, account_id)
+        account_id = McpOauthGrant.account_for(server["identity_mode"], account_id)
+        grant = McpOauthGrant.get_for_account(name, account_id)
     if not grant:
         raise HTTPException(
             status_code=404,
@@ -257,4 +257,4 @@ async def disconnect_mcp_server(name: str) -> None:
         if server_row:
             server_row.identity_mode = None
     if server["identity_mode"] == IdentityMode.SHARED:
-        McpServer.set_enabled(name, False)
+        McpServer.set_enabled(name, is_enabled=False)

--- a/backend/druks/mcp/routes.py
+++ b/backend/druks/mcp/routes.py
@@ -240,7 +240,7 @@ async def disconnect_mcp_server(name: str) -> None:
         raise HTTPException(status_code=404, detail=f"MCP server {name!r} is not an OAuth server.")
     if not server["identity_mode"]:
         raise HTTPException(status_code=404, detail=f"MCP server {name!r} has no grant.")
-    account_id = McpOauthGrant.grant_account(server["identity_mode"], current_account_id.get())
+    account_id = McpOauthGrant.get_grant_account(server["identity_mode"], current_account_id.get())
     grant = McpOauthGrant.get_for_account(name, account_id)
     if not grant:
         raise HTTPException(

--- a/backend/druks/mcp/routes.py
+++ b/backend/druks/mcp/routes.py
@@ -238,11 +238,10 @@ async def disconnect_mcp_server(name: str) -> None:
     server = McpServer.get_resolved(current_account_id.get()).get(name)
     if not server or server["token_source"] != TokenSource.OAUTH:
         raise HTTPException(status_code=404, detail=f"MCP server {name!r} is not an OAuth server.")
-    account_id = current_account_id.get()
-    grant = None
-    if server["identity_mode"]:
-        account_id = McpOauthGrant.account_for(server["identity_mode"], account_id)
-        grant = McpOauthGrant.get_for_account(name, account_id)
+    if not server["identity_mode"]:
+        raise HTTPException(status_code=404, detail=f"MCP server {name!r} has no grant.")
+    account_id = McpOauthGrant.account_for(server["identity_mode"], current_account_id.get())
+    grant = McpOauthGrant.get_for_account(name, account_id)
     if not grant:
         raise HTTPException(
             status_code=404,

--- a/backend/druks/mcp/schemas.py
+++ b/backend/druks/mcp/schemas.py
@@ -8,13 +8,14 @@ NonBlank = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)
 
 
 class McpServerResponse(BaseResponse):
-    # A pure projection of one ``McpServer.get_resolved()`` item — the dict's
+    # A pure projection of one account's ``McpServer.get_resolved()`` item — the dict's
     # ``token`` is not a field here, so the secret can't serialize (and it
     # arrives as a Secret, redacted even if it did).
     name: str
     url: str
     is_enabled: bool
     token_source: str
+    identity_mode: str | None
     builtin: bool
     # The deployment env var an env-sourced server reads its token from
     # ("" otherwise) — a var name, never a value.

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -205,7 +205,7 @@ class Workspace:
                 if not token:
                     raise SourceEnvVarUnsetError(server["name"], server["source_env_var"])
             else:  # oauth
-                grant_account = mcp_models.McpOauthGrant.account_for(
+                grant_account = mcp_models.McpOauthGrant.grant_account(
                     server["identity_mode"], run_account
                 )
                 token = await oauth.mint_access_token(server["name"], grant_account)

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -13,6 +13,7 @@ from druks.mcp.constants import TOKEN_ENV_PREFIX
 from druks.mcp.enums import TokenSource
 from druks.mcp.exceptions import MissingTokenError, SourceEnvVarUnsetError
 from druks.mcp.helpers import get_bearer_token_env_var
+from druks.user_settings.models import UserSettings
 
 if TYPE_CHECKING:
     from druks.durable.enums import AgentCallStatus
@@ -146,14 +147,14 @@ class Workspace:
         # credentials itself. Base: none.
         return ()
 
-    async def run_agent(self, **kwargs: Any) -> AgentResult:
-        run_kwargs = await self.with_mcp_servers(**self.get_agent_run_kwargs(**kwargs))
+    async def run_agent(self, *, account_id: str | None, **kwargs: Any) -> AgentResult:
+        run_kwargs = await self.with_mcp_servers(account_id, **self.get_agent_run_kwargs(**kwargs))
         # with_mcp_servers is the run's last DB read; commit so the step's
         # connection isn't held idle through the minutes the agent runs.
         db_session().commit()
         return await self.sandbox.run_agent(**run_kwargs)
 
-    async def with_mcp_servers(self, **kwargs: Any) -> dict[str, Any]:
+    async def with_mcp_servers(self, account_id: str | None, **kwargs: Any) -> dict[str, Any]:
         # Fold every MCP server into this call — the workspace's required
         # servers, then the operator registry's enabled entries. Each becomes a
         # wire shape on ``mcp_servers`` (url + derived env var, never the
@@ -167,6 +168,7 @@ class Workspace:
         enabled = mcp_models.McpServer.list_enabled()
         if not required and not enabled:
             return kwargs
+        run_account = account_id or UserSettings.get().fallback_account_id
         # ``extra_env`` may be omitted or an explicit ``None`` (both valid for the
         # underlying run_agent); treat them the same so the merge never unpacks None.
         env = dict(kwargs.get("extra_env") or {})
@@ -203,7 +205,10 @@ class Workspace:
                 if not token:
                     raise SourceEnvVarUnsetError(server["name"], server["source_env_var"])
             else:  # oauth
-                token = await oauth.mint_access_token(server["name"])
+                scope_account_id = mcp_models.McpOauthGrant.scope_account(
+                    server["identity_mode"], run_account
+                )
+                token = await oauth.mint_access_token(server["name"], scope_account_id)
             bearer_token_env_var = ""
             if token:
                 bearer_token_env_var = get_bearer_token_env_var(server["name"])

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -205,10 +205,10 @@ class Workspace:
                 if not token:
                     raise SourceEnvVarUnsetError(server["name"], server["source_env_var"])
             else:  # oauth
-                scope_account_id = mcp_models.McpOauthGrant.scope_account(
+                grant_account = mcp_models.McpOauthGrant.account_for(
                     server["identity_mode"], run_account
                 )
-                token = await oauth.mint_access_token(server["name"], scope_account_id)
+                token = await oauth.mint_access_token(server["name"], grant_account)
             bearer_token_env_var = ""
             if token:
                 bearer_token_env_var = get_bearer_token_env_var(server["name"])

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -205,7 +205,7 @@ class Workspace:
                 if not token:
                     raise SourceEnvVarUnsetError(server["name"], server["source_env_var"])
             else:  # oauth
-                grant_account = mcp_models.McpOauthGrant.grant_account(
+                grant_account = mcp_models.McpOauthGrant.get_grant_account(
                     server["identity_mode"], run_account
                 )
                 token = await oauth.mint_access_token(server["name"], grant_account)

--- a/backend/migrations/versions/e6f1a2b3c4d5_mcp_oauth_grants_are_per_account.py
+++ b/backend/migrations/versions/e6f1a2b3c4d5_mcp_oauth_grants_are_per_account.py
@@ -1,0 +1,78 @@
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e6f1a2b3c4d5"
+down_revision: str | Sequence[str] | None = "b9e4d21c7a03"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO accounts (id, username, created_at)
+            VALUES ('system', 'system', CURRENT_TIMESTAMP)
+            ON CONFLICT DO NOTHING
+            """
+        )
+    )
+    op.add_column("mcp_servers", sa.Column("identity_mode", sa.String(), nullable=True))
+    op.add_column(
+        "mcp_oauth_grants",
+        sa.Column("account_id", sa.String(), server_default="system", nullable=False),
+    )
+    op.create_foreign_key(
+        "mcp_oauth_grants_account_id_fkey",
+        "mcp_oauth_grants",
+        "accounts",
+        ["account_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE mcp_servers
+            SET identity_mode = 'shared'
+            WHERE EXISTS (
+                SELECT 1
+                FROM mcp_oauth_grants
+                WHERE mcp_oauth_grants.server_name = mcp_servers.name
+            )
+            """
+        )
+    )
+    op.drop_constraint(
+        "mcp_oauth_grants_server_name_key",
+        "mcp_oauth_grants",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "mcp_oauth_grants_server_name_account_id_key",
+        "mcp_oauth_grants",
+        ["server_name", "account_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "mcp_oauth_grants_server_name_account_id_key",
+        "mcp_oauth_grants",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "mcp_oauth_grants_server_name_key",
+        "mcp_oauth_grants",
+        ["server_name"],
+    )
+    op.drop_constraint(
+        "mcp_oauth_grants_account_id_fkey",
+        "mcp_oauth_grants",
+        type_="foreignkey",
+    )
+    op.drop_column("mcp_oauth_grants", "account_id")
+    op.drop_column("mcp_servers", "identity_mode")

--- a/backend/tests/ship/test_build_workspace.py
+++ b/backend/tests/ship/test_build_workspace.py
@@ -49,7 +49,7 @@ async def test_build_workspace_declares_its_github_mcp(druks_db):
         mcp_token="ghs_reviewer",
         skills=("python-house-rules",),
     )
-    kwargs = await workspace.with_mcp_servers(**workspace.get_agent_run_kwargs())
+    kwargs = await workspace.with_mcp_servers(None, **workspace.get_agent_run_kwargs())
 
     assert kwargs["extra_env"] == {get_bearer_token_env_var(GITHUB_MCP_NAME): "ghs_reviewer"}
     github = next(s for s in kwargs["mcp_servers"] if s.name == GITHUB_MCP_NAME)

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -146,9 +146,9 @@ def _store_grant(
         (IdentityMode.PER_USER, None),
     ),
 )
-def test_account_for_rejects_unresolved_modes(identity_mode, account_id):
+def test_grant_account_rejects_unresolved_modes(identity_mode, account_id):
     with pytest.raises(UnresolvedGrantAccountError):
-        McpOauthGrant.account_for(identity_mode, account_id)
+        McpOauthGrant.grant_account(identity_mode, account_id)
 
 
 # --- connect: discovery + DCR + PKCE ---------------------------------------

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -470,7 +470,7 @@ async def test_mint_times_out_loudly_when_the_refresh_lock_never_frees(druks_db,
         await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
 
 
-async def test_mint_cache_and_refresh_lock_are_per_scope(auth_server, druks_db):
+async def test_mint_cache_and_refresh_lock_are_per_account(auth_server, druks_db):
     first = Account.get_or_create("first@example.com")
     second = Account.get_or_create("second@example.com")
     _store_grant(account_id=first.id, identity_mode=IdentityMode.PER_USER)

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -19,9 +19,9 @@ from druks.mcp.constants import (
 from druks.mcp.enums import IdentityMode, TokenSource
 from druks.mcp.exceptions import (
     GrantRefreshError,
-    InvalidGrantScopeError,
     MissingGrantError,
     OauthConnectError,
+    UnresolvedGrantAccountError,
 )
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.mcp.models import McpOauthGrant, McpServer
@@ -146,9 +146,9 @@ def _store_grant(
         (IdentityMode.PER_USER, None),
     ),
 )
-def test_scope_account_rejects_unresolved_scopes(identity_mode, account_id):
-    with pytest.raises(InvalidGrantScopeError):
-        McpOauthGrant.scope_account(identity_mode, account_id)
+def test_account_for_rejects_unresolved_modes(identity_mode, account_id):
+    with pytest.raises(UnresolvedGrantAccountError):
+        McpOauthGrant.account_for(identity_mode, account_id)
 
 
 # --- connect: discovery + DCR + PKCE ---------------------------------------
@@ -268,7 +268,7 @@ async def test_complete_connect_exchanges_code_and_stores_the_grant(auth_server,
     name = await oauth.complete_connect(state=state, code="code-1")
 
     assert name == _NAME
-    grant = McpOauthGrant.get_for_scope(_NAME, SYSTEM_ACCOUNT_ID)
+    grant = McpOauthGrant.get_for_account(_NAME, SYSTEM_ACCOUNT_ID)
     assert grant.refresh_token.decrypt() == "rt-1"
     assert grant.resource == _SERVER_URL
     assert grant.client_id == "client-123"
@@ -401,7 +401,8 @@ async def test_mint_refreshes_on_cache_miss_and_persists_rotation(auth_server, d
     assert refresh["refresh_token"] == "rt-old"
     assert refresh["resource"] == _SERVER_URL
     # Rotation: the provider's new refresh token replaced the stored one.
-    assert McpOauthGrant.get_for_scope(_NAME, SYSTEM_ACCOUNT_ID).refresh_token.decrypt() == "rt-new"
+    stored = McpOauthGrant.get_for_account(_NAME, SYSTEM_ACCOUNT_ID)
+    assert stored.refresh_token.decrypt() == "rt-new"
 
     # A second mint within the TTL reuses the cache — no second refresh.
     assert await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID) == "at-2"
@@ -609,7 +610,7 @@ def test_callback_route_completes_the_connect(tmp_path, registry_state, auth_ser
         # The page notifies the opener tab, then closes itself.
         assert "BroadcastChannel('druks-mcp-connect')" in page.text
         assert "window.close()" in page.text
-        assert McpOauthGrant.get_for_scope(_NAME, SYSTEM_ACCOUNT_ID)
+        assert McpOauthGrant.get_for_account(_NAME, SYSTEM_ACCOUNT_ID)
         # Connecting is the explicit "use this server" — it enables too.
         assert McpServer.get_for_name(_NAME).is_enabled is True
 
@@ -641,7 +642,7 @@ async def test_disconnect_route_drops_grant_and_cache(
 
     with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
         assert client.delete(f"/api/mcp-servers/{_NAME}/grant").status_code == 204
-        assert not McpOauthGrant.get_for_scope(_NAME, SYSTEM_ACCOUNT_ID)
+        assert not McpOauthGrant.get_for_account(_NAME, SYSTEM_ACCOUNT_ID)
         # The mirror of connect-enables: no grant, no calls, so no dead entry
         # riding into VMs.
         assert McpServer.get_for_name(_NAME).is_enabled is False
@@ -767,8 +768,8 @@ async def test_per_user_disconnect_preserves_other_accounts_grant_and_cache(tmp_
         )
         assert response.status_code == 204
 
-    assert not McpOauthGrant.get_for_scope(_NAME, disconnected.id)
-    assert McpOauthGrant.get_for_scope(_NAME, connected.id)
+    assert not McpOauthGrant.get_for_account(_NAME, disconnected.id)
+    assert McpOauthGrant.get_for_account(_NAME, connected.id)
     assert McpServer.get_for_name(_NAME).is_enabled is True
     druks.redis._client = None
     assert not await get_client().get(disconnected_key)

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -7,6 +7,8 @@ from urllib.parse import parse_qsl, urlparse
 import druks.redis
 import httpx
 import pytest
+from druks.accounts.constants import SYSTEM_ACCOUNT_ID
+from druks.accounts.models import Account
 from druks.extensions.registry import mcp_servers
 from druks.mcp import oauth
 from druks.mcp.constants import (
@@ -14,13 +16,19 @@ from druks.mcp.constants import (
     OAUTH_CONNECT_STATE_PREFIX,
     OAUTH_REFRESH_LOCK_PREFIX,
 )
-from druks.mcp.enums import TokenSource
-from druks.mcp.exceptions import GrantRefreshError, MissingGrantError, OauthConnectError
+from druks.mcp.enums import IdentityMode, TokenSource
+from druks.mcp.exceptions import (
+    GrantRefreshError,
+    InvalidGrantScopeError,
+    MissingGrantError,
+    OauthConnectError,
+)
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.mcp.models import McpOauthGrant, McpServer
 from druks.redis import close_client, get_client
 from druks.sandbox.datastructures import Workspace
 from druks.testing import configure_app_for_test, make_settings
+from druks.user_settings.models import UserSettings
 from fastapi.testclient import TestClient
 
 _NAME = "linear_oauth"
@@ -106,9 +114,23 @@ def _register_oauth_server(name: str = _NAME, enabled: bool = True) -> None:
     )
 
 
-def _store_grant(refresh_token: str = "rt-1") -> McpOauthGrant:
+def _store_grant(
+    refresh_token: str = "rt-1",
+    *,
+    account_id: str = SYSTEM_ACCOUNT_ID,
+    identity_mode: IdentityMode = IdentityMode.SHARED,
+) -> McpOauthGrant:
+    server = McpServer.get_for_name(_NAME)
+    if not server:
+        server = McpServer.create(
+            name=_NAME,
+            url=_SERVER_URL,
+            token_source=TokenSource.OAUTH,
+        )
+    server.identity_mode = identity_mode
     return McpOauthGrant.store(
         server_name=_NAME,
+        account_id=account_id,
         refresh_token=refresh_token,
         token_endpoint=f"{_AUTH_BASE}/token",
         resource=_SERVER_URL,
@@ -116,11 +138,30 @@ def _store_grant(refresh_token: str = "rt-1") -> McpOauthGrant:
     )
 
 
+@pytest.mark.parametrize(
+    ("identity_mode", "account_id"),
+    (
+        (None, "account-1"),
+        ("unknown", "account-1"),
+        (IdentityMode.PER_USER, None),
+    ),
+)
+def test_scope_account_rejects_unresolved_scopes(identity_mode, account_id):
+    with pytest.raises(InvalidGrantScopeError):
+        McpOauthGrant.scope_account(identity_mode, account_id)
+
+
 # --- connect: discovery + DCR + PKCE ---------------------------------------
 
 
 async def test_begin_connect_builds_consent_url_and_stashes_pkce_state(auth_server):
-    url = await oauth.begin_connect(_NAME, _SERVER_URL, _ENDPOINT)
+    url = await oauth.begin_connect(
+        _NAME,
+        _SERVER_URL,
+        _ENDPOINT,
+        account_id=SYSTEM_ACCOUNT_ID,
+        identity_mode=IdentityMode.SHARED,
+    )
 
     assert url.startswith(f"{_AUTH_BASE}/authorize?")
     params = dict(parse_qsl(urlparse(url).query))
@@ -141,20 +182,34 @@ async def test_begin_connect_builds_consent_url_and_stashes_pkce_state(auth_serv
     assert params["code_challenge"] == expected
     assert pending["token_endpoint"] == f"{_AUTH_BASE}/token"
     assert pending["name"] == _NAME
+    assert pending["account_id"] == SYSTEM_ACCOUNT_ID
+    assert pending["identity_mode"] == IdentityMode.SHARED
 
 
 async def test_begin_connect_without_registration_endpoint_fails_loudly(auth_server):
     auth_server.registration_supported = False
 
     with pytest.raises(OauthConnectError, match="dynamic client registration"):
-        await oauth.begin_connect(_NAME, _SERVER_URL, _ENDPOINT)
+        await oauth.begin_connect(
+            _NAME,
+            _SERVER_URL,
+            _ENDPOINT,
+            account_id=SYSTEM_ACCOUNT_ID,
+            identity_mode=IdentityMode.SHARED,
+        )
 
 
 async def test_begin_connect_without_metadata_fails_loudly(auth_server):
     auth_server.discovery_supported = False
 
     with pytest.raises(OauthConnectError, match="no authorization-server metadata"):
-        await oauth.begin_connect(_NAME, _SERVER_URL, _ENDPOINT)
+        await oauth.begin_connect(
+            _NAME,
+            _SERVER_URL,
+            _ENDPOINT,
+            account_id=SYSTEM_ACCOUNT_ID,
+            identity_mode=IdentityMode.SHARED,
+        )
 
 
 async def test_begin_connect_rejects_resource_metadata_about_another_server(auth_server):
@@ -163,7 +218,13 @@ async def test_begin_connect_rejects_resource_metadata_about_another_server(auth
     auth_server.resource = "https://other.test/sse"
 
     with pytest.raises(OauthConnectError, match="protected-resource metadata"):
-        await oauth.begin_connect(_NAME, _SERVER_URL, _ENDPOINT)
+        await oauth.begin_connect(
+            _NAME,
+            _SERVER_URL,
+            _ENDPOINT,
+            account_id=SYSTEM_ACCOUNT_ID,
+            identity_mode=IdentityMode.SHARED,
+        )
 
 
 async def test_begin_connect_skips_metadata_claiming_another_issuer(auth_server):
@@ -172,24 +233,42 @@ async def test_begin_connect_skips_metadata_claiming_another_issuer(auth_server)
     auth_server.issuer = "https://evil.test"
 
     with pytest.raises(OauthConnectError, match="no authorization-server metadata"):
-        await oauth.begin_connect(_NAME, _SERVER_URL, _ENDPOINT)
+        await oauth.begin_connect(
+            _NAME,
+            _SERVER_URL,
+            _ENDPOINT,
+            account_id=SYSTEM_ACCOUNT_ID,
+            identity_mode=IdentityMode.SHARED,
+        )
 
 
 async def test_begin_connect_requires_s256_when_methods_are_advertised(auth_server):
     auth_server.code_challenge_methods = ["plain"]
 
     with pytest.raises(OauthConnectError, match="S256"):
-        await oauth.begin_connect(_NAME, _SERVER_URL, _ENDPOINT)
+        await oauth.begin_connect(
+            _NAME,
+            _SERVER_URL,
+            _ENDPOINT,
+            account_id=SYSTEM_ACCOUNT_ID,
+            identity_mode=IdentityMode.SHARED,
+        )
 
 
 async def test_complete_connect_exchanges_code_and_stores_the_grant(auth_server, druks_db):
-    url = await oauth.begin_connect(_NAME, _SERVER_URL, _ENDPOINT)
+    url = await oauth.begin_connect(
+        _NAME,
+        _SERVER_URL,
+        _ENDPOINT,
+        account_id=SYSTEM_ACCOUNT_ID,
+        identity_mode=IdentityMode.SHARED,
+    )
     state = dict(parse_qsl(urlparse(url).query))["state"]
 
     name = await oauth.complete_connect(state=state, code="code-1")
 
     assert name == _NAME
-    grant = McpOauthGrant.get_for_server(_NAME)
+    grant = McpOauthGrant.get_for_scope(_NAME, SYSTEM_ACCOUNT_ID)
     assert grant.refresh_token.decrypt() == "rt-1"
     assert grant.resource == _SERVER_URL
     assert grant.client_id == "client-123"
@@ -201,8 +280,8 @@ async def test_complete_connect_exchanges_code_and_stores_the_grant(auth_server,
 
     # Nothing is cached at connect (the grant is real only once this commits);
     # the first delivery mints from it, carrying the grant's resource binding.
-    assert not await get_client().get(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}")
-    assert await oauth.mint_access_token(_NAME) == "at-1"
+    assert not await get_client().get(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}:{SYSTEM_ACCOUNT_ID}")
+    assert await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID) == "at-1"
     refresh = auth_server.token_requests[1]
     assert refresh["grant_type"] == "refresh_token"
     assert refresh["resource"] == _SERVER_URL
@@ -214,12 +293,92 @@ async def test_complete_connect_exchanges_code_and_stores_the_grant(auth_server,
 
 async def test_complete_connect_without_refresh_token_stores_nothing(auth_server, druks_db):
     auth_server.token_response = {"access_token": "at-1", "expires_in": 3600}
-    url = await oauth.begin_connect(_NAME, _SERVER_URL, _ENDPOINT)
+    url = await oauth.begin_connect(
+        _NAME,
+        _SERVER_URL,
+        _ENDPOINT,
+        account_id=SYSTEM_ACCOUNT_ID,
+        identity_mode=IdentityMode.SHARED,
+    )
     state = dict(parse_qsl(urlparse(url).query))["state"]
 
     with pytest.raises(OauthConnectError, match="no refresh token"):
         await oauth.complete_connect(state=state, code="code-1")
-    assert not McpOauthGrant.get_for_server(_NAME)
+    assert not McpOauthGrant.list_for_server(_NAME)
+
+
+async def test_two_shared_connects_converge_on_one_grant(auth_server, druks_db):
+    first = Account.get_or_create("first@example.com")
+    second = Account.get_or_create("second@example.com")
+
+    for account in (first, second):
+        url = await oauth.begin_connect(
+            _NAME,
+            _SERVER_URL,
+            _ENDPOINT,
+            account_id=account.id,
+            identity_mode=IdentityMode.SHARED,
+        )
+        state = dict(parse_qsl(urlparse(url).query))["state"]
+        await oauth.complete_connect(state=state, code=account.id)
+
+    grants = McpOauthGrant.list_for_server(_NAME)
+    assert McpServer.get_for_name(_NAME).identity_mode == IdentityMode.SHARED
+    assert [grant.account_id for grant in grants] == [SYSTEM_ACCOUNT_ID]
+
+
+async def test_two_per_user_connects_store_two_grants(auth_server, druks_db):
+    first = Account.get_or_create("first@example.com")
+    second = Account.get_or_create("second@example.com")
+
+    for account in (first, second):
+        url = await oauth.begin_connect(
+            _NAME,
+            _SERVER_URL,
+            _ENDPOINT,
+            account_id=account.id,
+            identity_mode=IdentityMode.PER_USER,
+        )
+        state = dict(parse_qsl(urlparse(url).query))["state"]
+        await oauth.complete_connect(state=state, code=account.id)
+
+    grants = McpOauthGrant.list_for_server(_NAME)
+    assert McpServer.get_for_name(_NAME).identity_mode == IdentityMode.PER_USER
+    assert {grant.account_id for grant in grants} == {first.id, second.id}
+
+
+async def test_concurrent_first_connects_converge_on_the_claimed_mode(auth_server, druks_db):
+    first = Account.get_or_create("first@example.com")
+    second = Account.get_or_create("second@example.com")
+    first_url = await oauth.begin_connect(
+        _NAME,
+        _SERVER_URL,
+        _ENDPOINT,
+        account_id=first.id,
+        identity_mode=IdentityMode.SHARED,
+    )
+    second_url = await oauth.begin_connect(
+        _NAME,
+        _SERVER_URL,
+        _ENDPOINT,
+        account_id=second.id,
+        identity_mode=IdentityMode.PER_USER,
+    )
+    first_state = dict(parse_qsl(urlparse(first_url).query))["state"]
+    second_state = dict(parse_qsl(urlparse(second_url).query))["state"]
+
+    await asyncio.gather(
+        oauth.complete_connect(state=first_state, code="first"),
+        oauth.complete_connect(state=second_state, code="second"),
+    )
+
+    identity_mode = McpServer.get_for_name(_NAME).identity_mode
+    grant_accounts = {grant.account_id for grant in McpOauthGrant.list_for_server(_NAME)}
+    assert identity_mode in {IdentityMode.SHARED, IdentityMode.PER_USER}
+    if identity_mode == IdentityMode.SHARED:
+        assert grant_accounts == {SYSTEM_ACCOUNT_ID}
+    else:
+        assert grant_accounts == {first.id, second.id}
 
 
 # --- mint: cache, refresh, rotation, eviction -------------------------------
@@ -233,7 +392,7 @@ async def test_mint_refreshes_on_cache_miss_and_persists_rotation(auth_server, d
         "expires_in": 300,
     }
 
-    token = await oauth.mint_access_token(_NAME)
+    token = await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
 
     assert token == "at-2"
     refresh = auth_server.token_requests[0]
@@ -242,16 +401,16 @@ async def test_mint_refreshes_on_cache_miss_and_persists_rotation(auth_server, d
     assert refresh["refresh_token"] == "rt-old"
     assert refresh["resource"] == _SERVER_URL
     # Rotation: the provider's new refresh token replaced the stored one.
-    assert McpOauthGrant.get_for_server(_NAME).refresh_token.decrypt() == "rt-new"
+    assert McpOauthGrant.get_for_scope(_NAME, SYSTEM_ACCOUNT_ID).refresh_token.decrypt() == "rt-new"
 
     # A second mint within the TTL reuses the cache — no second refresh.
-    assert await oauth.mint_access_token(_NAME) == "at-2"
+    assert await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID) == "at-2"
     assert len(auth_server.token_requests) == 1
 
 
 async def test_mint_without_grant_fails_loudly(druks_db):
     with pytest.raises(MissingGrantError, match=_NAME):
-        await oauth.mint_access_token(_NAME)
+        await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
 
 
 async def test_mint_refresh_rejection_fails_loudly_and_evicts_the_cache(auth_server, druks_db):
@@ -259,8 +418,8 @@ async def test_mint_refresh_rejection_fails_loudly_and_evicts_the_cache(auth_ser
     auth_server.token_status = 400
 
     with pytest.raises(GrantRefreshError, match=_NAME):
-        await oauth.mint_access_token(_NAME)
-    assert not await get_client().get(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}")
+        await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
+    assert not await get_client().get(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}:{SYSTEM_ACCOUNT_ID}")
 
 
 async def test_mint_rejects_a_malformed_token_response(auth_server, druks_db):
@@ -268,7 +427,7 @@ async def test_mint_rejects_a_malformed_token_response(auth_server, druks_db):
     auth_server.token_malformed = True
 
     with pytest.raises(GrantRefreshError, match="malformed JSON"):
-        await oauth.mint_access_token(_NAME)
+        await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
 
 
 async def test_mint_rejects_a_token_response_without_an_access_token(auth_server, druks_db):
@@ -276,7 +435,7 @@ async def test_mint_rejects_a_token_response_without_an_access_token(auth_server
     auth_server.token_response = {"refresh_token": "rt-2", "expires_in": 3600}
 
     with pytest.raises(GrantRefreshError, match="no access token"):
-        await oauth.mint_access_token(_NAME)
+        await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
 
 
 async def test_mint_losing_the_refresh_lock_polls_for_the_winners_token(
@@ -288,14 +447,14 @@ async def test_mint_losing_the_refresh_lock_polls_for_the_winners_token(
     _store_grant()
     redis = get_client()
     monkeypatch.setattr(oauth, "OAUTH_MINT_WAIT_INTERVAL_SECONDS", 0)
-    await redis.set(f"{OAUTH_REFRESH_LOCK_PREFIX}{_NAME}", "1")
+    await redis.set(f"{OAUTH_REFRESH_LOCK_PREFIX}{_NAME}:{SYSTEM_ACCOUNT_ID}", "1")
 
     async def _winner_finishes():
-        await redis.set(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}", "at-winner")
-        await redis.delete(f"{OAUTH_REFRESH_LOCK_PREFIX}{_NAME}")
+        await redis.set(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}:{SYSTEM_ACCOUNT_ID}", "at-winner")
+        await redis.delete(f"{OAUTH_REFRESH_LOCK_PREFIX}{_NAME}:{SYSTEM_ACCOUNT_ID}")
 
     winner = asyncio.create_task(_winner_finishes())
-    assert await oauth.mint_access_token(_NAME) == "at-winner"
+    assert await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID) == "at-winner"
     await winner
     assert not auth_server.token_requests
 
@@ -304,10 +463,23 @@ async def test_mint_times_out_loudly_when_the_refresh_lock_never_frees(druks_db,
     _store_grant()
     monkeypatch.setattr(oauth, "OAUTH_MINT_WAIT_INTERVAL_SECONDS", 0)
     monkeypatch.setattr(oauth, "OAUTH_MINT_WAIT_ATTEMPTS", 3)
-    await get_client().set(f"{OAUTH_REFRESH_LOCK_PREFIX}{_NAME}", "1")
+    await get_client().set(f"{OAUTH_REFRESH_LOCK_PREFIX}{_NAME}:{SYSTEM_ACCOUNT_ID}", "1")
 
     with pytest.raises(GrantRefreshError, match="concurrent refresh"):
-        await oauth.mint_access_token(_NAME)
+        await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
+
+
+async def test_mint_cache_and_refresh_lock_are_per_scope(auth_server, druks_db):
+    first = Account.get_or_create("first@example.com")
+    second = Account.get_or_create("second@example.com")
+    _store_grant(account_id=first.id, identity_mode=IdentityMode.PER_USER)
+    _store_grant(account_id=second.id, identity_mode=IdentityMode.PER_USER)
+    redis = get_client()
+    await redis.set(f"{OAUTH_REFRESH_LOCK_PREFIX}{_NAME}:{first.id}", "1")
+
+    assert await oauth.mint_access_token(_NAME, second.id) == "at-1"
+    assert not await redis.get(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}:{first.id}")
+    assert await redis.get(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}:{second.id}") == b"at-1"
 
 
 # --- delivery: the oauth branch of the fold ---------------------------------
@@ -317,7 +489,9 @@ async def test_delivery_mints_and_injects_the_oauth_token(registry_state, auth_s
     _register_oauth_server()
     _store_grant()
 
-    kwargs = await Workspace(sandbox=_FakeSandbox()).with_mcp_servers()  # type: ignore[arg-type]
+    kwargs = await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+        SYSTEM_ACCOUNT_ID
+    )
 
     var = get_bearer_token_env_var(_NAME)
     assert kwargs["extra_env"][var] == "at-1"
@@ -331,9 +505,55 @@ async def test_delivery_fails_loudly_for_an_unconnected_enabled_oauth_server(
     registry_state, druks_db
 ):
     _register_oauth_server()
+    server = McpServer.create(name=_NAME, url=_SERVER_URL, token_source=TokenSource.OAUTH)
+    server.identity_mode = IdentityMode.SHARED
 
     with pytest.raises(MissingGrantError, match=_NAME):
-        await Workspace(sandbox=_FakeSandbox()).with_mcp_servers()  # type: ignore[arg-type]
+        await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+            SYSTEM_ACCOUNT_ID
+        )
+
+
+async def test_delivery_names_the_account_missing_its_per_user_grant(druks_db):
+    account = Account.get_or_create("run@example.com")
+    server = McpServer.create(name=_NAME, url=_SERVER_URL, token_source=TokenSource.OAUTH)
+    server.identity_mode = IdentityMode.PER_USER
+
+    with pytest.raises(MissingGrantError) as error:
+        await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+            account.id
+        )
+
+    assert error.value.name == _NAME
+    assert error.value.account_id == account.id
+    assert _NAME in str(error.value)
+    assert account.id in str(error.value)
+
+
+async def test_delivery_without_a_run_account_uses_the_fallback(auth_server, druks_db):
+    fallback = Account.get_or_create("fallback@example.com")
+    UserSettings.get().set_fallback_account(fallback.id)
+    _store_grant(account_id=fallback.id, identity_mode=IdentityMode.PER_USER)
+
+    kwargs = await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+        None
+    )
+
+    assert kwargs["extra_env"][get_bearer_token_env_var(_NAME)] == "at-1"
+
+
+async def test_delivery_with_a_named_account_does_not_use_the_fallback(auth_server, druks_db):
+    fallback = Account.get_or_create("fallback@example.com")
+    named = Account.get_or_create("named@example.com")
+    UserSettings.get().set_fallback_account(fallback.id)
+    _store_grant(account_id=fallback.id, identity_mode=IdentityMode.PER_USER)
+
+    with pytest.raises(MissingGrantError) as error:
+        await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+            named.id
+        )
+
+    assert error.value.account_id == named.id
 
 
 # --- API: connect / callback / disconnect / badge ---------------------------
@@ -342,21 +562,33 @@ async def test_delivery_fails_loudly_for_an_unconnected_enabled_oauth_server(
 def test_connect_route_requires_druks_endpoint(tmp_path, registry_state, druks_db):
     _register_oauth_server()
     with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
-        response = client.post(f"/api/mcp-servers/{_NAME}/connect")
+        response = client.post(
+            f"/api/mcp-servers/{_NAME}/connect",
+            json={"identity_mode": IdentityMode.SHARED},
+        )
         assert response.status_code == 409
         assert "DRUKS_ENDPOINT" in response.text
 
 
 def test_connect_route_rejects_a_non_oauth_server(tmp_path, druks_db):
     with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
-        assert client.post("/api/mcp-servers/github/connect").status_code == 404
+        assert (
+            client.post(
+                "/api/mcp-servers/github/connect",
+                json={"identity_mode": IdentityMode.SHARED},
+            ).status_code
+            == 404
+        )
 
 
 def test_connect_route_returns_the_consent_url(tmp_path, registry_state, auth_server, druks_db):
     _register_oauth_server()
     settings = make_settings(tmp_path, endpoint=_ENDPOINT)
     with TestClient(configure_app_for_test(settings=settings)) as client:
-        response = client.post(f"/api/mcp-servers/{_NAME}/connect")
+        response = client.post(
+            f"/api/mcp-servers/{_NAME}/connect",
+            json={"identity_mode": IdentityMode.SHARED},
+        )
         assert response.status_code == 200
         assert response.json()["authorizationUrl"].startswith(f"{_AUTH_BASE}/authorize?")
 
@@ -366,7 +598,10 @@ def test_callback_route_completes_the_connect(tmp_path, registry_state, auth_ser
     settings = make_settings(tmp_path, endpoint=_ENDPOINT)
 
     with TestClient(configure_app_for_test(settings=settings)) as client:
-        url = client.post(f"/api/mcp-servers/{_NAME}/connect").json()["authorizationUrl"]
+        url = client.post(
+            f"/api/mcp-servers/{_NAME}/connect",
+            json={"identity_mode": IdentityMode.SHARED},
+        ).json()["authorizationUrl"]
         state = dict(parse_qsl(urlparse(url).query))["state"]
         page = client.get("/api/mcp-servers/oauth/callback", params={"state": state, "code": "c"})
         assert page.status_code == 200
@@ -374,7 +609,7 @@ def test_callback_route_completes_the_connect(tmp_path, registry_state, auth_ser
         # The page notifies the opener tab, then closes itself.
         assert "BroadcastChannel('druks-mcp-connect')" in page.text
         assert "window.close()" in page.text
-        assert McpOauthGrant.get_for_server(_NAME)
+        assert McpOauthGrant.get_for_scope(_NAME, SYSTEM_ACCOUNT_ID)
         # Connecting is the explicit "use this server" — it enables too.
         assert McpServer.get_for_name(_NAME).is_enabled is True
 
@@ -399,14 +634,14 @@ async def test_disconnect_route_drops_grant_and_cache(
 ):
     _register_oauth_server()
     _store_grant()
-    await oauth.mint_access_token(_NAME)
+    await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
     # The mint's Redis client is bound to this test's loop; close it so the
     # route dials its own — the cached token lives in Redis either way.
     await close_client()
 
     with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
         assert client.delete(f"/api/mcp-servers/{_NAME}/grant").status_code == 204
-        assert not McpOauthGrant.get_for_server(_NAME)
+        assert not McpOauthGrant.get_for_scope(_NAME, SYSTEM_ACCOUNT_ID)
         # The mirror of connect-enables: no grant, no calls, so no dead entry
         # riding into VMs.
         assert McpServer.get_for_name(_NAME).is_enabled is False
@@ -417,7 +652,46 @@ async def test_disconnect_route_drops_grant_and_cache(
     # shutdown to have nulled it — a portal-bound client awaited from here
     # parks forever, it doesn't raise.
     druks.redis._client = None
-    assert not await get_client().get(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}")
+    assert not await get_client().get(f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}:{SYSTEM_ACCOUNT_ID}")
+
+
+def test_shared_disconnect_allows_per_user_reconnect(
+    tmp_path, registry_state, auth_server, druks_db
+):
+    _register_oauth_server()
+    operator = Account.get_or_create("op@example.com")
+    settings = make_settings(tmp_path, endpoint=_ENDPOINT)
+
+    with TestClient(configure_app_for_test(settings=settings)) as client:
+        shared_url = client.post(
+            f"/api/mcp-servers/{_NAME}/connect",
+            json={"identity_mode": IdentityMode.SHARED},
+        ).json()["authorizationUrl"]
+        shared_state = dict(parse_qsl(urlparse(shared_url).query))["state"]
+        assert (
+            client.get(
+                "/api/mcp-servers/oauth/callback",
+                params={"state": shared_state, "code": "shared"},
+            ).status_code
+            == 200
+        )
+        assert client.delete(f"/api/mcp-servers/{_NAME}/grant").status_code == 204
+
+        per_user_url = client.post(
+            f"/api/mcp-servers/{_NAME}/connect",
+            json={"identity_mode": IdentityMode.PER_USER},
+        ).json()["authorizationUrl"]
+        per_user_state = dict(parse_qsl(urlparse(per_user_url).query))["state"]
+        assert (
+            client.get(
+                "/api/mcp-servers/oauth/callback",
+                params={"state": per_user_state, "code": "per-user"},
+            ).status_code
+            == 200
+        )
+
+    assert McpServer.get_for_name(_NAME).identity_mode == IdentityMode.PER_USER
+    assert {grant.account_id for grant in McpOauthGrant.list_for_server(_NAME)} == {operator.id}
 
 
 def test_api_has_token_reflects_the_grant_and_leaks_no_secret(tmp_path, registry_state, druks_db):
@@ -432,3 +706,92 @@ def test_api_has_token_reflects_the_grant_and_leaks_no_secret(tmp_path, registry
         server = next(s for s in listed.json() if s["name"] == _NAME)
         assert server["hasToken"] is True
         assert "rt-secret-value" not in listed.text
+
+
+def test_connect_route_rejects_a_conflicting_identity_mode(tmp_path, druks_db):
+    _store_grant()
+
+    with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
+        response = client.post(
+            f"/api/mcp-servers/{_NAME}/connect",
+            json={"identity_mode": IdentityMode.PER_USER},
+        )
+
+    assert response.status_code == 409
+    assert IdentityMode.SHARED in response.json()["detail"]
+
+
+def test_api_has_token_is_scoped_to_the_requesting_account(tmp_path, druks_db):
+    connected = Account.get_or_create("connected@example.com")
+    unconnected = Account.get_or_create("unconnected@example.com")
+    _store_grant(account_id=connected.id, identity_mode=IdentityMode.PER_USER)
+    settings = make_settings(tmp_path, auth_mode="header", auth_header="X-Test-User")
+
+    with TestClient(configure_app_for_test(settings=settings, authenticated=False)) as client:
+        connected_response = client.get(
+            "/api/mcp-servers", headers={"X-Test-User": connected.username}
+        )
+        unconnected_response = client.get(
+            "/api/mcp-servers", headers={"X-Test-User": unconnected.username}
+        )
+
+    connected_server = next(
+        server for server in connected_response.json() if server["name"] == _NAME
+    )
+    unconnected_server = next(
+        server for server in unconnected_response.json() if server["name"] == _NAME
+    )
+    assert connected_server["identityMode"] == IdentityMode.PER_USER
+    assert connected_server["hasToken"] is True
+    assert unconnected_server["identityMode"] == IdentityMode.PER_USER
+    assert unconnected_server["hasToken"] is False
+
+
+async def test_per_user_disconnect_preserves_other_accounts_grant_and_cache(tmp_path, druks_db):
+    disconnected = Account.get_or_create("disconnect@example.com")
+    connected = Account.get_or_create("connected@example.com")
+    _store_grant(account_id=disconnected.id, identity_mode=IdentityMode.PER_USER)
+    _store_grant(account_id=connected.id, identity_mode=IdentityMode.PER_USER)
+    redis = get_client()
+    disconnected_key = f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}:{disconnected.id}"
+    connected_key = f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}:{connected.id}"
+    await redis.set(disconnected_key, "disconnect-token")
+    await redis.set(connected_key, "connected-token")
+    await close_client()
+    settings = make_settings(tmp_path, auth_mode="header", auth_header="X-Test-User")
+
+    with TestClient(configure_app_for_test(settings=settings, authenticated=False)) as client:
+        response = client.delete(
+            f"/api/mcp-servers/{_NAME}/grant",
+            headers={"X-Test-User": disconnected.username},
+        )
+        assert response.status_code == 204
+
+    assert not McpOauthGrant.get_for_scope(_NAME, disconnected.id)
+    assert McpOauthGrant.get_for_scope(_NAME, connected.id)
+    assert McpServer.get_for_name(_NAME).is_enabled is True
+    druks.redis._client = None
+    assert not await get_client().get(disconnected_key)
+    assert await get_client().get(connected_key) == b"connected-token"
+
+
+async def test_removal_drops_every_grant_and_cached_token(tmp_path, druks_db):
+    first = Account.get_or_create("first@example.com")
+    second = Account.get_or_create("second@example.com")
+    _store_grant(account_id=first.id, identity_mode=IdentityMode.PER_USER)
+    _store_grant(account_id=second.id, identity_mode=IdentityMode.PER_USER)
+    redis = get_client()
+    first_key = f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}:{first.id}"
+    second_key = f"{OAUTH_ACCESS_TOKEN_PREFIX}{_NAME}:{second.id}"
+    await redis.set(first_key, "first-token")
+    await redis.set(second_key, "second-token")
+    await close_client()
+
+    with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
+        assert client.delete(f"/api/mcp-servers/{_NAME}").status_code == 204
+
+    assert not McpServer.get_for_name(_NAME)
+    assert not McpOauthGrant.list_for_server(_NAME)
+    druks.redis._client = None
+    assert not await get_client().get(first_key)
+    assert not await get_client().get(second_key)

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -146,9 +146,9 @@ def _store_grant(
         (IdentityMode.PER_USER, None),
     ),
 )
-def test_grant_account_rejects_unresolved_modes(identity_mode, account_id):
+def test_get_grant_account_rejects_unresolved_modes(identity_mode, account_id):
     with pytest.raises(UnresolvedGrantAccountError):
-        McpOauthGrant.grant_account(identity_mode, account_id)
+        McpOauthGrant.get_grant_account(identity_mode, account_id)
 
 
 # --- connect: discovery + DCR + PKCE ---------------------------------------

--- a/backend/tests/test_mcp_registry.py
+++ b/backend/tests/test_mcp_registry.py
@@ -2,7 +2,9 @@ import json
 
 import httpx
 import pytest
+from druks.accounts.constants import SYSTEM_ACCOUNT_ID
 from druks.mcp import registry
+from druks.mcp.enums import IdentityMode
 from druks.mcp.exceptions import RegistryUnavailableError
 from druks.mcp.models import McpOauthGrant, McpServer
 from druks.mcp.registry import derive_server_name, resolve_candidates, search_registry
@@ -339,9 +341,7 @@ def test_add_from_registry_writes_the_row_and_redacts_the_secret(tmp_path, monke
     assert row.secret_headers["X-Api-Key"] == "acme-api-secret"
 
 
-def test_add_from_registry_oauth_candidate_ships_dark_and_connects(
-    tmp_path, monkeypatch, druks_db
-):
+def test_add_from_registry_oauth_candidate_ships_dark_and_connects(tmp_path, monkeypatch, druks_db):
     with _client_with_registry(tmp_path, monkeypatch, _GRAFANA) as client:
         created = client.post(
             "/api/mcp-servers/registry",
@@ -359,21 +359,32 @@ def test_add_from_registry_oauth_candidate_ships_dark_and_connects(
         # would fail every delivery.
         assert body["isEnabled"] is False
         assert body["hasToken"] is False
+        assert body["identityMode"] is None
 
         # The added row connects through the existing flow, against the row's
         # registry-supplied url.
         begun = []
 
-        async def fake_begin_connect(name, server_url, endpoint):
-            begun.append((name, server_url, endpoint))
+        async def fake_begin_connect(name, server_url, endpoint, *, account_id, identity_mode):
+            begun.append((name, server_url, endpoint, account_id, identity_mode))
             return "https://consent.example/authorize"
 
         monkeypatch.setattr("druks.mcp.oauth.begin_connect", fake_begin_connect)
-        connect = client.post("/api/mcp-servers/grafana/connect")
+        connect = client.post(
+            "/api/mcp-servers/grafana/connect",
+            json={"identity_mode": IdentityMode.PER_USER},
+        )
 
         assert connect.status_code == 200
         assert connect.json()["authorizationUrl"] == "https://consent.example/authorize"
-        assert begun == [("grafana", "https://mcp.grafana.com/mcp", "http://druks.test")]
+        assert len(begun) == 1
+        assert begun[0][0:3] == (
+            "grafana",
+            "https://mcp.grafana.com/mcp",
+            "http://druks.test",
+        )
+        assert begun[0][3]
+        assert begun[0][4] == IdentityMode.PER_USER
 
     row = McpServer.get_for_name("grafana")
     assert row.headers == {"X-Grafana-URL": "https://acme.grafana.net"}
@@ -411,9 +422,7 @@ def test_add_from_registry_rejects_missing_required_and_unknown_headers(
         assert not McpServer.get_for_name("observer")
 
 
-def test_add_from_registry_rejects_an_entry_without_an_http_remote(
-    tmp_path, monkeypatch, druks_db
-):
+def test_add_from_registry_rejects_an_entry_without_an_http_remote(tmp_path, monkeypatch, druks_db):
     # stdio/oci-only and unpinned: resolvable in search, not installable.
     with _client_with_registry(tmp_path, monkeypatch, _entry("com.mcparmory/grafana")) as client:
         created = client.post(
@@ -433,6 +442,7 @@ def test_removing_a_connected_row_drops_its_grant(tmp_path, monkeypatch, druks_d
         )
         McpOauthGrant.store(
             server_name="grafana",
+            account_id=SYSTEM_ACCOUNT_ID,
             refresh_token="rt",
             token_endpoint="https://as.example/token",
             resource="https://mcp.grafana.com/mcp",
@@ -443,4 +453,4 @@ def test_removing_a_connected_row_drops_its_grant(tmp_path, monkeypatch, druks_d
 
     # An orphan grant would revive as this name's credential on re-add.
     assert not McpServer.get_for_name("grafana")
-    assert not McpOauthGrant.get_for_server("grafana")
+    assert not McpOauthGrant.list_for_server("grafana")

--- a/backend/tests/test_mcp_servers.py
+++ b/backend/tests/test_mcp_servers.py
@@ -42,7 +42,9 @@ def _sandbox_config() -> SandboxSettings:
 async def _delivery(**kwargs) -> dict:
     # Delivery is resolved at the workspace seam: the enabled servers become wire
     # shapes on ``mcp_servers`` and their tokens land in ``extra_env``.
-    return await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(**kwargs)  # type: ignore[arg-type]
+    return await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+        None, **kwargs
+    )
 
 
 def _requiring_workspace(*servers: RequiredMcpServer) -> Workspace:
@@ -129,7 +131,7 @@ async def test_required_server_delivers_beside_the_registry(druks_db):
         )
     )
 
-    kwargs = await workspace.with_mcp_servers()
+    kwargs = await workspace.with_mcp_servers(None)
 
     github = next(s for s in kwargs["mcp_servers"] if s.name == "github")
     assert github.url == "https://api.githubcopilot.com/mcp/"
@@ -154,7 +156,7 @@ async def test_required_server_owns_its_name_against_a_registry_twin(druks_db):
         ),
     )
 
-    kwargs = await workspace.with_mcp_servers()
+    kwargs = await workspace.with_mcp_servers(None)
 
     delivered = [s for s in kwargs["mcp_servers"] if s.name == "linear"]
     assert len(delivered) == 1
@@ -172,7 +174,7 @@ async def test_duplicate_required_names_are_refused(druks_db):
     )
 
     with pytest.raises(ValueError, match="duplicate required"):
-        await workspace.with_mcp_servers()
+        await workspace.with_mcp_servers(None)
 
 
 def test_required_server_token_stays_out_of_reprs():
@@ -321,15 +323,12 @@ async def test_bearerless_server_delivers_without_a_bearer(druks_db):
     assert "extra_env" not in kwargs
 
 
-def test_bearerless_server_resolves_ready_with_its_headers(druks_db):
+def test_bearerless_server_merges_with_its_headers(druks_db):
     _grafana_shaped_server()
 
-    grafana = McpServer.get_resolved()["grafana"]
+    grafana = McpServer._merged()["grafana"]
     assert grafana["token_source"] == ""
     assert grafana["headers"] == {"X-Grafana-URL": "https://acme.grafana.net"}
-    # Nothing blocks delivery auth — the secret header is stored — so the
-    # API reads it ready.
-    assert grafana["has_token"] is True
     assert grafana["secret_headers"]["X-Api-Key"] == "grafana-api-secret"
 
 
@@ -461,7 +460,7 @@ def test_packaged_catalog_ships_linear_disabled(registry_state, druks_db):
     load_mcp_catalog(PACKAGED_MCP_CATALOG)
 
     assert "github" not in mcp_servers
-    builtins = [s for s in McpServer.get_resolved().values() if s["builtin"]]
+    builtins = [s for s in McpServer._merged().values() if s["builtin"]]
     assert [s["name"] for s in builtins] == ["linear"]
     linear = builtins[0]
     assert linear["url"] == "https://mcp.linear.app/mcp"
@@ -551,7 +550,7 @@ def test_db_overlay_still_disables_a_catalog_entry(tmp_path, registry_state, dru
 
     McpServer.create(name="figma_test", url="https://mcp.figma.test/", is_enabled=False)
 
-    resolved = McpServer.get_resolved()["figma_test"]
+    resolved = McpServer._merged()["figma_test"]
     assert resolved["builtin"] is True
     assert "figma_test" not in {s["name"] for s in McpServer.list_enabled()}
 
@@ -570,7 +569,7 @@ def test_catalog_enabled_false_ships_the_entry_dark(tmp_path, registry_state, dr
         )
     )
 
-    resolved = McpServer.get_resolved()
+    resolved = McpServer._merged()
     assert resolved["dark_test"]["is_enabled"] is False
     assert resolved["lit_test"]["is_enabled"] is True
     enabled_names = {s["name"] for s in McpServer.list_enabled()}

--- a/backend/tests/test_secrets.py
+++ b/backend/tests/test_secrets.py
@@ -2,6 +2,7 @@ import base64
 import os
 
 import pytest
+from druks.accounts.constants import SYSTEM_ACCOUNT_ID
 from druks.core.models import Uuid7Pk
 from druks.mcp.models import McpOauthGrant, McpServer
 from druks.models import Base
@@ -31,6 +32,7 @@ def _key() -> str:
 def _store_grant(refresh_token: str = "rt-secret", client_secret: str = "") -> McpOauthGrant:
     return McpOauthGrant.store(
         server_name="notion",
+        account_id=SYSTEM_ACCOUNT_ID,
         refresh_token=refresh_token,
         token_endpoint="https://auth.test/token",
         resource="https://mcp.notion.test/sse",
@@ -47,18 +49,17 @@ def test_stored_secrets_are_ciphertext_and_reads_restore_them(druks_db):
     druks_db.expire_all()
     row = McpServer.get_for_name("linear")
     assert row.token.decrypt() == _TOKEN
-    # The resolved view every consumer reads carries the Secret itself, so it
+    # The merged view every consumer reads carries the Secret itself, so the
     # plaintext exists only where decrypt() is called.
-    resolved = McpServer.get_resolved()["linear"]
-    assert resolved["token"].decrypt() == _TOKEN
-    assert resolved["has_token"] is True
+    merged = McpServer._merged()["linear"]
+    assert merged["token"].decrypt() == _TOKEN
 
 
 def test_grant_secret_halves_round_trip(druks_db):
     _store_grant(refresh_token="rt-secret", client_secret="cs-secret")
 
     druks_db.expire_all()
-    grant = McpOauthGrant.get_for_server("notion")
+    grant = McpOauthGrant.get_for_scope("notion", SYSTEM_ACCOUNT_ID)
     assert grant.refresh_token.decrypt() == "rt-secret"
     assert grant.client_secret.decrypt() == "cs-secret"
 
@@ -159,7 +160,7 @@ def test_ciphertext_is_bound_to_its_column(druks_db):
     druks_db.execute(text("UPDATE mcp_oauth_grants SET client_secret = refresh_token"))
     druks_db.expire_all()
 
-    grant = McpOauthGrant.get_for_server("notion")
+    grant = McpOauthGrant.get_for_scope("notion", SYSTEM_ACCOUNT_ID)
     with pytest.raises(SecretDecryptError):
         grant.refresh_token.decrypt()
     with pytest.raises(SecretDecryptError):
@@ -177,7 +178,10 @@ def test_prepended_key_still_decrypts(monkeypatch, druks_db):
     monkeypatch.setenv("DRUKS_SECRETS_KEY", f"{_key()},{old_key}")
     druks_db.expire_all()
     assert McpServer.get_for_name("linear").token.decrypt() == _TOKEN
-    assert McpOauthGrant.get_for_server("notion").refresh_token.decrypt() == "rt-secret"
+    assert (
+        McpOauthGrant.get_for_scope("notion", SYSTEM_ACCOUNT_ID).refresh_token.decrypt()
+        == "rt-secret"
+    )
 
 
 # --- EncryptedJsonField (via the test-only model) ---------------------------

--- a/backend/tests/test_secrets.py
+++ b/backend/tests/test_secrets.py
@@ -59,7 +59,7 @@ def test_grant_secret_halves_round_trip(druks_db):
     _store_grant(refresh_token="rt-secret", client_secret="cs-secret")
 
     druks_db.expire_all()
-    grant = McpOauthGrant.get_for_scope("notion", SYSTEM_ACCOUNT_ID)
+    grant = McpOauthGrant.get_for_account("notion", SYSTEM_ACCOUNT_ID)
     assert grant.refresh_token.decrypt() == "rt-secret"
     assert grant.client_secret.decrypt() == "cs-secret"
 
@@ -160,7 +160,7 @@ def test_ciphertext_is_bound_to_its_column(druks_db):
     druks_db.execute(text("UPDATE mcp_oauth_grants SET client_secret = refresh_token"))
     druks_db.expire_all()
 
-    grant = McpOauthGrant.get_for_scope("notion", SYSTEM_ACCOUNT_ID)
+    grant = McpOauthGrant.get_for_account("notion", SYSTEM_ACCOUNT_ID)
     with pytest.raises(SecretDecryptError):
         grant.refresh_token.decrypt()
     with pytest.raises(SecretDecryptError):
@@ -179,7 +179,7 @@ def test_prepended_key_still_decrypts(monkeypatch, druks_db):
     druks_db.expire_all()
     assert McpServer.get_for_name("linear").token.decrypt() == _TOKEN
     assert (
-        McpOauthGrant.get_for_scope("notion", SYSTEM_ACCOUNT_ID).refresh_token.decrypt()
+        McpOauthGrant.get_for_account("notion", SYSTEM_ACCOUNT_ID).refresh_token.decrypt()
         == "rt-secret"
     )
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -251,10 +251,10 @@ export const api = {
   removeMcpServer: (name: string) => deleteRequest(`/api/mcp-servers/${encodeURIComponent(name)}`),
   // OAuth servers: connect returns the consent URL to open; the grant lands via
   // the provider's redirect to druks' callback, never through this client.
-  connectMcpServer: (name: string) =>
+  connectMcpServer: (name: string, identityMode: string) =>
     postJSON<{ authorizationUrl: string }>(
       `/api/mcp-servers/${encodeURIComponent(name)}/connect`,
-      {},
+      { identity_mode: identityMode },
     ),
   disconnectMcpServer: (name: string) =>
     deleteRequest(`/api/mcp-servers/${encodeURIComponent(name)}/grant`),

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -475,6 +475,7 @@ export interface McpServer {
   url: string
   isEnabled: boolean
   tokenSource: string
+  identityMode: string | null
   // A catalog-declared server — managed by druks, can't be removed here,
   // only disabled.
   builtin: boolean

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1379,6 +1379,7 @@ function McpServerRow({
   onConnect: (name: string, identityMode: string) => Promise<void>
   onDisconnect: (name: string) => Promise<void>
 }) {
+  const claimedMode = server.identityMode
   // A built-in (catalog entry) is managed by druks: disable, never remove.
   return (
     <div className={'mcp-row' + (server.isEnabled ? '' : ' is-off')}>
@@ -1390,7 +1391,7 @@ function McpServerRow({
         {tokenStatusLabel(server)}
       </span>
       {server.tokenSource === 'oauth' &&
-        (server.identityMode === null ? (
+        (claimedMode === null ? (
           // The first connect claims how this server's credential is held;
           // afterwards the choice is fixed until the last grant is dropped.
           <>
@@ -1415,7 +1416,7 @@ function McpServerRow({
           <>
             <button
               className="set-btn primary"
-              onClick={() => void onConnect(server.name, server.identityMode)}
+              onClick={() => void onConnect(server.name, claimedMode)}
               disabled={busy}
               title="Opens the provider's consent page."
             >

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1120,7 +1120,7 @@ function McpServersPane() {
     }
   }
 
-  async function connect(name: string) {
+  async function connect(name: string, identityMode: string) {
     setBusy(true)
     setError(null)
     // Opened synchronously, while the click's activation is still live — a tab
@@ -1129,7 +1129,7 @@ function McpServersPane() {
     // refetches on window focus when the operator returns from consent.
     const consentTab = window.open('', '_blank')
     try {
-      const { authorizationUrl } = await api.connectMcpServer(name)
+      const { authorizationUrl } = await api.connectMcpServer(name, identityMode)
       if (consentTab) consentTab.location.assign(authorizationUrl)
       else window.location.assign(authorizationUrl)
     } catch (e) {
@@ -1376,9 +1376,10 @@ function McpServerRow({
   busy: boolean
   onToggle: (name: string, isEnabled: boolean) => Promise<void>
   onRemove: (name: string) => Promise<void>
-  onConnect: (name: string) => Promise<void>
+  onConnect: (name: string, identityMode: string) => Promise<void>
   onDisconnect: (name: string) => Promise<void>
 }) {
+  const [identityMode, setIdentityMode] = useState('shared')
   // A built-in (catalog entry) is managed by druks: disable, never remove.
   return (
     <div className={'mcp-row' + (server.isEnabled ? '' : ' is-off')}>
@@ -1389,26 +1390,44 @@ function McpServerRow({
       <span className={'mcp-tok' + (server.hasToken ? ' ok' : ' missing')}>
         {tokenStatusLabel(server)}
       </span>
-      {server.tokenSource === 'oauth' &&
-        (server.hasToken ? (
-          <button
-            className="sc-remove"
-            onClick={() => void onDisconnect(server.name)}
-            disabled={busy}
-            title="Drop the stored grant; agents lose access until re-connected."
-          >
-            disconnect
-          </button>
-        ) : (
+      {server.tokenSource === 'oauth' && (
+        <>
+          {server.identityMode === null && (
+            <select
+              className="set-select"
+              value={identityMode}
+              onChange={(event) => setIdentityMode(event.target.value)}
+              disabled={busy}
+              aria-label={`Identity mode for ${server.name}`}
+            >
+              <option value="shared">shared</option>
+              <option value="per_user">per user</option>
+            </select>
+          )}
           <button
             className="set-btn primary"
-            onClick={() => void onConnect(server.name)}
+            onClick={() => void onConnect(server.name, server.identityMode ?? identityMode)}
             disabled={busy}
-            title="Authorize druks with this server; opens the provider's consent page."
+            title={
+              server.hasToken
+                ? "Replace this account's grant through the provider's consent page."
+                : "Authorize druks with this server; opens the provider's consent page."
+            }
           >
-            connect
+            {server.hasToken ? 'reconnect' : 'connect'}
           </button>
-        ))}
+          {server.hasToken && (
+            <button
+              className="sc-remove"
+              onClick={() => void onDisconnect(server.name)}
+              disabled={busy}
+              title="Drop this account's stored grant."
+            >
+              disconnect
+            </button>
+          )}
+        </>
+      )}
       <Switch on={server.isEnabled} onClick={() => void onToggle(server.name, !server.isEnabled)} disabled={busy} />
       {server.builtin ? (
         <span className="mcp-managed" title="Managed by druks — disable it instead of removing.">

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1379,7 +1379,6 @@ function McpServerRow({
   onConnect: (name: string, identityMode: string) => Promise<void>
   onDisconnect: (name: string) => Promise<void>
 }) {
-  const [identityMode, setIdentityMode] = useState('shared')
   // A built-in (catalog entry) is managed by druks: disable, never remove.
   return (
     <div className={'mcp-row' + (server.isEnabled ? '' : ' is-off')}>
@@ -1390,44 +1389,50 @@ function McpServerRow({
       <span className={'mcp-tok' + (server.hasToken ? ' ok' : ' missing')}>
         {tokenStatusLabel(server)}
       </span>
-      {server.tokenSource === 'oauth' && (
-        <>
-          {server.identityMode === null && (
-            <select
-              className="set-select"
-              value={identityMode}
-              onChange={(event) => setIdentityMode(event.target.value)}
-              disabled={busy}
-              aria-label={`Identity mode for ${server.name}`}
-            >
-              <option value="shared">shared</option>
-              <option value="per_user">per user</option>
-            </select>
-          )}
-          <button
-            className="set-btn primary"
-            onClick={() => void onConnect(server.name, server.identityMode ?? identityMode)}
-            disabled={busy}
-            title={
-              server.hasToken
-                ? "Replace this account's grant through the provider's consent page."
-                : "Authorize druks with this server; opens the provider's consent page."
-            }
-          >
-            {server.hasToken ? 'reconnect' : 'connect'}
-          </button>
-          {server.hasToken && (
+      {server.tokenSource === 'oauth' &&
+        (server.identityMode === null ? (
+          // The first connect claims how this server's credential is held;
+          // afterwards the choice is fixed until the last grant is dropped.
+          <>
             <button
-              className="sc-remove"
-              onClick={() => void onDisconnect(server.name)}
+              className="set-btn primary"
+              onClick={() => void onConnect(server.name, 'shared')}
               disabled={busy}
-              title="Drop this account's stored grant."
+              title="One connection every run uses; opens the provider's consent page."
             >
-              disconnect
+              connect for everyone
             </button>
-          )}
-        </>
-      )}
+            <button
+              className="set-btn"
+              onClick={() => void onConnect(server.name, 'per_user')}
+              disabled={busy}
+              title="Each account connects its own; opens the provider's consent page."
+            >
+              connect your account
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              className="set-btn primary"
+              onClick={() => void onConnect(server.name, server.identityMode)}
+              disabled={busy}
+              title="Opens the provider's consent page."
+            >
+              {server.hasToken ? 'reconnect' : 'connect'}
+            </button>
+            {server.hasToken && (
+              <button
+                className="sc-remove"
+                onClick={() => void onDisconnect(server.name)}
+                disabled={busy}
+                title="Drop this account's stored grant."
+              >
+                disconnect
+              </button>
+            )}
+          </>
+        ))}
       <Switch on={server.isEnabled} onClick={() => void onToggle(server.name, !server.isEnabled)} disabled={busy} />
       {server.builtin ? (
         <span className="mcp-managed" title="Managed by druks — disable it instead of removing.">


### PR DESCRIPTION
MCP OAuth grants were instance-global: one person's consent served every run, and every write to the connected service carried that identity.

An OAuth server now has an identity mode, claimed by its first connect:

- **shared** — one grant, stored under the system account, serves every run.
- **per_user** — each account connects its own; a run authenticates as the account that dispatched it. Undispatched runs use the fallback account; a run whose account has no grant fails at delivery naming the account and the server.

Grants are keyed by `(server_name, account_id)`, and the same account keys the token cache, refresh lock, and eviction. Disconnect touches only the caller's grant; deleting the last grant reopens the mode choice. Static and env-sourced tokens are unchanged. The migration backfills existing grants as their server's shared grant.
