### PR TITLE
The installer stops advertising GHCR_TOKEN

### DIFF
--- a/backend/druks/cli.py
+++ b/backend/druks/cli.py
@@ -36,8 +36,7 @@ def main() -> None:
         "setup",
         help=(
             "Create or update druks.toml and render the install .env. "
-            "Exits 0 when boot-ready, 3 when gaps remain, and 4 when an "
-            "existing pre-TOML .env needs hand migration."
+            "Exits 0 when boot-ready and 3 when gaps remain."
         ),
     )
     setup_parser.add_argument("env_path", help="Path to the rendered .env.")

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -207,7 +207,6 @@ provider = ""
 service_url = ""
 service_token = ""
 image = ""
-service_tokens = ""
 timeout = 180
 
 # Put drukbox environment in [sandbox.<provider>]. The table is passed through

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -11,7 +11,6 @@ from typing import Any
 import tomlkit
 
 GAPS_EXIT_CODE = 3
-MIGRATION_EXIT_CODE = 4
 
 _COMPOSE_ENV_KEYS = (
     "DRUKS_UID",
@@ -74,7 +73,7 @@ _KNOWN_TOML_KEYS = {
         "secrets_key",
     ),
     "paths": ("data_dir", "claude_home", "codex_home", "claude_json"),
-    "sandbox": ("provider", "service_url", "service_token", "image", "service_tokens", "timeout"),
+    "sandbox": ("provider", "service_url", "service_token", "image", "timeout"),
     "env": (),
 }
 
@@ -110,10 +109,6 @@ def run_setup(
     print_fn: Callable[[str], None] = print,
 ) -> int:
     toml_path = env_path.parent / "druks.toml"
-    if env_path.exists() and not toml_path.exists():
-        _print_migration_recipe(print_fn, env_path, toml_path)
-        return MIGRATION_EXIT_CODE
-
     is_fresh = not toml_path.exists()
     is_changed = is_fresh
     if is_fresh:
