### PR TITLE
Give the MCP settings pane a readable hierarchy

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { Fragment, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { api } from '../api/client'
@@ -444,7 +444,17 @@ function RailGlyph({ name }: { name: string }) {
 // Switch + dropdown menu
 // ---------------------------------------------------------------------------
 
-function Switch({ on, onClick, disabled }: { on: boolean; onClick: () => void; disabled?: boolean }) {
+function Switch({
+  on,
+  onClick,
+  disabled,
+  label,
+}: {
+  on: boolean
+  onClick: () => void
+  disabled?: boolean
+  label?: string
+}) {
   return (
     <button
       type="button"
@@ -452,6 +462,7 @@ function Switch({ on, onClick, disabled }: { on: boolean; onClick: () => void; d
       onClick={onClick}
       disabled={disabled}
       aria-pressed={on}
+      aria-label={label}
     />
   )
 }
@@ -1022,6 +1033,7 @@ function McpServersPane() {
   const [candidates, setCandidates] = useState<McpRegistryCandidate[] | null>(null)
   const [selected, setSelected] = useState<McpRegistryCandidate | null>(null)
   const [headerValues, setHeaderValues] = useState<Record<string, string>>({})
+  const fieldId = useId()
   const servers = serversQuery.data ?? []
 
   const refresh = () => queryClient.invalidateQueries({ queryKey: ['mcpServers'] })
@@ -1158,19 +1170,34 @@ function McpServersPane() {
   )
 
   return (
-    <div className="set-pane">
-      <div className="set-pane-head">
-        <div className="set-pane-sub">
-          Add an <b>MCP server</b> your agents can call. Enabled servers are carried into every
-          sandbox VM; secrets ride the run env and never land in emitted config.
+    <div className="set-pane mcp-pane">
+      <header className="mcp-pane-head">
+        <h2 className="mcp-pane-title">MCP Servers</h2>
+        <p className="mcp-pane-sub">
+          Tools your agents can call. Enabled servers are carried into every sandbox VM; secrets
+          ride the run env and never land in emitted config.
+        </p>
+      </header>
+
+      {error && (
+        <div className="mcp-error" role="alert">
+          {error}
         </div>
-      </div>
-      <div className="set-group">
-        <div className="set-group-label">add from registry</div>
+      )}
+
+      <section className="mcp-section">
+        <h3 className="mcp-h">Add from registry</h3>
+        <p className="mcp-help">
+          Search the official MCP registry — most servers install with no token at all.
+        </p>
         <div className="mcp-reg-search">
+          <label className="mcp-sr-only" htmlFor={`${fieldId}-search`}>
+            Search the MCP registry
+          </label>
           <input
+            id={`${fieldId}-search`}
             className="skill-add-input"
-            placeholder="search the official MCP registry — grafana, sentry, …"
+            placeholder="grafana, sentry, …"
             value={registryQuery}
             onChange={(e) => setRegistryQuery(e.target.value)}
             onKeyDown={(e) => {
@@ -1182,17 +1209,18 @@ function McpServersPane() {
             disabled={searching}
           />
           <button
-            className="set-btn ghost"
+            className="set-btn primary"
             disabled={searching || !registryQuery.trim()}
+            aria-busy={searching}
             onClick={() => void searchRegistry()}
           >
-            {searching ? 'searching…' : 'search'}
+            {searching ? 'Searching…' : 'Search'}
           </button>
         </div>
         {candidates && candidates.length === 0 && (
-          <div className="set-field-help">
+          <p className="mcp-help">
             No matching servers with a hosted (HTTP) endpoint in the registry.
-          </div>
+          </p>
         )}
         {candidates && candidates.length > 0 && (
           <div className="mcp-reg-results">
@@ -1203,30 +1231,35 @@ function McpServersPane() {
                     'mcp-reg-row' +
                     (selected?.registryName === candidate.registryName ? ' is-selected' : '')
                   }
+                  aria-expanded={selected?.registryName === candidate.registryName}
                   onClick={() => select(candidate)}
                   disabled={busy}
                 >
-                  <span className="mcp-name">{candidate.name}</span>
-                  <span className={'mcp-reg-badge' + (candidate.official ? ' official' : '')}>
-                    {candidate.official ? 'official' : 'community'}
+                  <span className="mcp-reg-top">
+                    <span className="mcp-name">{candidate.name}</span>
+                    <span className={'mcp-reg-badge' + (candidate.official ? ' official' : '')}>
+                      {candidate.official ? 'official' : 'community'}
+                    </span>
                   </span>
+                  <span className="mcp-url">{candidate.url}</span>
                   <span className="mcp-reg-desc" title={candidate.registryName}>
                     {candidate.description}
                   </span>
-                  <span className="mcp-url">{candidate.url}</span>
                 </button>
                 {selected?.registryName === candidate.registryName && (
                   <div className="mcp-reg-form">
                     {selected.headers.map((header) => (
-                      <div className="set-field" key={header.name}>
-                        <span className="set-field-label">
+                      <div className="mcp-field" key={header.name}>
+                        <label className="mcp-label tech" htmlFor={`${fieldId}-${header.name}`}>
                           {header.name}
-                          {header.isRequired ? ' *' : ''}
-                        </span>
+                          {header.isRequired && <span className="mcp-req"> (required)</span>}
+                        </label>
                         <input
+                          id={`${fieldId}-${header.name}`}
                           className="skill-add-input"
                           type={header.isSecret ? 'password' : 'text'}
                           placeholder={header.placeholder}
+                          required={header.isRequired}
                           value={headerValues[header.name] ?? ''}
                           onChange={(e) =>
                             setHeaderValues((values) => ({
@@ -1239,23 +1272,22 @@ function McpServersPane() {
                           data-lpignore="true"
                           disabled={busy}
                         />
-                        {header.description && (
-                          <span className="set-field-help">{header.description}</span>
-                        )}
+                        {header.description && <p className="mcp-help">{header.description}</p>}
                       </div>
                     ))}
                     {!selected.headers.some((header) => header.isSecret) && (
-                      <div className="set-field-help">
-                        Uses OAuth — click <b>connect</b> on the added server to authorize it.
-                      </div>
+                      <p className="mcp-help">
+                        Uses OAuth — use <b>Connect</b> on the added server to authorize it.
+                      </p>
                     )}
                     <div>
                       <button
                         className="set-btn primary"
                         disabled={busy || missingRequired}
+                        aria-busy={busy}
                         onClick={() => void install(selected)}
                       >
-                        {busy ? 'installing…' : 'install'}
+                        {busy ? 'Installing…' : 'Install'}
                       </button>
                     </div>
                   </div>
@@ -1264,73 +1296,89 @@ function McpServersPane() {
             ))}
           </div>
         )}
-      </div>
-      <div className="set-group">
-        <div className="set-group-label">add custom server</div>
-        <div className="mcp-add">
-          <div className="set-field">
-            <span className="set-field-label">name</span>
-            <input
-              className="skill-add-input"
-              placeholder="linear"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              autoComplete="off"
-              data-1p-ignore=""
-              data-lpignore="true"
-              disabled={busy}
-            />
+      </section>
+
+      <details className="mcp-custom">
+        <summary className="mcp-custom-summary">Add a custom server</summary>
+        <div className="mcp-custom-body">
+          <p className="mcp-help">
+            For a server that isn&apos;t in the registry. All three fields are required.
+          </p>
+          <div className="mcp-form-grid">
+            <div className="mcp-field">
+              <label className="mcp-label" htmlFor={`${fieldId}-name`}>
+                Name <span className="mcp-req">(required)</span>
+              </label>
+              <input
+                id={`${fieldId}-name`}
+                className="skill-add-input"
+                placeholder="linear"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoComplete="off"
+                data-1p-ignore=""
+                data-lpignore="true"
+                disabled={busy}
+              />
+            </div>
+            <div className="mcp-field">
+              <label className="mcp-label" htmlFor={`${fieldId}-url`}>
+                URL <span className="mcp-req">(required)</span>
+              </label>
+              <input
+                id={`${fieldId}-url`}
+                className="skill-add-input"
+                placeholder="https://mcp.linear.app/mcp"
+                required
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                autoComplete="off"
+                data-1p-ignore=""
+                data-lpignore="true"
+                disabled={busy}
+              />
+            </div>
+            <div className="mcp-field">
+              <label className="mcp-label" htmlFor={`${fieldId}-token`}>
+                Bearer token <span className="mcp-req">(required)</span>
+              </label>
+              <input
+                id={`${fieldId}-token`}
+                className="skill-add-input"
+                type="password"
+                required
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void add()
+                }}
+                autoComplete="new-password"
+                data-1p-ignore=""
+                data-lpignore="true"
+                disabled={busy}
+              />
+              <p className="mcp-help">Stored write-only — never returned or emitted in config.</p>
+            </div>
           </div>
-          <div className="set-field">
-            <span className="set-field-label">url</span>
-            <input
-              className="skill-add-input"
-              placeholder="https://mcp.linear.app/mcp"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              autoComplete="off"
-              data-1p-ignore=""
-              data-lpignore="true"
-              disabled={busy}
-            />
-          </div>
-          <div className="set-field">
-            <span className="set-field-label">bearer token</span>
-            <input
-              className="skill-add-input"
-              type="password"
-              value={token}
-              onChange={(e) => setToken(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') void add()
-              }}
-              autoComplete="new-password"
-              data-1p-ignore=""
-              data-lpignore="true"
-              disabled={busy}
-            />
-          </div>
-          {/* The empty label keeps the button in the inputs' row under top
-              alignment — same offset as the real labels, so it tracks their
-              height instead of hardcoding it. */}
-          <div className="set-field">
-            <span className="set-field-label">&nbsp;</span>
+          <div>
             <button
               className="set-btn primary"
               disabled={busy || !name.trim() || !url.trim() || !token.trim()}
+              aria-busy={busy}
               onClick={() => void add()}
             >
-              {busy ? 'adding…' : 'add'}
+              {busy ? 'Adding…' : 'Add server'}
             </button>
           </div>
         </div>
-        {error && <div className="set-skill-error">{error}</div>}
-      </div>
+      </details>
+
       {servers.length > 0 && (
-        <div className="set-group">
-          <div className="set-group-label">
-            servers<span className="gl-count">{servers.length}</span>
-          </div>
+        <section className="mcp-section">
+          <h3 className="mcp-h">
+            Servers<span className="gl-count">{servers.length}</span>
+          </h3>
           <div className="mcp-servers">
             {servers.map((server: McpServer) => (
               <McpServerRow
@@ -1344,7 +1392,7 @@ function McpServersPane() {
               />
             ))}
           </div>
-        </div>
+        </section>
       )}
     </div>
   )
@@ -1352,16 +1400,16 @@ function McpServersPane() {
 
 function tokenStatusLabel(server: McpServer): string {
   if (server.tokenSource === 'static_from_env') {
-    return `${server.sourceEnvVar}${server.hasToken ? ' set' : ' unset'}`
+    return `${server.sourceEnvVar} ${server.hasToken ? 'set' : 'unset'}`
   }
   if (server.tokenSource === 'oauth') {
-    return server.hasToken ? 'connected' : 'not connected'
+    return server.hasToken ? 'Connected' : 'Not connected'
   }
   if (!server.tokenSource) {
     // No bearer — header-auth'd (or auth-free): nothing to connect or store.
-    return 'ready'
+    return 'Ready'
   }
-  return server.hasToken ? 'token set' : 'no token'
+  return server.hasToken ? 'Token set' : 'No token'
 }
 
 function McpServerRow({
@@ -1380,75 +1428,90 @@ function McpServerRow({
   onDisconnect: (name: string) => Promise<void>
 }) {
   const claimedMode = server.identityMode
-  // A built-in (catalog entry) is managed by druks: disable, never remove.
+  // A header-auth'd (or auth-free) server holds no credential to connect.
+  const isLive = server.hasToken || !server.tokenSource
   return (
     <div className={'mcp-row' + (server.isEnabled ? '' : ' is-off')}>
       <div className="mcp-id">
-        <span className="mcp-name">{server.name}</span>
-        <span className="mcp-url">{server.url}</span>
+        <span className="mcp-name" title={server.name}>
+          {server.name}
+        </span>
+        <span className="mcp-url" title={server.url}>
+          {server.url}
+        </span>
       </div>
-      <span className={'mcp-tok' + (server.hasToken ? ' ok' : ' missing')}>
+      <span className={'mcp-conn' + (isLive ? ' is-live' : '')}>
+        <span className="mcp-conn-dot" />
         {tokenStatusLabel(server)}
       </span>
-      {server.tokenSource === 'oauth' &&
-        (claimedMode === null ? (
-          // The first connect claims how this server's credential is held;
-          // afterwards the choice is fixed until the last grant is dropped.
-          <>
-            <button
-              className="set-btn primary"
-              onClick={() => void onConnect(server.name, 'shared')}
-              disabled={busy}
-              title="One connection every run uses; opens the provider's consent page."
-            >
-              connect for everyone
-            </button>
-            <button
-              className="set-btn"
-              onClick={() => void onConnect(server.name, 'per_user')}
-              disabled={busy}
-              title="Each account connects its own; opens the provider's consent page."
-            >
-              connect your account
-            </button>
-          </>
-        ) : (
-          <>
-            <button
-              className="set-btn primary"
-              onClick={() => void onConnect(server.name, claimedMode)}
-              disabled={busy}
-              title="Opens the provider's consent page."
-            >
-              {server.hasToken ? 'reconnect' : 'connect'}
-            </button>
-            {server.hasToken && (
-              <button
-                className="sc-remove"
-                onClick={() => void onDisconnect(server.name)}
-                disabled={busy}
-                title="Drop this account's stored grant."
-              >
-                disconnect
-              </button>
-            )}
-          </>
-        ))}
-      <Switch on={server.isEnabled} onClick={() => void onToggle(server.name, !server.isEnabled)} disabled={busy} />
-      {server.builtin ? (
-        <span className="mcp-managed" title="Managed by druks — disable it instead of removing.">
-          managed
+      <div className="mcp-row-foot">
+        <span className="mcp-enable">
+          <Switch
+            on={server.isEnabled}
+            onClick={() => void onToggle(server.name, !server.isEnabled)}
+            disabled={busy}
+            label={`Enabled — ${server.name}`}
+          />
+          <span className="mcp-enable-label">Enabled</span>
         </span>
-      ) : (
-        <button
-          className="sc-remove"
-          onClick={() => void onRemove(server.name)}
-          disabled={busy}
-          title="remove server"
-        >
-          ✕ remove
-        </button>
-      )}
+        <div className="mcp-actions">
+          {server.tokenSource === 'oauth' &&
+            (claimedMode === null ? (
+              // The first connect claims how this server's credential is held;
+              // afterwards the choice is fixed until the last grant is dropped.
+              <>
+                <button
+                  className="set-btn primary"
+                  onClick={() => void onConnect(server.name, 'shared')}
+                  disabled={busy}
+                  title="One connection every run uses; opens the provider's consent page."
+                >
+                  Connect for everyone
+                </button>
+                <button
+                  className="set-btn ghost"
+                  onClick={() => void onConnect(server.name, 'per_user')}
+                  disabled={busy}
+                  title="Each account connects its own; opens the provider's consent page."
+                >
+                  Connect your account
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  className={'set-btn ' + (server.hasToken ? 'ghost' : 'primary')}
+                  onClick={() => void onConnect(server.name, claimedMode)}
+                  disabled={busy}
+                  title="Opens the provider's consent page."
+                >
+                  {server.hasToken ? 'Reconnect' : 'Connect'}
+                </button>
+                {server.hasToken && (
+                  <button
+                    className="set-btn danger"
+                    onClick={() => void onDisconnect(server.name)}
+                    disabled={busy}
+                    title="Drop this account's stored grant."
+                  >
+                    Disconnect
+                  </button>
+                )}
+              </>
+            ))}
+          {/* A built-in (catalog entry) is managed by druks: disable, never remove. */}
+          {!server.builtin && (
+            <button
+              className="set-btn danger quiet"
+              onClick={() => void onRemove(server.name)}
+              disabled={busy}
+              title="Remove this server from every sandbox."
+            >
+              Remove
+            </button>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1075,6 +1075,11 @@ input.set-select { background-image: none; padding-right: 12px; }
 .set-btn.primary { background: color-mix(in oklch, var(--accent) 18%, var(--surface)); color: var(--accent); border: 1px solid color-mix(in oklch, var(--accent) 50%, transparent); }
 .set-btn.primary:hover { background: color-mix(in oklch, var(--accent) 28%, var(--surface)); border-color: var(--accent); }
 .set-btn.primary:disabled { opacity: 0.45; cursor: default; box-shadow: none; }
+.set-btn.danger { color: var(--bucket-dead); border: 1px solid color-mix(in oklch, var(--bucket-dead) 38%, transparent); background: color-mix(in oklch, var(--bucket-dead) 8%, transparent); }
+.set-btn.danger:hover { background: color-mix(in oklch, var(--bucket-dead) 18%, var(--surface)); border-color: var(--bucket-dead); }
+/* Destructive but not the point of the row — it earns its red on hover. */
+.set-btn.danger.quiet { color: var(--text-dim); border-color: var(--border); background: none; }
+.set-btn.danger.quiet:hover { color: var(--bucket-dead); }
 
 .skill-add { display: flex; align-items: center; gap: 10px; max-width: 620px; }
 .skill-add-input { flex: 1; height: 36px; border: 1px solid var(--border); border-radius: 5px; background: var(--bg); outline: none; color: var(--text); font-family: var(--font-mono); font-size: 13px; padding: 0 12px; }
@@ -1105,37 +1110,82 @@ input.set-select { background-image: none; padding-right: 12px; }
 .skill-row.is-off .sk-name { color: var(--text-dim); }
 .skill-row.is-off .sk-desc { color: var(--text-faint); }
 
-/* Columns sized to their content: slug, url (longest), token. Top-aligned:
-   password managers inject widgets below an input, and with bottom alignment
-   that extra height shoves the input up. Top alignment pins the inputs' row
-   no matter what an extension appends inside a field. */
-.mcp-add { display: grid; grid-template-columns: 150px minmax(0, 1.6fr) minmax(0, 1fr) auto; gap: 12px; align-items: start; max-width: 760px; }
-/* skill-add-input's flex: 1 means "grow wide" in the skills row; inside the
-   column-flex set-field the axis flips and its basis: 0 collapses the fixed
-   height. Neutralize it so height: 36px holds. */
-.mcp-add .skill-add-input { flex: none; }
-.mcp-add .set-btn { height: 36px; }
-.mcp-reg-search { display: flex; gap: 12px; max-width: 760px; }
-.mcp-reg-search .skill-add-input { flex: 1; }
-.mcp-reg-results { display: flex; flex-direction: column; gap: 8px; max-width: 760px; }
-.mcp-reg-row { display: grid; grid-template-columns: auto auto minmax(0, 1fr) auto; gap: 12px; align-items: center; width: 100%; padding: 10px 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); cursor: pointer; text-align: left; font: inherit; }
-.mcp-reg-row:hover { border-color: var(--border-loud); }
-.mcp-reg-row.is-selected { border-color: color-mix(in oklch, var(--accent) 50%, transparent); border-radius: 7px 7px 0 0; }
-.mcp-reg-badge { font-family: var(--font-mono); font-size: 10px; padding: 2px 7px; border-radius: 4px; border: 1px solid var(--border); color: var(--text-dim); }
-.mcp-reg-badge.official { color: var(--accent-violet); border-color: color-mix(in oklch, var(--accent-violet) 40%, transparent); }
-.mcp-reg-desc { font-size: 12px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.mcp-reg-form { display: flex; flex-direction: column; gap: 12px; max-width: 760px; padding: 12px 14px; border: 1px solid color-mix(in oklch, var(--accent) 50%, transparent); border-top: none; border-radius: 0 0 7px 7px; background: var(--surface); }
-.mcp-reg-form .skill-add-input { flex: none; }
+/* The agent-access pane reuses the row primitives (.mcp-row / .mcp-id /
+   .mcp-tok) for its token list, so everything the MCP pane redefines is
+   scoped under .mcp-pane. */
 .mcp-servers { display: flex; flex-direction: column; gap: 8px; }
 .mcp-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto auto; gap: 14px; align-items: center; padding: 10px 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); }
 .mcp-row.is-off { opacity: 0.6; }
 .mcp-id { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.mcp-name { font-family: var(--font-mono); font-size: 12.5px; color: var(--text); }
-.mcp-url { font-size: 12px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mcp-name { font-family: var(--font-mono); font-size: 12.5px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mcp-url { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .mcp-tok { font-family: var(--font-mono); font-size: 10px; padding: 2px 7px; border-radius: 4px; border: 1px solid var(--border); color: var(--text-dim); }
-.mcp-tok.ok { color: var(--accent-violet); border-color: color-mix(in oklch, var(--accent-violet) 40%, transparent); }
-.mcp-tok.missing { color: var(--bucket-dead); border-color: color-mix(in oklch, var(--bucket-dead) 45%, transparent); }
-.mcp-managed { font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); padding: 5px 10px; }
+
+/* One measure for every band, so search, form and server list share an edge. */
+.mcp-pane { gap: 24px; }
+.mcp-pane > * { max-width: 760px; }
+.mcp-pane-head { display: flex; flex-direction: column; gap: 6px; }
+.mcp-pane-title { margin: 0; font-size: 17px; font-weight: 600; letter-spacing: -0.01em; color: var(--text); }
+.mcp-pane-sub { margin: 0; font-size: 13px; line-height: 1.5; color: var(--text-mid); }
+.mcp-section { display: flex; flex-direction: column; gap: 12px; }
+.mcp-h { margin: 0; font-size: 14px; font-weight: 600; color: var(--text); }
+.mcp-h .gl-count { font-weight: 400; }
+.mcp-help { margin: 0; font-size: 12px; line-height: 1.45; color: var(--text-dim); }
+.mcp-h + .mcp-help { margin-top: -8px; }
+.mcp-error { padding: 9px 12px; border: 1px solid color-mix(in oklch, var(--bucket-dead) 40%, transparent); border-radius: 6px; background: color-mix(in oklch, var(--bucket-dead) 8%, var(--surface)); font-size: 12.5px; color: var(--bucket-dead); }
+
+.mcp-field { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.mcp-label { font-size: 12px; font-weight: 500; color: var(--text-mid); }
+.mcp-label.tech { font-family: var(--font-mono); font-size: 11.5px; }
+.mcp-req { font-weight: 400; color: var(--text-faint); }
+.mcp-sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
+/* skill-add-input's flex: 1 means "grow wide" in the skills row; inside a
+   column-flex field the axis flips and its basis: 0 collapses the fixed
+   height. Neutralize it so height: 36px holds. */
+.mcp-pane .skill-add-input { flex: none; width: 100%; }
+.mcp-pane .set-btn { display: inline-flex; align-items: center; height: 36px; padding: 0 14px; font-family: var(--font-sans); font-size: 12.5px; letter-spacing: 0; }
+.mcp-pane :is(button, input, summary):focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.mcp-pane button:disabled { opacity: 0.45; cursor: default; }
+.mcp-pane input:disabled { opacity: 0.6; cursor: default; }
+
+.mcp-reg-search { display: flex; gap: 10px; }
+.mcp-pane .mcp-reg-search .skill-add-input { flex: 1; min-width: 0; }
+.mcp-reg-results { display: flex; flex-direction: column; gap: 8px; }
+.mcp-reg-row { display: flex; flex-direction: column; gap: 3px; width: 100%; padding: 10px 13px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); cursor: pointer; text-align: left; font: inherit; }
+.mcp-reg-row:hover { border-color: var(--border-loud); background: var(--surface-3); }
+.mcp-reg-row.is-selected { border-color: color-mix(in oklch, var(--accent) 50%, transparent); border-radius: 7px 7px 0 0; background: var(--surface-3); }
+.mcp-reg-top { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.mcp-reg-badge { flex-shrink: 0; font-family: var(--font-mono); font-size: 10px; padding: 2px 7px; border-radius: 4px; border: 1px solid var(--border); color: var(--text-dim); }
+.mcp-reg-badge.official { color: var(--accent-violet); border-color: color-mix(in oklch, var(--accent-violet) 40%, transparent); }
+.mcp-reg-desc { font-size: 12px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.mcp-reg-form { display: flex; flex-direction: column; gap: 13px; padding: 14px; border: 1px solid color-mix(in oklch, var(--accent) 50%, transparent); border-top: none; border-radius: 0 0 7px 7px; background: var(--surface); }
+
+/* Secondary by weight, not by hiding: one quiet control until it is wanted. */
+.mcp-custom { border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); }
+.mcp-custom-summary { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-radius: 7px; font-size: 13px; color: var(--text-mid); cursor: pointer; list-style: none; }
+.mcp-custom-summary::-webkit-details-marker { display: none; }
+.mcp-custom-summary::before { content: '›'; font-family: var(--font-mono); color: var(--text-faint); transition: transform 120ms; }
+.mcp-custom-summary:hover { color: var(--text); }
+.mcp-custom[open] .mcp-custom-summary { border-bottom: 1px solid var(--border); border-radius: 7px 7px 0 0; color: var(--text); }
+.mcp-custom[open] .mcp-custom-summary::before { transform: rotate(90deg); }
+.mcp-custom-body { display: flex; flex-direction: column; gap: 14px; padding: 14px; }
+.mcp-form-grid { display: grid; grid-template-columns: minmax(160px, 1fr) minmax(200px, 1.4fr); gap: 14px; }
+.mcp-form-grid > .mcp-field:last-child { grid-column: 1 / -1; }
+
+/* Two tiers — identity + connection, then availability + actions. Placement is
+   explicit so no control can wrap into an orphaned position. */
+.mcp-pane .mcp-row { grid-template-columns: minmax(0, 1fr) auto; gap: 10px 14px; align-items: start; padding: 12px 14px; transition: border-color 120ms, background 120ms; }
+.mcp-pane .mcp-row:hover { border-color: var(--border-loud); }
+.mcp-pane .mcp-row.is-off { opacity: 1; background: var(--surface); }
+.mcp-pane .mcp-row.is-off :is(.mcp-id, .mcp-conn) { opacity: 0.5; }
+.mcp-conn { display: inline-flex; align-items: center; gap: 7px; justify-self: end; padding-top: 2px; font-size: 12px; font-weight: 500; color: var(--decision-request-revision); white-space: nowrap; }
+.mcp-conn-dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
+.mcp-conn.is-live { color: var(--outcome-merged); }
+.mcp-conn.is-live .mcp-conn-dot { box-shadow: 0 0 8px color-mix(in oklch, var(--outcome-merged) 60%, transparent); }
+.mcp-row-foot { grid-column: 1 / -1; display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 10px 12px; padding-top: 11px; border-top: 1px solid var(--border-soft); }
+.mcp-enable { display: inline-flex; align-items: center; gap: 9px; }
+.mcp-enable-label { font-size: 12.5px; color: var(--text-mid); }
+.mcp-actions { display: flex; align-items: center; justify-content: flex-end; flex-wrap: wrap; gap: 8px; }
 
 @media (max-width: 720px) {
   .set-extension-toggles { grid-template-columns: 1fr; }
@@ -1144,9 +1194,9 @@ input.set-select { background-image: none; padding-right: 12px; }
   .skill-row { grid-template-columns: 1fr; }
   .skill-row .sk-desc { display: none; }
   .mcp-row { grid-template-columns: 1fr auto; row-gap: 8px; }
-  .mcp-add { grid-template-columns: 1fr; align-items: stretch; }
-  .mcp-reg-row { grid-template-columns: auto auto; row-gap: 6px; }
-  .mcp-reg-row .mcp-url { display: none; }
+  .mcp-pane .mcp-row { grid-template-columns: minmax(0, 1fr); }
+  .mcp-conn { justify-self: start; }
+  .mcp-form-grid { grid-template-columns: 1fr; }
 }
 
 


### PR DESCRIPTION
The MCP pane had no title and leaned on tiny uppercase mono for every level of heading, so nothing read as more important than anything else. The server row was a flat four-column grid whose controls wrapped into disconnected positions, and connection state sat next to the enablement switch with no distinction between the two concepts.

## Hierarchy

A sans title and section headings carry the structure; mono is kept for the technical values — server names, URLs, registry header names.

## Add flows

Registry search is the primary path. The custom form moves into a native `<details>` disclosure: secondary by weight, one keystroke to open. Inside, a balanced two-up grid (name / URL, then a full-width token) replaces the four-column squeeze, every input has a real `<label>` with a `(required)` marker, and the submit sits on its own row. Search, form and server list share one measure so their edges line up down the pane.

## The server row

Two explicit tiers instead of one flat grid — identity and connection on the first line, availability and actions on the second — so no control can wrap into an orphaned position at narrow widths.

- **Connected** is the strongest signal in the row: the success color with a lit dot. Not-connected takes the warn amber.
- **Reconnect** is a neutral ghost button, **Disconnect** is deliberately destructive, **Remove** earns its red on hover.
- The enablement switch gains a visible `Enabled` label and an accessible name, so availability reads as a separate concept from connection.

The `managed` metadata label is gone with no badge in its place. Built-in servers still cannot be removed — the row simply omits the button.

## Also

Errors moved to a pane-level `role="alert"`: they come from row actions too, and would have been hidden inside the collapsed form. Focus-visible rings, `aria-busy` on async buttons, explicit disabled states, and `title` + ellipsis on long names and URLs.

The agent-access pane reuses `.mcp-row` / `.mcp-id` / `.mcp-tok` for its token list, so every new layout rule is scoped under `.mcp-pane` and that pane renders unchanged. No API, OAuth, registry or connection behavior is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)