### PR TITLE
Core run actions live on the runs surface

### DIFF
--- a/backend/druks/api/app.py
+++ b/backend/druks/api/app.py
@@ -15,6 +15,7 @@ from druks.accounts.dependencies import current_account, resolve_single_operator
 from druks.accounts.exceptions import AuthConfigurationError
 from druks.accounts.routes import router as auth_router
 from druks.api.artifacts import router as artifacts_router
+from druks.api.exceptions import AgentApiError
 from druks.api.runs import router as runs_router
 from druks.database import configure_session, create_engine_from_url, db_session, session_scope
 from druks.durable.engine import init_dbos, launch, shutdown
@@ -22,7 +23,6 @@ from druks.events.routes import router as events_router
 from druks.extensions.loader import iter_extensions, load
 from druks.harnesses.routes import router as harness_connection_router
 from druks.mcp.catalog import load_mcp_catalog
-from druks.mcp.gateway.exceptions import AgentApiError
 from druks.mcp.gateway.routes import router as gateway_router
 from druks.mcp.routes import router as mcp_router
 from druks.notifications.routes import external_router as notifications_external_router

--- a/backend/druks/api/exceptions.py
+++ b/backend/druks/api/exceptions.py
@@ -1,0 +1,45 @@
+from typing import ClassVar
+
+
+class AgentApiError(Exception):
+    # Base for the agent surface's wire errors: each subclass names its HTTP
+    # status and stable code, serialized as the one {code, message, retryable}
+    # response shape. Messages are authored for the caller — never tracebacks,
+    # paths, or engine internals. retryable=True marks a failure the caller can
+    # fix by re-reading state and retrying.
+    status_code: ClassVar[int] = 400
+    code: ClassVar[str] = ""
+    retryable: ClassVar[bool] = False
+
+
+class RunNotFound(AgentApiError):
+    status_code = 404
+    code = "RUN_NOT_FOUND"
+
+    def __init__(self, run_id: str) -> None:
+        super().__init__(f"No run {run_id}.")
+
+
+class RunNotActive(AgentApiError):
+    status_code = 409
+    code = "RUN_NOT_ACTIVE"
+
+    def __init__(self, run_id: str) -> None:
+        super().__init__(f"Run {run_id} already ended.")
+
+
+class RunNotFailed(AgentApiError):
+    status_code = 409
+    code = "RUN_NOT_FAILED"
+
+    def __init__(self, run_id: str) -> None:
+        super().__init__(f"Run {run_id} did not fail.")
+
+
+class SubjectBusy(AgentApiError):
+    status_code = 409
+    code = "SUBJECT_BUSY"
+    retryable = True
+
+    def __init__(self, run_id: str) -> None:
+        super().__init__(f"The subject already has active run {run_id}.")

--- a/backend/druks/api/runs.py
+++ b/backend/druks/api/runs.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter, HTTPException, status
+from typing import Annotated
 
-from druks.api.schemas import ResumeRequest
+from fastapi import APIRouter, Body, HTTPException, status
+
+from druks.api.exceptions import RunNotActive, RunNotFailed, RunNotFound, SubjectBusy
+from druks.api.schemas import CancelRunResponse, ResumeRequest, RetryRunResponse
 from druks.durable.enums import RunState
 from druks.durable.models import Run
 from druks.notifications.exceptions import InvalidChoiceError
@@ -24,3 +27,56 @@ async def resume_run(run_id: str, body: ResumeRequest) -> None:
     except InvalidChoiceError as error:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, str(error)) from error
     await run.resume(**resume_payload)