@@ -128,18 +123,6 @@ def run_setup(
             _set_value(document, value_path, value)
     else:
         document = tomlkit.parse(toml_path.read_text())
-        sandbox = document.get("sandbox")
-        configured_provider = _get_string(document, ("sandbox", "provider"))
-        if (
-            isinstance(sandbox, MutableMapping)
-            and configured_provider
-            and "env" in sandbox
-            and configured_provider not in sandbox
-        ):
-            sandbox[configured_provider] = sandbox["env"]
-            del sandbox["env"]
-            print_fn(f"Renamed [sandbox.env] to [sandbox.{configured_provider}].")
-            is_changed = True
 
     for assignment in set_values:
         value_path, value = _parse_assignment(assignment)
@@ -467,9 +450,7 @@ def _render_env(
 
     service_tokens = ""
     if provider != "docker":
-        service_tokens = _get_string(config, ("sandbox", "service_tokens")) or _get_string(
-            config, ("sandbox", "service_token")
-        )
+        service_tokens = _get_string(config, ("sandbox", "service_token"))
 
     sections = (
         (
@@ -699,23 +680,6 @@ def _shape_message(provider: str) -> str:
         f"provider {provider!r} → remote shape; drukbox validates the name — "
         "check `druks doctor` after boot"
     )
-
-
-def _print_migration_recipe(
-    print_fn: Callable[[str], None],
-    env_path: Path,
-    toml_path: Path,
-) -> None:
-    print_fn(f"Refusing to replace existing {env_path}: {toml_path} does not exist.")
-    print_fn("Back up .env and hand-write druks.toml, copying values verbatim:")
-    print_fn("  - DRUKS_POSTGRES_PASSWORD → [secrets].postgres_password")
-    print_fn("  - DRUKS_SECRETS_KEY → [secrets].secrets_key")
-    print_fn("  - DRUKS_WEBHOOK_SECRET → [secrets].webhook_secret")
-    print_fn("  - DRUKS_SANDBOX_SERVICE_TOKEN → [sandbox].service_token")
-    print_fn("  - GITHUB_*_APP_ID → [github]")
-    print_fn("  - provider and its credentials → [sandbox] and [sandbox.<provider>]")
-    print_fn("  - other hand-added .env keys → [env]")
-    print_fn("Nothing was written.")
 
 
 def _print_outcome(

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 from druks.settings import Settings
-from druks.setup_env import GAPS_EXIT_CODE, MIGRATION_EXIT_CODE, read_env, run_setup
+from druks.setup_env import GAPS_EXIT_CODE, read_env, run_setup
 
 DROPPED_RENDER_KEYS = {
     "DRUKS_AUTH_MODE": ("identity.mode", "jwt"),
@@ -149,28 +149,6 @@ def test_exe_provider_environment_renders_verbatim(tmp_path):
     assert values["CUSTOM_DRUKBOX_VALUE"] == "verbatim"
 
 
-def test_legacy_sandbox_table_is_renamed_to_the_provider_table(tmp_path):
-    env_path = tmp_path / ".env"
-    _run(env_path)
-    toml_path = tmp_path / "druks.toml"
-    toml_path.write_text(
-        toml_path.read_text().replace(
-            "[sandbox.exe]",
-            "# credentials for this provider\n[sandbox.env]",
-        )
-    )
-    printed = []
-
-    _run(env_path, print_fn=printed.append)
-
-    written = toml_path.read_text()
-    assert "Renamed [sandbox.env] to [sandbox.exe]." in printed
-    assert "[sandbox.exe]" in written
-    assert "[sandbox.env]" not in written
-    assert "# credentials for this provider" in written
-    assert read_env(env_path)["EXE_API_URL"] == "https://exe.dev"
-
-
 def test_foreign_provider_table_is_a_named_gap(tmp_path):
     env_path = tmp_path / ".env"
     printed = []
@@ -218,30 +196,6 @@ def test_non_string_known_setting_is_refused(tmp_path):
 
     with pytest.raises(ValueError, match="github.operator_app_id must be a string"):
         _run(env_path)
-
-
-def test_pre_toml_guard_refuses_without_writing(tmp_path):
-    env_path = tmp_path / ".env"
-    env_path.write_text("DRUKS_POSTGRES_PASSWORD=keep\n")
-    before = env_path.read_bytes()
-    printed = []
-
-    rc = _run(env_path, print_fn=printed.append)
-
-    assert rc == MIGRATION_EXIT_CODE
-    assert env_path.read_bytes() == before
-    assert {path.name for path in tmp_path.iterdir()} == {".env"}
-    output = "\n".join(printed)
-    for key in (
-        "DRUKS_POSTGRES_PASSWORD",
-        "DRUKS_SECRETS_KEY",
-        "DRUKS_WEBHOOK_SECRET",
-        "DRUKS_SANDBOX_SERVICE_TOKEN",
-        "GITHUB_*_APP_ID",
-        "[sandbox.<provider>]",
-        "other hand-added .env keys → [env]",
-    ):
-        assert key in output
 
 
 def test_set_updates_toml_and_rerender_preserves_the_values(tmp_path):

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -31,9 +31,7 @@ The Druks application and sandbox images are published for both `linux/amd64`
 and `linux/arm64`.
 
 Everything else — `compose.yaml`, the Caddyfile, `druks.toml`, the rendered
-`.env`, image pulls, and DB init — is handled by `install.sh`. (While the
-ghcr.io images require auth, export `GHCR_TOKEN` — a PAT with `read:packages`
-— and the installer logs in with it.)
+`.env`, image pulls, and DB init — is handled by `install.sh`.
 
 ### 1. Run the installer
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,7 +105,7 @@ fi
 
 # ---------------------------------------------------------------------------
 # 3. TOML setup + .env render — the required-values brain is ``druks setup``
-#    (exit 0 = boot-ready, 3 = gaps, 4 = pre-TOML hand migration required)
+#    (exit 0 = boot-ready, 3 = gaps)
 # ---------------------------------------------------------------------------
 TTY_FLAGS=(-i)
 SETUP_ARGS=(--provider "$PROVIDER" --install-dir "$INSTALL_DIR" --home "$HOME")
@@ -123,7 +123,6 @@ set -e
 case "$setup_rc" in
   0) ;;        # boot-ready — fall through to pull + boot
   3) exit 0 ;; # gaps remain — setup printed the checklist; re-run when done
-  4) exit 4 ;; # pre-TOML .env — setup printed the hand-migration recipe
   *) echo "druks setup failed (exit $setup_rc)" >&2; exit "$setup_rc" ;;
 esac
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,35 +2,26 @@
 # Druks installer — the only thing you fetch on a fresh box.
 #
 # Idempotent: re-run any time to pull a fresh compose.yaml + new images.
-# Deployment configuration lives in druks.toml. ``druks setup`` (run from
-# the backend image) creates it on a fresh box, prompts for required values,
-# and renders the complete .env artifact. Edit druks.toml and re-run this
-# installer to render and apply it. When everything needed to boot is present
-# the same run migrates the DB (out of band, once — never on boot) and brings
-# the stack up; otherwise it prints the remaining checklist and exits.
-# Claude/Codex subscription auth is NOT a prerequisite: connect them from the
-# dashboard after boot.
-#
-# Three install shapes are selected from DRUKS_PROVIDER: `docker` is local,
-# `exe` pre-seeds exe.dev + tailnet configuration, and every other drukbox
-# provider name uses the generic remote shape.
+# Deployment configuration lives in druks.toml; ``druks setup`` (run from the
+# backend image) creates it, prompts for required values, and renders .env.
+# When everything needed to boot is present the same run migrates the DB (out
+# of band, once — never on boot) and brings the stack up; otherwise it prints
+# the remaining checklist and exits. Claude/Codex subscription auth is not a
+# prerequisite: connect them from the dashboard after boot.
 #
 # Usage:
 #
 #   bash <(curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh)
 #
 # Env knobs:
-#   GHCR_TOKEN            optional — GitHub PAT with `read:packages` scope,
-#                         only needed while the ghcr.io images require auth.
 #   DRUKS_INSTALL_DIR     default ~/druks
 #   DRUKS_REF             default main — tag or full SHA to fetch deploy files from
 #   DRUKS_TAG             image tag to pull/run; defaults to the v* DRUKS_REF,
 #                         sha-<DRUKS_REF> for a full SHA, or latest for main
-#   DRUKS_PROVIDER        default exe — sandbox provider on the first run.
-#                         `docker` selects the local shape, `exe` selects the
-#                         exe.dev shape, and any other name selects the generic
-#                         remote shape. Drukbox validates provider names.
-#                         Ignored after druks.toml exists.
+#   DRUKS_PROVIDER        default exe — sandbox provider on the first run, which
+#                         picks the install shape: `docker` local, `exe` exe.dev
+#                         + tailnet, any other name generic remote. Drukbox
+#                         validates it. Ignored after druks.toml exists.
 #
 # Flags:
 #   --apps                provision the operator + reviewer GitHub Apps via
@@ -85,13 +76,8 @@ mkdir -p caddy
 fetch_from_repo deploy/caddy/Caddyfile caddy/Caddyfile
 
 # ---------------------------------------------------------------------------
-# 2. ghcr login + backend image — ``druks setup`` runs from the image
+# 2. backend image — ``druks setup`` runs from it
 # ---------------------------------------------------------------------------
-if [ -n "${GHCR_TOKEN:-}" ]; then
-  echo "→ logging in to ghcr.io"
-  echo "$GHCR_TOKEN" | docker login ghcr.io -u token --password-stdin >/dev/null
-fi
-
 BACKEND_IMAGE="ghcr.io/czpython/druks:$IMAGE_TAG"
 echo "→ pulling $BACKEND_IMAGE"
 docker pull -q "$BACKEND_IMAGE" >/dev/null
@@ -137,6 +123,7 @@ set -e
 case "$setup_rc" in
   0) ;;        # boot-ready — fall through to pull + boot
   3) exit 0 ;; # gaps remain — setup printed the checklist; re-run when done
