### PR TITLE
Identify as the client these OAuth endpoints serve

### DIFF
--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -29,6 +29,7 @@ _USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 # Beta flag the Claude CLI sends for OAuth-scoped endpoints.
 _OAUTH_BETA = "oauth-2025-04-20"
 _ANTHROPIC_VERSION = "2023-06-01"
+_CLAUDE_CODE_USER_AGENT = "claude-code/2.1.0"
 
 
 class ClaudeHarness(Harness):
@@ -300,6 +301,7 @@ class ClaudeHarness(Harness):
             "Authorization": f"Bearer {token.access_token}",
             "anthropic-beta": _OAUTH_BETA,
             "anthropic-version": _ANTHROPIC_VERSION,
+            "User-Agent": _CLAUDE_CODE_USER_AGENT,
         }
         return _USAGE_URL, headers
 
@@ -309,6 +311,7 @@ class ClaudeHarness(Harness):
             "Authorization": f"Bearer {token.access_token}",
             "anthropic-beta": _OAUTH_BETA,
             "anthropic-version": _ANTHROPIC_VERSION,
+            "User-Agent": _CLAUDE_CODE_USER_AGENT,
         }
 
     @classmethod

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -366,6 +366,7 @@ async def test_claude_fetch_usage_success(monkeypatch, druks_db):
     assert parsed.week.percent_left == 52
     assert calls[0]["headers"]["Authorization"] == "Bearer tok"
     assert calls[0]["headers"]["anthropic-beta"] == "oauth-2025-04-20"
+    assert calls[0]["headers"]["User-Agent"].startswith("claude-code/")
 
 
 async def test_claude_fetch_usage_http_error(monkeypatch, druks_db):

--- a/frontend/src/components/UsagePanel.tsx
+++ b/frontend/src/components/UsagePanel.tsx
@@ -215,22 +215,26 @@ function ProviderPanel({
             <UnmeteredWindow today={today} />
           ) : (
             <>
-              <WindowRow
-                label="5h window"
-                metric={usage.fiveHour}
-                spark={history?.fiveHour}
-                sparkLabel="remaining · last 5h"
-                sparkId={`${label}-5h`}
-                rateNoun="window"
-              />
-              <WindowRow
-                label="weekly"
-                metric={usage.week}
-                spark={history?.week}
-                sparkLabel="remaining · this week"
-                sparkId={`${label}-wk`}
-                rateNoun="week"
-              />
+              {usage.fiveHour && (
+                <WindowRow
+                  label="5h window"
+                  metric={usage.fiveHour}
+                  spark={history?.fiveHour}
+                  sparkLabel="remaining · last 5h"
+                  sparkId={`${label}-5h`}
+                  rateNoun="window"
+                />
+              )}
+              {usage.week && (
+                <WindowRow
+                  label="weekly"
+                  metric={usage.week}
+                  spark={history?.week}
+                  sparkLabel="remaining · this week"
+                  sparkId={`${label}-wk`}
+                  rateNoun="week"
+                />
+              )}
             </>
           )}
         </div>
@@ -269,7 +273,7 @@ function WindowRow({
   rateNoun,
 }: {
   label: string
-  metric: UsageMetric | null
+  metric: UsageMetric
   spark: UsageHistoryPoint[] | undefined
   sparkLabel: string
   sparkId: string
@@ -277,7 +281,7 @@ function WindowRow({
 }) {
   const now = useNow(1000)
 
-  if (!metric || metric.percentLeft === null) {
+  if (metric.percentLeft === null) {
     return (
       <div className="us-win us-win-missing">
         <div className="us-win-top">


### PR DESCRIPTION
`api.anthropic.com/api/oauth/usage` and the model-discovery endpoint belong to the Claude Code CLI rather than the public API, and druks called both with no `User-Agent`. It works today, but an unrecognised caller is a plausible thing for a private endpoint to start refusing — and because `_error_tag` maps 401/403 to `unauthorized`, the failure would present as an expired token and send every operator to re-authenticate instead of at the real cause. It would also fail every install simultaneously.

Both requests now identify as `claude-code/<version>`, the same posture CodexBar takes.

Verified against the live endpoint before merging — same request with and without the header:

```
no UA             -> 200, 1745 bytes
claude-code/2.1.0 -> 200, 1745 bytes
```

Identical, so nothing changes today; the change is purely about not being anonymous when it starts to matter. The version is pinned rather than detected: druks runs agents in sandboxes, so there is no local CLI on the API host to interrogate.

Also folds in the follow-up from #163: a window the plan does not have is no longer rendered as an empty `—` row. Codex plans metered only weekly genuinely have no five-hour window, and drawing a blank row for it reads as missing data rather than as a window that does not exist. A window that exists but has no reading still shows `—`, and a failed scrape still takes the existing `available: false` path.