+
+
+# The "agent" tag also derives each route below into an MCP tool: its docstring
+# is the tool description and operation_id is the tool name — renaming one is a
+# break, never a refactor side effect.
+
+
+@router.post(
+    "/{run_id}/cancel",
+    operation_id="cancel_run",
+    tags=["agent"],
+    response_model=CancelRunResponse,
+    response_model_by_alias=True,
+)
+async def cancel_run(
+    run_id: str, reason: Annotated[str, Body(embed=True, min_length=1, max_length=500)]
+) -> CancelRunResponse:
+    """Cancel an active run, recording the reason as its failure; a repeat
+    cancel reports already_cancelled."""
+    run = Run.get(run_id)
+    if not run:
+        raise RunNotFound(run_id)
+    if run.state == RunState.CANCELLED.value:
+        return CancelRunResponse(run_id=run.id, result="already_cancelled")
+    if not run.is_active:
+        raise RunNotActive(run_id)
+    await run.cancel(failure=reason)
+    return CancelRunResponse(run_id=run.id, result="cancelled")
+
+
+@router.post(
+    "/{run_id}/retry",
+    operation_id="retry_run",
+    tags=["agent"],
+    response_model=RetryRunResponse,
+    response_model_by_alias=True,
+)
+async def retry_run(run_id: str) -> RetryRunResponse:
+    """Rerun a failed run from the step that killed it, reusing every
+    completed step."""
+    run = Run.get(run_id)
+    if not run:
+        raise RunNotFound(run_id)
+    if run.state != RunState.FAILED.value:
+        raise RunNotFailed(run_id)
+
+    subject = run.subject
+    if subject:
+        latest = Run.get_latest_for_subject(subject["type"], subject["id"])
+        if latest and latest.is_active:
+            raise SubjectBusy(latest.id)
+
+    return RetryRunResponse(run_id=await run.retry())

--- a/backend/druks/api/schemas.py
+++ b/backend/druks/api/schemas.py
@@ -17,6 +17,15 @@ class ResumeRequest(BaseModel):
     note: str = ""
 
 
+class CancelRunResponse(BaseResponse):
+    run_id: str
+    result: Literal["cancelled", "already_cancelled"]
+
+
+class RetryRunResponse(BaseResponse):
+    run_id: str
+
+
 class ArtifactContent(BaseResponse):
     # A call's renderable output, served to the in-app review so it can show the
     # plan (or other markdown) beside its controls.

--- a/backend/druks/mcp/gateway/exceptions.py
+++ b/backend/druks/mcp/gateway/exceptions.py
@@ -1,23 +1,4 @@
-from typing import ClassVar
-
-
-class AgentApiError(Exception):
-    # Base for the agent surface's wire errors: each subclass names its HTTP
-    # status and stable code, serialized as the one {code, message, retryable}
-    # response shape. Messages are authored for the caller — never tracebacks,
-    # paths, or engine internals. retryable=True marks a failure the caller can
-    # fix by re-reading state and retrying.
-    status_code: ClassVar[int] = 400
-    code: ClassVar[str] = ""
-    retryable: ClassVar[bool] = False
-
-
-class RunNotFound(AgentApiError):
-    status_code = 404
-    code = "RUN_NOT_FOUND"
-
-    def __init__(self, run_id: str) -> None:
-        super().__init__(f"No run {run_id}.")
+from druks.api.exceptions import AgentApiError
 
 
 class GateNotOpen(AgentApiError):
@@ -57,28 +38,3 @@ class AgentCallNotFound(AgentApiError):
 
     def __init__(self, call_id: str) -> None:
         super().__init__(f"No agent call {call_id}.")
-
-
-class RunNotActive(AgentApiError):
-    status_code = 409
-    code = "RUN_NOT_ACTIVE"
-
-    def __init__(self, run_id: str) -> None:
-        super().__init__(f"Run {run_id} already ended.")
-
-
-class RunNotFailed(AgentApiError):
-    status_code = 409
-    code = "RUN_NOT_FAILED"
-
-    def __init__(self, run_id: str) -> None:
-        super().__init__(f"Run {run_id} did not fail.")
-
-
-class SubjectBusy(AgentApiError):
-    status_code = 409
-    code = "SUBJECT_BUSY"
-    retryable = True
-
-    def __init__(self, run_id: str) -> None:
-        super().__init__(f"The subject already has active run {run_id}.")

