### PR TITLE
Keep every weekly quota window and page through them

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -193,13 +193,8 @@ class Agent:
                 scrape = UsageScrape.latest_for(harness.name, connection.account_id)
                 if scrape:
                     now = datetime.now(UTC)
-                    # The nearest window still ahead: the five-hour one usually
-                    # turns first; an exhausted week is what the caller caps on.
-                    reset = scrape.five_hour_resets_at
-                    if reset and reset > now:
-                        return (reset - now).total_seconds()
-                    reset = scrape.week_resets_at
-                    if reset and reset > now:
+                    reset = scrape.soonest_reset_after(now)
+                    if reset:
                         return (reset - now).total_seconds()
                 # No scrape yet, or nothing ahead of now: a blind half hour.
                 return _QUOTA_FALLBACK_WAIT_SECONDS

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 import httpx
+from pydantic import TypeAdapter
 
 from druks.database import db_session
 from druks.mcp import models as mcp_models
@@ -29,6 +30,7 @@ from .datastructures import (
     CompletedConnect,
     HarnessRunResult,
     OAuthToken,
+    ParsedMetric,
     ParsedModels,
     ParsedUsage,
     RotationResult,
@@ -57,6 +59,8 @@ _REFRESH_LOCK_TTL_SECONDS = 300
 MANIFEST_SCHEMA_VERSION = 2
 
 Token = OAuthToken | CodexToken
+
+_WEEKLY_WINDOWS = TypeAdapter(tuple[ParsedMetric, ...])
 
 
 class Harness(ABC):
@@ -497,10 +501,7 @@ class Harness(ABC):
         if parsed.five_hour:
             snapshot.five_hour_percent_left = parsed.five_hour.percent_left
             snapshot.five_hour_resets_at = parsed.five_hour.resets_at
-        if parsed.week:
-            snapshot.week_percent_left = parsed.week.percent_left
-            snapshot.week_resets_at = parsed.week.resets_at
-            snapshot.week_model = parsed.week.model
+        snapshot.weeks = _WEEKLY_WINDOWS.dump_python(parsed.weeks, mode="json")
         snapshot.save()
         return {
             "harness": cls.name,

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -324,10 +324,10 @@ class ClaudeHarness(Harness):
         if not isinstance(data, dict) or not any(k in data for k in ("five_hour", "seven_day")):
             return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
         try:
-            five_hour, week = _claude_windows(data)
+            five_hour, weeks = _claude_windows(data)
         except (KeyError, TypeError, ValueError):
             return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
-        return ParsedUsage(ok=True, five_hour=five_hour, week=week, raw=raw)
+        return ParsedUsage(ok=True, five_hour=five_hour, weeks=weeks, raw=raw)
 
     @classmethod
     def _parse_models(cls, raw: str) -> ParsedModels:
@@ -355,9 +355,8 @@ def _oauth_block(data: dict) -> dict:
     return block if isinstance(block, dict) else data
 
 
-def _claude_windows(data: dict) -> tuple[ParsedMetric | None, ParsedMetric | None]:
-    """The five-hour and weekly quotas that bind. A plan can meter one model
-    tighter than the rest, and that limit stops work first."""
+def _claude_windows(data: dict) -> tuple[ParsedMetric | None, tuple[ParsedMetric, ...]]:
+    """The binding five-hour window and every weekly window in provider order."""
     five_hour, weekly = [], []
     for limit in data.get("limits") or []:
         # A limit can be scoped to something other than a model, which leaves
@@ -372,10 +371,11 @@ def _claude_windows(data: dict) -> tuple[ParsedMetric | None, ParsedMetric | Non
             weekly.append(window)
         elif limit["group"] == "session":
             five_hour.append(window)
-    return (
-        ParsedMetric.binding(five_hour) or _claude_metric(data.get("five_hour")),
-        ParsedMetric.binding(weekly) or _claude_metric(data.get("seven_day")),
-    )
+    if not weekly and (fallback_week := _claude_metric(data.get("seven_day"))):
+        weekly.append(fallback_week)
+    binding_five_hour = ParsedMetric.binding(five_hour) or _claude_metric(data.get("five_hour"))
+    weekly_windows = tuple(weekly)
+    return binding_five_hour, weekly_windows
 
 
 def _claude_metric(block: object) -> ParsedMetric | None:

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -430,10 +430,10 @@ class CodexHarness(Harness):
             return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
         plan = data.get("plan_type") if isinstance(data.get("plan_type"), str) else None
         try:
-            five_hour, week = _codex_windows(data)
+            five_hour, weeks = _codex_windows(data)
         except (AttributeError, KeyError, TypeError, ValueError):
             return ParsedUsage(ok=False, error="unexpected_payload", plan_tier=plan, raw=raw)
-        if not five_hour and not week:
+        if not five_hour and not weeks:
             # Business/enterprise accounts with unlimited credits carry
             # ``rate_limit: null`` — no windows is the expected shape, not
             # a parse failure. Report permanently-full buckets.
@@ -444,7 +444,7 @@ class CodexHarness(Harness):
                     ok=True,
                     plan_tier=plan,
                     five_hour=full,
-                    week=full,
+                    weeks=(full,),
                     unlimited=True,
                     raw=raw,
                 )
@@ -453,7 +453,7 @@ class CodexHarness(Harness):
             ok=True,
             plan_tier=plan,
             five_hour=five_hour,
-            week=week,
+            weeks=weeks,
             raw=raw,
         )
 
@@ -708,10 +708,11 @@ class CodexHarness(Harness):
         )
 
 
-def _codex_windows(usage: dict) -> tuple[ParsedMetric | None, ParsedMetric | None]:
-    """The five-hour and weekly quotas that bind. A window's declared length
-    names it, not the slot it arrives in, and a separately metered model
-    exhausts before the account-wide quota does."""
+def _codex_windows(usage: dict) -> tuple[ParsedMetric | None, tuple[ParsedMetric, ...]]:
+    """The binding five-hour window and every weekly window in provider order.
+
+    A window's declared length names it, not the slot it arrives in.
+    """
     rate_limits = [(None, usage["rate_limit"] or {})]
     for metered in usage.get("additional_rate_limits") or []:
         rate_limits.append((metered["limit_name"], metered["rate_limit"] or {}))
