### PR TITLE
An error result classifies even when claude exits clean

### DIFF
--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -112,12 +112,15 @@ class Harness(ABC):
     def check_returncode(cls, result: HarnessRunResult) -> None:
         if result.returncode != 0:
             detail = _terminal_detail(result.stdout)
-            message = f"{cls.name} exited with {result.returncode}.{detail}"
-            lowered = detail.lower()
-            for marker, error in cls.failure_markers.items():
-                if marker in lowered:
-                    raise error(message)
-            raise exceptions.HarnessError(message)
+            raise cls.classify(detail, f"{cls.name} exited with {result.returncode}.{detail}")
+
+    @classmethod
+    def classify(cls, detail: str, message: str) -> exceptions.HarnessError:
+        lowered = detail.lower()
+        for marker, error in cls.failure_markers.items():
+            if marker in lowered:
+                return error(message)
+        return exceptions.HarnessError(message)
 
     def get_manifest(
         self,

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -160,6 +160,13 @@ class ClaudeHarness(Harness):
         cost_usd, cost_metadata = extract_claude_cost_from_envelope(envelope)
         write_cost(artifact_dir / run_id, cost_usd=cost_usd, metadata=cost_metadata)
 
+        if envelope.get("is_error"):
+            # The CLI can finish cleanly around a failed turn (max turns, an
+            # error result on exit 0); unclassified it would fall through to
+            # contract validation and read as bad agent output.
+            detail = str(envelope.get("result") or "")[:300]
+            raise self.classify(detail, f"claude reported an error. {detail}".rstrip())
+
         structured: Any = envelope.get("structured_output")
         if structured is None:
             structured = envelope.get("result")

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -470,6 +470,42 @@ def test_check_returncode_classifies_the_terminal_error(
     assert str(excinfo.value).startswith(f"{harness.name} exited with 1. ")
 
 
+def test_parse_classifies_an_error_result_despite_exit_zero(ctx: SimpleNamespace):
+    stdout = (
+        b'{"type":"result","subtype":"error_during_execution","is_error":true,'
+        b'"result":"You\'ve hit your session limit \xc2\xb7 resets 5:10pm (UTC)",'
+        b'"total_cost_usd":0.42,"usage":{"input_tokens":10}}\n'
+    )
+    harness = ClaudeHarness(model=None, fast_mode=False, effort=None)
+
+    with pytest.raises(HarnessUsageLimitError) as excinfo:
+        harness.parse(
+            HarnessRunResult(returncode=0, stdout=stdout, stderr=b""),
+            artifact_dir=ctx.artifact_dir,
+            run_id="call-0",
+        )
+
+    assert str(excinfo.value).startswith("claude reported an error.")
+    # The run really happened, so its cost still lands before the raise.
+    cost = json.loads((ctx.artifact_dir / "call-0" / "cost.json").read_text())
+    assert cost["cost_usd"] == 0.42
+
+
+def test_parse_keeps_an_unmatched_error_result_bare(ctx: SimpleNamespace):
+    stdout = b'{"type":"result","subtype":"error_max_turns","is_error":true,"result":"max turns"}\n'
+    harness = ClaudeHarness(model=None, fast_mode=False, effort=None)
+
+    with pytest.raises(HarnessError) as excinfo:
+        harness.parse(
+            HarnessRunResult(returncode=0, stdout=stdout, stderr=b""),
+            artifact_dir=ctx.artifact_dir,
+            run_id="call-0",
+        )
+
+    assert type(excinfo.value) is HarnessError
+    assert excinfo.value.retry is Retry.NEVER
+
+
 def test_agent_result_names_the_agent_in_its_failure():
     result = AgentResult(
         output=None,


### PR DESCRIPTION
## What changed

Claude can finish with exit 0 around a failed turn — an `is_error` result event (`error_max_turns`, `error_during_execution`, or an error text on a clean exit). That death skipped `check_returncode` entirely, fell through to contract validation, and died as a pydantic `ValidationError` attributed to bad agent output — unclassified, so the retry layer never saw it either.

- The marker walk moves from inside `check_returncode` into `Harness.classify(detail, message)`; `check_returncode` uses it unchanged for the nonzero-exit path.
- `ClaudeHarness.parse` raises `self.classify(...)` when the envelope says `is_error`, with the message shape `claude reported an error. <detail>`. A session-limit text on exit 0 now classifies as `usage_limit` (and quota-retries); unmatched texts like `error_max_turns` stay bare, never-retried `HarnessError` — but honestly labeled instead of a misattributed contract failure.
- The raise lands after the cost sidecar write, so a run that really happened still records what it cost — better than the nonzero-exit path can do.

Codex needs nothing: its exit-0 failure shapes already surface as `HarnessInvalidOutputError` via the missing/invalid `output.json`.

## Verification

- `uv run ruff check` / `ruff format --check` — clean; `pyright` on touched files — identical to main's baseline (3 pre-existing override errors).
- New tests pin both branches (classified session-limit with the cost side-effect asserted, unmatched stays bare) plus a smoke of the untouched happy path; the suite gates in CI.