--- a/backend/druks/mcp/gateway/routes.py
+++ b/backend/druks/mcp/gateway/routes.py
@@ -1,6 +1,4 @@
-from typing import Annotated
-
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Depends
 
 from druks.accounts.dependencies import current_account
 from druks.accounts.models import Account
@@ -52,32 +50,6 @@ async def get_agent_call(call_id: str) -> schemas.AgentCallDetailResponse:
     """One agent call's metadata with bounded transcript and stderr tails and
     an artifact chunk."""
     return services.get_agent_call(call_id)
-
-
-@router.post(
-    "/runs/{run_id}/cancel",
-    operation_id="cancel_run",
-    response_model=schemas.CancelRunResponse,
-    response_model_by_alias=True,
-)
-async def cancel_run(
-    run_id: str, reason: Annotated[str, Body(embed=True, min_length=1, max_length=500)]
-) -> schemas.CancelRunResponse:
-    """Cancel an active run, recording the reason as its failure; a repeat
-    cancel reports already_cancelled."""
-    return await services.cancel_run(run_id, reason=reason)
-
-
-@router.post(
-    "/runs/{run_id}/retry",
-    operation_id="retry_run",
-    response_model=schemas.RetryRunResponse,
-    response_model_by_alias=True,
-)
-async def retry_run(run_id: str) -> schemas.RetryRunResponse:
-    """Rerun a failed run from the step that killed it, reusing every
-    completed step."""
-    return await services.retry_run(run_id)
 
 
 @router.get(

--- a/backend/druks/mcp/gateway/schemas.py
+++ b/backend/druks/mcp/gateway/schemas.py
@@ -48,15 +48,6 @@ class AgentCallDetailResponse(BaseResponse):
     artifact: ArtifactContent | None = None
 
 
-class CancelRunResponse(BaseResponse):
-    run_id: str
-    result: Literal["cancelled", "already_cancelled"]
-
-
-class RetryRunResponse(BaseResponse):
-    run_id: str
-
-
 class AgentHarnessUsage(BaseResponse):
     # *_history: percent-left trend samples, oldest first.
     name: str

--- a/backend/druks/mcp/gateway/services.py
+++ b/backend/druks/mcp/gateway/services.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 
 from druks.accounts.models import Account
+from druks.api.exceptions import RunNotFound
 from druks.core.utils.time import operator_local_day
 from druks.database import db_session
 from druks.durable.enums import RunState
@@ -28,7 +29,7 @@ _HISTORY_POINTS = 8
 def get_gate(run_id: str) -> schemas.GateResponse:
     run = Run.get(run_id)
     if not run:
-        raise exceptions.RunNotFound(run_id)
+        raise RunNotFound(run_id)
     if run.state != RunState.PARKED.value:
         raise exceptions.GateNotOpen(run_id)
     ask = run.input_request
@@ -48,7 +49,7 @@ async def answer_gate(
 ) -> schemas.GateAnswerResponse:
     run = Run.get(run_id)
     if not run:
-        raise exceptions.RunNotFound(run_id)
+        raise RunNotFound(run_id)
     db_session().expire(run)  # the receipt/park comparison must read fresh
     if run.answer_parked_at == parked_at:
         return schemas.GateAnswerResponse(
@@ -83,34 +84,6 @@ def get_agent_call(call_id: str) -> schemas.AgentCallDetailResponse:
         stderr=read_slice(layout.stderr, offset=-_STDERR_TAIL_BYTES, limit=_STDERR_TAIL_BYTES).text,
         artifact=_artifact_content(Artifact.get_for_call(call.id)),
     )
-
-
-async def cancel_run(run_id: str, *, reason: str) -> schemas.CancelRunResponse:
-    run = Run.get(run_id)
-    if not run:
-        raise exceptions.RunNotFound(run_id)
-    if run.state == RunState.CANCELLED.value:
-        return schemas.CancelRunResponse(run_id=run.id, result="already_cancelled")
-    if not run.is_active:
-        raise exceptions.RunNotActive(run_id)
-    await run.cancel(failure=reason)
-    return schemas.CancelRunResponse(run_id=run.id, result="cancelled")
-
-
-async def retry_run(run_id: str) -> schemas.RetryRunResponse:
-    run = Run.get(run_id)
-    if not run:
-        raise exceptions.RunNotFound(run_id)
-    if run.state != RunState.FAILED.value:
-        raise exceptions.RunNotFailed(run_id)
-
-    subject = run.subject
-    if subject:
-        latest = Run.get_latest_for_subject(subject["type"], subject["id"])
-        if latest and latest.is_active:
-            raise exceptions.SubjectBusy(latest.id)
-
-    return schemas.RetryRunResponse(run_id=await run.retry())
 
 
 def _artifact_content(artifact: Artifact | None) -> schemas.ArtifactContent | None:

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -73,7 +73,7 @@ def test_openapi_pins_the_six_agent_routes(client: TestClient):
         (method, path): operation
         for path, operations in schema["paths"].items()
         for method, operation in operations.items()
-        if operation.get("tags") == ["agent"]
+        if "agent" in operation.get("tags", [])
     }
     assert {key: op["operationId"] for key, op in found.items()} == _MCP_ROUTES
 

