### PR TITLE
Encrypt secret-kind extension settings at rest

### DIFF
--- a/backend/druks/extensions/base.py
+++ b/backend/druks/extensions/base.py
@@ -16,6 +16,7 @@ from .registry import autodiscover
 from .registry import workflows as workflow_registry
 from .settings import (
     coerce_setting_value,
+    field_kind,
     validate_setting_override,
     validate_settings_declaration,
 )
@@ -121,7 +122,12 @@ class Extension:
         if not model:
             raise TypeError(f"extension {cls.name!r} declares no Settings")
         values = {
-            name: SettingsOverride.extension_setting(cls.name, name, field.default)
+            name: SettingsOverride.extension_setting(
+                cls.name,
+                name,
+                field.default,
+                is_secret=field_kind(field) == "secret",
+            )
             for name, field in model.model_fields.items()
         }
         return model.model_validate(values)
@@ -136,7 +142,12 @@ class Extension:
         if value is not None:
             value = coerce_setting_value(model, field, value)
             validate_setting_override(model, cls.settings().model_dump(), field, value)
-        SettingsOverride.set_extension_setting(cls.name, field, value)
+        SettingsOverride.set_extension_setting(
+            cls.name,
+            field,
+            value,
+            is_secret=field_kind(model.model_fields[field]) == "secret",
+        )
 
     @classmethod
     def agents(cls) -> "list[Agent]":

--- a/backend/druks/user_settings/models.py
+++ b/backend/druks/user_settings/models.py
@@ -10,6 +10,7 @@ from sqlalchemy.types import String
 
 from druks.database import db_session
 from druks.models import Base
+from druks.secrets.fields import EncryptedTextField
 
 from .datastructures import (
     ResolvedEffort,
@@ -151,7 +152,8 @@ class SettingsOverride(Base):
     __tablename__ = "settings_overrides"
 
     key: Mapped[str] = mapped_column(String, primary_key=True)
-    value: Mapped[Any] = mapped_column(JSONB)
+    value: Mapped[Any] = mapped_column(JSONB(none_as_null=True), nullable=True)
+    secret_value = EncryptedTextField(default="")
 
     @classmethod
     def read(cls, key: str) -> Any | None:
@@ -221,10 +223,29 @@ class SettingsOverride(Base):
         cls.write(f"workflow:{kind}:{field}", value)
 
     @classmethod
-    def extension_setting(cls, extension: str, field: str, default: Any) -> Any:
-        value = cls.read(f"extension:{extension}:{field}")
-        return default if value is None else value
+    def extension_setting(cls, extension: str, field: str, default: Any, *, is_secret: bool) -> Any:
+        row = db_session().get(cls, f"extension:{extension}:{field}")
+        if is_secret:
+            return row.secret_value.decrypt() if row and row.secret_value else default
+        return row.value if row else default
 
     @classmethod
-    def set_extension_setting(cls, extension: str, field: str, value: Any) -> None:
-        cls.write(f"extension:{extension}:{field}", value)
+    def set_extension_setting(
+        cls, extension: str, field: str, value: Any, *, is_secret: bool
+    ) -> None:
+        key = f"extension:{extension}:{field}"
+        if value is None or not is_secret:
+            cls.write(key, value)
+            return
+        session = db_session()
+        row = session.get(cls, key)
+        if row:
+            row.value = None
+            row.secret_value = value
+        else:
+            row = cls(key=key, value=None, secret_value=value)
+            session.add(row)
+        session.flush()
+        # Assignment leaves the plaintext str on the instance; expire it so the
+        # next read loads the envelope.
+        session.expire(row)

--- a/backend/druks/user_settings/reads.py
+++ b/backend/druks/user_settings/reads.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic.fields import FieldInfo
 
+from druks.database import db_session
+from druks.extensions.settings import field_kind
 from druks.harnesses.registry import get_harness_for_model
 
 from .models import SettingsOverride
@@ -41,9 +43,8 @@ def get_agent_setting(agent: "Agent") -> AgentSettingResponse:
 def get_settings_field(
     name: str, field: FieldInfo, *, value: Any, override_key: str
 ) -> SettingsFieldResponse:
-    return SettingsFieldResponse.from_field(
-        name, field, value=value, overridden=SettingsOverride.read(override_key) is not None
-    )
+    overridden = db_session().get(SettingsOverride, override_key) is not None
+    return SettingsFieldResponse.from_field(name, field, value=value, overridden=overridden)
 
 
 def get_workflow_settings(workflow: "type[Workflow]") -> WorkflowSettingsResponse:
@@ -109,7 +110,12 @@ def get_extension_settings(extension: "type[Extension]") -> ExtensionSettingsRes
             get_settings_field(
                 name,
                 field,
-                value=SettingsOverride.extension_setting(extension.name, name, field.default),
+                value=SettingsOverride.extension_setting(
+                    extension.name,
+                    name,
+                    field.default,
+                    is_secret=field_kind(field) == "secret",
+                ),
                 override_key=f"extension:{extension.name}:{name}",
             )
             for name, field in (model.model_fields if model else {}).items()

--- a/backend/migrations/versions/f7c1a0e9d2b4_encrypt_secret_extension_settings.py
+++ b/backend/migrations/versions/f7c1a0e9d2b4_encrypt_secret_extension_settings.py
@@ -1,0 +1,39 @@
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "f7c1a0e9d2b4"
+down_revision: str | Sequence[str] | None = "e6f1a2b3c4d5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "settings_overrides",
+        sa.Column(
+            "secret_value",
+            sa.LargeBinary(),
+            server_default=sa.text("''::bytea"),
+            nullable=False,
+        ),
+    )
+    op.alter_column(
+        "settings_overrides",
+        "value",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "settings_overrides",
+        "value",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        nullable=False,
+    )
+    op.drop_column("settings_overrides", "secret_value")

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 
+from druks.contrib.ship.extension import Ship
+from druks.database import db_session
 from druks.testing import configure_app_for_test, make_settings