@@ -731,4 +732,4 @@ def _codex_windows(usage: dict) -> tuple[ParsedMetric | None, ParsedMetric | Non
                 weekly.append(window)
             else:
                 five_hour.append(window)
-    return ParsedMetric.binding(five_hour), ParsedMetric.binding(weekly)
+    return ParsedMetric.binding(five_hour), tuple(weekly)

--- a/backend/druks/harnesses/datastructures.py
+++ b/backend/druks/harnesses/datastructures.py
@@ -78,7 +78,7 @@ class ParsedUsage:
     error: str | None = None
     plan_tier: str | None = None
     five_hour: ParsedMetric | None = None
-    week: ParsedMetric | None = None
+    weeks: tuple[ParsedMetric, ...] = ()
     # Unmetered plan (e.g. Codex business with unlimited credits). The
     # windows above are synthesized permanently-full buckets; consumers
     # should render "unmetered" rather than a quota that never moves.

--- a/backend/druks/mcp/gateway/services.py
+++ b/backend/druks/mcp/gateway/services.py
@@ -136,18 +136,19 @@ def _harness_usage(name: str, account_id: str, *, now: datetime) -> schemas.Agen
         if point.five_hour_percent_left is not None and point.scraped_at >= five_hour_cutoff
     ]
     week = [
-        UsageHistoryPoint(t=point.scraped_at, pct=point.week_percent_left)
+        UsageHistoryPoint(t=point.scraped_at, pct=binding["percent_left"])
         for point in history
-        if point.week_percent_left is not None
+        if (binding := point.binding_week())
     ]
+    binding_week = row.binding_week() or {}
     return schemas.AgentHarnessUsage(
         name=name,
         is_connected=is_connected,
         plan_tier=row.plan_tier,
         five_hour_percent_left=row.five_hour_percent_left,
         five_hour_resets_at=row.five_hour_resets_at,
-        week_percent_left=row.week_percent_left,
-        week_resets_at=row.week_resets_at,
+        week_percent_left=binding_week.get("percent_left"),
+        week_resets_at=binding_week.get("resets_at"),
         is_unlimited=row.unlimited,
         scraped_at=row.scraped_at,
         five_hour_history=downsample(five_hour, cap=_HISTORY_POINTS),

--- a/backend/druks/usage/models.py
+++ b/backend/druks/usage/models.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
+from typing import Any
 
 from sqlalchemy import ForeignKey, Index, delete, select
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from druks.db import Base, db_session
@@ -33,12 +35,8 @@ class UsageScrape(Base):
     # doesn't have a 5h concept yet so it stays null for the codex row.
     five_hour_percent_left: Mapped[int | None]
     five_hour_resets_at: Mapped[datetime | None]
-    # Weekly window — both CLIs expose this.
-    week_percent_left: Mapped[int | None]
-    week_resets_at: Mapped[datetime | None]
-    # Set when the weekly window meters one model separately from the
-    # rest, naming it. None covers every model.
-    week_model: Mapped[str | None]
+    # Weekly windows in provider order, including separately metered models.
+    weeks: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, default=list)
     # Unmetered plan (Codex business/enterprise with unlimited credits).
     # The window percentages above are synthesized permanently-full
     # buckets when this is set — the UI renders "unmetered" instead of
@@ -68,6 +66,24 @@ class UsageScrape(Base):
             .order_by(cls.scraped_at.asc())
         )
         return list(db_session().execute(stmt).scalars())
+
+    def binding_week(self) -> dict[str, Any] | None:
+        """The window closest to exhaustion — whichever stops work first."""
+        reported_windows = [week for week in self.weeks if week["percent_left"] is not None]
+        if reported_windows:
+            return min(reported_windows, key=lambda week: week["percent_left"])
+
+    def soonest_reset_after(self, now: datetime) -> datetime | None:
+        resets = []
+        if self.five_hour_resets_at and self.five_hour_resets_at > now:
+            resets.append(self.five_hour_resets_at)
+        for week in self.weeks:
+            if week["resets_at"]:
+                reset = datetime.fromisoformat(week["resets_at"])
+                if reset > now:
+                    resets.append(reset)
+        if resets:
+            return min(resets)
 
     def save(self) -> None:
         if not self.scraped_at:

--- a/backend/druks/usage/routes.py
+++ b/backend/druks/usage/routes.py
@@ -19,6 +19,7 @@ from druks.usage.schemas import (
     UsageMetricSummary,
     UsageResponse,
     UsageTodayResponse,
+    UsageWindowHistory,
 )
 from druks.usage.trends import FIVE_HOUR_RANGE, WEEK_RANGE, downsample
 from druks.user_settings.models import HarnessSettings, UserSettings
@@ -146,15 +147,23 @@ def _harness_history(name: str, account_id: str, *, now: datetime) -> UsageHarne
         for row in rows
         if row.five_hour_percent_left is not None and row.scraped_at >= five_hour_cutoff
     ]
-    week = [
-        UsageHistoryPoint(t=row.scraped_at, pct=row.week_percent_left)
-        for row in rows
-        if row.week_percent_left is not None
-    ]
+    weekly_points: dict[str | None, list[UsageHistoryPoint]] = {}
+    for row in rows:
+        for week in row.weeks:
+            if week["percent_left"] is not None:
+                weekly_points.setdefault(week["model"], []).append(
+                    UsageHistoryPoint(t=row.scraped_at, pct=week["percent_left"])
+                )
     return UsageHarnessHistory(
         name=name,
         five_hour=downsample(five_hour, cap=_MAX_SPARK_POINTS),
-        week=downsample(week, cap=_MAX_SPARK_POINTS),
+        weeks=[
+            UsageWindowHistory(
+                model=model,
+                points=downsample(points, cap=_MAX_SPARK_POINTS),
+            )
+            for model, points in weekly_points.items()
+        ],
     )
 
 
