### PR TITLE
Report the quota window that binds

### DIFF
--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -500,6 +500,7 @@ class Harness(ABC):
         if parsed.week:
             snapshot.week_percent_left = parsed.week.percent_left
             snapshot.week_resets_at = parsed.week.resets_at
+            snapshot.week_model = parsed.week.model
         snapshot.save()
         return {
             "harness": cls.name,

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -319,12 +319,11 @@ class ClaudeHarness(Harness):
             return ParsedUsage(ok=False, error="unparseable", raw=raw)
         if not isinstance(data, dict) or not any(k in data for k in ("five_hour", "seven_day")):
             return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
-        return ParsedUsage(
-            ok=True,
-            five_hour=_claude_metric(data.get("five_hour")),
-            week=_claude_metric(data.get("seven_day")),
-            raw=raw,
-        )
+        try:
+            five_hour, week = _claude_windows(data)
+        except (KeyError, TypeError, ValueError):
+            return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
+        return ParsedUsage(ok=True, five_hour=five_hour, week=week, raw=raw)
 
     @classmethod
     def _parse_models(cls, raw: str) -> ParsedModels:
@@ -350,6 +349,29 @@ def _oauth_block(data: dict) -> dict:
     flat shape too."""
     block = data.get("claudeAiOauth") if isinstance(data, dict) else None
     return block if isinstance(block, dict) else data
+
+
+def _claude_windows(data: dict) -> tuple[ParsedMetric | None, ParsedMetric | None]:
+    """The five-hour and weekly quotas that bind. A plan can meter one model
+    tighter than the rest, and that limit stops work first."""
+    five_hour, weekly = [], []
+    for limit in data.get("limits") or []:
+        # A limit can be scoped to something other than a model, which leaves
+        # it counting toward the quota but with no model to name.
+        scope = limit["scope"] or {}
+        window = ParsedMetric(
+            percent_left=max(0, min(100, round(100 - limit["percent"]))),
+            resets_at=_parse_iso(limit.get("resets_at")),
+            model=(scope.get("model") or {}).get("display_name"),
+        )
+        if limit["group"] == "weekly":
+            weekly.append(window)
+        elif limit["group"] == "session":
+            five_hour.append(window)
+    return (
+        ParsedMetric.binding(five_hour) or _claude_metric(data.get("five_hour")),
+        ParsedMetric.binding(weekly) or _claude_metric(data.get("seven_day")),
+    )
 
 
 def _claude_metric(block: object) -> ParsedMetric | None:

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -430,7 +430,7 @@ class CodexHarness(Harness):
             return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
         plan = data.get("plan_type") if isinstance(data.get("plan_type"), str) else None
         try:
-            five_hour, week = _codex_windows(data["rate_limit"] or {})
+            five_hour, week = _codex_windows(data)
         except (AttributeError, KeyError, TypeError, ValueError):
             return ParsedUsage(ok=False, error="unexpected_payload", plan_tier=plan, raw=raw)
         if not five_hour and not week:
@@ -708,21 +708,27 @@ class CodexHarness(Harness):
         )
 
 
-def _codex_windows(rate_limit: dict) -> tuple[ParsedMetric | None, ParsedMetric | None]:
-    """The five-hour and weekly quotas, in that order. Raises if a window the
-    payload reports is unreadable — a window we cannot place is a broken
-    payload, not a missing quota."""
-    five_hour = week = None
-    for slot in ("primary_window", "secondary_window"):
-        block = rate_limit.get(slot)
-        if not block:
-            continue
-        window = ParsedMetric(
-            percent_left=max(0, min(100, round(100 - block["used_percent"]))),
-            resets_at=datetime.fromtimestamp(block["reset_at"], tz=UTC),
-        )
-        if block["limit_window_seconds"] >= _WEEKLY_WINDOW_MINIMUM_SECONDS:
-            week = window
-        else:
-            five_hour = window
-    return five_hour, week
+def _codex_windows(usage: dict) -> tuple[ParsedMetric | None, ParsedMetric | None]:
+    """The five-hour and weekly quotas that bind. A window's declared length
+    names it, not the slot it arrives in, and a separately metered model
+    exhausts before the account-wide quota does."""
+    rate_limits = [(None, usage["rate_limit"] or {})]
+    for metered in usage.get("additional_rate_limits") or []:
+        rate_limits.append((metered["limit_name"], metered["rate_limit"] or {}))
+
+    five_hour, weekly = [], []
+    for model, rate_limit in rate_limits:
+        for slot in ("primary_window", "secondary_window"):
+            block = rate_limit.get(slot)
+            if not block:
+                continue
+            window = ParsedMetric(
+                percent_left=max(0, min(100, round(100 - block["used_percent"]))),
+                resets_at=datetime.fromtimestamp(block["reset_at"], tz=UTC),
+                model=model,
+            )
+            if block["limit_window_seconds"] >= _WEEKLY_WINDOW_MINIMUM_SECONDS:
+                weekly.append(window)
+            else:
+                five_hour.append(window)
+    return ParsedMetric.binding(five_hour), ParsedMetric.binding(weekly)

--- a/backend/druks/harnesses/datastructures.py
+++ b/backend/druks/harnesses/datastructures.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -55,6 +56,20 @@ class RotationResult:
 class ParsedMetric:
     percent_left: int | None
     resets_at: datetime | None
+    # Set when a plan meters this model separately; None covers them all.
+    model: str | None = None
+
+    @classmethod
+    def binding(cls, windows: Sequence[Self]) -> Self | None:
+        """The window closest to exhaustion — whichever stops work first."""
+        binding = None
+        remaining = 0
+        for window in windows:
+            if window.percent_left is None:
+                continue
+            if binding is None or window.percent_left < remaining:
+                binding, remaining = window, window.percent_left
+        return binding
 
 
 @dataclass(frozen=True)

--- a/backend/druks/usage/models.py
+++ b/backend/druks/usage/models.py
@@ -36,6 +36,9 @@ class UsageScrape(Base):
     # Weekly window — both CLIs expose this.
     week_percent_left: Mapped[int | None]
     week_resets_at: Mapped[datetime | None]
+    # Set when the weekly window meters one model separately from the
+    # rest, naming it. None covers every model.
+    week_model: Mapped[str | None]
     # Unmetered plan (Codex business/enterprise with unlimited credits).
     # The window percentages above are synthesized permanently-full
     # buckets when this is set — the UI renders "unmetered" instead of

--- a/backend/druks/usage/routes.py
+++ b/backend/druks/usage/routes.py
@@ -174,7 +174,7 @@ def _summarize(
         connected=connected,
         plan_tier=row.plan_tier,
         five_hour=_metric(row.five_hour_percent_left, row.five_hour_resets_at),
-        week=_metric(row.week_percent_left, row.week_resets_at),
+        week=_metric(row.week_percent_left, row.week_resets_at, row.week_model),
         unlimited=row.unlimited,
         scraped_at=row.scraped_at,
         age_seconds=age,
@@ -184,10 +184,12 @@ def _summarize(
     )
 
 
-def _metric(percent_left: int | None, resets_at: datetime | None) -> UsageMetricSummary | None:
+def _metric(
+    percent_left: int | None, resets_at: datetime | None, model: str | None = None
+) -> UsageMetricSummary | None:
     if percent_left is None and resets_at is None:
         return
-    return UsageMetricSummary(percent_left=percent_left, resets_at=resets_at)
+    return UsageMetricSummary(percent_left=percent_left, resets_at=resets_at, model=model)
 
 
 def _age_seconds(scraped_at: datetime | None, *, now: datetime) -> int | None:

--- a/backend/druks/usage/schemas.py
+++ b/backend/druks/usage/schemas.py
@@ -8,6 +8,9 @@ from druks.schemas import BaseResponse
 class UsageMetricSummary(BaseResponse):
     percent_left: int | None = None
     resets_at: datetime | None = None
+    # Set when this window meters one model separately from the rest,
+    # naming it. None covers every model.
+    model: str | None = None
 
 
 class UsageHarnessSummary(BaseResponse):

--- a/backend/migrations/versions/a4b7c2e91d63_weekly_window_records_its_model.py
+++ b/backend/migrations/versions/a4b7c2e91d63_weekly_window_records_its_model.py
@@ -1,0 +1,18 @@
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a4b7c2e91d63"
+down_revision: str | Sequence[str] | None = "f7c1a0e9d2b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("usage_scrapes", sa.Column("week_model", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("usage_scrapes", "week_model")

--- a/backend/tests/test_harness_usage_parsing.py
+++ b/backend/tests/test_harness_usage_parsing.py
@@ -1,6 +1,108 @@
 import json
 
+from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
+
+
+def test_claude_parse_reports_the_weekly_limit_that_binds() -> None:
+    """A weekly limit scoped to one model can bind well before the all-models
+    one — reporting the all-models figure overstates what is left."""
+    parsed = ClaudeHarness._parse_usage(
+        json.dumps(
+            {
+                "five_hour": {"utilization": 36.0},
+                "seven_day": {"utilization": 63.0},
+                "limits": [
+                    {"group": "session", "percent": 36, "scope": None},
+                    {"group": "weekly", "percent": 63, "scope": None},
+                    {
+                        "group": "weekly",
+                        "percent": 75,
+                        "scope": {"model": {"display_name": "Fable"}},
+                    },
+                ],
+            }
+        )
+    )
+
+    assert parsed.ok
+    assert parsed.week is not None
+    assert parsed.week.percent_left == 25
+    assert parsed.week.model == "Fable"
+
+
+def test_claude_parse_counts_a_limit_scoped_to_something_other_than_a_model() -> None:
+    """A limit can be scoped by surface rather than model — it still counts
+    toward the quota, it just has no model to name."""
+    parsed = ClaudeHarness._parse_usage(
+        json.dumps(
+            {
+                "five_hour": {"utilization": 10.0},
+                "seven_day": {"utilization": 20.0},
+                "limits": [
+                    {"group": "weekly", "percent": 20, "scope": None},
+                    {
+                        "group": "weekly",
+                        "percent": 90,
+                        "scope": {"model": None, "surface": "code"},
+                    },
+                ],
+            }
+        )
+    )
+
+    assert parsed.ok
+    assert parsed.week is not None
+    assert parsed.week.percent_left == 10
+    assert parsed.week.model is None
+
+
+def test_claude_parse_falls_back_to_seven_day_without_limits() -> None:
+    parsed = ClaudeHarness._parse_usage(
+        json.dumps({"five_hour": {"utilization": 16.0}, "seven_day": {"utilization": 48.0}})
+    )
+
+    assert parsed.ok
+    assert parsed.week is not None and parsed.week.percent_left == 52
+    assert parsed.week.model is None
+
+
+def test_codex_parse_reports_the_metered_model_that_binds() -> None:
+    """Codex meters some models separately, and such a quota exhausts before
+    the account-wide one."""
+    parsed = CodexHarness._parse_usage(
+        json.dumps(
+            {
+                "plan_type": "prolite",
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 2,
+                        "limit_window_seconds": 604800,
+                        "reset_at": 1786173475,
+                    },
+                    "secondary_window": None,
+                },
+                "additional_rate_limits": [
+                    {
+                        "limit_name": "GPT-5.3-Codex-Spark",
+                        "rate_limit": {
+                            "primary_window": {
+                                "used_percent": 80,
+                                "limit_window_seconds": 604800,
+                                "reset_at": 1786181580,
+                            },
+                            "secondary_window": None,
+                        },
+                    }
+                ],
+            }
+        )
+    )
+
+    assert parsed.ok
+    assert parsed.week is not None
+    assert parsed.week.percent_left == 20
+    assert parsed.week.model == "GPT-5.3-Codex-Spark"
 
 
 def test_codex_parse_treats_unlimited_credits_as_full_buckets() -> None:

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -358,6 +358,7 @@ export interface FeedResponse {
 export interface UsageMetric {
   percentLeft: number | null
   resetsAt: string | null
+  model: string | null
 }
 
 export interface UsageHarnessSummary {

--- a/frontend/src/components/UsagePanel.tsx
+++ b/frontend/src/components/UsagePanel.tsx
@@ -303,6 +303,7 @@ function WindowRow({
       <div className="us-win-top">
         <span className="us-win-label mono">
           <b>{label}</b>
+          {metric.model ? ` · ${metric.model}` : ''}
           {note ? ` · ${note}` : ''}
         </span>
         <span className={`us-win-pct mono h-${tone}`}>
@@ -434,14 +435,13 @@ function Spark({ data, tone, id }: { data: number[]; tone: UsageTone; id: string
 function TodaySection({ today }: { today: UsageTodayResponse }) {
   const totalSpend = today.harnesses.reduce((sum, h) => sum + h.spendUsd, 0)
   const totalTokens = today.harnesses.reduce((sum, h) => sum + h.tokens, 0)
-  const tzLabel = today.timezone === 'UTC' ? 'utc' : today.timezone.toLowerCase()
   const harnessColor = harnessColors(today.harnesses.map((h) => h.name))
 
   return (
     <>
       <div className="us-section-head">
         <span className="us-section-rule" />
-        <span className="us-section-title mono">today · since 00:00 {tzLabel}</span>
+        <span className="us-section-title mono">druks runs · today</span>
         <span className="us-section-sub mono">{describeLoad(today)}</span>
       </div>
       <div className="us-today">


### PR DESCRIPTION
Both providers meter some models separately, and such a quota reaches exhaustion well before the account-wide one. druks read only the account-wide window, so it overstated remaining capacity — for the usage panel and for the MCP surface agents consult before running.

Claude carries these as scoped entries in `limits[]`; on this account the all-models weekly sits at 63% used while a Fable-scoped weekly is at 75% with `severity: warning`, so druks reported 37% left when the binding limit had 25%. `limits[]` is the live mechanism — the older `seven_day_opus` / `seven_day_sonnet` fields are null in real payloads.

Codex carries the same idea as `additional_rate_limits`, one entry per separately metered model (`GPT-5.3-Codex-Spark` today, sitting at 0% used).

Each harness now collects every window the account is subject to and asks `ParsedMetric.binding` which one stops work first. The chosen window carries the model it is scoped to, so the panel names it rather than showing an unexplained number. Payloads without the per-model entries behave exactly as before.

Separately, the spend section is relabelled `druks runs · today`. The quota bars above it are account-wide — they include any client on the same subscription — while spend and tokens only ever counted druks' own runs. Nothing said so, which made the two halves of the card look like they disagreed.

Not covered here: splitting the quota bar between druks and other clients. That needs a tokens-to-percent rate derived from accumulated history, and there are only ~15 usable intervals so far.
