### PR TITLE
druks reads its config from druks.toml; .env carries only what other processes need

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
-# Host-run Druks development configuration. Copy to `.env`.
-# Production installation uses `druks setup` through scripts/install.sh, which
-# writes the Compose and provider settings as well.
+# Host-run Druks development environment. Copy to `.env`; copy
+# `druks.toml.example` to `druks.toml` for authored application configuration.
 
 # Durable application and DBOS state. deploy/compose.dev.yaml creates druks_dev
 # for the app and a separate druks database rebuilt by pytest.
@@ -9,59 +8,22 @@ DRUKS_DATABASE_URL=postgresql+psycopg://druks:druks@localhost:5432/druks_dev
 # Short-lived coordination: webhook claims, OAuth state/token caches, and the
 # sandbox provisioning gate. Workflow state lives in Postgres, not Redis.
 DRUKS_REDIS_URL=redis://127.0.0.1:6379/0
+DRUKS_TEST_DATABASE_URL=postgresql+psycopg://druks:druks@localhost:5432/druks_test
+DRUKS_TEST_REDIS_URL=redis://127.0.0.1:6379/15
 
 # Logs, artifacts, installed skills, and per-host sandbox keys.
 DRUKS_DATA_DIR=~/.druks
 DRUKS_LOG_LEVEL=INFO
 
-# Required. Base64-encoded 32-byte master keys, comma-separated; the first
-# encrypts and all may decrypt. Generate one:
-#   python3 -c 'import base64, os; print(base64.b64encode(os.urandom(32)).decode())'
-DRUKS_SECRETS_KEY=
-
-# Browser identity. `none` = no authentication (loopback dashboard, exactly one
-# operator account, created by the first harness connect). Behind a trusted
-# identity edge, switch to header mode and name the header your edge injects —
-# there is no default (exe.dev: X-ExeDev-Email, Teleport: X-Forwarded-Email,
-# Cloudflare Access: Cf-Access-Authenticated-User-Email):
-#   DRUKS_AUTH_MODE=header
-#   DRUKS_AUTH_HEADER=<your edge's identity header>
-# Or, for an edge that signs its assertions, jwt mode verifies the token in
-# DRUKS_AUTH_HEADER against the edge's JWKS:
-#   DRUKS_AUTH_MODE=jwt
-#   DRUKS_AUTH_HEADER=<your edge's assertion header>
-#   DRUKS_AUTH_JWKS_URL=https://your-edge/.well-known/jwks.json
-#   DRUKS_AUTH_JWT_ISSUER=https://your-edge
-#   DRUKS_AUTH_JWT_AUDIENCE=https://your-druks
-#   DRUKS_AUTH_JWT_IDENTITY_CLAIM=email
-DRUKS_AUTH_MODE=none
-
-# Webhook authentication and public ingress. DRUKS_WEBHOOK_HOST is used only
-# for the doctor's external probe; leave it empty when no public ingress exists.
-DRUKS_WEBHOOK_SECRET=change-me
-DRUKS_WEBHOOK_HOST=
-
-# Browser-visible dashboard base URL for MCP OAuth callbacks. Empty disables
-# connecting OAuth MCP servers.
-DRUKS_ENDPOINT=
-
-# Bundled build extension: operator and reviewer GitHub Apps.
+# Optional process and container-path overrides.
 GITHUB_API_URL=https://api.github.com
-GITHUB_OPERATOR_APP_ID=
 GITHUB_OPERATOR_PRIVATE_KEY_PATH=
-GITHUB_REVIEWER_APP_ID=
 GITHUB_REVIEWER_PRIVATE_KEY_PATH=
 
 # Optional Slack interactivity authentication. Destination webhook URLs are
 # configured in the dashboard.
 SLACK_SIGNING_SECRET=
 
-# Drukbox. Empty URL disables sandbox-backed execution. The local development
-# setup in docs/full-local.md uses http://127.0.0.1:8000 and dev-token.
-DRUKS_SANDBOX_SERVICE_URL=
-DRUKS_SANDBOX_SERVICE_TOKEN=
-DRUKS_SANDBOX_SERVICE_TIMEOUT=180
-DRUKS_SANDBOX_IMAGE=
 DRUKS_SANDBOX_KEYS_DIR=~/.druks/sandbox-keys
 
 # Optional non-auth CLI configuration copied into sandboxes. Subscription

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+druks.toml
 .claude/
 .DS_Store
 .venv/

--- a/backend/druks/accounts/dependencies.py
+++ b/backend/druks/accounts/dependencies.py
@@ -53,11 +53,11 @@ async def _resolve_operator(request: Request) -> Account | None:
     """None only during none/zero setup. header maps the asserted email; jwt
     maps its verified identity claim; none ignores the header entirely."""
     settings = request.app.state.settings
-    if settings.auth_mode == "none":
+    if settings.identity.mode == "none":
         return resolve_single_operator()
-    values = request.headers.getlist(settings.auth_header)
+    values = request.headers.getlist(settings.identity.header)
     if len(values) == 1 and (asserted := values[0].strip()):
-        if settings.auth_mode == "header":
+        if settings.identity.mode == "header":
             return Account.get_or_create(asserted)
         try:
             email = await verify_assertion(asserted, settings)
@@ -66,7 +66,7 @@ async def _resolve_operator(request: Request) -> Account | None:
         return Account.get_or_create(email)
     raise HTTPException(
         status_code=401,
-        detail=f"The edge must assert exactly one nonblank {settings.auth_header} identity.",
+        detail=f"The edge must assert exactly one nonblank {settings.identity.header} identity.",
     )
 
 

--- a/backend/druks/accounts/jwt.py
+++ b/backend/druks/accounts/jwt.py
@@ -19,16 +19,18 @@ async def verify_assertion(token: str, settings: Settings) -> str:
     """The verified identity claim of an edge-minted assertion, else
     InvalidAssertionError."""
     verifier = _verifier(
-        settings.auth_jwks_url, settings.auth_jwt_issuer, settings.auth_jwt_audience
+        settings.identity.jwks_url,
+        settings.identity.jwt_issuer,
+        settings.identity.jwt_audience,
     )
     access = await verifier.verify_token(token)
     # The verifier checks signature, issuer, audience, and expiry-if-present;
     # our contract additionally requires exp and a nonblank string identity.
     if not access or "exp" not in access.claims:
         raise InvalidAssertionError("Assertion rejected.")
-    claim = access.claims.get(settings.auth_jwt_identity_claim)
+    claim = access.claims.get(settings.identity.jwt_identity_claim)
     if isinstance(claim, str) and claim.strip():
         return claim.strip()
     raise InvalidAssertionError(
-        f"Assertion carries no usable {settings.auth_jwt_identity_claim} claim."
+        f"Assertion carries no usable {settings.identity.jwt_identity_claim} claim."
     )