@@ -168,13 +177,19 @@ def _summarize(
     if not row:
         return UsageHarnessSummary(name=name, available=False, connected=connected)
     age = _age_seconds(row.scraped_at, now=now)
+    five_hour = None
+    if row.five_hour_percent_left is not None or row.five_hour_resets_at:
+        five_hour = UsageMetricSummary(
+            percent_left=row.five_hour_percent_left,
+            resets_at=row.five_hour_resets_at,
+        )
     return UsageHarnessSummary(
         name=name,
         available=row.parse_ok,
         connected=connected,
         plan_tier=row.plan_tier,
-        five_hour=_metric(row.five_hour_percent_left, row.five_hour_resets_at),
-        week=_metric(row.week_percent_left, row.week_resets_at, row.week_model),
+        five_hour=five_hour,
+        weeks=[UsageMetricSummary.model_validate(week) for week in row.weeks],
         unlimited=row.unlimited,
         scraped_at=row.scraped_at,
         age_seconds=age,
@@ -182,14 +197,6 @@ def _summarize(
         error=row.error,
         raw_output=row.raw_output,
     )
-
-
-def _metric(
-    percent_left: int | None, resets_at: datetime | None, model: str | None = None
-) -> UsageMetricSummary | None:
-    if percent_left is None and resets_at is None:
-        return
-    return UsageMetricSummary(percent_left=percent_left, resets_at=resets_at, model=model)
 
 
 def _age_seconds(scraped_at: datetime | None, *, now: datetime) -> int | None:

--- a/backend/druks/usage/schemas.py
+++ b/backend/druks/usage/schemas.py
@@ -26,7 +26,7 @@ class UsageHarnessSummary(BaseResponse):
     connected: bool
     plan_tier: str | None = None
     five_hour: UsageMetricSummary | None = None
-    week: UsageMetricSummary | None = None
+    weeks: list[UsageMetricSummary] = Field(default_factory=list)
     # Unmetered plan (Codex business/enterprise). The window buckets are
     # synthesized permanently-full — the UI shows "unmetered" plus
     # actual consumption from druks' own run records instead of a
@@ -59,14 +59,19 @@ class UsageHistoryPoint(BaseResponse):
     pct: int
 
 
+class UsageWindowHistory(BaseResponse):
+    model: str | None = None
+    points: list[UsageHistoryPoint] = Field(default_factory=list)
+
+
 class UsageHarnessHistory(BaseResponse):
     name: str
     # Percent-left samples, oldest first. ``five_hour`` covers the last
-    # ~6h (one full 5h window plus headroom); ``week`` covers the last
-    # 7 days, downsampled. Either list is empty when the harness never
-    # reported that window.
+    # ~6h (one full 5h window plus headroom); ``weeks`` covers the last
+    # 7 days as one downsampled series per weekly window. Either list is
+    # empty when the harness never reported that window.
     five_hour: list[UsageHistoryPoint] = Field(default_factory=list)
-    week: list[UsageHistoryPoint] = Field(default_factory=list)
+    weeks: list[UsageWindowHistory] = Field(default_factory=list)
 
 
 class UsageHistoryResponse(BaseResponse):

--- a/backend/migrations/versions/b6d9e2c4f8a1_usage_scrapes_keep_weekly_windows.py
+++ b/backend/migrations/versions/b6d9e2c4f8a1_usage_scrapes_keep_weekly_windows.py
@@ -1,0 +1,70 @@
+"""usage scrapes keep weekly windows
+
+Revision ID: b6d9e2c4f8a1
+Revises: a4b7c2e91d63
+Create Date: 2026-08-01 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "b6d9e2c4f8a1"
+down_revision: str | Sequence[str] | None = "a4b7c2e91d63"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "usage_scrapes",
+        sa.Column(
+            "weeks",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE usage_scrapes
+            SET weeks = jsonb_build_array(
+                jsonb_build_object(
+                    'percent_left', week_percent_left,
+                    'resets_at', week_resets_at,
+                    'model', week_model
+                )
+            )
+            WHERE week_percent_left IS NOT NULL OR week_resets_at IS NOT NULL
+            """
+        )
+    )
+    op.drop_column("usage_scrapes", "week_model")
+    op.drop_column("usage_scrapes", "week_resets_at")
+    op.drop_column("usage_scrapes", "week_percent_left")
+
+
+def downgrade() -> None:
+    op.add_column("usage_scrapes", sa.Column("week_percent_left", sa.Integer(), nullable=True))
+    op.add_column(
+        "usage_scrapes",
+        sa.Column("week_resets_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column("usage_scrapes", sa.Column("week_model", sa.String(), nullable=True))
+    op.execute(
+        sa.text(
+            """
+            UPDATE usage_scrapes
+            SET week_percent_left = (weeks -> 0 ->> 'percent_left')::integer,
+                week_resets_at = (weeks -> 0 ->> 'resets_at')::timestamptz,
+                week_model = weeks -> 0 ->> 'model'
+            WHERE jsonb_array_length(weeks) > 0
+            """
+        )
+    )
+    op.drop_column("usage_scrapes", "weeks")

--- a/backend/tests/test_agent_services.py
+++ b/backend/tests/test_agent_services.py
@@ -412,8 +412,18 @@ def test_get_usage_is_a_bounded_pure_read(druks_db, account):
             plan_tier="max",
             five_hour_percent_left=90 - tick,
             five_hour_resets_at=now + timedelta(hours=2),
-            week_percent_left=80 - tick,
-            week_resets_at=now + timedelta(days=3),
+            weeks=[
+                {
+                    "percent_left": 80 - tick,
+                    "resets_at": (now + timedelta(days=3)).isoformat(),
+                    "model": None,
+                },
+                {
+                    "percent_left": 40 - tick,
+                    "resets_at": (now + timedelta(days=2)).isoformat(),
+                    "model": "Fable",
+                },
+            ],
         ).save()
 
     usage = services.get_usage(account)
@@ -424,10 +434,12 @@ def test_get_usage_is_a_bounded_pure_read(druks_db, account):
     claude = next(h for h in usage.harnesses if h.name == "claude")
     assert claude.plan_tier == "max"
     assert claude.five_hour_percent_left == 90
+    assert claude.week_percent_left == 40
+    assert claude.week_resets_at == now + timedelta(days=2)
     assert len(claude.five_hour_history) <= 8
     assert len(claude.week_history) <= 8
     # The newest sample anchors each trend.
-    assert claude.week_history[-1].pct == 80
+    assert claude.week_history[-1].pct == 40
     assert len(usage.model_dump_json(by_alias=True).encode()) <= 4 * 1024
 
 

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -1,12 +1,12 @@
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from conftest import make_agent_result
 from druks import agents
 from druks.durable import AgentCall, WorkflowError
+from druks.usage.models import UsageScrape
 
 
 class DummyOutput(agents.AgentOutput):
@@ -409,9 +409,20 @@ async def test_body_level_quota_waits_for_the_reset_once(
         agents.UsageScrape,
         "latest_for",
         classmethod(
-            lambda _cls, _harness, _account_id: SimpleNamespace(
-                five_hour_resets_at=now + timedelta(hours=1),
-                week_resets_at=now + timedelta(days=1),
+            lambda _cls, _harness, _account_id: UsageScrape(
+                five_hour_resets_at=now + timedelta(hours=2),
+                weeks=[
+                    {
+                        "percent_left": 0,
+                        "resets_at": (now + timedelta(hours=1)).isoformat(),
+                        "model": "Fable",
+                    },
+                    {
+                        "percent_left": 20,
+                        "resets_at": (now + timedelta(days=1)).isoformat(),
+                        "model": None,
+                    },
+                ],
             )
         ),
     )
@@ -456,9 +467,15 @@ async def test_body_level_quota_reset_over_six_hours_reraises_without_sleeping(
         agents.UsageScrape,
         "latest_for",
         classmethod(
-            lambda _cls, _harness, _account_id: SimpleNamespace(
+            lambda _cls, _harness, _account_id: UsageScrape(
                 five_hour_resets_at=now + timedelta(hours=7),
-                week_resets_at=now + timedelta(days=1),
+                weeks=[
+                    {
+                        "percent_left": 0,
+                        "resets_at": (now + timedelta(days=1)).isoformat(),
+                        "model": None,
+                    }
+                ],
             )
         ),
     )

--- a/backend/tests/test_api_usage.py
+++ b/backend/tests/test_api_usage.py
@@ -91,7 +91,10 @@ def test_get_usage_serializes_latest_per_harness(client, extension_settings) -> 
                 plan_tier="Max",
                 five_hour_percent_left=54,
                 five_hour_resets_at=datetime(2026, 5, 23, 18, 40, tzinfo=UTC),
-                week_percent_left=38,
+                weeks=[
+                    {"percent_left": 38, "resets_at": None, "model": None},
+                    {"percent_left": 0, "resets_at": None, "model": "Fable"},
+                ],
                 scraped_at=datetime.now(UTC) - timedelta(seconds=45),
             ),
         ],
@@ -105,7 +108,10 @@ def test_get_usage_serializes_latest_per_harness(client, extension_settings) -> 
     assert claude["available"] is True
     assert claude["planTier"] == "Max"
     assert claude["fiveHour"]["percentLeft"] == 54
-    assert claude["week"]["percentLeft"] == 38
+    assert [(week["percentLeft"], week["model"]) for week in claude["weeks"]] == [
+        (38, None),
+        (0, "Fable"),
+    ]
     assert claude["ageSeconds"] is not None
     assert 30 <= claude["ageSeconds"] <= 90  # close to the planted 45s
     assert claude["stale"] is False
@@ -140,7 +146,7 @@ def test_get_usage_exposes_unlimited_flag(client, extension_settings) -> None:
                 parse_ok=True,
                 plan_tier="business",
                 five_hour_percent_left=100,
-                week_percent_left=100,
+                weeks=[{"percent_left": 100, "resets_at": None, "model": None}],
                 unlimited=True,
             ),
         ],
