### PR TITLE
Name a Codex quota window by its length, not its slot

### DIFF
--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -49,6 +49,10 @@ _TOKEN_COUNT_MARKERS = ('"type":"token_count"', '"type": "token_count"')
 _CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
 _CODEX_USER_AGENT = "codex-cli"
 
+# A quota window is named by its declared length, not the slot it arrives in:
+# a plan whose only quota is weekly reports it as the primary window.
+_WEEKLY_WINDOW_MINIMUM_SECONDS = 24 * 3600
+
 
 @dataclass(frozen=True)
 class _Usage:
@@ -424,11 +428,12 @@ class CodexHarness(Harness):
             return ParsedUsage(ok=False, error="unparseable", raw=raw)
         if not isinstance(data, dict) or "rate_limit" not in data:
             return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
-        rate_limit = data.get("rate_limit") or {}
         plan = data.get("plan_type") if isinstance(data.get("plan_type"), str) else None
-        five_hour = _codex_window(rate_limit.get("primary_window"))
-        week = _codex_window(rate_limit.get("secondary_window"))
-        if five_hour is None and week is None:
+        try:
+            five_hour, week = _codex_windows(data["rate_limit"] or {})
+        except (AttributeError, KeyError, TypeError, ValueError):
+            return ParsedUsage(ok=False, error="unexpected_payload", plan_tier=plan, raw=raw)
+        if not five_hour and not week:
             # Business/enterprise accounts with unlimited credits carry
             # ``rate_limit: null`` — no windows is the expected shape, not
             # a parse failure. Report permanently-full buckets.
@@ -703,23 +708,21 @@ class CodexHarness(Harness):
         )
 
 
-def _codex_window(block: object) -> ParsedMetric | None:
-    if not isinstance(block, dict):
-        return None
-    used = block.get("used_percent")
-    percent_left = None
-    if isinstance(used, (int, float)):
-        percent_left = max(0, min(100, int(round(100 - used))))
-    resets_at = _codex_reset(block.get("reset_at"))
-    if percent_left is None and resets_at is None:
-        return None
-    return ParsedMetric(percent_left=percent_left, resets_at=resets_at)
-
-
-def _codex_reset(value: object) -> datetime | None:
-    if not isinstance(value, (int, float)):
-        return None
-    try:
-        return datetime.fromtimestamp(value, tz=UTC)
-    except (OverflowError, OSError, ValueError):
-        return None
+def _codex_windows(rate_limit: dict) -> tuple[ParsedMetric | None, ParsedMetric | None]:
+    """The five-hour and weekly quotas, in that order. Raises if a window the
+    payload reports is unreadable — a window we cannot place is a broken
+    payload, not a missing quota."""
+    five_hour = week = None
+    for slot in ("primary_window", "secondary_window"):
+        block = rate_limit.get(slot)
+        if not block:
+            continue
+        window = ParsedMetric(
+            percent_left=max(0, min(100, round(100 - block["used_percent"]))),
+            resets_at=datetime.fromtimestamp(block["reset_at"], tz=UTC),
+        )
+        if block["limit_window_seconds"] >= _WEEKLY_WINDOW_MINIMUM_SECONDS:
+            week = window
+        else:
+            five_hour = window
+    return five_hour, week

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -389,16 +389,24 @@ async def test_fetch_usage_without_a_token_skips_http(monkeypatch, druks_db):
 async def test_codex_fetch_usage_success(monkeypatch, druks_db):
     connection = _seed_codex(account_id="acc-7")
     body = {
-        "plan_type": "prolite",
+        "plan_type": "pro",
         "rate_limit": {
-            "primary_window": {"used_percent": 39, "reset_at": 1780625132},
-            "secondary_window": {"used_percent": 39, "reset_at": 1781211932},
+            "primary_window": {
+                "used_percent": 39,
+                "limit_window_seconds": 18000,
+                "reset_at": 1780625132,
+            },
+            "secondary_window": {
+                "used_percent": 39,
+                "limit_window_seconds": 604800,
+                "reset_at": 1781211932,
+            },
         },
     }
     calls = _mock_get(monkeypatch, _resp(200, body))
     parsed = await CodexHarness.fetch_usage(connection, now=_NOW)
     assert parsed.ok is True
-    assert parsed.plan_tier == "prolite"
+    assert parsed.plan_tier == "pro"
     assert parsed.five_hour.percent_left == 61
     assert parsed.week.percent_left == 61
     assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acc-7"

--- a/backend/tests/test_harness_usage_parsing.py
+++ b/backend/tests/test_harness_usage_parsing.py
@@ -23,6 +23,49 @@ def test_codex_parse_treats_unlimited_credits_as_full_buckets() -> None:
     assert parsed.unlimited is True
 
 
+def test_codex_parse_places_a_weekly_only_plan_in_the_week_window() -> None:
+    """A plan whose only quota is weekly reports it as the primary window."""
+    parsed = CodexHarness._parse_usage(
+        json.dumps(
+            {
+                "plan_type": "prolite",
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 2,
+                        "limit_window_seconds": 604800,
+                        "reset_at": 1786173475,
+                    },
+                    "secondary_window": None,
+                },
+            }
+        )
+    )
+
+    assert parsed.ok
+    assert parsed.five_hour is None
+    assert parsed.week is not None and parsed.week.percent_left == 98
+
+
+def test_codex_parse_rejects_an_unreadable_window() -> None:
+    parsed = CodexHarness._parse_usage(
+        json.dumps(
+            {
+                "plan_type": "pro",
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 5,
+                        "limit_window_seconds": "one week",
+                        "reset_at": 1786173475,
+                    }
+                },
+            }
+        )
+    )
+
+    assert not parsed.ok
+    assert parsed.error == "unexpected_payload"
+
+
 def test_codex_parse_still_fails_without_windows_or_unlimited() -> None:
     parsed = CodexHarness._parse_usage(
         json.dumps({"plan_type": "plus", "rate_limit": None, "credits": {"unlimited": False}})


### PR DESCRIPTION
Codex's weekly usage window always rendered empty, and the weekly numbers appeared under the "5h window" label — a five-hour window claiming to reset in six days.

`_parse_usage` assigned `rate_limit.primary_window` to the five-hour quota and `secondary_window` to the weekly one, by position. The prolite plan reports a single quota, weekly, in the primary slot with `secondary_window: null`. Every window the endpoint sends declares its own `limit_window_seconds`, so length now names the window and position is ignored.

Reading a window also stops coercing field by field. `used_percent`, `reset_at` and `limit_window_seconds` are always present, so they are read as required and a malformed window raises into the `unexpected_payload` the caller already returns. The previous per-field fallbacks turned an unreadable window into a plausible five-hour quota — the same class of error as the bug being fixed. Window parsing collapses to one function, and `_codex_window` / `_codex_reset` are gone.

Plans that report both windows are unaffected.

Note for whoever deploys: a plan with no five-hour window now reports `five_hour = None`, which the usage panel draws as `5h window —`. That row is honest but empty; omitting a window the plan does not have is a follow-up.