+from druks.user_settings.models import SettingsOverride
 from fastapi.testclient import TestClient
+from sqlalchemy import text
 
 
 def _build_client(tmp_path: Path) -> TestClient:
@@ -233,25 +237,138 @@ def test_extensions_surface_build_agents_and_workflow_defaults(tmp_path: Path):
     }
 
 
-def test_extension_secret_write_never_returns_the_value(tmp_path: Path):
+def test_extension_secret_round_trip_encrypts_at_rest(tmp_path: Path):
     secret = "linear-secret-value"
+    key = "extension:ship:linear_api_key"
     with _build_client(tmp_path) as client:
         written = client.patch(
             "/api/settings/extensions",
             json={"extensionSettings": {"ship": {"linear_api_key": secret}}},
         )
+        stored = (
+            db_session()
+            .execute(
+                text(
+                    "SELECT value, value IS NULL AS value_is_null, secret_value "
+                    "FROM settings_overrides WHERE key = :key"
+                ),
+                {"key": key},
+            )
+            .one()
+        )
         read = client.get("/api/settings/extensions")
+        resolved = Ship.settings().linear_api_key
 
     assert written.status_code == 200
     assert read.status_code == 200
+    assert stored.value is None
+    assert stored.value_is_null is True
+    assert stored.secret_value
+    assert secret.encode() not in stored.secret_value
     assert secret not in written.text
     assert secret not in read.text
+    assert resolved and resolved.get_secret_value() == secret
     ship = next(extension for extension in read.json()["extensions"] if extension["name"] == "ship")
     field = next(setting for setting in ship["settings"] if setting["name"] == "linear_api_key")
     assert field["type"] == "secret"
     assert field["value"] is None
     assert field["default"] is None
     assert field["secretSet"] is True
+    assert field["overridden"] is True
+
+
+def test_extension_secret_plaintext_row_is_unset_until_resaved(tmp_path: Path):
+    secret = "legacy-plaintext-secret"
+    key = "extension:ship:linear_api_key"
+    db_session().add(SettingsOverride(key=key, value=secret))
+    db_session().flush()
+
+    with _build_client(tmp_path) as client:
+        initial = _ship_extension(client)
+        resolved_initial = Ship.settings().linear_api_key
+        saved = client.patch(
+            "/api/settings/extensions",
+            json={"extensionSettings": {"ship": {"linear_api_key": secret}}},
+        )
+        stored = (
+            db_session()
+            .execute(
+                text(
+                    "SELECT value, value IS NULL AS value_is_null, secret_value "
+                    "FROM settings_overrides WHERE key = :key"
+                ),
+                {"key": key},
+            )
+            .one()
+        )
+
+    initial_field = next(
+        setting for setting in initial["settings"] if setting["name"] == "linear_api_key"
+    )
+    assert initial_field["secretSet"] is False
+    assert resolved_initial is None
+    assert saved.status_code == 200
+    assert stored.value is None
+    assert stored.value_is_null is True
+    assert stored.secret_value
+    assert secret.encode() not in stored.secret_value
+
+
+def test_extension_non_secret_setting_stays_in_value(tmp_path: Path):
+    url = "https://example.atlassian.net"
+    key = "extension:ship:jira_base_url"
+
+    with _build_client(tmp_path) as client:
+        written = client.patch(
+            "/api/settings/extensions",
+            json={"extensionSettings": {"ship": {"jira_base_url": url}}},
+        )
+        stored = (
+            db_session()
+            .execute(
+                text("SELECT value, secret_value FROM settings_overrides WHERE key = :key"),
+                {"key": key},
+            )
+            .one()
+        )
+        ship = _ship_extension(client)
+
+    field = next(setting for setting in ship["settings"] if setting["name"] == "jira_base_url")
+    assert written.status_code == 200
+    assert stored.value == url
+    assert stored.secret_value == b""
+    assert Ship.settings().jira_base_url == url
+    assert field["value"] == url
+    assert field["overridden"] is True
+
+
+def test_clearing_extension_secret_deletes_the_override(tmp_path: Path):
+    key = "extension:ship:linear_api_key"
+
+    with _build_client(tmp_path) as client:
+        client.patch(
+            "/api/settings/extensions",
+            json={"extensionSettings": {"ship": {"linear_api_key": "linear-secret-value"}}},
+        )
+        cleared = client.patch(
+            "/api/settings/extensions",
+            json={"extensionSettings": {"ship": {"linear_api_key": None}}},
+        )
+        stored = (
+            db_session()
+            .execute(
+                text("SELECT 1 FROM settings_overrides WHERE key = :key"),
+                {"key": key},
+            )
+            .one_or_none()
+        )
+        ship = _ship_extension(client)
+
+    field = next(setting for setting in ship["settings"] if setting["name"] == "linear_api_key")
+    assert cleared.status_code == 200
+    assert stored is None
+    assert Ship.settings().linear_api_key is None
+    assert field["secretSet"] is False
 
 
 def test_extensions_override_agent_model_persists(tmp_path: Path):