@@ -159,7 +165,10 @@ def test_usage_history_serializes_series_oldest_first(client, extension_settings
             harness="claude",
             parse_ok=True,
             five_hour_percent_left=pct,
-            week_percent_left=90 - i,
+            weeks=[
+                {"percent_left": 90 - i, "resets_at": None, "model": None},
+                {"percent_left": 40 - i, "resets_at": None, "model": "Fable"},
+            ],
             scraped_at=now - timedelta(minutes=10 * i),
         )
         for i, pct in enumerate([20, 40, 60])
@@ -170,7 +179,10 @@ def test_usage_history_serializes_series_oldest_first(client, extension_settings
             harness="claude",
             parse_ok=True,
             five_hour_percent_left=95,
-            week_percent_left=99,
+            weeks=[
+                {"percent_left": 99, "resets_at": None, "model": None},
+                {"percent_left": 49, "resets_at": None, "model": "Fable"},
+            ],
             scraped_at=now - timedelta(hours=12),
         ),
     )
@@ -183,9 +195,21 @@ def test_usage_history_serializes_series_oldest_first(client, extension_settings
     body = client.get("/api/usage/history").json()
 
     assert [p["pct"] for p in _harness(body, "claude")["fiveHour"]] == [60, 40, 20]
-    assert [p["pct"] for p in _harness(body, "claude")["week"]] == [99, 88, 89, 90]
+    assert [series["model"] for series in _harness(body, "claude")["weeks"]] == [None, "Fable"]
+    assert [p["pct"] for p in _harness(body, "claude")["weeks"][0]["points"]] == [
+        99,
+        88,
+        89,
+        90,
+    ]
+    assert [p["pct"] for p in _harness(body, "claude")["weeks"][1]["points"]] == [
+        49,
+        38,
+        39,
+        40,
+    ]
     assert _harness(body, "codex")["fiveHour"] == []
-    assert _harness(body, "codex")["week"] == []
+    assert _harness(body, "codex")["weeks"] == []
 
 
 def test_usage_today_aggregates_spend_and_tokens_by_provider(
@@ -290,7 +314,7 @@ def _fake_fetch(fetched: list):
             error=None,
             plan_tier=None,
             five_hour=ParsedMetric(percent_left=50, resets_at=None),
-            week=None,
+            weeks=(),
             unlimited=False,
             raw="{}",
         )

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -363,7 +363,7 @@ async def test_claude_fetch_usage_success(monkeypatch, druks_db):
     parsed = await ClaudeHarness.fetch_usage(connection, now=_NOW)
     assert parsed.ok is True
     assert parsed.five_hour.percent_left == 84
-    assert parsed.week.percent_left == 52
+    assert parsed.weeks[0].percent_left == 52
     assert calls[0]["headers"]["Authorization"] == "Bearer tok"
     assert calls[0]["headers"]["anthropic-beta"] == "oauth-2025-04-20"
     assert calls[0]["headers"]["User-Agent"].startswith("claude-code/")
@@ -409,7 +409,7 @@ async def test_codex_fetch_usage_success(monkeypatch, druks_db):
     assert parsed.ok is True
     assert parsed.plan_tier == "pro"
     assert parsed.five_hour.percent_left == 61
-    assert parsed.week.percent_left == 61
+    assert parsed.weeks[0].percent_left == 61
     assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acc-7"
 
 

--- a/backend/tests/test_harness_usage_parsing.py
+++ b/backend/tests/test_harness_usage_parsing.py
@@ -4,9 +4,7 @@ from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 
 
-def test_claude_parse_reports_the_weekly_limit_that_binds() -> None:
-    """A weekly limit scoped to one model can bind well before the all-models
-    one — reporting the all-models figure overstates what is left."""
+def test_claude_parse_keeps_every_weekly_limit_in_provider_order() -> None:
     parsed = ClaudeHarness._parse_usage(
         json.dumps(
             {
@@ -17,7 +15,7 @@ def test_claude_parse_reports_the_weekly_limit_that_binds() -> None:
                     {"group": "weekly", "percent": 63, "scope": None},
                     {
                         "group": "weekly",
-                        "percent": 75,
+                        "percent": 100,
                         "scope": {"model": {"display_name": "Fable"}},
                     },
                 ],
@@ -26,9 +24,10 @@ def test_claude_parse_reports_the_weekly_limit_that_binds() -> None:
     )
 
     assert parsed.ok
-    assert parsed.week is not None
-    assert parsed.week.percent_left == 25
-    assert parsed.week.model == "Fable"
+    assert [(week.percent_left, week.model) for week in parsed.weeks] == [
+        (37, None),
+        (0, "Fable"),
+    ]
 
 
 def test_claude_parse_counts_a_limit_scoped_to_something_other_than_a_model() -> None:
@@ -52,9 +51,10 @@ def test_claude_parse_counts_a_limit_scoped_to_something_other_than_a_model() ->
     )
 
     assert parsed.ok
-    assert parsed.week is not None
-    assert parsed.week.percent_left == 10
-    assert parsed.week.model is None
+    assert [(week.percent_left, week.model) for week in parsed.weeks] == [
+        (80, None),
+        (10, None),
+    ]
 
 
 def test_claude_parse_falls_back_to_seven_day_without_limits() -> None:
@@ -63,13 +63,12 @@ def test_claude_parse_falls_back_to_seven_day_without_limits() -> None:
     )
 
     assert parsed.ok
