### PR TITLE
Release 0.1.0 with a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to Druks. Versions follow [semantic versioning](https://semver.org);
+while Druks is pre-1.0, a minor bump may break compatibility.
+
+## [0.1.0] — 2026-08-02
+
+### Added
+
+- **Multi-tenancy.** Each person signs in through the edge, connects their own
+  Claude and Codex subscriptions, and sees their own quota and spend.
+- **MCP endpoint.** Druks serves `/mcp`. Point an agent at it with a personal
+  access token to answer gates, retry runs, and read usage.
+- **MCP server installs.** Search the official registry from Settings and install
+  a server by name, connected once for everyone or separately per account.
+- **`druks.toml`.** One authored config file; the installer renders `.env` from it.
+- **Review extension.** A second bundled app. It reviews a pull request against a
+  checkout of the repo and posts one GitHub review.
+- **Plan gate.** Choose who approves a plan: a human, the machine, or the machine
+  and then a human.
+- **Failure recovery.** Agent calls retry transient harness failures and wait out
+  quota windows. A run that died can be retried from the step that killed it.
+- **Encryption at rest** for harness credentials, MCP headers, and secret settings.
+- **Extension testing.** Installing Druks registers pytest fixtures, so an
+  extension tests itself without a Druks checkout.
+
+### Changed
+
+- **`build` is now `ship`**, packaged under `druks.contrib.ship` and served at
+  `/api/ship`.
+- **Trackers belong to ship.** An installation names one tracker and holds its
+  credentials in the dashboard.
+- **Subjects.** A workflow declares what its runs are about, and the subject
+  answers for its own status, timeline, and board.
+- **The journal replaces workflow state.** A run records typed facts and
+  announces them.
+- **Models come from the provider**, not a list shipped in the code.
+- **The events feed is one global timeline.**
+
+### Removed
+
+- **The scoper** — no brief agent, no refinement statuses.
+- **Environment-variable configuration.** Secrets, endpoints, GitHub App ids, and
+  tracker credentials moved to `druks.toml` and dashboard settings.
+- **`druks.ticketing`** from the platform. A tracker now only pushes status.
+- **`Workflow.set_state()`, `Extension.format_event()`, and
+  `Extension.subject_type`**, replaced by the journal, feed facts, and the
+  subject class.
+- **Jira remote links and sub-task creation.**
+
+## [0.0.1] — 2026-07-12
+
+Initial public release.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ with the route that matches what you are doing.
   settings, integrations, MCP, skills, and stored-secret handling.
 - [Connect your agent](connect-your-agent.md) — the `/mcp` endpoint, personal
   access tokens, and client configuration.
+- [Changelog](../CHANGELOG.md) — what each release added, changed, and removed.
 - [Troubleshooting](troubleshooting.md) — symptom-driven diagnosis for boot,
   webhooks, harnesses, sandboxes, gates, and recovery.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,7 +13,8 @@ publishes the matching version tag and the immutable SHA tag; it does not move
    workflow checks from [Development](development.md#verification).
 3. Review migrations and workflow replay compatibility. A container rollback
    does not downgrade Postgres or DBOS state.
-4. Update the version in `pyproject.toml` and user-facing release notes.
+4. Update the version in `pyproject.toml` and add the release's section to
+   [the changelog](../CHANGELOG.md).
 5. Merge the release change and record the resulting full commit SHA.
 
 Create a signed annotated tag from that exact commit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "druks"
-version = "0.0.1"
+version = "0.1.0"
 description = "Autonomous software delivery; the self-hosted home for durable agent apps."
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -534,7 +534,7 @@ wheels = [
 
 [[package]]
 name = "druks"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Druks has one published version, `v0.0.1`, which is the squashed initial commit. `main` is 168 commits and 426 files past it with no record of what moved. This adds that record and cuts the next release.

`CHANGELOG.md` lists `0.0.1` as the initial public release and `0.1.0` as everything since, split into what was added, changed, and removed. The version bump is 0.1.0 rather than 0.0.2 because the public surface moved: the bundled extension is `ship` and its routes are `/api/ship/*`, `druks.ticketing` is gone from the platform, `Workflow.set_state()` and `Extension.format_event()` are deleted, configuration moved from `.env` to `druks.toml`, and the migration chain restarts at a new baseline. The scaffold template depends on an unpinned `druks`, so a minor bump is what lets an extension pin `druks<0.1`.

The version lives only in `pyproject.toml`. `docs/index.md` lists the changelog, and the release process now names the file it asks you to update.