--- a/backend/tests/test_proof_extension_migration.py
+++ b/backend/tests/test_proof_extension_migration.py
@@ -16,7 +16,6 @@ _PACKAGE_ROOT = Path(__file__).resolve().parent / "druks-field_notes" / "druks_f
 _VERSIONS = _PACKAGE_ROOT / "migrations" / "versions"
 
 
-
 def _config() -> Config:
     config = Config(str(_ALEMBIC_INI))
     config.set_main_option("version_locations", str(_VERSIONS))

--- a/backend/tests/test_settings_overrides.py
+++ b/backend/tests/test_settings_overrides.py
@@ -7,13 +7,13 @@ from druks.user_settings.models import SettingsOverride
 
 def test_extension_setting_override_then_default(druks_db):
     # No override → the declared default passed by the caller.
-    assert SettingsOverride.extension_setting("ship", "auto_merge", True) is True
+    assert SettingsOverride.extension_setting("ship", "auto_merge", True, is_secret=False) is True
     # An override wins — including turning it off.
-    SettingsOverride.set_extension_setting("ship", "auto_merge", False)
-    assert SettingsOverride.extension_setting("ship", "auto_merge", True) is False
+    SettingsOverride.set_extension_setting("ship", "auto_merge", False, is_secret=False)
+    assert SettingsOverride.extension_setting("ship", "auto_merge", True, is_secret=False) is False
     # Clearing reverts to the caller's default.
-    SettingsOverride.set_extension_setting("ship", "auto_merge", None)
-    assert SettingsOverride.extension_setting("ship", "auto_merge", True) is True
+    SettingsOverride.set_extension_setting("ship", "auto_merge", None, is_secret=False)
+    assert SettingsOverride.extension_setting("ship", "auto_merge", True, is_secret=False) is True
 
 
 def test_workflow_setting_namespaced_by_kind(druks_db):

--- a/backend/tests/test_webhooks_slack.py
+++ b/backend/tests/test_webhooks_slack.py
@@ -207,9 +207,7 @@ async def test_malformed_payloads_400_never_500_never_resume(tmp_path, druks_db,
     assert Notification.get(notification.id).state == "pending"
 
 
-async def test_unknown_interactivity_type_is_acknowledged_unhandled(
-    tmp_path, druks_db, resume_spy
-):
+async def test_unknown_interactivity_type_is_acknowledged_unhandled(tmp_path, druks_db, resume_spy):
     _parked_notification(druks_db)
     body = urlencode({"payload": json.dumps({"type": "view_submission"})}).encode()
 


### PR DESCRIPTION
Secret-kind extension settings (tracker API tokens, webhook secrets) now persist as AES-GCM ciphertext in a new `secret_value` column on `settings_overrides`, the same envelope convention as harness and MCP credentials. A secret write always nulls `value`; non-secret fields are untouched. The kind decision sits at the extension-settings read/write choke points, so every caller is covered without touching consumers.

One migration adds the column; there is no data migration. If a plaintext secret row exists at upgrade (credentials entered between deploys), it resolves as unset and one re-save stores the ciphertext and scrubs the stale plaintext.

ENG-805