-    assert parsed.week is not None and parsed.week.percent_left == 52
-    assert parsed.week.model is None
+    assert len(parsed.weeks) == 1
+    assert parsed.weeks[0].percent_left == 52
+    assert parsed.weeks[0].model is None
 
 
-def test_codex_parse_reports_the_metered_model_that_binds() -> None:
-    """Codex meters some models separately, and such a quota exhausts before
-    the account-wide one."""
+def test_codex_parse_keeps_every_weekly_limit_in_provider_order() -> None:
     parsed = CodexHarness._parse_usage(
         json.dumps(
             {
@@ -100,9 +99,10 @@ def test_codex_parse_reports_the_metered_model_that_binds() -> None:
     )
 
     assert parsed.ok
-    assert parsed.week is not None
-    assert parsed.week.percent_left == 20
-    assert parsed.week.model == "GPT-5.3-Codex-Spark"
+    assert [(week.percent_left, week.model) for week in parsed.weeks] == [
+        (98, None),
+        (20, "GPT-5.3-Codex-Spark"),
+    ]
 
 
 def test_codex_parse_treats_unlimited_credits_as_full_buckets() -> None:
@@ -121,7 +121,7 @@ def test_codex_parse_treats_unlimited_credits_as_full_buckets() -> None:
     assert parsed.ok
     assert parsed.plan_tier == "business"
     assert parsed.five_hour is not None and parsed.five_hour.percent_left == 100
-    assert parsed.week is not None and parsed.week.percent_left == 100
+    assert len(parsed.weeks) == 1 and parsed.weeks[0].percent_left == 100
     assert parsed.unlimited is True
 
 
@@ -145,7 +145,7 @@ def test_codex_parse_places_a_weekly_only_plan_in_the_week_window() -> None:
 
     assert parsed.ok
     assert parsed.five_hour is None
-    assert parsed.week is not None and parsed.week.percent_left == 98
+    assert len(parsed.weeks) == 1 and parsed.weeks[0].percent_left == 98
 
 
 def test_codex_parse_rejects_an_unreadable_window() -> None:

--- a/backend/tests/test_usage_poll.py
+++ b/backend/tests/test_usage_poll.py
@@ -1,7 +1,9 @@
 import gc
+import json
 
 import pytest
 from druks.harnesses.base import Harness
+from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.datastructures import ParsedMetric, ParsedUsage
 from druks.usage.models import UsageScrape
 
@@ -22,14 +24,14 @@ def _metric(percent_left: int) -> ParsedMetric:
 
 
 def _usage(
-    *, ok=True, error=None, plan_tier=None, five=None, week=None, unlimited=False
+    *, ok=True, error=None, plan_tier=None, five=None, weeks=(), unlimited=False
 ) -> ParsedUsage:
     return ParsedUsage(
         ok=ok,
         error=error,
         plan_tier=plan_tier,
         five_hour=five,
-        week=week,
+        weeks=weeks,
         unlimited=unlimited,
         raw="{}" if ok else "",
     )
@@ -69,10 +71,10 @@ async def _poll(*harnesses) -> list[dict[str, object]]:
 
 async def test_successful_fetch_persists_per_harness(druks_db) -> None:
     results = await _poll(
-        _harness("claude", lambda: _usage(five=_metric(84), week=_metric(52))),
+        _harness("claude", lambda: _usage(five=_metric(84), weeks=(_metric(52),))),
         _harness(
             "codex",
-            lambda: _usage(plan_tier="prolite", five=_metric(61), week=_metric(61)),
+            lambda: _usage(plan_tier="prolite", five=_metric(61), weeks=(_metric(61),)),
         ),
     )
     druks_db.flush()
@@ -83,12 +85,43 @@ async def test_successful_fetch_persists_per_harness(druks_db) -> None:
     claude_row = UsageScrape.latest_for("claude", _connection().account_id)
     assert claude_row is not None
     assert claude_row.five_hour_percent_left == 84
-    assert claude_row.week_percent_left == 52
+    assert claude_row.weeks == [
+        {"percent_left": 52, "resets_at": None, "model": None},
+    ]
 
     codex_row = UsageScrape.latest_for("codex", _connection().account_id)
     assert codex_row is not None
     assert codex_row.plan_tier == "prolite"
-    assert codex_row.week_percent_left == 61
+    assert codex_row.weeks[0]["percent_left"] == 61
+
+
+async def test_claude_weekly_windows_survive_parse_and_poll_in_order(druks_db) -> None:
+    parsed = ClaudeHarness._parse_usage(
+        json.dumps(
+            {
+                "five_hour": {"utilization": 20},
+                "seven_day": {"utilization": 30},
+                "limits": [
+                    {"group": "weekly", "percent": 30, "scope": None},
+                    {
+                        "group": "weekly",
+                        "percent": 100,
+                        "scope": {"model": {"display_name": "Fable"}},
+                    },
+                ],
+            }
+        )
+    )
+
+    await _poll(_harness("claude", lambda: parsed))
+    druks_db.flush()
+
+    row = UsageScrape.latest_for("claude", _connection().account_id)
+    assert row is not None
+    assert [(week["percent_left"], week["model"]) for week in row.weeks] == [
+        (70, None),
+        (0, "Fable"),
+    ]
 
 
 async def test_credential_error_records_error_snapshot(druks_db) -> None:
@@ -125,7 +158,10 @@ async def test_snapshot_persists_unlimited_flag(druks_db) -> None:
         _harness(
             "codex",
             lambda: _usage(
-                plan_tier="business", five=_metric(100), week=_metric(100), unlimited=True
+                plan_tier="business",
+                five=_metric(100),
+                weeks=(_metric(100),),
+                unlimited=True,
             ),
         )
     )

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -372,7 +372,7 @@ export interface UsageHarnessSummary {
   connected: boolean
   planTier: string | null
   fiveHour: UsageMetric | null
-  week: UsageMetric | null
+  weeks: UsageMetric[]
   // Unmetered plan (e.g. Codex business). The window metrics are
   // synthesized permanently-full buckets — render "unmetered" plus
   // actual consumption instead of a quota bar that never moves.
@@ -393,10 +393,15 @@ export interface UsageHistoryPoint {
   pct: number
 }
 
+export interface UsageWindowHistory {
+  model: string | null
+  points: UsageHistoryPoint[]
+}
+
 export interface UsageHarnessHistory {
   name: string
   fiveHour: UsageHistoryPoint[]
-  week: UsageHistoryPoint[]
+  weeks: UsageWindowHistory[]
 }
 
 export interface UsageHistoryResponse {

--- a/frontend/src/components/UsagePanel.test.tsx
+++ b/frontend/src/components/UsagePanel.test.tsx
@@ -1,0 +1,136 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { UsageHistoryResponse, UsageResponse, UsageTodayResponse } from '../api/types'
+import { UsagePanel } from './UsagePanel'
+
+const usage: UsageResponse = {
+  harnesses: [
+    {
+      name: 'claude',
+      available: true,
+      connected: true,
+      planTier: 'max',
+      fiveHour: { percentLeft: 81, resetsAt: null, model: null },
+      weeks: [
+        { percentLeft: 62, resetsAt: null, model: null },
+        { percentLeft: 0, resetsAt: null, model: 'Fable' },
+      ],
+      unlimited: false,
+      scrapedAt: '2026-08-01T10:00:00Z',
+      ageSeconds: 30,
+      stale: false,
+      error: null,
+      rawOutput: null,
+    },
+  ],
+}
+
+const history: UsageHistoryResponse = {
+  harnesses: [
+    {
+      name: 'claude',
+      fiveHour: [],
+      weeks: [
+        {
+          model: 'Fable',
+          points: [
+            { t: '2026-07-31T10:00:00Z', pct: 20 },
+            { t: '2026-08-01T10:00:00Z', pct: 0 },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+const today: UsageTodayResponse = {
+  day: '2026-08-01',
+  timezone: 'UTC',
+  harnesses: [],
+}
+
+function stubFetch(summary: UsageResponse = usage, usageHistory: UsageHistoryResponse = history) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn<(url: string) => Promise<Response>>(async (url) => {
+      if (url === '/api/usage') return Response.json(summary)
+      if (url === '/api/usage/history') return Response.json(usageHistory)
+      if (url === '/api/usage/today') return Response.json(today)
+      if (url === '/api/usage/refresh') return Response.json(null)
+      return new Response('{}', { status: 404 })
+    }),
+  )
+}
+
+function renderPanel() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <UsagePanel />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('UsagePanel', () => {
+  it('pages model-scoped weekly capacity without exhausting the harness', async () => {
+    stubFetch()
+    const { container } = renderPanel()
+
+    await screen.findByText('Fable weekly limit reached')
+    expect(container.querySelector('.us-week-carousel .us-win-label')?.textContent).toBe(
+      'weekly · Fable · exhausted',
+    )
+    expect(screen.getByText('0%')).toBeTruthy()
+    expect(container.querySelector('.us-week-carousel .us-spark')).toBeTruthy()
+    expect(container.querySelectorAll('.us-week-dot')).toHaveLength(2)
+    expect(screen.getByText(/New claude runs on Fable will fail until the window resets/)).toBeTruthy()
+    expect(screen.queryByText(/New claude runs will fail until the window resets/)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next weekly window' }))
+
+    expect(screen.getByText('62%')).toBeTruthy()
+    expect(container.querySelector('.us-week-carousel .us-spark')).toBeNull()
+    expect(screen.queryByText('weekly · Fable · exhausted')).toBeNull()
+  })
+
+  it('pages between weekly windows with the same scope', async () => {
+    const duplicateScopes: UsageResponse = {
+      harnesses: [
+        {
+          ...usage.harnesses[0]!,
+          weeks: [
+            { percentLeft: 80, resetsAt: null, model: null },
+            { percentLeft: 10, resetsAt: null, model: null },
+          ],
+        },
+      ],
+    }
+    const duplicateHistory: UsageHistoryResponse = {
+      harnesses: [
+        {
+          name: 'claude',
+          fiveHour: [],
+          weeks: [
+            { model: null, points: [] },
+            { model: null, points: [] },
+          ],
+        },
+      ],
+    }
+    stubFetch(duplicateScopes, duplicateHistory)
+    renderPanel()
+
+    expect(await screen.findByText('10%')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Next weekly window' }))
+    expect(screen.getByText('80%')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Show weekly window 2 of 2: all models' }))
+    expect(screen.getByText('10%')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/UsagePanel.tsx
+++ b/frontend/src/components/UsagePanel.tsx
@@ -114,38 +114,47 @@ interface Exhausted {
   harness: string
   windowLabel: string
   resetsAt: string | null
+  model: string | null
 }
 
 function findExhausted(usage: UsageHarnessSummary): Exhausted | null {
   if (!usage.available || usage.unlimited) return null
-  const windows: Array<[string, UsageMetric | null]> = [
-    ['5-hour', usage.fiveHour],
-    ['weekly', usage.week],
-  ]
-  for (const [label, metric] of windows) {
-    if (metric && metric.percentLeft === 0) {
-      return { harness: usage.name, windowLabel: label, resetsAt: metric.resetsAt }
-    }
+  const windows = usage.weeks.map((metric) => ({ label: 'weekly', metric }))
+  if (usage.fiveHour) windows.unshift({ label: '5-hour', metric: usage.fiveHour })
+
+  const empty = windows.filter(({ metric }) => metric.percentLeft === 0)
+  const exhausted = empty.find(({ metric }) => !metric.model) ?? empty[0]
+  if (!exhausted) return null
+  return {
+    harness: usage.name,
+    windowLabel: exhausted.label,
+    resetsAt: exhausted.metric.resetsAt,
+    model: exhausted.metric.model,
   }
-  return null
 }
 
 function hasCapacity(usage: UsageHarnessSummary): boolean {
   if (!usage.available) return false
   if (usage.unlimited) return true
-  const percents = [usage.fiveHour, usage.week]
-    .map((m) => m?.percentLeft)
-    .filter((v): v is number => v !== null && v !== undefined)
-  return percents.length > 0 && percents.every((v) => v > 0)
+  const windows = usage.fiveHour ? [usage.fiveHour, ...usage.weeks] : usage.weeks
+  const unscopedExhausted = windows.some((metric) => !metric.model && metric.percentLeft === 0)
+  const hasRoom = windows.some((metric) => metric.percentLeft !== null && metric.percentLeft > 0)
+  return !unscopedExhausted && hasRoom
 }
 
 function ExhaustionAlert({ harnesses }: { harnesses: UsageHarnessSummary[] }) {
   const now = useNow(1000)
-  const exhausted = harnesses.map(findExhausted).find((e) => e !== null) ?? null
+  const exhaustedWindows = harnesses
+    .map(findExhausted)
+    .filter((window): window is Exhausted => window !== null)
+  const exhausted = exhaustedWindows.find((window) => !window.model) ?? exhaustedWindows[0] ?? null
   if (!exhausted) return null
 
   const alternative = harnesses.find((h) => h.name !== exhausted.harness && hasCapacity(h))
   const resetSeconds = secondsUntil(exhausted.resetsAt, now)
+  const title = exhausted.model
+    ? `${exhausted.model} ${exhausted.windowLabel} limit reached`
+    : `${capitalize(exhausted.harness)} ${exhausted.windowLabel} limit reached`
 
   return (
     <div className="us-alert" role="alert">
@@ -154,20 +163,29 @@ function ExhaustionAlert({ harnesses }: { harnesses: UsageHarnessSummary[] }) {
       </div>
       <div className="us-alert-body">
         <div className="us-alert-line1">
-          <span className="us-alert-title">
-            {capitalize(exhausted.harness)} {exhausted.windowLabel} limit reached
+          <span className="us-alert-title">{title}</span>
+          <span className="us-alert-tag mono">
+            {exhausted.model ? 'model exhausted' : 'no capacity'}
           </span>
-          <span className="us-alert-tag mono">no capacity</span>
         </div>
         <div className="us-alert-sub">
-          New {exhausted.harness} runs will fail until the window resets.{' '}
-          {alternative ? (
+          {exhausted.model ? (
             <span>
-              <b>{capitalize(alternative.name)} has capacity</b> — route new work there to keep
-              builds moving.
+              New {exhausted.harness} runs on {exhausted.model} will fail until the window resets.{' '}
+              <b>{capitalize(exhausted.harness)} still has capacity for other models.</b>
             </span>
           ) : (
-            <span>No other provider has spare capacity either.</span>
+            <>
+              New {exhausted.harness} runs will fail until the window resets.{' '}
+              {alternative ? (
+                <span>
+                  <b>{capitalize(alternative.name)} has capacity</b> — route new work there to keep
+                  builds moving.
+                </span>
+              ) : (
+                <span>No other provider has spare capacity either.</span>
+              )}
+            </>
           )}
         </div>
       </div>
@@ -225,15 +243,8 @@ function ProviderPanel({
                   rateNoun="window"
                 />
               )}
-              {usage.week && (
-                <WindowRow
-                  label="weekly"
-                  metric={usage.week}
-                  spark={history?.week}
-                  sparkLabel="remaining · this week"
-                  sparkId={`${label}-wk`}
-                  rateNoun="week"
-                />
+              {usage.weeks.length > 0 && (
+                <WeeklyCarousel harness={label} weeks={usage.weeks} history={history} />
               )}
             </>
           )}
@@ -262,6 +273,80 @@ function ProviderPanel({
   )
 }
 
+/** Which window binds — closest to exhaustion, whichever stops work first. */
+function indexOfBinding(weeks: UsageMetric[]): number {
+  let binding = 0
+  weeks.forEach((week, index) => {
+    const room = week.percentLeft ?? Infinity
+    if (room < (weeks[binding]?.percentLeft ?? Infinity)) binding = index
+  })
+  return binding
+}
+
+function WeeklyCarousel({
+  harness,
+  weeks,
+  history,
+}: {
+  harness: string
+  weeks: UsageMetric[]
+  history: UsageHarnessHistory | undefined
+}) {
+  const bindingIndex = indexOfBinding(weeks)
+  const [selectedIndex, setSelectedIndex] = useState(bindingIndex)
+  const currentIndex = selectedIndex < weeks.length ? selectedIndex : bindingIndex
+  const metric = weeks[currentIndex]
+  if (!metric) return null
+  const multiple = weeks.length > 1
+  const previousIndex = (currentIndex - 1 + weeks.length) % weeks.length
+  const nextIndex = (currentIndex + 1) % weeks.length
+  const spark = history?.weeks.find((window) => window.model === metric.model)?.points
+  return (
+    <div className="us-week-carousel">
+      <WindowRow
+        label="weekly"
+        metric={metric}
+        spark={spark}
+        sparkLabel="remaining · this week"
+        sparkId={`${harness}-wk-${currentIndex}`}
+        rateNoun="week"
+      />
+      {multiple && (
+        <div className="us-week-pages">
+          <button
+            type="button"
+            className="us-week-arrow"
+            aria-label="Previous weekly window"
+            onClick={() => setSelectedIndex(previousIndex)}
+          >
+            ‹
+          </button>
+          <div className="us-week-dots">
+            {weeks.map((window, index) => (
+              <button
+                key={index}
+                type="button"
+                className={`us-week-dot ${index === currentIndex ? 'is-current' : ''}`}
+                aria-label={`Show weekly window ${index + 1} of ${weeks.length}: ${window.model ?? 'all models'}`}
+                aria-current={index === currentIndex ? 'true' : undefined}
+                onClick={() => setSelectedIndex(index)}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            className="us-week-arrow"
+            aria-label="Next weekly window"
+            onClick={() => setSelectedIndex(nextIndex)}
+          >
+            ›
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ---- Window block -----------------------------------------------------------
 
 function WindowRow({
@@ -287,6 +372,7 @@ function WindowRow({
         <div className="us-win-top">
           <span className="us-win-label mono">
             <b>{label}</b>
+            {metric.model ? ` · ${metric.model}` : ''}
           </span>
           <span className="us-win-pct mono dim">—</span>
         </div>

--- a/frontend/src/components/UsagePill.tsx
+++ b/frontend/src/components/UsagePill.tsx
@@ -11,7 +11,7 @@ import type { UsageHarnessSummary } from '../api/types'
  *
  *   ◯ c 82%   ◯ x 36%
  *
- * The colour key is the "headline" metric — whichever of 5h vs weekly
+ * The colour key is the "headline" metric — whichever rate-limit window
  * has less left. Click navigates to ``/usage`` for the full detail
  * panel. Tooltip carries the breakdown so a quick hover gives you the
  * full picture without leaving the current page.
@@ -73,13 +73,15 @@ function MiniPill({ usage, short }: { usage: UsageHarnessSummary; short: string 
   )
 }
 
-// "Headline" metric — the smaller of (5h, week). That's the one most
-// likely to bite you next; the panel shows both side-by-side.
+// "Headline" metric — the smallest reported window is the one most
+// likely to bite you next; the panel identifies its scope.
 function headlineMetric(usage: UsageHarnessSummary): number | null {
   if (!usage.available) return null
   const candidates: number[] = []
   if (usage.fiveHour && usage.fiveHour.percentLeft !== null) candidates.push(usage.fiveHour.percentLeft)
-  if (usage.week && usage.week.percentLeft !== null) candidates.push(usage.week.percentLeft)
+  for (const week of usage.weeks) {
+    if (week.percentLeft !== null) candidates.push(week.percentLeft)
+  }
   if (candidates.length === 0) return null
   return Math.min(...candidates)
 }
@@ -111,8 +113,11 @@ function buildTooltip(usage: UsageHarnessSummary): string {
   if (usage.fiveHour && usage.fiveHour.percentLeft !== null) {
     lines.push(`  5h: ${usage.fiveHour.percentLeft}% left${formatResets(usage.fiveHour.resetsAt)}`)
   }
-  if (usage.week && usage.week.percentLeft !== null) {
-    lines.push(`  week: ${usage.week.percentLeft}% left${formatResets(usage.week.resetsAt)}`)
+  for (const week of usage.weeks) {
+    if (week.percentLeft !== null) {
+      const scope = week.model ? ` · ${week.model}` : ''
+      lines.push(`  week${scope}: ${week.percentLeft}% left${formatResets(week.resetsAt)}`)
+    }
   }
   if (usage.scrapedAt) {
     lines.push(`scraped ${formatAge(usage.ageSeconds)} ago`)

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1562,6 +1562,35 @@ input.set-select { background-image: none; padding-right: 12px; }
 .us-win-pct-num { font-size: 19px; font-weight: 500; line-height: 1; }
 .us-win-pct-unit { font-size: 11px; color: var(--text-dim); letter-spacing: 0.04em; }
 .us-win-missing { padding-bottom: 8px; }
+.us-week-carousel { border-bottom: 1px dashed var(--border-soft); }
+.us-week-carousel:last-child { border-bottom: none; }
+.us-week-carousel .us-win { border-bottom: none; padding-bottom: 8px; }
+.us-week-pages {
+  display: flex; align-items: center; justify-content: center; gap: 10px;
+  min-height: 24px; padding-bottom: 4px;
+}
+.us-week-arrow {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px; padding: 0;
+  border: 1px solid transparent; border-radius: 2px;
+  background: transparent; color: var(--text-dim);
+  font-size: 17px; line-height: 1; cursor: pointer;
+}
+.us-week-arrow:hover { color: var(--text-mid); border-color: var(--border); background: var(--surface-2); }
+.us-week-arrow:focus-visible,
+.us-week-dot:focus-visible { outline: 1px solid var(--fam); outline-offset: 1px; }
+.us-week-dots { display: inline-flex; align-items: center; gap: 6px; }
+.us-week-dot {
+  position: relative;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: transparent;
+}
+.us-week-dot::after {
+  content: ''; position: absolute; left: 50%; top: 50%;
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--text-faint); transform: translate(-50%, -50%);
+}
+.us-week-dot.is-current::after { background: var(--text-mid); }
 
 /* health coloring */
 .h-ok   { color: var(--outcome-merged); }


### PR DESCRIPTION
A plan can meter one model's weekly quota separately from the rest. The parser kept only the window closest to exhaustion and discarded the others, so once that model ran out the weekly meter pinned to its 0% with nothing to roll over to — and the panel announced the whole harness was out when only one model was.

Every weekly window a plan reports is now kept end to end. `usage_scrapes` stores them as one ordered list, `/usage` returns all of them, and `/usage/history` returns a series per window. The weekly row becomes a carousel: it opens on the window that binds, and dots show the operator there are others — one of which may still have room.

The exhaustion banner scopes its warning. An unscoped window at 0% still means new runs on that harness will fail; a window metered to one model says so, and names the model.

The five-hour meter is unchanged: singular, unscoped, fixed above the weekly row.

Migration `b6d9e2c4f8a1` folds the three `week_*` columns into `weeks` and reverses.

Closes ENG-809.