--- a/backend/druks/accounts/routes.py
+++ b/backend/druks/accounts/routes.py
@@ -14,7 +14,7 @@ async def get_identity(
     request: Request, account: Account | None = Depends(current_account_or_setup)
 ) -> IdentityResponse:
     return IdentityResponse(
-        auth_mode=request.app.state.settings.auth_mode,
+        auth_mode=request.app.state.settings.identity.mode,
         account=AccountResponse.model_validate(account) if account else None,
         # An account needs onboarding exactly while it has no harness
         # connection; none/zero is onboarding before the account exists.

--- a/backend/druks/api/app.py
+++ b/backend/druks/api/app.py
@@ -61,7 +61,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # workflows may deliver MCP servers immediately. A bad catalog stops
         # boot here, loudly. (The suite loads it from a conftest fixture.)
         load_mcp_catalog(settings.mcp_catalog_path)
-        if settings.auth_mode == "none":
+        if settings.identity.mode == "none":
             # A drifted none-mode install (more than one operator account) must
             # refuse at boot, not per request; the per-request resolver repeats
             # the check for drift that happens while running.

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -184,7 +184,7 @@ class Build(Workflow):
             raise FatalError(
                 f"Could not mint the reviewer GitHub App token for {repo}; build "
                 "requires it for its github MCP server. Configure "
-                "GITHUB_REVIEWER_APP_ID and its private key."
+                "github.reviewer_app_id and its private key."
             ) from error
         return {
             **await super().get_workspace_kwargs(sandbox),
@@ -198,7 +198,7 @@ class Build(Workflow):
     async def get_prompt_context(self, **context: Any) -> dict[str, Any]:
         work_item = self.subject
         target_repo = ProjectRepo.get_for_repo(self.input.repo, raise_on_missing=True)
-        endpoint = load_settings().endpoint.rstrip("/")
+        endpoint = load_settings().urls.endpoint.rstrip("/")
         work_item_url = f"{endpoint}/work-items/{work_item.id}" if endpoint else ""
         prompt_context = BuildPromptContext(
             repo=self.input.repo,

--- a/backend/druks/core/apis/github.py
+++ b/backend/druks/core/apis/github.py
@@ -500,26 +500,26 @@ def _fold_comments_into_body(body: str, comments: list[ReviewComment]) -> str:
 
 
 def get_github_client(settings: Settings) -> GitHubClient:
-    if settings.github_operator_app_id and settings.github_operator_private_key_path:
+    if settings.github.operator_app_id and settings.github_operator_private_key_path:
         return GitHubClient(
-            app_id=settings.github_operator_app_id,
+            app_id=settings.github.operator_app_id,
             private_key=settings.github_operator_private_key_path.read_text(),
             base_url=settings.github_api_url,
         )
     raise GitHubAppNotConfiguredError(
-        "Operator GitHub App credentials are required: set GITHUB_OPERATOR_APP_ID and "
+        "Operator GitHub App credentials are required: set github.operator_app_id and "
         "GITHUB_OPERATOR_PRIVATE_KEY_PATH."
     )
 
 
 def get_reviewer_github_client(settings: Settings) -> GitHubClient:
-    if settings.github_reviewer_app_id and settings.github_reviewer_private_key_path:
+    if settings.github.reviewer_app_id and settings.github_reviewer_private_key_path:
         return GitHubClient(
-            app_id=settings.github_reviewer_app_id,
+            app_id=settings.github.reviewer_app_id,
             private_key=settings.github_reviewer_private_key_path.read_text(),
             base_url=settings.github_api_url,
         )
     raise GitHubAppNotConfiguredError(
-        "Reviewer GitHub App credentials are required: set GITHUB_REVIEWER_APP_ID and "
+        "Reviewer GitHub App credentials are required: set github.reviewer_app_id and "
         "GITHUB_REVIEWER_PRIVATE_KEY_PATH."
     )

--- a/backend/druks/core/webhooks/github.py
+++ b/backend/druks/core/webhooks/github.py
@@ -28,7 +28,7 @@ class GitHubEvents(Webhook):
         verify_hmac_sha256(
             self.raw_body,
             self.request.headers.get(self.SIGNATURE_HEADER),
-            self.settings.webhook_secret,
+            self.settings.secrets.webhook_secret,
         )
         return True
 

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib
+import os
 import pkgutil
 import socket
 import time
@@ -37,12 +38,12 @@ class CheckResult:
 
 
 def check_webhook_secret(settings: Settings) -> CheckResult:
-    secret = settings.webhook_secret
+    secret = settings.secrets.webhook_secret
     if not secret or secret == "change-me":
         return CheckResult(
             name="webhook_secret",
             ok=False,
-            detail="DRUKS_WEBHOOK_SECRET is empty or the placeholder.",
+            detail="secrets.webhook_secret is empty or the placeholder.",
         )
     return CheckResult(name="webhook_secret", ok=True, detail="set")
 
@@ -74,9 +75,9 @@ def check_installations(settings: Settings) -> CheckResult:
 def check_github_operator_app(settings: Settings) -> CheckResult:
     return _check_github_app(
         name="github_operator_app",
-        app_id=settings.github_operator_app_id,
+        app_id=settings.github.operator_app_id,
         pem_path=settings.github_operator_private_key_path,
-        env_id="GITHUB_OPERATOR_APP_ID",
+        id_key="github.operator_app_id",
         env_pem="GITHUB_OPERATOR_PRIVATE_KEY_PATH",
     )
 
@@ -84,9 +85,9 @@ def check_github_operator_app(settings: Settings) -> CheckResult:
 def check_github_reviewer_app(settings: Settings) -> CheckResult:
     return _check_github_app(
         name="github_reviewer_app",
-        app_id=settings.github_reviewer_app_id,
+        app_id=settings.github.reviewer_app_id,
         pem_path=settings.github_reviewer_private_key_path,
-        env_id="GITHUB_REVIEWER_APP_ID",
+        id_key="github.reviewer_app_id",
         env_pem="GITHUB_REVIEWER_PRIVATE_KEY_PATH",
     )
 
@@ -96,11 +97,11 @@ def _check_github_app(
     name: str,
     app_id: str | None,
     pem_path: Path | None,
-    env_id: str,
+    id_key: str,
     env_pem: str,
 ) -> CheckResult:
     if not app_id:
-        return CheckResult(name=name, ok=False, detail=f"{env_id} is unset.")
+        return CheckResult(name=name, ok=False, detail=f"{id_key} is unset.")
     if not pem_path:
         return CheckResult(name=name, ok=False, detail=f"{env_pem} is unset.")
     if not pem_path.exists():
@@ -186,7 +187,7 @@ def check_webhook_ingress(settings: Settings) -> CheckResult:
     """An unsigned probe POST must come back 401 — druks itself rejecting
     it proves the path DNS → TLS → edge → druks works. Anything else means
     the request died in front of druks (wrong DNS record, foreign proxy)."""
-    host = settings.webhook_host
+    host = settings.urls.webhook_host
     if not host:
         return CheckResult(name="webhook_ingress", ok=True, detail="not configured")
     url = f"https://{host}/_external/github/events/"
@@ -233,7 +234,7 @@ def check_database(settings: Settings) -> CheckResult:
 
 
 def check_drukbox(settings: Settings) -> CheckResult:
-    if not settings.sandbox_service_url:
+    if not settings.sandbox.service_url:
         return CheckResult(
             name="drukbox",
             ok=True,
@@ -254,9 +255,9 @@ def check_drukbox(settings: Settings) -> CheckResult:
 
 async def _drukbox_doctor(settings: Settings):
     api = SandboxAPI(
-        base_url=settings.sandbox_service_url,
-        token=settings.sandbox_service_token,
-        timeout=settings.sandbox_service_timeout,
+        base_url=settings.sandbox.service_url,
+        token=settings.sandbox.service_token,
+        timeout=settings.sandbox.timeout,
     )
     try:
         return await api.doctor()
@@ -269,7 +270,7 @@ def check_sandbox_e2e(settings: Settings) -> CheckResult:
     the acquire-time connection and a reattach from a GET-built record.
     Costs one VM-minute — opt-in via ``druks doctor --sandbox``, never
     part of the default check set."""
-    if not settings.sandbox_service_url:
+    if not settings.sandbox.service_url:
         return CheckResult(name="sandbox_e2e", ok=True, detail="not configured")
     try:
         detail = asyncio.run(_sandbox_e2e())
@@ -483,11 +484,14 @@ def print_results(results: list[CheckResult]) -> int:
 
 
 def main(*, sandbox: bool = False) -> int:
+    config_path = os.environ.get("DRUKS_CONFIG")
+    config_source = config_path or ("./druks.toml" if Path("druks.toml").exists() else "env only")
+    print(f"doctor: config source: {config_source}")
     try:
         settings = load_settings()
     except Exception as error:  # noqa: BLE001 — Settings can raise any validator error
         print(f"✗  load_settings           {error}")
         print()
-        print("doctor: could not load Settings. Fix .env and re-run.")
+        print("doctor: could not load Settings. Fix the configuration and re-run.")
         return 1
     return print_results(run_checks(settings, sandbox=sandbox))

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -88,7 +88,8 @@ class ClaudeHarness(Harness):
     ) -> AgentInvocation:
         if not self.sandbox:
             raise exceptions.HarnessError(
-                "claude harness requires sandbox settings — set DRUKS_SANDBOX_SERVICE_URL et al.",
+                "claude harness requires sandbox settings — set sandbox.service_url and "
+                "related TOML settings.",
             )
 
         in_vm_run_dir = f"{get_runs_root(ssh_username)}/{run_id}"

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -576,7 +576,7 @@ class CodexHarness(Harness):
         if not self.sandbox:
             raise HarnessError(
                 f"{self.name} harness requires sandbox settings — set "
-                "DRUKS_SANDBOX_SERVICE_URL et al.",
+                "sandbox.service_url and related TOML settings.",
             )
 
         cmd = self._build_codex_wrapper(

--- a/backend/druks/harnesses/datastructures.py
+++ b/backend/druks/harnesses/datastructures.py
@@ -117,10 +117,10 @@ class SandboxSettings:
     @classmethod
     def from_settings(cls, settings: Settings) -> Self:
         return cls(
-            service_url=settings.sandbox_service_url,
-            service_token=settings.sandbox_service_token,
-            service_timeout=settings.sandbox_service_timeout,
-            image=settings.sandbox_image,
+            service_url=settings.sandbox.service_url,
+            service_token=settings.sandbox.service_token,
+            service_timeout=settings.sandbox.timeout,
+            image=settings.sandbox.image,
             claude_config_dir=settings.claude_config_dir,
             codex_config_dir=settings.codex_config_dir,
             skills_dir=settings.skills_dir,
@@ -128,6 +128,6 @@ class SandboxSettings:
 
     @classmethod
     def maybe_from_settings(cls, settings: Settings) -> Self | None:
-        if not settings.sandbox_service_url:
+        if not settings.sandbox.service_url:
             return None
         return cls.from_settings(settings)

--- a/backend/druks/mcp/constants.py
+++ b/backend/druks/mcp/constants.py
@@ -19,7 +19,7 @@ REGISTRY_CACHE_TTL_SECONDS = 300
 
 # OAuth connect + mint plumbing. The callback path is public API surface — the
 # authorization server redirects the operator's browser to
-# {DRUKS_ENDPOINT}{OAUTH_CALLBACK_PATH} after consent. Access tokens cache in
+# {urls.endpoint}{OAUTH_CALLBACK_PATH} after consent. Access tokens cache in
 # Redis under the token key prefix for their lifetime minus the skew (so a
 # token injected into a run never expires moments after delivery); pending
 # connect state (PKCE verifier + endpoints) lives under the connect prefix for

--- a/backend/druks/mcp/routes.py
+++ b/backend/druks/mcp/routes.py
@@ -182,13 +182,13 @@ async def connect_mcp_server(
             status_code=409,
             detail=f"MCP server {name!r} already uses {server['identity_mode']!r} identity.",
         )
-    endpoint = request.app.state.settings.endpoint
+    endpoint = request.app.state.settings.urls.endpoint
     if not endpoint:
         # The authorization server redirects the operator's browser back to
         # druks, so the flow needs the address that browser reaches druks at.
         raise HTTPException(
             status_code=409,
-            detail="Set DRUKS_ENDPOINT to the base URL the operator's browser reaches druks "
+            detail="Set urls.endpoint to the base URL the operator's browser reaches druks "
             "at, to connect OAuth MCP servers.",
         )
     try:

--- a/backend/druks/sandbox/client.py
+++ b/backend/druks/sandbox/client.py
@@ -73,7 +73,7 @@ class Client:
         api = self._api()
         try:
             settings = load_settings()
-            image = image_override or settings.sandbox_image
+            image = image_override or settings.sandbox.image
             # Fixed lease: drukbox reaps the host when this lapses, so a run whose
             # worker dies frees its VM without a druks-side reconciler.
             expires_at = datetime.now(UTC) + timedelta(seconds=SANDBOX_HOST_LEASE_SECONDS)
@@ -188,9 +188,9 @@ class Client:
     def _api(self) -> SandboxAPI:
         settings = load_settings()
         return SandboxAPI(
-            base_url=settings.sandbox_service_url,
-            token=settings.sandbox_service_token,
-            timeout=settings.sandbox_service_timeout,
+            base_url=settings.sandbox.service_url,
+            token=settings.sandbox.service_token,
+            timeout=settings.sandbox.timeout,
         )
 
 

--- a/backend/druks/secrets/exceptions.py
+++ b/backend/druks/secrets/exceptions.py
@@ -1,11 +1,11 @@
 class SecretDecryptError(Exception):
     # A stored secret exists but none of the configured keys decrypt it — the
-    # usual cause is a key dropped from DRUKS_SECRETS_KEY while rows still
+    # usual cause is a key dropped from secrets.secrets_key while rows still
     # encrypted under it existed. Named so a delivery failure points at the
     # key config, not a bare crypto traceback.
     def __init__(self) -> None:
         super().__init__(
             "A stored secret could not be decrypted with the configured "
-            "DRUKS_SECRETS_KEY keys. If a key was rotated out, prepend the "
+            "secrets.secrets_key keys. If a key was rotated out, prepend the "
             "current key with it again; otherwise re-enter the secret."
         )

--- a/backend/druks/secrets/utils.py
+++ b/backend/druks/secrets/utils.py
@@ -29,7 +29,7 @@ _HKDF_INFO = b"druks-secrets-v1"
 
 @lru_cache
 def keys(raw: str) -> tuple[bytes, ...]:
-    # ``raw`` arrives settings-validated (Settings.secrets_key): non-empty,
+    # ``raw`` arrives settings-validated (Settings.secrets.secrets_key): non-empty,
     # every segment base64 for 32 bytes. First key encrypts, every key
     # decrypts.
     return tuple(base64.b64decode(segment.strip()) for segment in raw.split(","))
@@ -42,7 +42,7 @@ def _derive_key(master: bytes, salt: bytes) -> bytes:
 def encrypt(plaintext: bytes, aad: str) -> bytes:
     salt = os.urandom(_SALT_LEN)
     nonce = os.urandom(_NONCE_LEN)
-    ciphertext = AESGCM(_derive_key(keys(load_settings().secrets_key)[0], salt)).encrypt(
+    ciphertext = AESGCM(_derive_key(keys(load_settings().secrets.secrets_key)[0], salt)).encrypt(
         nonce, plaintext, aad.encode()
     )
     return _ENVELOPE_V1 + salt + nonce + ciphertext
@@ -56,7 +56,7 @@ def decrypt(envelope: bytes, aad: str) -> bytes:
     salt = envelope[1 : 1 + _SALT_LEN]
     nonce = envelope[1 + _SALT_LEN : _HEADER_LEN]
     ciphertext = envelope[_HEADER_LEN:]
-    for master in keys(load_settings().secrets_key):
+    for master in keys(load_settings().secrets.secrets_key):
         try:
             return AESGCM(_derive_key(master, salt)).decrypt(nonce, ciphertext, aad.encode())
         except (InvalidTag, ValueError):

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -1,11 +1,17 @@
 import base64
 import logging
+import os
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
 import asyncssh
-from pydantic import BeforeValidator, Field, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseModel, BeforeValidator, Field, model_validator
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+)
 
 DEFAULT_DATA_DIR = Path("/var/lib/druks")
 
@@ -64,6 +70,109 @@ ExpandedPath = Annotated[Path, BeforeValidator(_expand_path)]
 OptionalExpandedPath = Annotated[Path | None, BeforeValidator(_expand_optional_path)]
 
 
+def _config_path() -> Path | None:
+    if configured := os.environ.get("DRUKS_CONFIG"):
+        path = Path(configured).expanduser()
+        if path.is_file():
+            return path
+        raise ValueError(f"DRUKS_CONFIG is not a file: {path}")
+    default = Path("druks.toml")
+    return default if default.is_file() else None
+
+
+class _PrunedTomlSource(TomlConfigSettingsSource):
+    def __call__(self) -> dict[str, Any]:
+        def drop_blank_values(value: Any) -> Any:
+            if isinstance(value, dict):
+                return {key: drop_blank_values(item) for key, item in value.items() if item != ""}
+            return value
+
+        return drop_blank_values(super().__call__())
+
+
+class Identity(BaseModel):
+    # How a browser request resolves an account. ``none``: no authentication —
+    # loopback-only deployments with a single operator account. ``header``: the
+    # edge (exe.dev, Teleport, Cloudflare Access, …) authenticates and asserts
+    # the operator's email in ``identity.header``; druks maps it to an account.
+    # ``jwt``: the edge asserts a signed JWT in ``identity.header`` instead;
+    # druks verifies it against the JWKS below and maps its identity claim.
+    # Bearer personal access tokens resolve first in every mode.
+    mode: Literal["none", "header", "jwt"] = "none"
+    # No default: the operator names their edge's header explicitly — druks
+    # blesses no provider.
+    header: str = ""
+    jwks_url: str = ""
+    jwt_issuer: str = ""
+    jwt_audience: str = ""
+    jwt_identity_claim: str = "email"
+
+    @model_validator(mode="after")
+    def _auth_mode_is_fully_configured(self) -> "Identity":
+        if self.mode != "none" and not self.header.strip():
+            raise ValueError(
+                "identity.header must name the edge's identity header "
+                f"when identity.mode={self.mode}"
+            )
+        if self.mode != "none" and self.header.strip().lower() == "authorization":
+            # Authorization is the PAT slot and always parses bearer-first — an
+            # assertion configured there could never be read, locking everyone out.
+            raise ValueError("identity.header cannot be Authorization — that slot is PAT-only")
+        if self.mode == "jwt":
+            required = {
+                "identity.jwks_url": self.jwks_url,
+                "identity.jwt_issuer": self.jwt_issuer,
+                "identity.jwt_audience": self.jwt_audience,
+                "identity.jwt_identity_claim": self.jwt_identity_claim,
+            }
+            missing = [name for name, value in required.items() if not value.strip()]
+            if missing:
+                raise ValueError(f"identity.mode=jwt requires {', '.join(missing)}")
+        return self
+
+
+class GitHub(BaseModel):
+    # Where druks may act is the operator Extension's installation set — GitHub's
+    # own state: webhooks only arrive from installations, tokens only mint
+    # for them. See GitHubClient.list_installation_accounts.
+    operator_app_id: EmptyToNone = None
+    reviewer_app_id: EmptyToNone = None
+
+
+class Urls(BaseModel):
+    # The base URL the operator's browser reaches druks at (the dashboard host,
+    # not the webhook ingress). The OAuth connect flow builds its callback
+    # redirect from it; empty disables connecting OAuth MCP servers, loudly.
+    endpoint: str = ""
+    # Public hostname webhook senders POST to (Caddy serves it; see
+    # deploy/compose.yaml). Druks itself only reads it for the doctor's
+    # ingress probe — empty when the edge carries webhooks some other way.
+    webhook_host: str = ""
+
+
+class Secrets(BaseModel):
+    webhook_secret: str = ""
+    # Encrypts stored secrets (MCP tokens, OAuth grants) at rest. Required —
+    # a missing or malformed key refuses boot; `druks setup` generates one.
+    secrets_key: SecretsKey
+
+
+class Sandbox(BaseModel):
+    # Connection details for clawhaven-sandbox-service. Druks calls
+    # ``POST /hosts`` per agent run to provision a VM, then SSHes in
+    # over Tailscale to execute the CLI inside it. See
+    # ``docs/design/sandboxed-execution.md`` for the full architecture.
+    #
+    # An empty URL disables sandbox-backed execution; workflows that call an
+    # agent then fail when they try to acquire a host.
+    service_url: str = ""
+    service_token: str = ""
+    # Empty → drukbox decides.
+    image: str = ""
+    # Sized for the slowest provisioner.
+    timeout: float = 180.0
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         populate_by_name=True,
@@ -74,10 +183,16 @@ class Settings(BaseSettings):
         # silently mutating shared state.
         frozen=True,
         # Validation errors surface in boot logs and doctor output; a bad
-        # DRUKS_SECRETS_KEY (or any secret-bearing field) must not echo its
+        # secrets.secrets_key (or any secret-bearing field) must not echo its
         # value there.
         hide_input_in_errors=True,
     )
+
+    identity: Identity = Identity()
+    github: GitHub = GitHub()
+    urls: Urls = Urls()
+    secrets: Secrets
+    sandbox: Sandbox = Sandbox()
 
     # ``data_dir`` is the root for run artifacts and logs (via computed
     # properties below).
@@ -89,45 +204,11 @@ class Settings(BaseSettings):
         alias="DRUKS_DATABASE_URL",
     )
 
-    # How a browser request resolves an account. ``none``: no authentication —
-    # loopback-only deployments with a single operator account. ``header``: the
-    # edge (exe.dev, Teleport, Cloudflare Access, …) authenticates and asserts
-    # the operator's email in ``auth_header``; druks maps it to an account.
-    # ``jwt``: the edge asserts a signed JWT in ``auth_header`` instead; druks
-    # verifies it against the JWKS below and maps its identity claim. Bearer
-    # personal access tokens resolve first in every mode.
-    auth_mode: Literal["none", "header", "jwt"] = Field(default="none", alias="DRUKS_AUTH_MODE")
-    # No default: the operator names their edge's header explicitly — druks
-    # blesses no provider.
-    auth_header: str = Field(default="", alias="DRUKS_AUTH_HEADER")
-    auth_jwks_url: str = Field(default="", alias="DRUKS_AUTH_JWKS_URL")
-    auth_jwt_issuer: str = Field(default="", alias="DRUKS_AUTH_JWT_ISSUER")
-    auth_jwt_audience: str = Field(default="", alias="DRUKS_AUTH_JWT_AUDIENCE")
-    auth_jwt_identity_claim: str = Field(default="email", alias="DRUKS_AUTH_JWT_IDENTITY_CLAIM")
-
-    webhook_secret: str = Field(default="", alias="DRUKS_WEBHOOK_SECRET")
-    # Public hostname webhook senders POST to (Caddy serves it; see
-    # deploy/compose.yaml). Druks itself only reads it for the doctor's
-    # ingress probe — empty when the edge carries webhooks some other way.
-    webhook_host: str = Field(default="", alias="DRUKS_WEBHOOK_HOST")
-    # The base URL the operator's browser reaches druks at (the dashboard host,
-    # not the webhook ingress). The OAuth connect flow builds its callback
-    # redirect from it; empty disables connecting OAuth MCP servers, loudly.
-    endpoint: str = Field(default="", alias="DRUKS_ENDPOINT")
-    # Encrypts stored secrets (MCP tokens, OAuth grants) at rest. Required —
-    # a missing or malformed key refuses boot; `druks setup` generates one.
-    secrets_key: SecretsKey = Field(alias="DRUKS_SECRETS_KEY")
-    # Where druks may act is the operator Extension's installation set — GitHub's
-    # own state: webhooks only arrive from installations, tokens only mint
-    # for them. See GitHubClient.list_installation_accounts.
-
     github_api_url: str = Field(default="https://api.github.com", alias="GITHUB_API_URL")
-    github_operator_app_id: EmptyToNone = Field(default=None, alias="GITHUB_OPERATOR_APP_ID")
     github_operator_private_key_path: OptionalExpandedPath = Field(  # type: ignore[assignment]
         default=None,
         alias="GITHUB_OPERATOR_PRIVATE_KEY_PATH",
     )
-    github_reviewer_app_id: EmptyToNone = Field(default=None, alias="GITHUB_REVIEWER_APP_ID")
     github_reviewer_private_key_path: OptionalExpandedPath = Field(  # type: ignore[assignment]
         default=None,
         alias="GITHUB_REVIEWER_PRIVATE_KEY_PATH",
@@ -138,22 +219,6 @@ class Settings(BaseSettings):
     slack_signing_secret: str = Field(default="", alias="SLACK_SIGNING_SECRET")
 
     redis_url: str = Field(default="redis://127.0.0.1:6379/0", alias="DRUKS_REDIS_URL")
-    # Connection details for clawhaven-sandbox-service. Druks calls
-    # ``POST /hosts`` per agent run to provision a VM, then SSHes in
-    # over Tailscale to execute the CLI inside it. See
-    # ``docs/design/sandboxed-execution.md`` for the full architecture.
-    #
-    # An empty URL disables sandbox-backed execution; workflows that call an
-    # agent then fail when they try to acquire a host.
-    sandbox_service_url: str = Field(default="", alias="DRUKS_SANDBOX_SERVICE_URL")
-    sandbox_service_token: str = Field(default="", alias="DRUKS_SANDBOX_SERVICE_TOKEN")
-    # Sized for the slowest provisioner.
-    sandbox_service_timeout: float = Field(
-        default=180.0,
-        alias="DRUKS_SANDBOX_SERVICE_TIMEOUT",
-    )
-    # Empty → drukbox decides.
-    sandbox_image: str = Field(default="", alias="DRUKS_SANDBOX_IMAGE")
     # Per-VM SSH keys when drukbox returns them; empty otherwise.
     sandbox_keys_dir: ExpandedPath = Field(
         default=DEFAULT_DATA_DIR / "sandbox-keys",
@@ -203,28 +268,21 @@ class Settings(BaseSettings):
 
     log_level: str = Field(default="INFO", alias="DRUKS_LOG_LEVEL")
 
-    @model_validator(mode="after")
-    def _auth_mode_is_fully_configured(self) -> "Settings":
-        if self.auth_mode != "none" and not self.auth_header.strip():
-            raise ValueError(
-                "DRUKS_AUTH_HEADER must name the edge's identity header "
-                f"when DRUKS_AUTH_MODE={self.auth_mode}"
-            )
-        if self.auth_mode != "none" and self.auth_header.strip().lower() == "authorization":
-            # Authorization is the PAT slot and always parses bearer-first — an
-            # assertion configured there could never be read, locking everyone out.
-            raise ValueError("DRUKS_AUTH_HEADER cannot be Authorization — that slot is PAT-only")
-        if self.auth_mode == "jwt":
-            required = {
-                "DRUKS_AUTH_JWKS_URL": self.auth_jwks_url,
-                "DRUKS_AUTH_JWT_ISSUER": self.auth_jwt_issuer,
-                "DRUKS_AUTH_JWT_AUDIENCE": self.auth_jwt_audience,
-                "DRUKS_AUTH_JWT_IDENTITY_CLAIM": self.auth_jwt_identity_claim,
-            }
-            missing = [name for name, value in required.items() if not value.strip()]
-            if missing:
-                raise ValueError(f"DRUKS_AUTH_MODE=jwt requires {', '.join(missing)}")
-        return self
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            _PrunedTomlSource(settings_cls, toml_file=_config_path()),
+            env_settings,
+            dotenv_settings,
+        )
 
     @property
     def logs_dir(self) -> Path:
@@ -261,9 +319,9 @@ def setup_logging(settings: Settings) -> None:
     asyncssh.set_log_level(logging.WARNING)
     asyncssh.set_sftp_log_level(logging.WARNING)
 
-    if not settings.webhook_secret:
+    if not settings.secrets.webhook_secret:
         logging.getLogger(__name__).warning(
-            "DRUKS_WEBHOOK_SECRET is not set — all webhooks will be rejected.",
+            "secrets.webhook_secret is not set — all webhooks will be rejected.",
         )
 
 

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -5,7 +5,6 @@ import re
 import secrets
 import tomllib
 from collections.abc import Callable, Mapping, MutableMapping
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -23,123 +22,41 @@ _COMPOSE_ENV_KEYS = (
 )
 _ENV_KEY_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
-
-@dataclass(frozen=True)
-class Entry:
-    key: str
-    source: tuple[str, ...] = ()
-    fixed: str = ""
-    is_required: bool = False
-    prompt: str = ""
-    is_install_path: bool = False
-    is_remote_only: bool = False
-
-
-@dataclass(frozen=True)
-class Section:
-    title: str
-    entries: tuple[Entry, ...]
-
-
-_SECTIONS = (
-    Section(
-        "GITHUB",
-        (
-            Entry(
-                "GITHUB_OPERATOR_APP_ID",
-                ("github", "operator_app_id"),
-                is_required=True,
-                prompt="Operator GitHub App id (or run install.sh --apps later)",
-            ),
-            Entry(
-                "GITHUB_OPERATOR_PRIVATE_KEY_PATH",
-                ("github", "operator_pem"),
-                is_install_path=True,
-            ),
-            Entry("GITHUB_OPERATOR_PEM", ("github", "operator_pem"), is_install_path=True),
-            Entry(
-                "GITHUB_REVIEWER_APP_ID",
-                ("github", "reviewer_app_id"),
-                is_required=True,
-                prompt="Reviewer GitHub App id (or run install.sh --apps later)",
-            ),
-            Entry(
-                "GITHUB_REVIEWER_PRIVATE_KEY_PATH",
-                ("github", "reviewer_pem"),
-                is_install_path=True,
-            ),
-            Entry("GITHUB_REVIEWER_PEM", ("github", "reviewer_pem"), is_install_path=True),
-            Entry(
-                "DRUKS_ENDPOINT",
-                ("urls", "endpoint"),
-                prompt="Base URL the operator's browser reaches druks at (enter to skip)",
-            ),
-        ),
-    ),
-    Section(
-        "GENERATED SECRETS",
-        (
-            Entry(
-                "DRUKS_POSTGRES_PASSWORD",
-                ("secrets", "postgres_password"),
-                is_required=True,
-            ),
-            Entry("DRUKS_WEBHOOK_SECRET", ("secrets", "webhook_secret"), is_required=True),
-            Entry("DRUKS_SECRETS_KEY", ("secrets", "secrets_key"), is_required=True),
-        ),
-    ),
-    Section(
-        "DEPLOYMENT DEFAULTS",
-        (
-            Entry("DRUKS_DATA_DIR", ("paths", "data_dir")),
-            Entry("DRUKS_UPSTREAM", fixed="127.0.0.1:8001"),
-            Entry("DRUKS_CLAUDE_HOME", ("paths", "claude_home")),
-            Entry("DRUKS_CODEX_HOME", ("paths", "codex_home")),
-            Entry("DRUKS_CLAUDE_JSON", ("paths", "claude_json")),
-            Entry("DRUKS_WEBHOOK_HOST", ("urls", "webhook_host")),
-            Entry("DATABASE_URL", fixed="sqlite+aiosqlite:////data/drukbox.db"),
-            Entry("REDIS_URL", fixed="redis://127.0.0.1:6379/2"),
-        ),
-    ),
-    Section(
-        "IDENTITY",
-        (
-            Entry("DRUKS_AUTH_MODE", ("identity", "mode"), is_required=True),
-            Entry("DRUKS_AUTH_HEADER", ("identity", "header")),
-            Entry("DRUKS_AUTH_JWKS_URL", ("identity", "jwks_url")),
-            Entry("DRUKS_AUTH_JWT_ISSUER", ("identity", "jwt_issuer")),
-            Entry("DRUKS_AUTH_JWT_AUDIENCE", ("identity", "jwt_audience")),
-            Entry(
-                "DRUKS_AUTH_JWT_IDENTITY_CLAIM",
-                ("identity", "jwt_identity_claim"),
-            ),
-        ),
-    ),
-    Section(
-        "SANDBOX",
-        (
-            Entry("DEFAULT_HOST_PROVIDER", ("sandbox", "provider"), is_required=True),
-            Entry(
-                "DRUKS_SANDBOX_SERVICE_URL",
-                ("sandbox", "service_url"),
-                is_required=True,
-            ),
-            Entry(
-                "DRUKS_SANDBOX_SERVICE_TOKEN",
-                ("secrets", "sandbox_service_token"),
-                is_required=True,
-            ),
-            Entry(
-                "SERVICE_TOKENS",
-                ("sandbox", "service_tokens"),
-                is_remote_only=True,
-            ),
-            Entry("DRUKS_SANDBOX_IMAGE", ("sandbox", "image")),
-        ),
-    ),
+# Env keys druks owns — setup renders them into .env, or the app reads their
+# value from druks.toml directly. [env] and provider tables may not carry them.
+_OWNED_ENV_KEYS = frozenset(
+    {
+        "GITHUB_OPERATOR_PEM",
+        "GITHUB_REVIEWER_PEM",
+        "DRUKS_POSTGRES_PASSWORD",
+        "DRUKS_DATA_DIR",
+        "DRUKS_UPSTREAM",
+        "DRUKS_CLAUDE_HOME",
+        "DRUKS_CODEX_HOME",
+        "DRUKS_CLAUDE_JSON",
+        "DRUKS_WEBHOOK_HOST",
+        "DATABASE_URL",
+        "REDIS_URL",
+        "DRUKS_AUTH_HEADER",
+        "DEFAULT_HOST_PROVIDER",
+        "SERVICE_TOKENS",
+        "DRUKS_AUTH_MODE",
+        "DRUKS_AUTH_JWKS_URL",
+        "DRUKS_AUTH_JWT_ISSUER",
+        "DRUKS_AUTH_JWT_AUDIENCE",
+        "DRUKS_AUTH_JWT_IDENTITY_CLAIM",
+        "DRUKS_ENDPOINT",
+        "DRUKS_WEBHOOK_SECRET",
+        "DRUKS_SECRETS_KEY",
+        "GITHUB_OPERATOR_APP_ID",
+        "GITHUB_OPERATOR_PRIVATE_KEY_PATH",
+        "GITHUB_REVIEWER_APP_ID",
+        "GITHUB_REVIEWER_PRIVATE_KEY_PATH",
+        "DRUKS_SANDBOX_SERVICE_URL",
+        "DRUKS_SANDBOX_SERVICE_TOKEN",
+        "DRUKS_SANDBOX_IMAGE",
+    }
 )
-
-_OWNED_ENV_KEYS = frozenset(entry.key for section in _SECTIONS for entry in section.entries)
 _KNOWN_TOML_KEYS = {
     "identity": (
         "mode",
@@ -155,10 +72,9 @@ _KNOWN_TOML_KEYS = {
         "postgres_password",
         "webhook_secret",
         "secrets_key",
-        "sandbox_service_token",
     ),
     "paths": ("data_dir", "claude_home", "codex_home", "claude_json"),
-    "sandbox": ("provider", "service_url", "image", "service_tokens"),
+    "sandbox": ("provider", "service_url", "service_token", "image", "service_tokens", "timeout"),
     "env": (),
 }
 
@@ -199,6 +115,7 @@ def run_setup(
         return MIGRATION_EXIT_CODE
 
     is_fresh = not toml_path.exists()
+    is_changed = is_fresh
     if is_fresh:
         provider = provider.strip()
         if interactive:
@@ -211,8 +128,19 @@ def run_setup(
             _set_value(document, value_path, value)
     else:
         document = tomlkit.parse(toml_path.read_text())
+        sandbox = document.get("sandbox")
+        configured_provider = _get_string(document, ("sandbox", "provider"))
+        if (
+            isinstance(sandbox, MutableMapping)
+            and configured_provider
+            and "env" in sandbox
+            and configured_provider not in sandbox
+        ):
+            sandbox[configured_provider] = sandbox["env"]
+            del sandbox["env"]
+            print_fn(f"Renamed [sandbox.env] to [sandbox.{configured_provider}].")
+            is_changed = True
 
-    is_changed = is_fresh
     for assignment in set_values:
         value_path, value = _parse_assignment(assignment)
         _set_value(document, value_path, value)
@@ -282,7 +210,6 @@ webhook_host = ""
 postgres_password = ""
 webhook_secret = ""
 secrets_key = ""
-sandbox_service_token = ""
 
 # Host paths. Relative PEM paths are resolved against the install directory.
 [paths]
@@ -295,16 +222,17 @@ claude_json = ""
 [sandbox]
 provider = ""
 service_url = ""
+service_token = ""
 image = ""
 service_tokens = ""
+timeout = 180
 
-# Drukbox environment, passed through to the remote stack verbatim.
-# Local docker shape: host-run drukbox reads its own env, so this table
-# is not rendered. Provider reference: https://github.com/czpython/drukbox
-# (docs/deploy.md).
-[sandbox.env]
+# Put drukbox environment in [sandbox.<provider>]. The table is passed through
+# to remote stacks verbatim; the local docker shape renders no provider table.
+# Provider reference: https://github.com/czpython/drukbox (docs/deploy.md).
 
-# Additional deployment settings; keys render verbatim unless owned by druks.
+# Raw environment for processes druks does not model (drukbox, Caddy, libraries
+# reading os.environ); keys render verbatim unless owned by druks.
 [env]
 """
 
@@ -315,7 +243,7 @@ def _fresh_values(*, provider: str, home: str) -> tuple[tuple[tuple[str, ...], s
             (("identity", "mode"), "none"),
             (("urls", "endpoint"), "http://localhost:8001"),
             (("sandbox", "service_url"), "http://127.0.0.1:8000"),
-            (("secrets", "sandbox_service_token"), "dev-token"),
+            (("sandbox", "service_token"), "dev-token"),
             (("sandbox", "image"), "ghcr.io/czpython/druks-sandbox:latest"),
         )
     elif provider == "exe":
@@ -323,22 +251,22 @@ def _fresh_values(*, provider: str, home: str) -> tuple[tuple[tuple[str, ...], s
             (("identity", "mode"), "header"),
             (("identity", "header"), "X-ExeDev-Email"),
             (("sandbox", "service_url"), "http://127.0.0.1:8780"),
-            (("secrets", "sandbox_service_token"), _hex_secret()),
-            (("sandbox", "env", "EXE_API_TOKEN"), ""),
-            (("sandbox", "env", "TAILSCALE_TAILNET"), ""),
-            (("sandbox", "env", "TAILSCALE_OAUTH_CLIENT_ID"), ""),
-            (("sandbox", "env", "TAILSCALE_OAUTH_CLIENT_SECRET"), ""),
-            (("sandbox", "env", "EXE_API_URL"), "https://exe.dev"),
-            (("sandbox", "env", "EXE_DEFAULT_IMAGE"), "ghcr.io/boldsoftware/exeuntu:latest"),
-            (("sandbox", "env", "TAILSCALE_ENABLED"), "true"),
-            (("sandbox", "env", "TAILSCALE_API_TIMEOUT"), "30"),
-            (("sandbox", "env", "TAILSCALE_AUTH_TAGS"), "tag:sandbox"),
+            (("sandbox", "service_token"), _hex_secret()),
+            (("sandbox", "exe", "EXE_API_TOKEN"), ""),
+            (("sandbox", "exe", "TAILSCALE_TAILNET"), ""),
+            (("sandbox", "exe", "TAILSCALE_OAUTH_CLIENT_ID"), ""),
+            (("sandbox", "exe", "TAILSCALE_OAUTH_CLIENT_SECRET"), ""),
+            (("sandbox", "exe", "EXE_API_URL"), "https://exe.dev"),
+            (("sandbox", "exe", "EXE_DEFAULT_IMAGE"), "ghcr.io/boldsoftware/exeuntu:latest"),
+            (("sandbox", "exe", "TAILSCALE_ENABLED"), "true"),
+            (("sandbox", "exe", "TAILSCALE_API_TIMEOUT"), "30"),
+            (("sandbox", "exe", "TAILSCALE_AUTH_TAGS"), "tag:sandbox"),
         )
     else:
         shape = (
             (("identity", "mode"), "header"),
             (("sandbox", "service_url"), "http://127.0.0.1:8780"),
-            (("secrets", "sandbox_service_token"), _hex_secret()),
+            (("sandbox", "service_token"), _hex_secret()),
         )
 
     return (
@@ -370,28 +298,44 @@ def _canonical_config(raw: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(table, dict):
             raise ValueError(f"druks.toml: [{table_name}] must be a table")
         for key in keys:
-            if not isinstance(table.setdefault(key, ""), str):
+            value = table.setdefault(key, "")
+            if table_name == "sandbox" and key == "timeout":
+                if type(value) not in (str, int, float):
+                    raise ValueError("druks.toml: sandbox.timeout must be a number or string")
+            elif not isinstance(value, str):
                 raise ValueError(f"druks.toml: {table_name}.{key} must be a string")
 
-    sandbox_env = config["sandbox"].setdefault("env", {})
-    if not isinstance(sandbox_env, dict):
-        raise ValueError("druks.toml: [sandbox.env] must be a table")
-    for env_name, env_table in (("sandbox.env", sandbox_env), ("env", config["env"])):
-        for key, value in env_table.items():
+    provider_tables = _provider_tables(config["sandbox"])
+    for provider_name, provider_table in provider_tables.items():
+        if not isinstance(provider_table, dict):
+            raise ValueError(f"druks.toml: [sandbox.{provider_name}] must be a table")
+        for key, value in provider_table.items():
             if not isinstance(value, str):
-                raise ValueError(f"druks.toml: {env_name}.{key} must be a string")
+                raise ValueError(f"druks.toml: sandbox.{provider_name}.{key} must be a string")
+            if not _ENV_KEY_PATTERN.fullmatch(key):
+                raise ValueError(
+                    f"druks.toml: sandbox.{provider_name} key {key!r} is not an env name"
+                )
+
+    for key, value in config["env"].items():
+        if not isinstance(value, str):
+            raise ValueError(f"druks.toml: env.{key} must be a string")
 
     for table_name, table in config.items():
         if not isinstance(table, dict):
             _require_scalar("", table_name, table)
             continue
         for key, value in table.items():
-            if table_name in _KNOWN_TOML_KEYS and (
-                key in _KNOWN_TOML_KEYS[table_name] or (table_name, key) == ("sandbox", "env")
-            ):
+            if table_name in _KNOWN_TOML_KEYS and key in _KNOWN_TOML_KEYS[table_name]:
+                continue
+            if table_name == "sandbox" and key in provider_tables:
                 continue
             _require_scalar(f"{table_name}.", key, value)
     return config
+
+
+def _provider_tables(sandbox: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in sandbox.items() if key not in _KNOWN_TOML_KEYS["sandbox"]}
 
 
 def _require_scalar(prefix: str, key: str, value: Any) -> None:
@@ -435,10 +379,21 @@ def _prompt_values(
     input_fn: Callable[[str], str],
 ) -> bool:
     prompts = [
-        (entry.source, entry.prompt, entry.is_required)
-        for section in _SECTIONS
-        for entry in section.entries
-        if entry.source and entry.prompt
+        (
+            ("github", "operator_app_id"),
+            "Operator GitHub App id (or run install.sh --apps later)",
+            True,
+        ),
+        (
+            ("github", "reviewer_app_id"),
+            "Reviewer GitHub App id (or run install.sh --apps later)",
+            True,
+        ),
+        (
+            ("urls", "endpoint"),
+            "Base URL the operator's browser reaches druks at (enter to skip)",
+            False,
+        ),
     ]
     identity_mode = _get_string(document, ("identity", "mode"))
     if identity_mode in {"header", "jwt"}:
@@ -462,19 +417,19 @@ def _prompt_values(
     if _get_string(document, ("sandbox", "provider")) == "exe":
         prompts.extend(
             (
-                (("sandbox", "env", "EXE_API_TOKEN"), "exe.dev API token", True),
+                (("sandbox", "exe", "EXE_API_TOKEN"), "exe.dev API token", True),
                 (
-                    ("sandbox", "env", "TAILSCALE_TAILNET"),
+                    ("sandbox", "exe", "TAILSCALE_TAILNET"),
                     'Tailscale magic-DNS suffix (e.g. "yourtail.ts.net")',
                     True,
                 ),
                 (
-                    ("sandbox", "env", "TAILSCALE_OAUTH_CLIENT_ID"),
+                    ("sandbox", "exe", "TAILSCALE_OAUTH_CLIENT_ID"),
                     "Tailscale OAuth client id",
                     False,
                 ),
                 (
-                    ("sandbox", "env", "TAILSCALE_OAUTH_CLIENT_SECRET"),
+                    ("sandbox", "exe", "TAILSCALE_OAUTH_CLIENT_SECRET"),
                     "Tailscale OAuth client secret",
                     False,
                 ),
@@ -505,33 +460,66 @@ def _render_env(
     extras: dict[str, str],
 ) -> str:
     provider = _get_string(config, ("sandbox", "provider"))
+
+    def pem(key: str) -> str:
+        configured = _get_string(config, ("github", key))
+        return _resolve_install_path(configured, install_dir) if configured else ""
+
+    service_tokens = ""
+    if provider != "docker":
+        service_tokens = _get_string(config, ("sandbox", "service_tokens")) or _get_string(
+            config, ("sandbox", "service_token")
+        )
+
+    sections = (
+        (
+            "GITHUB",
+            (
+                ("GITHUB_OPERATOR_PEM", pem("operator_pem")),
+                ("GITHUB_REVIEWER_PEM", pem("reviewer_pem")),
+            ),
+        ),
+        (
+            "GENERATED SECRETS",
+            (("DRUKS_POSTGRES_PASSWORD", _get_string(config, ("secrets", "postgres_password"))),),
+        ),
+        (
+            "DEPLOYMENT DEFAULTS",
+            (
+                ("DRUKS_DATA_DIR", _get_string(config, ("paths", "data_dir"))),
+                ("DRUKS_UPSTREAM", "127.0.0.1:8001"),
+                ("DRUKS_CLAUDE_HOME", _get_string(config, ("paths", "claude_home"))),
+                ("DRUKS_CODEX_HOME", _get_string(config, ("paths", "codex_home"))),
+                ("DRUKS_CLAUDE_JSON", _get_string(config, ("paths", "claude_json"))),
+                ("DRUKS_WEBHOOK_HOST", _get_string(config, ("urls", "webhook_host"))),
+                ("DATABASE_URL", "sqlite+aiosqlite:////data/drukbox.db"),
+                ("REDIS_URL", "redis://127.0.0.1:6379/2"),
+            ),
+        ),
+        ("IDENTITY", (("DRUKS_AUTH_HEADER", _get_string(config, ("identity", "header"))),)),
+        (
+            "SANDBOX",
+            (
+                ("DEFAULT_HOST_PROVIDER", provider),
+                ("SERVICE_TOKENS", service_tokens),
+            ),
+        ),
+    )
+
     lines: list[str] = []
-    for section in _SECTIONS:
-        section_lines: list[str] = []
-        for entry in section.entries:
-            if entry.is_remote_only and provider == "docker":
-                continue
-            value = entry.fixed or _get_string(config, entry.source)
-            if entry.key == "SERVICE_TOKENS" and not value:
-                value = _get_string(config, ("secrets", "sandbox_service_token"))
-            if entry.is_install_path and value:
-                value = _resolve_install_path(value, install_dir)
-            if not value:
-                continue
-            section_lines.append(_env_line(entry.key, value))
+    for title, pairs in sections:
+        section_lines = [_env_line(key, value) for key, value in pairs if value]
         if section_lines:
-            lines.extend(("# " + "=" * 60, f"# {section.title}", "# " + "=" * 60, ""))
+            lines.extend(("# " + "=" * 60, f"# {title}", "# " + "=" * 60, ""))
             lines.extend(section_lines)
             lines.append("")
 
-    sandbox_env: dict[str, str] = config["sandbox"]["env"]
+    provider_environment: dict[str, str] = config["sandbox"].get(provider, {})
     if provider != "docker":
         pass_through = []
-        for key, value in sandbox_env.items():
+        for key, value in provider_environment.items():
             if _is_reserved_env_key(key) or not value:
                 continue
-            if not _ENV_KEY_PATTERN.fullmatch(key):
-                raise ValueError(f"druks.toml: sandbox.env key {key!r} is not an env name")
             pass_through.append(_env_line(key, value))
         if pass_through:
             lines.extend(
@@ -606,46 +594,61 @@ def _collect_gaps(
     install_dir: str,
 ) -> list[str]:
     gaps = [
-        f"{entry.key} is empty"
-        for section in _SECTIONS
-        for entry in section.entries
-        if entry.is_required and not _get_string(config, entry.source)
+        f"{'.'.join(path)} is empty"
+        for path in (
+            ("github", "operator_app_id"),
+            ("github", "reviewer_app_id"),
+            ("secrets", "postgres_password"),
+            ("secrets", "webhook_secret"),
+            ("secrets", "secrets_key"),
+            ("identity", "mode"),
+            ("sandbox", "provider"),
+            ("sandbox", "service_url"),
+            ("sandbox", "service_token"),
+        )
+        if not _get_string(config, path)
     ]
 
     identity_mode = _get_string(config, ("identity", "mode"))
     if identity_mode not in {"none", "header", "jwt"}:
         gaps.append("identity.mode must be one of: header, jwt, none")
     if identity_mode in {"header", "jwt"} and not _get_string(config, ("identity", "header")):
-        gaps.append("DRUKS_AUTH_HEADER is empty")
+        gaps.append("identity.header is empty")
     if identity_mode == "jwt":
-        for path, env_key in (
-            (("identity", "jwks_url"), "DRUKS_AUTH_JWKS_URL"),
-            (("identity", "jwt_issuer"), "DRUKS_AUTH_JWT_ISSUER"),
-            (("identity", "jwt_audience"), "DRUKS_AUTH_JWT_AUDIENCE"),
-            (("identity", "jwt_identity_claim"), "DRUKS_AUTH_JWT_IDENTITY_CLAIM"),
+        for path in (
+            ("identity", "jwks_url"),
+            ("identity", "jwt_issuer"),
+            ("identity", "jwt_audience"),
+            ("identity", "jwt_identity_claim"),
         ):
             if not _get_string(config, path):
-                gaps.append(f"{env_key} is empty")
+                gaps.append(f"{'.'.join(path)} is empty")
 
     provider = _get_string(config, ("sandbox", "provider"))
-    sandbox_env: dict[str, str] = config["sandbox"]["env"]
-    for key in sandbox_env:
-        if _is_reserved_env_key(key):
-            gaps.append(f"sandbox.env.{key} is reserved by druks")
+    provider_tables = _provider_tables(config["sandbox"])
+    for provider_name, provider_environment in provider_tables.items():
+        if provider_name != provider:
+            gaps.append(f"sandbox.{provider_name} is a stale provider table")
+        for key in provider_environment:
+            if _is_reserved_env_key(key):
+                gaps.append(f"sandbox.{provider_name}.{key} is reserved by druks")
 
     deployment_env: dict[str, str] = config["env"]
     for key in deployment_env:
         if key in _OWNED_ENV_KEYS:
             gaps.append(f"env.{key} is reserved by druks")
 
+    provider_environment = provider_tables.get(provider, {})
     if provider == "exe":
         for key in ("EXE_API_TOKEN", "TAILSCALE_TAILNET"):
-            if not _get_string(config, ("sandbox", "env", key)):
-                gaps.append(f"{key} is empty")
+            if not _get_string(config, ("sandbox", "exe", key)):
+                gaps.append(f"sandbox.exe.{key} is empty")
     elif provider != "docker" and not any(
-        value for key, value in sandbox_env.items() if not _is_reserved_env_key(key)
+        value for key, value in provider_environment.items() if not _is_reserved_env_key(key)
     ):
-        gaps.append(f"[sandbox.env] has no configured values for remote provider {provider!r}")
+        gaps.append(
+            f"[sandbox.{provider}] has no configured values for remote provider {provider!r}"
+        )
 
     for key in ("operator_pem", "reviewer_pem"):
         configured = _get_string(config, ("github", key))
@@ -708,9 +711,9 @@ def _print_migration_recipe(
     print_fn("  - DRUKS_POSTGRES_PASSWORD → [secrets].postgres_password")
     print_fn("  - DRUKS_SECRETS_KEY → [secrets].secrets_key")
     print_fn("  - DRUKS_WEBHOOK_SECRET → [secrets].webhook_secret")
-    print_fn("  - DRUKS_SANDBOX_SERVICE_TOKEN → [secrets].sandbox_service_token")
+    print_fn("  - DRUKS_SANDBOX_SERVICE_TOKEN → [sandbox].service_token")
     print_fn("  - GITHUB_*_APP_ID → [github]")
-    print_fn("  - provider and its credentials → [sandbox] and [sandbox.env]")
+    print_fn("  - provider and its credentials → [sandbox] and [sandbox.<provider>]")
     print_fn("  - other hand-added .env keys → [env]")
     print_fn("Nothing was written.")
 

--- a/backend/druks/testing.py
+++ b/backend/druks/testing.py
@@ -1,6 +1,7 @@
 import base64
 import os
 import secrets
+import tempfile
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from unittest import mock
@@ -63,10 +64,17 @@ def pytest_configure(config) -> None:
     including suites that never touch druks."""
     global _discovery_error
 
-    os.environ.setdefault("DRUKS_SECRETS_KEY", base64.b64encode(secrets.token_bytes(32)).decode())
-    # Under pytest, druks IS the test instance. Settings are read from the environment
-    # wherever they're needed — the app's Redis dialer among them — so overriding here
-    # is what keeps the code under test on the database and Redis the fixtures own.
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as settings_file:
+        settings_file.write(
+            f'[secrets]\nsecrets_key = "{base64.b64encode(secrets.token_bytes(32)).decode()}"\n'
+        )
+    settings_path = Path(settings_file.name)
+    os.environ.setdefault("DRUKS_CONFIG", str(settings_path))
+    config.add_cleanup(settings_path.unlink)
+    # Under pytest, druks IS the test instance. Infrastructure settings are read from
+    # the environment wherever they're needed — the app's Redis dialer among them — so
+    # overriding here keeps the code under test on the database and Redis the fixtures
+    # own.
     os.environ["DRUKS_DATABASE_URL"] = TEST_DATABASE_URL
     os.environ["DRUKS_REDIS_URL"] = TEST_REDIS_URL
     # App commits become savepoints inside the fixture's outer transaction, which
@@ -149,11 +157,12 @@ def make_settings(tmp_path: Path, **overrides: object) -> Settings:
     defaults = {
         "data_dir": tmp_path,
         "database_url": TEST_DATABASE_URL,
-        "webhook_secret": "test-secret",
+        "secrets": {
+            "webhook_secret": "test-secret",
+            "secrets_key": "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=",
+        },
         "github_api_url": "https://api.github.com",
-        "github_operator_app_id": None,
         "github_operator_private_key_path": None,
-        "github_reviewer_app_id": None,
         "github_reviewer_private_key_path": None,
         "redis_url": TEST_REDIS_URL,
         "log_level": "WARNING",

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -81,7 +81,10 @@ def test_openapi_pins_the_six_agent_routes(client: TestClient):
 def test_agent_routes_sit_behind_the_gate(tmp_path, druks_db):
     # Header mode: an unasserted request is a 401, not none-mode's setup 409.
     app = configure_app_for_test(
-        settings=make_settings(tmp_path, auth_mode="header", auth_header="X-Edge-Email"),
+        settings=make_settings(
+            tmp_path,
+            identity={"mode": "header", "header": "X-Edge-Email"},
+        ),
         authenticated=False,
     )
     with TestClient(app) as anonymous:

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -16,12 +16,11 @@ HEADER = "X-ExeDev-Email"
 OPERATOR = {HEADER: "op@example.com"}
 
 
-def _client(tmp_path: Path, **settings_overrides) -> TestClient:
-    settings_overrides.setdefault("auth_mode", "header")
-    if settings_overrides["auth_mode"] == "header":
-        settings_overrides.setdefault("auth_header", HEADER)
+def _client(tmp_path: Path, *, identity: dict[str, str] | None = None) -> TestClient:
+    if identity is None:
+        identity = {"mode": "header", "header": HEADER}
     app = configure_app_for_test(
-        settings=make_settings(tmp_path, **settings_overrides), authenticated=False
+        settings=make_settings(tmp_path, identity=identity), authenticated=False
     )
     return TestClient(app)
 
@@ -229,7 +228,7 @@ def test_the_operator_manages_the_token_lifecycle(tmp_path, druks_db):
 
 def test_the_none_mode_operator_manages_tokens_too(tmp_path, druks_db):
     Account.get_or_create("op@example.com")
-    with _client(tmp_path, auth_mode="none") as client:
+    with _client(tmp_path, identity={"mode": "none"}) as client:
         created = client.post("/api/auth/personal-tokens", json={"name": "local"})
         assert created.status_code == 200
         listed = client.get("/api/auth/personal-tokens").json()

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -6,22 +6,30 @@ import pytest
 from druks import doctor
 from druks.testing import make_settings
 
+_SECRETS_KEY = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
+
 
 def _named(results: list[doctor.CheckResult], name: str) -> doctor.CheckResult:
     return next(result for result in results if result.name == name)
 
 
 def test_webhook_secret_fails_on_placeholder(tmp_path: Path) -> None:
-    settings = make_settings(tmp_path, webhook_secret="change-me")
+    settings = make_settings(
+        tmp_path,
+        secrets={"webhook_secret": "change-me", "secrets_key": _SECRETS_KEY},
+    )
 
     result = doctor.check_webhook_secret(settings)
 
     assert not result.ok
-    assert "DRUKS_WEBHOOK_SECRET" in result.detail
+    assert "secrets.webhook_secret" in result.detail
 
 
 def test_webhook_secret_passes_when_set(tmp_path: Path) -> None:
-    settings = make_settings(tmp_path, webhook_secret="a-real-secret")
+    settings = make_settings(
+        tmp_path,
+        secrets={"webhook_secret": "a-real-secret", "secrets_key": _SECRETS_KEY},
+    )
 
     result = doctor.check_webhook_secret(settings)
 
@@ -72,7 +80,7 @@ def test_installations_fails_when_app_has_none(tmp_path: Path, monkeypatch) -> N
 def test_github_app_fails_when_pem_missing(tmp_path: Path) -> None:
     settings = make_settings(
         tmp_path,
-        github_operator_app_id="12345",
+        github={"operator_app_id": "12345"},
         github_operator_private_key_path=None,
     )
 
@@ -85,7 +93,7 @@ def test_github_app_fails_when_pem_missing(tmp_path: Path) -> None:
 def test_github_app_fails_when_pem_does_not_exist(tmp_path: Path) -> None:
     settings = make_settings(
         tmp_path,
-        github_operator_app_id="12345",
+        github={"operator_app_id": "12345"},
         github_operator_private_key_path=tmp_path / "missing.pem",
     )
 
@@ -100,7 +108,7 @@ def test_github_app_fails_when_pem_is_not_a_key(tmp_path: Path) -> None:
     pem_path.write_text("not actually a PEM key\n")
     settings = make_settings(
         tmp_path,
-        github_operator_app_id="12345",
+        github={"operator_app_id": "12345"},
         github_operator_private_key_path=pem_path,
     )
 
@@ -123,7 +131,7 @@ def test_github_app_passes_when_live_mint_succeeds(
     monkeypatch.setattr(doctor, "_github_app_slug", fake_slug)
     settings = make_settings(
         tmp_path,
-        github_operator_app_id="12345",
+        github={"operator_app_id": "12345"},
         github_operator_private_key_path=pem_path,
     )
 
@@ -146,7 +154,7 @@ def test_github_app_fails_when_live_mint_raises(
     monkeypatch.setattr(doctor, "_github_app_slug", fake_slug)
     settings = make_settings(
         tmp_path,
-        github_operator_app_id="12345",
+        github={"operator_app_id": "12345"},
         github_operator_private_key_path=pem_path,
     )
 
@@ -198,7 +206,7 @@ def test_redis_fails_on_unreachable_host(tmp_path: Path) -> None:
 def test_drukbox_passes_when_unconfigured(tmp_path: Path) -> None:
     """Sandbox URL empty → no drukbox to talk to."""
     settings = make_settings(tmp_path)
-    assert settings.sandbox_service_url == ""
+    assert settings.sandbox.service_url == ""
 
     result = doctor.check_drukbox(settings)
 
@@ -259,7 +267,7 @@ def test_webhook_ingress_passes_on_druks_401(tmp_path: Path, monkeypatch) -> Non
         "post",
         lambda url, content, timeout: httpx.Response(401),
     )
-    settings = make_settings(tmp_path, webhook_host="hooks.example.com")
+    settings = make_settings(tmp_path, urls={"webhook_host": "hooks.example.com"})
 
     result = doctor.check_webhook_ingress(settings)
 
@@ -274,7 +282,7 @@ def test_webhook_ingress_fails_on_foreign_404(tmp_path: Path, monkeypatch) -> No
         "post",
         lambda url, content, timeout: httpx.Response(404, headers={"server": "nginx"}),
     )
-    settings = make_settings(tmp_path, webhook_host="hooks.example.com")
+    settings = make_settings(tmp_path, urls={"webhook_host": "hooks.example.com"})
 
     result = doctor.check_webhook_ingress(settings)
 
@@ -342,7 +350,7 @@ def _fake_sandbox_client(monkeypatch, *, reattach_fails=False):
 
 
 def test_sandbox_e2e_not_configured_is_ok(tmp_path: Path) -> None:
-    settings = make_settings(tmp_path, sandbox_service_url="")
+    settings = make_settings(tmp_path, sandbox={"service_url": ""})
 
     result = doctor.check_sandbox_e2e(settings)
 
@@ -352,7 +360,7 @@ def test_sandbox_e2e_not_configured_is_ok(tmp_path: Path) -> None:
 
 def test_sandbox_e2e_exercises_dial_and_reattach(tmp_path: Path, monkeypatch) -> None:
     calls = _fake_sandbox_client(monkeypatch)
-    settings = make_settings(tmp_path, sandbox_service_url="http://127.0.0.1:8780")
+    settings = make_settings(tmp_path, sandbox={"service_url": "http://127.0.0.1:8780"})
 
     result = doctor.check_sandbox_e2e(settings)
 
@@ -365,7 +373,7 @@ def test_sandbox_e2e_failure_names_the_phase_and_releases(tmp_path: Path, monkey
     """A reattach failure is the bug class worth this check — the error
     surfaces in the detail, and the VM must still be released."""
     calls = _fake_sandbox_client(monkeypatch, reattach_fails=True)
-    settings = make_settings(tmp_path, sandbox_service_url="http://127.0.0.1:8780")
+    settings = make_settings(tmp_path, sandbox={"service_url": "http://127.0.0.1:8780"})
 
     result = doctor.check_sandbox_e2e(settings)
 
@@ -375,7 +383,7 @@ def test_sandbox_e2e_failure_names_the_phase_and_releases(tmp_path: Path, monkey
 
 
 def test_run_checks_includes_sandbox_e2e_only_when_flagged(tmp_path: Path) -> None:
-    settings = make_settings(tmp_path, sandbox_service_url="")
+    settings = make_settings(tmp_path, sandbox={"service_url": ""})
 
     default = {r.name for r in doctor.run_checks(settings)}
     flagged = {r.name for r in doctor.run_checks(settings, sandbox=True)}

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -28,7 +28,7 @@ def _client(tmp_path: Path, **settings_overrides) -> TestClient:
 
 
 def _header_client(tmp_path: Path) -> TestClient:
-    return _client(tmp_path, auth_mode="header", auth_header=HEADER)
+    return _client(tmp_path, identity={"mode": "header", "header": HEADER})
 
 
 def _grant(email: str = "me@example.com") -> dict:

--- a/backend/tests/test_identity_jwt.py
+++ b/backend/tests/test_identity_jwt.py
@@ -49,11 +49,13 @@ def _jwt_client(tmp_path: Path) -> TestClient:
     app = configure_app_for_test(
         settings=make_settings(
             tmp_path,
-            auth_mode="jwt",
-            auth_header=HEADER,
-            auth_jwks_url="https://edge.example.com/jwks.json",
-            auth_jwt_issuer=ISSUER,
-            auth_jwt_audience=AUDIENCE,
+            identity={
+                "mode": "jwt",
+                "header": HEADER,
+                "jwks_url": "https://edge.example.com/jwks.json",
+                "jwt_issuer": ISSUER,
+                "jwt_audience": AUDIENCE,
+            },
         ),
         authenticated=False,
     )

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -568,7 +568,7 @@ def test_connect_route_requires_druks_endpoint(tmp_path, registry_state, druks_d
             json={"identity_mode": IdentityMode.SHARED},
         )
         assert response.status_code == 409
-        assert "DRUKS_ENDPOINT" in response.text
+        assert "urls.endpoint" in response.text
 
 
 def test_connect_route_rejects_a_non_oauth_server(tmp_path, druks_db):
@@ -584,7 +584,7 @@ def test_connect_route_rejects_a_non_oauth_server(tmp_path, druks_db):
 
 def test_connect_route_returns_the_consent_url(tmp_path, registry_state, auth_server, druks_db):
     _register_oauth_server()
-    settings = make_settings(tmp_path, endpoint=_ENDPOINT)
+    settings = make_settings(tmp_path, urls={"endpoint": _ENDPOINT})
     with TestClient(configure_app_for_test(settings=settings)) as client:
         response = client.post(
             f"/api/mcp-servers/{_NAME}/connect",
@@ -596,7 +596,7 @@ def test_connect_route_returns_the_consent_url(tmp_path, registry_state, auth_se
 
 def test_callback_route_completes_the_connect(tmp_path, registry_state, auth_server, druks_db):
     _register_oauth_server(enabled=False)
-    settings = make_settings(tmp_path, endpoint=_ENDPOINT)
+    settings = make_settings(tmp_path, urls={"endpoint": _ENDPOINT})
 
     with TestClient(configure_app_for_test(settings=settings)) as client:
         url = client.post(
@@ -661,7 +661,7 @@ def test_shared_disconnect_allows_per_user_reconnect(
 ):
     _register_oauth_server()
     operator = Account.get_or_create("op@example.com")
-    settings = make_settings(tmp_path, endpoint=_ENDPOINT)
+    settings = make_settings(tmp_path, urls={"endpoint": _ENDPOINT})
 
     with TestClient(configure_app_for_test(settings=settings)) as client:
         shared_url = client.post(
@@ -726,7 +726,10 @@ def test_api_has_token_is_scoped_to_the_requesting_account(tmp_path, druks_db):
     connected = Account.get_or_create("connected@example.com")
     unconnected = Account.get_or_create("unconnected@example.com")
     _store_grant(account_id=connected.id, identity_mode=IdentityMode.PER_USER)
-    settings = make_settings(tmp_path, auth_mode="header", auth_header="X-Test-User")
+    settings = make_settings(
+        tmp_path,
+        identity={"mode": "header", "header": "X-Test-User"},
+    )
 
     with TestClient(configure_app_for_test(settings=settings, authenticated=False)) as client:
         connected_response = client.get(
@@ -759,7 +762,10 @@ async def test_per_user_disconnect_preserves_other_accounts_grant_and_cache(tmp_
     await redis.set(disconnected_key, "disconnect-token")
     await redis.set(connected_key, "connected-token")
     await close_client()
-    settings = make_settings(tmp_path, auth_mode="header", auth_header="X-Test-User")
+    settings = make_settings(
+        tmp_path,
+        identity={"mode": "header", "header": "X-Test-User"},
+    )
 
     with TestClient(configure_app_for_test(settings=settings, authenticated=False)) as client:
         response = client.delete(

--- a/backend/tests/test_mcp_registry.py
+++ b/backend/tests/test_mcp_registry.py
@@ -278,7 +278,9 @@ def _client_with_registry(tmp_path, monkeypatch, *entries):
         "_http",
         _client_returning(lambda _r: httpx.Response(200, json=payload)),
     )
-    app = configure_app_for_test(settings=make_settings(tmp_path, endpoint="http://druks.test"))
+    app = configure_app_for_test(
+        settings=make_settings(tmp_path, urls={"endpoint": "http://druks.test"})
+    )
     return TestClient(app)
 
 

--- a/backend/tests/test_sandbox_aws_direct.py
+++ b/backend/tests/test_sandbox_aws_direct.py
@@ -157,7 +157,10 @@ def _stub_acquire_settings(
         lambda: type(
             "_S",
             (),
-            {"sandbox_image": sandbox_image, "sandbox_keys_dir": tmp_path},
+            {
+                "sandbox": type("_Sandbox", (), {"image": sandbox_image})(),
+                "sandbox_keys_dir": tmp_path,
+            },
         )(),
     )
     return client_module.Client(), create_calls

--- a/backend/tests/test_secrets.py
+++ b/backend/tests/test_secrets.py
@@ -29,6 +29,12 @@ def _key() -> str:
     return base64.b64encode(os.urandom(32)).decode()
 
 
+def _set_key(monkeypatch, tmp_path, value: str) -> None:
+    config_path = tmp_path / "druks.toml"
+    config_path.write_text(f'[secrets]\nsecrets_key = "{value}"\n')
+    monkeypatch.setenv("DRUKS_CONFIG", str(config_path))
+
+
 def _store_grant(refresh_token: str = "rt-secret", client_secret: str = "") -> McpOauthGrant:
     return McpOauthGrant.store(
         server_name="notion",
@@ -64,21 +70,21 @@ def test_grant_secret_halves_round_trip(druks_db):
     assert grant.client_secret.decrypt() == "cs-secret"
 
 
-def test_loaded_secrets_are_lazy_and_redacted(monkeypatch, druks_db):
+def test_loaded_secrets_are_lazy_and_redacted(monkeypatch, tmp_path, druks_db):
     McpServer.create(name="linear", url="https://mcp.linear.app/sse", token=_TOKEN)
     druks_db.expire_all()
 
     # Loading and logging a row never touches key material — decryption
     # happens only on decrypt(), and repr leaks nothing either way.
     row = McpServer.get_for_name("linear")
-    monkeypatch.setenv("DRUKS_SECRETS_KEY", "")
+    _set_key(monkeypatch, tmp_path, "")
     assert repr(row.token) == "Secret(<redacted>)"
     assert str(row.token) == "Secret(<redacted>)"
-    with pytest.raises(ValidationError, match="at least one"):
+    with pytest.raises(ValidationError, match="Field required"):
         row.token.decrypt()
 
 
-def test_empty_value_needs_no_key(monkeypatch, druks_db):
+def test_empty_value_needs_no_key(monkeypatch, tmp_path, druks_db):
     # "" stores as empty bytes — presence checks and decrypt() of an absent
     # secret never touch key material (proven by breaking the key first).
     McpServer.create(name="linear", url="https://mcp.linear.app/sse", token="")
@@ -86,7 +92,7 @@ def test_empty_value_needs_no_key(monkeypatch, druks_db):
 
     assert bytes(druks_db.execute(text("SELECT token FROM mcp_servers")).scalar_one()) == b""
     row = McpServer.get_for_name("linear")
-    monkeypatch.setenv("DRUKS_SECRETS_KEY", "")
+    _set_key(monkeypatch, tmp_path, "")
     assert not row.token
     assert row.token.decrypt() == ""
 
@@ -99,39 +105,39 @@ def test_non_str_assignment_is_rejected(druks_db):
         druks_db.flush()
 
 
-def test_missing_key_refuses_boot(monkeypatch):
+def test_missing_key_refuses_boot(monkeypatch, tmp_path):
     # Blank and comma-noise-only both read as "no key" — the required setting
     # refuses at construction rather than falling back to plaintext.
     for broken in ("", ",", " , "):
-        monkeypatch.setenv("DRUKS_SECRETS_KEY", broken)
-        with pytest.raises(ValidationError, match="at least one"):
+        _set_key(monkeypatch, tmp_path, broken)
+        with pytest.raises(ValidationError, match="Field required|at least one"):
             load_settings()
 
 
-def test_key_validation_error_never_echoes_the_key(monkeypatch):
+def test_key_validation_error_never_echoes_the_key(monkeypatch, tmp_path):
     # A half-valid list fails validation, and the failure surfaces in boot
     # logs and doctor output — it must not echo the valid segment.
     good = _key()
-    monkeypatch.setenv("DRUKS_SECRETS_KEY", f"{good},not-base64!!")
+    _set_key(monkeypatch, tmp_path, f"{good},not-base64!!")
 
     with pytest.raises(ValidationError) as error_info:
         load_settings()
     assert good not in str(error_info.value)
 
 
-def test_malformed_key_refuses_boot(monkeypatch):
+def test_malformed_key_refuses_boot(monkeypatch, tmp_path):
     for broken in ("not-base64!!", base64.b64encode(b"short").decode()):
-        monkeypatch.setenv("DRUKS_SECRETS_KEY", broken)
+        _set_key(monkeypatch, tmp_path, broken)
         with pytest.raises(ValidationError, match="base64|32 bytes"):
             load_settings()
 
 
-def test_undecryptable_secret_raises_the_named_error(monkeypatch, druks_db):
+def test_undecryptable_secret_raises_the_named_error(monkeypatch, tmp_path, druks_db):
     # A key dropped from the list while rows written under it existed is the
     # usual cause — the error must say so, not surface a bare crypto traceback.
     McpServer.create(name="linear", url="https://mcp.linear.app/sse", token=_TOKEN)
     druks_db.expire_all()
-    monkeypatch.setenv("DRUKS_SECRETS_KEY", _key())
+    _set_key(monkeypatch, tmp_path, _key())
 
     with pytest.raises(SecretDecryptError, match="rotated out"):
         McpServer.get_for_name("linear").token.decrypt()
@@ -167,15 +173,15 @@ def test_ciphertext_is_bound_to_its_column(druks_db):
         grant.client_secret.decrypt()
 
 
-def test_prepended_key_still_decrypts(monkeypatch, druks_db):
+def test_prepended_key_still_decrypts(monkeypatch, tmp_path, druks_db):
     # Rotation is prepend-only: new writes use the first key; rows written
     # under an older key keep decrypting as long as it stays in the list.
     old_key = _key()
-    monkeypatch.setenv("DRUKS_SECRETS_KEY", old_key)
+    _set_key(monkeypatch, tmp_path, old_key)
     McpServer.create(name="linear", url="https://mcp.linear.app/sse", token=_TOKEN)
     _store_grant(refresh_token="rt-secret")
 
-    monkeypatch.setenv("DRUKS_SECRETS_KEY", f"{_key()},{old_key}")
+    _set_key(monkeypatch, tmp_path, f"{_key()},{old_key}")
     druks_db.expire_all()
     assert McpServer.get_for_name("linear").token.decrypt() == _TOKEN
     assert (

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,61 +1,148 @@
+import re
+
 import pytest
-from druks.settings import Settings, ensure_data_dirs, load_settings
+from druks.settings import Settings, ensure_data_dirs
 from druks.testing import make_settings
 from pydantic import ValidationError
 
-
-def test_auth_defaults_to_none_and_blesses_no_header(tmp_path, monkeypatch):
-    monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
-    monkeypatch.delenv("DRUKS_AUTH_MODE", raising=False)
-    monkeypatch.delenv("DRUKS_AUTH_HEADER", raising=False)
-    settings = load_settings()
-    assert settings.auth_mode == "none"
-    assert not settings.auth_header
+_SECRETS_KEY = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
 
 
-@pytest.mark.parametrize("auth_header", ["", "   "])
-def test_header_mode_requires_the_operator_to_name_the_header(tmp_path, monkeypatch, auth_header):
-    monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
+def test_auth_defaults_to_none_and_blesses_no_header(tmp_path):
+    settings = make_settings(tmp_path)
+    assert settings.identity.mode == "none"
+    assert not settings.identity.header
+
+
+@pytest.mark.parametrize("header", ["", "   "])
+def test_header_mode_requires_the_operator_to_name_the_header(tmp_path, header):
     with pytest.raises(ValidationError):
-        Settings(auth_mode="header", auth_header=auth_header)  # type: ignore[call-arg]
+        make_settings(tmp_path, identity={"mode": "header", "header": header})
 
 
 def test_jwt_mode_requires_its_verification_targets(tmp_path):
     complete = {
-        "auth_header": "X-Edge-Assertion",
-        "auth_jwks_url": "https://edge.example.com/jwks.json",
-        "auth_jwt_issuer": "https://edge.example.com",
-        "auth_jwt_audience": "druks",
+        "header": "X-Edge-Assertion",
+        "jwks_url": "https://edge.example.com/jwks.json",
+        "jwt_issuer": "https://edge.example.com",
+        "jwt_audience": "druks",
     }
-    settings = make_settings(tmp_path, auth_mode="jwt", **complete)
-    assert settings.auth_jwt_identity_claim == "email"
+    settings = make_settings(tmp_path, identity={"mode": "jwt", **complete})
+    assert settings.identity.jwt_identity_claim == "email"
     # Each required field, blanked in turn, refuses jwt mode.
     for name in complete:
         with pytest.raises(ValidationError):
-            make_settings(tmp_path, auth_mode="jwt", **{**complete, name: "  "})
+            make_settings(
+                tmp_path,
+                identity={"mode": "jwt", **complete, name: "  "},
+            )
 
 
-@pytest.mark.parametrize("auth_mode", ["header", "jwt"])
-def test_the_pat_slot_cannot_be_the_identity_header(tmp_path, auth_mode):
+@pytest.mark.parametrize("mode", ["header", "jwt"])
+def test_the_pat_slot_cannot_be_the_identity_header(tmp_path, mode):
     # Authorization always parses bearer-first, so an assertion configured
     # there could never be read — a total lockout, refused at startup.
     with pytest.raises(ValidationError):
         make_settings(
             tmp_path,
-            auth_mode=auth_mode,
-            auth_header="authorization",
-            auth_jwks_url="https://edge.example.com/jwks.json",
-            auth_jwt_issuer="https://edge.example.com",
-            auth_jwt_audience="druks",
+            identity={
+                "mode": mode,
+                "header": "authorization",
+                "jwks_url": "https://edge.example.com/jwks.json",
+                "jwt_issuer": "https://edge.example.com",
+                "jwt_audience": "druks",
+            },
         )
 
 
-def test_ensure_data_dirs_provisions_skills_dir(tmp_path, monkeypatch):
+def test_toml_populates_authored_submodels(tmp_path, monkeypatch):
+    config_path = tmp_path / "druks.toml"
+    config_path.write_text(
+        f"""
+[identity]
+mode = "header"
+header = "X-Edge-Email"
+
+[github]
+operator_app_id = "123"
+reviewer_app_id = "456"
+
+[urls]
+endpoint = "https://druks.example.com"
+webhook_host = "hooks.example.com"
+
+[secrets]
+webhook_secret = "webhook-secret"
+secrets_key = "{_SECRETS_KEY}"
+
+[sandbox]
+service_url = "https://sandbox.example.com"
+service_token = "sandbox-token"
+image = "sandbox:latest"
+timeout = 180
+""".strip()
+        + "\n"
+    )
+    monkeypatch.setenv("DRUKS_CONFIG", str(config_path))
+
+    settings = Settings()
+
+    assert settings.identity.mode == "header"
+    assert settings.identity.header == "X-Edge-Email"
+    assert settings.github.operator_app_id == "123"
+    assert settings.github.reviewer_app_id == "456"
+    assert settings.urls.endpoint == "https://druks.example.com"
+    assert settings.urls.webhook_host == "hooks.example.com"
+    assert settings.secrets.webhook_secret == "webhook-secret"
+    assert settings.secrets.secrets_key == _SECRETS_KEY
+    assert settings.sandbox.service_token == "sandbox-token"
+    assert settings.sandbox.service_url == "https://sandbox.example.com"
+    assert settings.sandbox.image == "sandbox:latest"
+    assert settings.sandbox.timeout == 180.0
+
+
+def test_auth_mode_environment_variable_is_ignored(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DRUKS_CONFIG", raising=False)
+    monkeypatch.setenv("DRUKS_AUTH_MODE", "header")
+
+    settings = Settings(secrets={"secrets_key": _SECRETS_KEY})
+
+    assert settings.identity.mode == "none"
+
+
+def test_blank_toml_value_uses_submodel_default(tmp_path, monkeypatch):
+    config_path = tmp_path / "druks.toml"
+    config_path.write_text(
+        f"""
+[identity]
+jwt_identity_claim = ""
+
+[secrets]
+secrets_key = "{_SECRETS_KEY}"
+""".strip()
+        + "\n"
+    )
+    monkeypatch.setenv("DRUKS_CONFIG", str(config_path))
+
+    settings = Settings()
+
+    assert settings.identity.jwt_identity_claim == "email"
+
+
+def test_missing_explicit_config_refuses_construction(tmp_path, monkeypatch):
+    config_path = tmp_path / "missing.toml"
+    monkeypatch.setenv("DRUKS_CONFIG", str(config_path))
+
+    with pytest.raises(ValueError, match=re.escape(str(config_path))):
+        Settings()
+
+
+def test_ensure_data_dirs_provisions_skills_dir(tmp_path):
     # The settings UI installs skill collections into skills_dir; if startup
     # doesn't create it, the first install's write raises OSError → opaque 500.
     # This is the DRUKS_SKILLS_DIR-outside-data_dir case that bit us.
-    monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
-    monkeypatch.setenv("DRUKS_SKILLS_DIR", str(tmp_path / "shared" / "skills"))
-    settings = load_settings()
+    skills_dir = tmp_path / "shared" / "skills"
+    settings = make_settings(tmp_path, sandbox_skills_dir=skills_dir)
     ensure_data_dirs(settings)
     assert settings.skills_dir.is_dir()

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -3,7 +3,26 @@ import tomllib
 from pathlib import Path
 
 import pytest
+from druks.settings import Settings
 from druks.setup_env import GAPS_EXIT_CODE, MIGRATION_EXIT_CODE, read_env, run_setup
+
+DROPPED_RENDER_KEYS = {
+    "DRUKS_AUTH_MODE": ("identity.mode", "jwt"),
+    "DRUKS_AUTH_JWKS_URL": ("identity.jwks_url", "https://edge.example/jwks"),
+    "DRUKS_AUTH_JWT_ISSUER": ("identity.jwt_issuer", "https://edge.example"),
+    "DRUKS_AUTH_JWT_AUDIENCE": ("identity.jwt_audience", "druks"),
+    "DRUKS_AUTH_JWT_IDENTITY_CLAIM": ("identity.jwt_identity_claim", "sub"),
+    "DRUKS_ENDPOINT": ("urls.endpoint", "https://druks.example"),
+    "DRUKS_WEBHOOK_SECRET": ("secrets.webhook_secret", "webhook-secret"),
+    "DRUKS_SECRETS_KEY": ("secrets.secrets_key", "secrets-key"),
+    "GITHUB_OPERATOR_APP_ID": ("github.operator_app_id", "101"),
+    "GITHUB_REVIEWER_APP_ID": ("github.reviewer_app_id", "202"),
+    "GITHUB_OPERATOR_PRIVATE_KEY_PATH": ("github.operator_pem", "operator.pem"),
+    "GITHUB_REVIEWER_PRIVATE_KEY_PATH": ("github.reviewer_pem", "reviewer.pem"),
+    "DRUKS_SANDBOX_SERVICE_URL": ("sandbox.service_url", "http://sandbox:8000"),
+    "DRUKS_SANDBOX_SERVICE_TOKEN": ("sandbox.service_token", "token"),
+    "DRUKS_SANDBOX_IMAGE": ("sandbox.image", "sandbox:latest"),
+}
 
 
 def _run(env_path: Path, **overrides):
@@ -34,16 +53,15 @@ def test_fresh_exe_render_matches_the_deployment_contract(tmp_path):
     assert values["TAILSCALE_ENABLED"] == "true"
     assert values["EXE_API_URL"] == "https://exe.dev"
     assert values["EXE_DEFAULT_IMAGE"] == "ghcr.io/boldsoftware/exeuntu:latest"
-    assert values["DRUKS_AUTH_MODE"] == "header"
     assert values["DRUKS_AUTH_HEADER"] == "X-ExeDev-Email"
-    assert values["SERVICE_TOKENS"] == values["DRUKS_SANDBOX_SERVICE_TOKEN"]
+    assert values["SERVICE_TOKENS"] == config["sandbox"]["service_token"]
     assert values["GITHUB_OPERATOR_PEM"] == "/home/op/druks/secrets/operator.pem"
     assert values["DRUKS_DATA_DIR"] == "/home/op/druks-data"
     assert "EXE_API_TOKEN" not in values
     assert "TAILSCALE_TAILNET" not in values
     assert len(config["secrets"]["postgres_password"]) == 64
     assert len(config["secrets"]["webhook_secret"]) == 64
-    assert len(config["secrets"]["sandbox_service_token"]) == 64
+    assert len(config["sandbox"]["service_token"]) == 64
     assert (tmp_path / "secrets").is_dir()
     assert (tmp_path / ".gitignore").read_text().splitlines() == [
         "druks.toml",
@@ -52,6 +70,21 @@ def test_fresh_exe_render_matches_the_deployment_contract(tmp_path):
     ]
     assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
     assert stat.S_IMODE((tmp_path / "druks.toml").stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize(
+    ("rendered_key", "assignment"),
+    [
+        (rendered_key, f"{toml_path}={value}")
+        for rendered_key, (toml_path, value) in DROPPED_RENDER_KEYS.items()
+    ],
+)
+def test_toml_application_setting_is_not_rendered(tmp_path, rendered_key, assignment):
+    env_path = tmp_path / ".env"
+
+    _run(env_path, provider="docker", set_values=(assignment,))
+
+    assert rendered_key not in read_env(env_path)
 
 
 def test_generic_remote_passes_provider_environment_without_enumeration(tmp_path):
@@ -67,7 +100,7 @@ def test_generic_remote_passes_provider_environment_without_enumeration(tmp_path
         provider="exoscale",
         interactive=True,
         input_fn=answer,
-        set_values=("sandbox.env.EXOSCALE_API_KEY=key",),
+        set_values=("sandbox.exoscale.EXOSCALE_API_KEY=key",),
     )
 
     values = read_env(env_path)
@@ -79,28 +112,112 @@ def test_generic_remote_passes_provider_environment_without_enumeration(tmp_path
     assert "TAILSCALE_ENABLED" not in values
 
 
-def test_docker_shape_matches_local_wiring_and_ignores_sandbox_env(tmp_path):
+def test_docker_shape_matches_local_wiring_and_ignores_provider_environment(tmp_path):
     env_path = tmp_path / ".env"
 
     assert (
         _run(
             env_path,
             provider="docker",
-            set_values=("sandbox.env.DOCKER_HOST=tcp://elsewhere",),
+            set_values=("sandbox.docker.DOCKER_HOST=tcp://elsewhere",),
         )
         == GAPS_EXIT_CODE
     )
 
     values = read_env(env_path)
     assert values["DEFAULT_HOST_PROVIDER"] == "docker"
-    assert values["DRUKS_SANDBOX_SERVICE_URL"] == "http://127.0.0.1:8000"
-    assert values["DRUKS_SANDBOX_SERVICE_TOKEN"] == "dev-token"
-    assert values["DRUKS_SANDBOX_IMAGE"] == "ghcr.io/czpython/druks-sandbox:latest"
-    assert values["DRUKS_ENDPOINT"] == "http://localhost:8001"
-    assert values["DRUKS_AUTH_MODE"] == "none"
     assert "DRUKS_AUTH_HEADER" not in values
     assert "SERVICE_TOKENS" not in values
     assert "DOCKER_HOST" not in values
+
+
+def test_exe_provider_environment_renders_verbatim(tmp_path):
+    env_path = tmp_path / ".env"
+
+    _run(
+        env_path,
+        set_values=(
+            "sandbox.exe.EXE_API_TOKEN=exe-token",
+            "sandbox.exe.TAILSCALE_TAILNET=tail.ts.net",
+            "sandbox.exe.CUSTOM_DRUKBOX_VALUE=verbatim",
+        ),
+    )
+
+    values = read_env(env_path)
+    assert values["EXE_API_TOKEN"] == "exe-token"
+    assert values["TAILSCALE_TAILNET"] == "tail.ts.net"
+    assert values["CUSTOM_DRUKBOX_VALUE"] == "verbatim"
+
+
+def test_legacy_sandbox_table_is_renamed_to_the_provider_table(tmp_path):
+    env_path = tmp_path / ".env"
+    _run(env_path)
+    toml_path = tmp_path / "druks.toml"
+    toml_path.write_text(
+        toml_path.read_text().replace(
+            "[sandbox.exe]",
+            "# credentials for this provider\n[sandbox.env]",
+        )
+    )
+    printed = []
+
+    _run(env_path, print_fn=printed.append)
+
+    written = toml_path.read_text()
+    assert "Renamed [sandbox.env] to [sandbox.exe]." in printed
+    assert "[sandbox.exe]" in written
+    assert "[sandbox.env]" not in written
+    assert "# credentials for this provider" in written
+    assert read_env(env_path)["EXE_API_URL"] == "https://exe.dev"
+
+
+def test_foreign_provider_table_is_a_named_gap(tmp_path):
+    env_path = tmp_path / ".env"
+    printed = []
+
+    rc = _run(
+        env_path,
+        set_values=("sandbox.other.OTHER_TOKEN=token",),
+        print_fn=printed.append,
+    )
+
+    assert rc == GAPS_EXIT_CODE
+    assert "sandbox.other is a stale provider table" in "\n".join(printed)
+    assert "OTHER_TOKEN" not in read_env(env_path)
+
+
+def test_docker_shape_renders_no_provider_environment(tmp_path):
+    env_path = tmp_path / ".env"
+
+    _run(
+        env_path,
+        provider="docker",
+        set_values=("sandbox.docker.LOCAL_DRUKBOX_VALUE=local",),
+    )
+
+    assert "LOCAL_DRUKBOX_VALUE" not in read_env(env_path)
+
+
+def test_integer_sandbox_timeout_round_trips(tmp_path):
+    env_path = tmp_path / ".env"
+
+    _run(env_path, provider="docker")
+    _run(env_path)
+
+    timeout = _read_toml(tmp_path / "druks.toml")["sandbox"]["timeout"]
+    assert timeout == 180
+    assert isinstance(timeout, int)
+
+
+def test_non_string_known_setting_is_refused(tmp_path):
+    env_path = tmp_path / ".env"
+    _run(env_path, provider="docker")
+    toml_path = tmp_path / "druks.toml"
+    body = toml_path.read_text().replace('operator_app_id = ""', "operator_app_id = 123")
+    toml_path.write_text(body)
+
+    with pytest.raises(ValueError, match="github.operator_app_id must be a string"):
+        _run(env_path)
 
 
 def test_pre_toml_guard_refuses_without_writing(tmp_path):
@@ -121,7 +238,7 @@ def test_pre_toml_guard_refuses_without_writing(tmp_path):
         "DRUKS_WEBHOOK_SECRET",
         "DRUKS_SANDBOX_SERVICE_TOKEN",
         "GITHUB_*_APP_ID",
-        "[sandbox.env]",
+        "[sandbox.<provider>]",
         "other hand-added .env keys → [env]",
     ):
         assert key in output
@@ -142,7 +259,10 @@ def test_set_updates_toml_and_rerender_preserves_the_values(tmp_path):
     _run(
         env_path,
         provider="exoscale",
-        set_values=("secrets.webhook_secret=rotated-secret",),
+        set_values=(
+            "secrets.webhook_secret=rotated-secret",
+            "urls.webhook_host=hooks.example.com",
+        ),
         print_fn=printed.append,
     )
 
@@ -151,8 +271,9 @@ def test_set_updates_toml_and_rerender_preserves_the_values(tmp_path):
     assert config["github"]["operator_app_id"] == "101"
     assert config["secrets"]["webhook_secret"] == "rotated-secret"
     assert config["sandbox"]["provider"] == "docker"
-    assert values["GITHUB_OPERATOR_APP_ID"] == "101"
-    assert values["DRUKS_WEBHOOK_SECRET"] == "rotated-secret"
+    assert "GITHUB_OPERATOR_APP_ID" not in values
+    assert "DRUKS_WEBHOOK_SECRET" not in values
+    assert values["DRUKS_WEBHOOK_HOST"] == "hooks.example.com"
     assert "docker compose up -d" in "\n".join(printed)
 
 
@@ -208,7 +329,7 @@ def test_owned_deployment_env_key_is_a_named_gap_and_is_not_rendered(tmp_path):
 
     assert rc == GAPS_EXIT_CODE
     assert "env.DRUKS_ENDPOINT is reserved by druks" in "\n".join(printed)
-    assert read_env(env_path)["DRUKS_ENDPOINT"] == "http://localhost:8001"
+    assert "DRUKS_ENDPOINT" not in read_env(env_path)
 
 
 def test_reserved_sandbox_env_key_is_a_named_gap_and_is_not_rendered(tmp_path):
@@ -219,14 +340,14 @@ def test_reserved_sandbox_env_key_is_a_named_gap_and_is_not_rendered(tmp_path):
         env_path,
         provider="exoscale",
         set_values=(
-            "sandbox.env.EXOSCALE_API_KEY=key",
-            "sandbox.env.DATABASE_URL=wrong",
+            "sandbox.exoscale.EXOSCALE_API_KEY=key",
+            "sandbox.exoscale.DATABASE_URL=wrong",
         ),
         print_fn=printed.append,
     )
 
     assert rc == GAPS_EXIT_CODE
-    assert "sandbox.env.DATABASE_URL is reserved by druks" in "\n".join(printed)
+    assert "sandbox.exoscale.DATABASE_URL is reserved by druks" in "\n".join(printed)
     assert read_env(env_path)["DATABASE_URL"] == "sqlite+aiosqlite:////data/drukbox.db"
 
 
@@ -283,7 +404,6 @@ def test_missing_known_tables_gap_without_rewriting_the_operators_file(tmp_path)
     _run(env_path, provider="docker")
     toml_path = tmp_path / "druks.toml"
     body = toml_path.read_text()
-    body = body.replace("[sandbox.env]\n", "")
     body = body.replace('provider = "docker"\n', "")
     toml_path.write_text(body)
     printed = []
@@ -296,11 +416,10 @@ def test_missing_known_tables_gap_without_rewriting_the_operators_file(tmp_path)
 
     config = _read_toml(toml_path)
     assert rc == GAPS_EXIT_CODE
-    assert "DEFAULT_HOST_PROVIDER is empty" in "\n".join(printed)
-    assert "GITHUB_REVIEWER_APP_ID is empty" in "\n".join(printed)
-    assert "env" not in config["sandbox"]
+    assert "sandbox.provider is empty" in "\n".join(printed)
+    assert "github.reviewer_app_id is empty" in "\n".join(printed)
     assert config["github"]["operator_app_id"] == "101"
-    assert read_env(env_path)["GITHUB_OPERATOR_APP_ID"] == "101"
+    assert "GITHUB_OPERATOR_APP_ID" not in read_env(env_path)
 
 
 def test_nested_operator_content_is_refused(tmp_path):
@@ -352,3 +471,40 @@ def test_fresh_interactive_run_prompts_for_provider_first(tmp_path):
 
     assert prompts[0] == "Sandbox provider [exe]: "
     assert _read_toml(tmp_path / "druks.toml")["sandbox"]["provider"] == "docker"
+
+
+def test_setup_toml_is_the_settings_source(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    secrets_dir = tmp_path / "secrets"
+    secrets_dir.mkdir()
+    (secrets_dir / "operator.pem").write_text("operator-pem")
+    (secrets_dir / "reviewer.pem").write_text("reviewer-pem")
+
+    rc = _run(
+        env_path,
+        set_values=(
+            "github.operator_app_id=101",
+            "github.reviewer_app_id=202",
+            "urls.endpoint=https://druks.example",
+            "urls.webhook_host=hooks.druks.example",
+            "sandbox.image=druks-sandbox:test",
+            "sandbox.timeout=240",
+            "sandbox.exe.EXE_API_TOKEN=exe-token",
+            "sandbox.exe.TAILSCALE_TAILNET=tail.ts.net",
+        ),
+    )
+
+    assert rc == 0
+    toml_path = tmp_path / "druks.toml"
+    config = _read_toml(toml_path)
+    monkeypatch.setenv("DRUKS_CONFIG", str(toml_path))
+    settings = Settings()
+
+    assert settings.identity.model_dump() == config["identity"]
+    assert settings.urls.model_dump() == config["urls"]
+    assert settings.secrets.webhook_secret == config["secrets"]["webhook_secret"]
+    assert settings.secrets.secrets_key == config["secrets"]["secrets_key"]
+    assert settings.sandbox.service_token == config["sandbox"]["service_token"]
+    assert settings.sandbox.service_url == config["sandbox"]["service_url"]
+    assert settings.sandbox.image == config["sandbox"]["image"]
+    assert settings.sandbox.timeout == float(config["sandbox"]["timeout"])

--- a/backend/tests/test_webhooks_framework.py
+++ b/backend/tests/test_webhooks_framework.py
@@ -31,7 +31,10 @@ def _isolated_registry():
 def settings(tmp_path) -> Settings:
     return Settings(
         data_dir=tmp_path,
-        webhook_secret="test-secret",
+        secrets={
+            "webhook_secret": "test-secret",
+            "secrets_key": "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=",
+        },
     )
 
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -45,7 +45,7 @@ First pass writes `~/druks/druks.toml` with random secrets pre-filled, creates
 `~/druks/secrets/`, renders `~/druks/.env`, and exits when required values are
 missing. It tells you exactly what to do next:
 
-- Edit `druks.toml`. For a generic remote shape, fill `[sandbox.env]` from
+- Edit `druks.toml`. For a generic remote shape, fill `[sandbox.<provider>]` from
   Drukbox's [configuration reference](https://github.com/czpython/drukbox).
 - Provision the two GitHub Apps: re-run the installer with `--apps`.
   It registers each app via GitHub's manifest flow — it prints a link
@@ -194,8 +194,9 @@ DRUKS_TAG=sha-0123456789abcdef0123456789abcdef01234567 docker compose up -d
 
 This rolls back the image, not the database schema. `druks init-db` only
 upgrades; it does not downgrade migrations. Before pinning an older image,
-confirm that its code can read the current schema and that in-flight workflows
-are compatible with that code.
+confirm that its code can read the current schema, the current `druks.toml`
+and rendered `.env`, and that in-flight workflows are compatible with that
+code.
 
 ## Logs / stop
 

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -13,6 +13,7 @@ x-druks: &druks
   env_file:
     - ./.env
   environment:
+    DRUKS_CONFIG: /app/druks.toml
     DRUKS_REDIS_URL: ${DRUKS_REDIS_URL:-redis://127.0.0.1:6379/0}
     DRUKS_DATABASE_URL: ${DRUKS_DATABASE_URL:-postgresql+psycopg://${DRUKS_POSTGRES_USER:-druks}:${DRUKS_POSTGRES_PASSWORD}@127.0.0.1:5432/${DRUKS_POSTGRES_DB:-druks}}
     DRUKS_DATA_DIR: /app/data
@@ -25,12 +26,10 @@ x-druks: &druks
     # VM at both ~/.claude/skills and ~/.codex/skills.
     DRUKS_SKILLS_DIR: /app/data/skills
     DRUKS_SANDBOX_KEYS_DIR: /app/sandbox-keys
-    # Encrypts stored secrets (MCP tokens, OAuth grants) at rest; the app
-    # refuses to boot without it. `druks setup` generates one into .env.
-    DRUKS_SECRETS_KEY: ${DRUKS_SECRETS_KEY:?set DRUKS_SECRETS_KEY in .env — druks setup generates one}
     GITHUB_OPERATOR_PRIVATE_KEY_PATH: /secrets/github_operator.pem
     GITHUB_REVIEWER_PRIVATE_KEY_PATH: /secrets/github_reviewer.pem
   volumes:
+    - ./druks.toml:/app/druks.toml:ro
     - ${DRUKS_DATA_HOST_DIR:-${DRUKS_DATA_DIR:-${HOME}/druks-data}}:/app/data
     # claude/codex config dirs (settings.json/plugins, config.toml/AGENTS.md),
     # carried into each sandbox at push time. Auth never reads them — tokens
@@ -118,7 +117,7 @@ services:
 
   caddy:
     # Stock Caddy — the identity edge + webhook TLS. A local install skips it
-    # (dashboard reached directly on 127.0.0.1:8001, DRUKS_AUTH_MODE=none), so
+    # (dashboard reached directly on 127.0.0.1:8001, identity.mode=none), so
     # it lives in the ``remote`` profile. Caddyfile is fetched next to this
     # compose file by install.sh.
     image: caddy:2.10-alpine
@@ -127,9 +126,9 @@ services:
     restart: unless-stopped
     environment:
       DRUKS_UPSTREAM: ${DRUKS_UPSTREAM:-127.0.0.1:8001}
-      # Both Caddy and druks read DRUKS_AUTH_HEADER (web gets it from env_file):
-      # Caddy requires the edge's assertion, druks maps it to an account. No
-      # default anywhere — the backend refuses header mode without it.
+      # Setup renders identity.header for Caddy; druks reads it from druks.toml.
+      # Caddy requires the edge's assertion, and druks maps it to an account.
+      # No default anywhere — the backend refuses header mode without it.
       DRUKS_AUTH_HEADER: ${DRUKS_AUTH_HEADER:-}
       # ``:-`` so an empty .env value still collapses to the inert loopback
       # default — Caddy treats set-but-empty as a real (broken) site address.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ without replacing the process.
 
 | Plane | Examples | Stored in |
 | --- | --- | --- |
-| Deployment | database, Redis, ingress, GitHub App keys, Drukbox, encryption key | `~/druks/druks.toml` |
+| Deployment | identity, ingress, GitHub App keys, Drukbox, encryption key | `~/druks/druks.toml` |
 | Dashboard | timezone, harness and tracker credentials, workflow and agent overrides, notifications, MCP servers, skills | Postgres |
 
 The installer renders the complete deployment `.env` from `druks.toml`; `.env`
@@ -20,9 +20,10 @@ Format follows habitat: repository-committed files such as ship's
 world; box-resident operator files are TOML because they render to env
 byte-exact. The two files share no keys and no reader.
 
-The [`Settings` model](../backend/druks/settings.py) remains the authority for
-process environment variables. [`.env.example`](../.env.example) is only the
-host-run development template.
+`druks.toml` is the authority for authored process configuration. Environment
+variables are reserved for Compose-injected infrastructure such as database,
+Redis, data, and container paths. [`.env.example`](../.env.example) is the
+host-run development template for that environment plane.
 
 ## Deployment file
 
@@ -36,19 +37,19 @@ host-run development template.
 | `[secrets]` | Generated deployment secrets |
 | `[paths]` | Host data and harness configuration paths |
 | `[sandbox]` | Drukbox provider, service URL, token behavior, and image override |
-| `[sandbox.env]` | Provider environment passed through to the remote stack |
+| `[sandbox.<provider>]` | Provider environment passed through to the remote stack |
 | `[env]` | Additional deployment environment settings rendered verbatim |
 
 A blank string is unset and is omitted from `.env`. Use `[env]` for settings
 without another `druks.toml` home, including additional `DRUKS_*` settings. A
 key already owned by the renderer is reported as a configuration gap instead
 of overriding its canonical value. On a remote shape,
-`[sandbox.env]` accepts the variables documented by
+`[sandbox.<provider>]` accepts the variables documented by
 [Drukbox](https://github.com/czpython/drukbox); Druks does not enumerate
 providers. `docker` and `exe` select shape-specific first-write templates.
 Every other provider name selects the generic remote shape and is validated by
 Drukbox.
-The local `docker` shape does not render `[sandbox.env]` because host-run
+The local `docker` shape does not render `[sandbox.<provider>]` because host-run
 Drukbox reads its own checkout's environment.
 
 Secrets are generated only when the TOML is first created. Preserve
@@ -66,7 +67,6 @@ this is the same single-writer path used by `install.sh --apps`.
 | `DRUKS_REDIS_URL` | `redis://127.0.0.1:6379/0` | Short-lived coordination and caches |
 | `DRUKS_DATA_DIR` | `/var/lib/druks` | Logs, artifacts, installed skills |
 | `DRUKS_LOG_LEVEL` | `INFO` | Python and DBOS log level |
-| `DRUKS_SECRETS_KEY` | none; required | MCP/OAuth secret encryption keys |
 
 Postgres is durable state. Redis is not the workflow state store: it supports
 short-lived concerns including webhook delivery claims, OAuth state and token
@@ -74,19 +74,19 @@ caches, and the sandbox provisioning gate.
 
 ## Public URLs and access control
 
-| Variable | Purpose |
+| TOML key | Purpose |
 | --- | --- |
-| `DRUKS_ENDPOINT` | Browser-visible dashboard base URL used to build MCP OAuth callbacks |
-| `DRUKS_WEBHOOK_HOST` | Public webhook hostname used by `druks doctor` for its ingress probe |
-| `DRUKS_WEBHOOK_SECRET` | Shared HMAC secret used by the GitHub webhook integration |
-| `DRUKS_AUTH_MODE` | `none` (default; no authentication, single operator), `header` (edge-asserted identity), or `jwt` (edge-signed assertion, verified) |
-| `DRUKS_AUTH_HEADER` | The trusted identity header; read by both the shipped Caddy edge and Druks. No default — header and jwt modes refuse to start without it |
-| `DRUKS_AUTH_JWKS_URL` | `jwt` mode: where the edge publishes its signing keys |
-| `DRUKS_AUTH_JWT_ISSUER` | `jwt` mode: required `iss` claim value |
-| `DRUKS_AUTH_JWT_AUDIENCE` | `jwt` mode: required `aud` claim value |
-| `DRUKS_AUTH_JWT_IDENTITY_CLAIM` | `jwt` mode: the claim mapped to the account (default `email`) |
+| `urls.endpoint` | Browser-visible dashboard base URL used to build MCP OAuth callbacks |
+| `urls.webhook_host` | Public webhook hostname used by `druks doctor` for its ingress probe |
+| `secrets.webhook_secret` | Shared HMAC secret used by the GitHub webhook integration |
+| `identity.mode` | `none` (default; no authentication, single operator), `header` (edge-asserted identity), or `jwt` (edge-signed assertion, verified) |
+| `identity.header` | The trusted identity header; rendered for the shipped Caddy edge too. No default — header and jwt modes refuse to start without it |
+| `identity.jwks_url` | `jwt` mode: where the edge publishes its signing keys |
+| `identity.jwt_issuer` | `jwt` mode: required `iss` claim value |
+| `identity.jwt_audience` | `jwt` mode: required `aud` claim value |
+| `identity.jwt_identity_claim` | `jwt` mode: the claim mapped to the account (default `email`) |
 
-`DRUKS_ENDPOINT` and `DRUKS_WEBHOOK_HOST` are different. The first is where an
+`urls.endpoint` and `urls.webhook_host` are different. The first is where an
 operator's browser reaches Druks; the second is the public ingress webhook
 senders reach. They may share a hostname on exe.dev.
 
@@ -98,15 +98,15 @@ order:
    through to the modes below.
 2. **`header` mode.** The edge (exe.dev, Teleport, Cloudflare Access, …)
    authenticates and asserts the operator's email as exactly one nonblank
-   `DRUKS_AUTH_HEADER` value; Druks trims outer whitespace and maps it to an
+   `identity.header` value; Druks trims outer whitespace and maps it to an
    account, creating one on first sight (open enrollment — the edge decides
    who reaches Druks at all; the account column is case-insensitive).
 3. **`jwt` mode.** The same assertion channel as `header` mode, but the value
    is a signed JWT: Druks verifies the RS256 signature against
-   `DRUKS_AUTH_JWKS_URL` (keys cached for five minutes and refetched on
+   `identity.jwks_url` (keys cached for five minutes and refetched on
    rotation), requires `exp`, `iss`, and `aud` to match the configured
    issuer and audience, and maps the verified
-   `DRUKS_AUTH_JWT_IDENTITY_CLAIM` through the same open enrollment. A
+   `identity.jwt_identity_claim` through the same open enrollment. A
    failed verification is a 401 naming only the failure class — never the
    token. Confirm the real edge's header name, claims, and rotation story
    before enabling the mode; the RS256 profile is pinned, not negotiated.
@@ -118,9 +118,9 @@ order:
    requests (and startup) loudly rather than guess.
 
 Trust requirements for `header` mode: the edge must authenticate every
-dashboard request, must strip any client-supplied copy of
-`DRUKS_AUTH_HEADER` before inserting its authenticated value — a client that
-can inject the header can be anyone — and must terminate TLS and set HSTS.
+dashboard request, must strip any client-supplied copy of the configured
+identity header before inserting its authenticated value — a client that can
+inject the header can be anyone — and must terminate TLS and set HSTS.
 `jwt` mode keeps the same strip requirement but adds cryptographic
 provenance: a forged header value fails signature verification instead of
 becoming an identity, so a misconfigured proxy degrades to a 401 rather
@@ -130,9 +130,9 @@ web listener itself binds loopback by default. In `none` mode there is no
 authentication at all, so the listener must stay loopback-only — never
 publish it.
 
-Any public listener that bypasses the identity edge must never forward
-`DRUKS_AUTH_HEADER` upstream. The shipped webhook listener already serves
-only provider-authenticated `/_external/*` and the PAT-authenticated `/mcp` —
+Any public listener that bypasses the identity edge must never forward the
+configured identity header upstream. The shipped webhook listener already
+serves only provider-authenticated `/_external/*` and the PAT-authenticated `/mcp` —
 nothing that resolves the header — and any future public listener (for example
 the planned MCP integrations listener) must keep that same isolation.
 
@@ -184,10 +184,13 @@ PEMs, and webhook secret into the install through `druks setup`.
 
 ### Operator app
 
-```dotenv
-GITHUB_OPERATOR_APP_ID=123456
-GITHUB_OPERATOR_PRIVATE_KEY_PATH=/secrets/github_operator.pem
-DRUKS_WEBHOOK_SECRET=<same secret configured on the app webhook>
+```toml
+[github]
+operator_app_id = "123456"
+operator_pem = "secrets/operator.pem"
+
+[secrets]
+webhook_secret = "<same secret configured on the app webhook>"
 ```
 
 Webhook URL:
@@ -206,9 +209,10 @@ Subscribe to issue comment, pull request, pull request review, and push events.
 
 ### Reviewer app
 
-```dotenv
-GITHUB_REVIEWER_APP_ID=123457
-GITHUB_REVIEWER_PRIVATE_KEY_PATH=/secrets/github_reviewer.pem
+```toml
+[github]
+reviewer_app_id = "123457"
+reviewer_pem = "secrets/reviewer.pem"
 ```
 
 It needs read access to metadata and contents and read/write access to pull
@@ -216,6 +220,8 @@ requests. It does not need a webhook.
 
 `GITHUB_API_URL` defaults to `https://api.github.com` and can point both clients
 at another compatible GitHub API endpoint.
+Compose pins `GITHUB_OPERATOR_PRIVATE_KEY_PATH` and
+`GITHUB_REVIEWER_PRIVATE_KEY_PATH` to the mounted in-container PEM paths.
 
 ## Ticketing integrations
 
@@ -250,18 +256,20 @@ connected.
 
 ## Sandboxes
 
-| Variable | Purpose |
+| TOML key | Purpose |
 | --- | --- |
-| `DRUKS_SANDBOX_SERVICE_URL` | Drukbox API base URL; empty disables sandbox-backed execution |
-| `DRUKS_SANDBOX_SERVICE_TOKEN` | Drukbox API token |
-| `DRUKS_SANDBOX_SERVICE_TIMEOUT` | Control-plane request timeout; default 180 seconds |
-| `DRUKS_SANDBOX_IMAGE` | Optional provider image override |
-| `DRUKS_SANDBOX_KEYS_DIR` | Per-host SSH private-key directory |
+| `sandbox.service_url` | Drukbox API base URL; empty disables sandbox-backed execution |
+| `sandbox.service_token` | Drukbox API token |
+| `sandbox.timeout` | Control-plane request timeout; default 180 seconds |
+| `sandbox.image` | Optional provider image override |
+
+`DRUKS_SANDBOX_KEYS_DIR` remains a process environment override for the
+per-host SSH private-key directory.
 
 `[sandbox].provider` accepts any Drukbox provider name. `docker` selects the
 local install shape, `exe` selects the exe.dev + tailnet shape, and every other
 name selects the generic remote shape. Provider-specific credentials and host
-options live in `[sandbox.env]` and are interpreted by Drukbox. See
+options live in `[sandbox.<provider>]` and are interpreted by Drukbox. See
 [deployment](../deploy/README.md) or [full local setup](full-local.md) for the
 topology.
 
@@ -303,7 +311,7 @@ is one of:
 
 - static token stored encrypted in Postgres
 - token read from a named process environment variable
-- OAuth connection, which requires `DRUKS_ENDPOINT`
+- OAuth connection, which requires `urls.endpoint`
 
 Enabled servers are delivered to both harnesses unless an extension workspace
 owns a required server with the same name. Tokens enter the agent environment
@@ -320,7 +328,7 @@ per-agent capability manifest records the delivered set.
 
 ## Credential custody and secrets at rest
 
-`DRUKS_SECRETS_KEY` encrypts MCP tokens and OAuth grants with AES-256-GCM.
+`secrets.secrets_key` encrypts MCP tokens and OAuth grants with AES-256-GCM.
 Each database column supplies authenticated associated data, and each value
 gets a derived encryption key. The setting is one or more comma-separated,
 base64-encoded 32-byte master keys:

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,17 +10,25 @@ From the repository root:
 ```bash
 docker compose -f deploy/compose.dev.yaml up -d
 uv sync --locked --dev
+cp druks.toml.example druks.toml
 cp .env.example .env
-python3 -c 'import base64, os; print("DRUKS_SECRETS_KEY=" + base64.b64encode(os.urandom(32)).decode())' >> .env
+python3 -c 'import base64, os; print(base64.b64encode(os.urandom(32)).decode())'
+```
+
+Paste the generated value into `secrets.secrets_key` in `druks.toml`, then
+initialize the development database:
+
+```bash
 uv run druks init-db
 ```
 
-Local development runs `DRUKS_AUTH_MODE=none` (the `.env.example` default):
-the loopback dashboard has no authentication and exactly one operator
-account, created by your first harness connection. To exercise `header` mode
-against the dev server, set `DRUKS_AUTH_MODE=header`, name a header in
-`DRUKS_AUTH_HEADER` (no default), and send it yourself (for example with a
-browser header extension or `curl -H 'X-Edge-Email: you@example.com'`).
+Settings reads `./druks.toml` from the current working directory. The example
+runs with `[identity].mode = "none"`: the loopback dashboard has no
+authentication and exactly one operator account, created by your first harness
+connection. To exercise `header` mode against the dev server, set
+`identity.mode = "header"` and `identity.header` in `druks.toml`, then send the
+header yourself (for example with a browser header extension or
+`curl -H 'X-Edge-Email: you@example.com'`).
 
 The dev Compose project creates two databases:
 
@@ -145,10 +153,11 @@ currently ship a Markdown linter or link-check command.
 Backend tests mock most provider boundaries. For a real local sandbox, run
 Drukbox on the host as described in [Full local setup](full-local.md) and set:
 
-```dotenv
-DRUKS_SANDBOX_SERVICE_URL=http://127.0.0.1:8000
-DRUKS_SANDBOX_SERVICE_TOKEN=dev-token
-DRUKS_SANDBOX_IMAGE=ghcr.io/czpython/druks-sandbox:latest
+```toml
+[sandbox]
+service_url = "http://127.0.0.1:8000"
+service_token = "dev-token"
+image = "ghcr.io/czpython/druks-sandbox:latest"
 ```
 
 `uv run druks doctor --sandbox` creates a real host. Run it deliberately; it is

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -34,7 +34,7 @@ The first run:
 
 - writes `~/druks/druks.toml` with `[sandbox].provider = "docker"`
 - renders `~/druks/.env` with `DEFAULT_HOST_PROVIDER=docker`
-- generates the database, webhook, notification, and stored-secret keys
+- generates the database, webhook, sandbox-service, and stored-secret keys
 - points Druks at Drukbox on `127.0.0.1:8000`
 - prints blank required fields and exits without booting if setup is incomplete
 
@@ -87,12 +87,12 @@ Success means the Compose services are up and the health endpoint returns
 Open **Settings → Harnesses** in the dashboard and connect Claude and Codex.
 Druks stores those subscription credentials in Postgres and writes a fresh
 credential file into each sandbox. It does not use host CLI login files.
-The local profile runs `DRUKS_AUTH_MODE=none` — no browser authentication and
-exactly one operator account. A fresh install shows onboarding until the
-first harness connection completes; that connection creates the sole operator
-account from the provider-verified email. Protect database access and backups
-as credential-bearing data; unlike MCP tokens and OAuth grants, harness
-payloads do not use the `DRUKS_SECRETS_KEY` envelope.
+The local profile runs with `[identity].mode = "none"` — no browser
+authentication and exactly one operator account. A fresh install shows
+onboarding until the first harness connection completes; that connection
+creates the sole operator account from the provider-verified email. Protect
+database access and backups as credential-bearing data; unlike MCP tokens and
+OAuth grants, harness payloads do not use the `[secrets].secrets_key` envelope.
 
 Agent calls refuse before provisioning if their selected harness is not
 connected. `druks doctor` reports the connection and token expiry for every
@@ -131,7 +131,7 @@ development Druks environment and invoke its documented trigger or
 
 ## Sandbox image
 
-`DRUKS_SANDBOX_IMAGE` selects the image Drukbox starts. The shipped
+`[sandbox].image` selects the image Drukbox starts. The shipped
 `ghcr.io/czpython/druks-sandbox:latest` image contains the non-root `druks`
 user plus Git, GitHub CLI, Node, Claude, and Codex.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,7 +30,7 @@ provider capacity and can take about a VM minute.
 
 Read the named field in the error. Common causes:
 
-- `DRUKS_SECRETS_KEY` is empty, not valid base64, or does not decode to 32 bytes
+- `secrets.secrets_key` is empty, not valid base64, or does not decode to 32 bytes
 - a mounted PEM path differs from the path visible inside the container
 - a `druks.toml` value renders an invalid process setting
 
@@ -72,15 +72,15 @@ Distinguish the failure by what you see:
 - **A redirect to `__exe.dev/login`** — no trusted identity header reached
   Caddy; sign in at the edge.
 - **A "couldn't resolve your identity" page (`header` mode 401)** — the
-  request reached Druks without exactly one nonblank `DRUKS_AUTH_HEADER`
+  request reached Druks without exactly one nonblank `identity.header`
   value. Confirm the proxy injects the header Druks expects, and that
   nothing between them drops or duplicates it.
 - **An "Assertion rejected: …" 401 (`jwt` mode)** — the edge asserted a token
   Druks could not verify. The named failure class says which check failed:
-  signature or key problems point at `DRUKS_AUTH_JWKS_URL` (is it reachable
+  signature or key problems point at `identity.jwks_url` (is it reachable
   from the container? did the edge rotate keys?), issuer/audience mismatches
-  at the `DRUKS_AUTH_JWT_*` values, and expiry classes at clock skew between
-  edge and host.
+  at `identity.jwt_issuer` or `identity.jwt_audience`, and expiry classes at
+  clock skew between edge and host.
 - **Onboarding ("connect a harness to finish setup")** — identity resolved
   but that account has no harness connection yet; in a fresh `none`-mode
   install the first completed connection creates the operator account.
@@ -97,12 +97,13 @@ in-flight connect attempts and other transient coordination.
 Check:
 
 ```bash
-grep -E '^(DRUKS_AUTH_MODE|DRUKS_AUTH_HEADER|DRUKS_UPSTREAM)=' ~/druks/.env
+sed -n '/^\[identity\]/,/^\[/p' ~/druks/druks.toml | grep '^mode ='
+grep -E '^(DRUKS_AUTH_HEADER|DRUKS_UPSTREAM)=' ~/druks/.env
 docker compose logs --tail=200 caddy web
 ```
 
 The local `docker` profile intentionally skips Caddy; use
-<http://127.0.0.1:8001>. It runs `DRUKS_AUTH_MODE=none` — no authentication —
+<http://127.0.0.1:8001>. It runs with `[identity].mode = "none"` — no authentication —
 and must remain loopback-only.
 
 ## Webhooks are not arriving
@@ -111,10 +112,10 @@ and must remain loopback-only.
    before debugging the provider.
 2. Confirm the provider URL is
    `https://<host>/_external/<provider>/events/`.
-3. Confirm its webhook secret matches the corresponding environment value.
+3. Confirm its webhook secret matches the corresponding `druks.toml` value.
 4. Inspect the provider's delivery log and `docker compose logs web`.
 
-When `DRUKS_WEBHOOK_HOST` is set, the doctor sends an unsigned GitHub probe and
+When `urls.webhook_host` is set, the doctor sends an unsigned GitHub probe and
 expects HTTP 401 from Druks. A different response means the request did not
 reach the webhook verifier.
 
@@ -158,7 +159,7 @@ docker compose logs --tail=200 sandbox-service sandbox-janitor
 ```
 
 For the local provider, Drukbox runs on the host, not in this Compose project.
-Confirm it listens at the URL in `DRUKS_SANDBOX_SERVICE_URL`. For remote
+Confirm it listens at `[sandbox].service_url` in `druks.toml`. For remote
 providers, a healthy Drukbox API does not prove SSH reachability; follow with
 `druks doctor --sandbox`.
 

--- a/druks.toml.example
+++ b/druks.toml.example
@@ -1,0 +1,29 @@
+# Host-run development configuration. Copy to `druks.toml`.
+# Reference: docs/configuration.md.
+
+[identity]
+mode = "none"
+header = ""
+jwks_url = ""
+jwt_issuer = ""
+jwt_audience = ""
+jwt_identity_claim = "email"
+
+[github]
+operator_app_id = ""
+reviewer_app_id = ""
+
+[urls]
+endpoint = ""
+webhook_host = ""
+
+[secrets]
+webhook_secret = "change-me"
+# python3 -c 'import base64, os; print(base64.b64encode(os.urandom(32)).decode())'
+secrets_key = ""
+
+[sandbox]
+service_url = ""
+service_token = ""
+image = ""
+timeout = 180

--- a/scripts/_github_app_setup.py
+++ b/scripts/_github_app_setup.py
@@ -7,37 +7,32 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-ENV_PATH = Path(".env")
+try:
+    import tomllib
+except ModuleNotFoundError:
+    tomllib = None
+
 TOML_PATH = Path("druks.toml")
 MANIFEST_DIR = Path(__file__).parent / "manifests"
 SETUP_PAGE = "https://druks.ai/app-setup/"
 
-# (role, env key, setting path, PEM path, default app name)
+# (role, TOML path, setting path, PEM path, default app name)
 ROLES = (
     (
         "operator",
-        "GITHUB_OPERATOR_APP_ID",
+        ("github", "operator_app_id"),
         "github.operator_app_id",
         Path("secrets/operator.pem"),
         "druks-operator",
     ),
     (
         "reviewer",
-        "GITHUB_REVIEWER_APP_ID",
+        ("github", "reviewer_app_id"),
         "github.reviewer_app_id",
         Path("secrets/reviewer.pem"),
         "druks-critic",
     ),
 )
-
-
-def read_env() -> dict[str, str]:
-    values = {}
-    for line in ENV_PATH.read_text().splitlines():
-        if line and not line.startswith("#") and "=" in line:
-            key, _, value = line.partition("=")
-            values[key] = value
-    return values
 
 
 def apply_values(updates: dict[str, str]) -> None:
@@ -98,16 +93,17 @@ def prompt_code(role: str) -> str:
 
 def provision(
     role: str,
-    env_key: str,
+    toml_path: tuple[str, str],
+    app_id: str,
     setting_path: str,
     pem_path: Path,
     default_name: str,
     public_url: str,
     org: str,
 ) -> None:
-    env = read_env()
-    if env.get(env_key):
-        answer = input(f"{env_key}={env[env_key]} already configured. Re-create? [y/N] ")
+    key = ".".join(toml_path)
+    if app_id:
+        answer = input(f"{key}={app_id} already configured. Re-create? [y/N] ")
         if answer.strip().lower() != "y":
             print(f"→ skipping {role}")
             return
@@ -157,19 +153,46 @@ def main() -> int:
         print("No druks.toml here — run install.sh first, then re-run with --apps.")
         return 1
 
-    # An empty apply still renders .env from druks.toml, so the endpoint
-    # read below sees the operator's current value.
-    apply_values({})
-    public_url = read_env().get("DRUKS_ENDPOINT") or input(
+    if not tomllib:
+        print("GitHub App setup requires Python 3.11+ (tomllib).", file=sys.stderr)
+        return 1
+
+    # .get chains: a hand-written druks.toml (the pre-TOML migration path) may
+    # omit tables the canonical writer always emits.
+    with TOML_PATH.open("rb") as config_file:
+        config = tomllib.load(config_file)
+    roles = tuple(
+        (
+            role,
+            toml_path,
+            config.get(toml_path[0], {}).get(toml_path[1], ""),
+            setting_path,
+            pem_path,
+            base_name,
+        )
+        for role, toml_path, setting_path, pem_path, base_name in ROLES
+    )
+    public_url = config.get("urls", {}).get("endpoint", "") or input(
         "Public base URL druks will be reachable on (e.g. https://druks.example.com): "
     ).strip().rstrip("/")
+
+    apply_values({})
     org = input("GitHub org slug (empty for a personal account): ").strip()
 
-    for role, env_key, setting_path, pem_path, base_name in ROLES:
+    for role, toml_path, app_id, setting_path, pem_path, base_name in roles:
         # App names are globally unique across GitHub; the org prefix gives
         # every deployment its own namespace.
         default_name = f"{org}-{base_name}" if org else base_name
-        provision(role, env_key, setting_path, pem_path, default_name, public_url, org)
+        provision(
+            role,
+            toml_path,
+            app_id,
+            setting_path,
+            pem_path,
+            default_name,
+            public_url,
+            org,
+        )
     return 0
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,6 +105,10 @@ if [ "${1:-}" = "--apps" ]; then
     exit 1
   }
   need python3
+  python3 -c 'import tomllib' >/dev/null 2>&1 || {
+    echo "GitHub App setup requires Python 3.11+ (tomllib)." >&2
+    exit 1
+  }
   echo "→ fetching app-setup script + manifests from $REPO@$REF"
   mkdir -p manifests
   fetch_from_repo scripts/_github_app_setup.py _github_app_setup.py


### PR DESCRIPTION
Config was authored in druks.toml but reached the app as rendered env vars, flattening app config and Compose infrastructure into one .env. Now druks reads its own config directly from druks.toml, and every Settings field has exactly one source: authored in the TOML, or injected by Compose as env — never both.

- `Settings` gains one sub-model per authored table — `identity`, `github`, `urls`, `secrets`, `sandbox` — loaded through a TOML source at `DRUKS_CONFIG`; these fields have no env aliases, so a stale .env can no longer shadow the authored file. Compose-injected infrastructure stays flat env.
- `DRUKS_CONFIG` set but unreadable refuses to boot: a lost mount must not come up with the identity edge silently off.
- `druks setup` renders a shrunk .env holding only what other processes read: Compose interpolation and mount sources, Caddy's edge keys, the drukbox pass-through, and the `[env]` escape hatch.
- `[sandbox.env]` is renamed by domain to `[sandbox.<provider>]` (still passed to drukbox verbatim); existing files are migrated in place on the next `druks setup`. `DRUKS_SANDBOX_SERVICE_TIMEOUT` becomes `[sandbox].timeout`.
- `install.sh --apps` reads druks.toml directly instead of scraping .env.
- Host dev authors `druks.toml` (new `druks.toml.example`); `.env.example` shrinks to the environment plane. Docs updated to match, including the rollback note: images from before this change read their config from .env, so rolling back past it requires the pre-migration backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)