+  4) exit 4 ;; # pre-TOML .env — setup printed the hand-migration recipe
   *) echo "druks setup failed (exit $setup_rc)" >&2; exit "$setup_rc" ;;
 esac
 
@@ -206,8 +193,8 @@ if [ "$PROVIDER" != "docker" ]; then
 fi
 
 # Migrations run out of band, once, before the app serves — never on boot.
-# `run --rm` starts the DB deps, applies the schema, and exits (Django's
-# `migrate`, not a service). Idempotent, so it doubles as the upgrade step.
+# `run --rm` starts the DB deps, applies the alembic schema, seeds, and exits.
+# Idempotent, so it doubles as the upgrade step.
 echo "→ druks init-db (idempotent)"
 docker compose run --rm web druks init-db
 if [ "$PROVIDER" != "docker" ]; then
@@ -221,8 +208,7 @@ docker compose up -d
 # ---------------------------------------------------------------------------
 # 5. Done — surface the next steps
 # ---------------------------------------------------------------------------
-common_next() {
-  cat <<MSG
+cat <<MSG
 
 ------------------------------------------------------------
 Stack is up. Verify with:
@@ -235,9 +221,7 @@ Then connect the coding CLIs from the dashboard — Settings →
 Harnesses → Connect for each of Claude and Codex. Agent runs
 refuse to start on a harness that isn't connected.
 MSG
-}
 
-common_next
 if [ "$PROVIDER" = "docker" ]; then
   cat <<MSG
 


### PR DESCRIPTION
The ghcr.io images pull anonymously, so the installer's optional
`docker login ghcr.io` is dead weight — the `GHCR_TOKEN` knob goes with it,
here and in the deploy README.

The rest is the same file catching up with what it does: the install-shape
paragraph folds into the `DRUKS_PROVIDER` knob it describes, `druks init-db`
is named as the alembic + seed step it is, the next-steps heredoc drops the
function it was called through exactly once, and setup's exit 4 (a pre-TOML
`.env` needing hand migration) exits on its own recipe instead of being
reported as a failure.