--- a/backend/tests/test_agent_services.py
+++ b/backend/tests/test_agent_services.py
@@ -6,6 +6,8 @@ from unittest import mock
 import pytest
 from conftest import make_test_note, seed_note_run
 from druks.accounts.models import Account
+from druks.api import runs
+from druks.api.exceptions import RunNotActive, RunNotFailed, RunNotFound, SubjectBusy
 from druks.durable.engine import run_queue
 from druks.durable.enums import WorkflowEvent
 from druks.durable.models import Artifact, Run
@@ -130,7 +132,7 @@ def test_get_gate_serves_the_artifact(druks_db):
 
 
 def test_get_gate_refuses_when_not_parked_or_external(druks_db):
-    with pytest.raises(exceptions.RunNotFound):
+    with pytest.raises(RunNotFound):
         services.get_gate("no-such-run")
 
     item = make_test_note()
@@ -154,7 +156,7 @@ def test_get_gate_refuses_when_not_parked_or_external(druks_db):
 
 
 async def test_answer_gate_error_taxonomy(druks_db, resume_spy):
-    with pytest.raises(exceptions.RunNotFound):
+    with pytest.raises(RunNotFound):
         await services.answer_gate(
             "no-such-run", parked_at=datetime.now(UTC), control="approve", answers={}, note=""
         )
@@ -247,22 +249,22 @@ async def test_cancel_run_paths(druks_db):
     item = make_test_note()
     run = seed_note_run(druks_db, note=item, state="running")
 
-    result = await services.cancel_run(run.id, reason="stuck")
+    result = await runs.cancel_run(run.id, reason="stuck")
     assert result.result == "cancelled"
     druks_db.expire_all()
     assert Run.get(run.id).state == "cancelled"
     assert Run.get(run.id).failure == "stuck"
 
-    again = await services.cancel_run(run.id, reason="stuck")
+    again = await runs.cancel_run(run.id, reason="stuck")
     assert again.result == "already_cancelled"
 
     finished_item = make_test_note()
     finished = seed_note_run(druks_db, note=finished_item, state="finished")
-    with pytest.raises(exceptions.RunNotActive):
-        await services.cancel_run(finished.id, reason="late")
+    with pytest.raises(RunNotActive):
+        await runs.cancel_run(finished.id, reason="late")
 
-    with pytest.raises(exceptions.RunNotFound):
-        await services.cancel_run("no-such-run", reason="x")
+    with pytest.raises(RunNotFound):
+        await runs.cancel_run("no-such-run", reason="x")
 
 
 async def test_run_retry_forks_from_the_failed_step(druks_db, monkeypatch):
@@ -336,8 +338,8 @@ async def test_retry_run_refuses_a_non_failed_run(druks_db, monkeypatch):
     retry = mock.AsyncMock()
     monkeypatch.setattr(Run, "retry", retry)
 
-    with pytest.raises(exceptions.RunNotFailed) as error:
-        await services.retry_run(run.id)
+    with pytest.raises(RunNotFailed) as error:
+        await runs.retry_run(run.id)
 
     assert error.value.code == "RUN_NOT_FAILED"
     assert error.value.retryable is False
@@ -351,8 +353,8 @@ async def test_retry_run_refuses_a_busy_subject(druks_db, monkeypatch):
     retry = mock.AsyncMock()
     monkeypatch.setattr(Run, "retry", retry)
 
-    with pytest.raises(exceptions.SubjectBusy) as error:
-        await services.retry_run(failed.id)
+    with pytest.raises(SubjectBusy) as error:
+        await runs.retry_run(failed.id)
 
     assert str(error.value) == f"The subject already has active run {active.id}."
     assert error.value.retryable is True
@@ -364,15 +366,15 @@ async def test_retry_run_retries_a_failed_run(druks_db, monkeypatch):
     retry = mock.AsyncMock(return_value="retried-run")
     monkeypatch.setattr(Run, "retry", retry)
 
-    result = await services.retry_run(run.id)
+    result = await runs.retry_run(run.id)
 
     assert result.run_id == "retried-run"
     retry.assert_awaited_once_with()
 
 
 async def test_retry_run_refuses_a_missing_run(druks_db):
-    with pytest.raises(exceptions.RunNotFound) as error:
-        await services.retry_run("no-such-run")
+    with pytest.raises(RunNotFound) as error:
+        await runs.retry_run("no-such-run")
 
     assert error.value.code == "RUN_NOT_FOUND"
     assert error.value.retryable is False

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -36,13 +36,14 @@ _WIRE_HEADERS = {
     "Content-Type": "application/json",
 }
 
-# tools/list order is the gateway router's declaration order.
+# tools/list order is route declaration order: the runs router mounts before
+# the gateway router.
 _TOOL_NAMES = [
+    "cancel_run",
+    "retry_run",
     "get_gate",
     "answer_gate",
     "get_agent_call",
-    "cancel_run",
-    "retry_run",
     "get_usage",
 ]
 


### PR DESCRIPTION
POST /api/runs/{run_id}/cancel and POST /api/runs/{run_id}/retry are core run actions the frontend depends on, yet they lived in the MCP gateway (a protocol adapter). They move to `druks/api/runs.py` beside resume, with their logic inlined the way resume's is — operation ids, docstrings, paths, and wire shapes unchanged. `CancelRunResponse`/`RetryRunResponse` move to `druks/api/schemas.py` with them.

The MCP derivation already consumes routes by tag wherever they live (fastmcp matches `RouteMap` tags as a subset), so the moved routes just carry the `"agent"` tag alongside the runs router's own. tools/list still serves the same six tools — get_gate, answer_gate, get_agent_call, cancel_run, retry_run, get_usage — with unchanged annotations, descriptions, and schema constraints; only their order shifts, since the runs router mounts before the gateway router. The gateway keeps what exists only for the tool surface: gates, agent calls, usage.

The `AgentApiError` base and the run-action errors (`RunNotFound`, `RunNotActive`, `RunNotFailed`, `SubjectBusy`) move to a new `druks/api/exceptions.py`, so the runs surface and the app's `{code, message, retryable}` handler stop importing from the adapter. Gate and agent-call errors stay in the gateway, subclassing the api base — the dependency arrow now runs adapter→core only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
