### PR TITLE
Pinned verification commands keep the CI check that proves them

### DIFF
--- a/backend/druks/contrib/ship/policy.py
+++ b/backend/druks/contrib/ship/policy.py
@@ -26,6 +26,22 @@ class VerificationProfile(BaseModel):
     lint_commands: tuple[str, ...] = ()
     typecheck_commands: tuple[str, ...] = ()
 
+    def get_commands(self, *, detected: dict[str, Any]) -> dict[str, Any]:
+        """These commands, each paired with the CI check the profiler detected for it."""
+        checks = {
+            entry["command"]: entry["ci_check"]
+            for entries in detected.values()
+            for entry in entries
+        }
+        return {
+            key: [{"command": command, "ci_check": checks.get(command)} for command in commands]
+            for key, commands in (
+                ("test_commands", self.test_commands),
+                ("lint_commands", self.lint_commands),
+                ("typecheck_commands", self.typecheck_commands),
+            )
+        }
+
 
 class RepoPolicy(BaseModel):
     """The operator's ``.druks/ship/config.yml``, validated whole so a typo'd

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -427,20 +427,9 @@ class Profile(Workflow):
         policy = await RepoPolicy.resolve(project_repo.full_name)
         effective = dict(baseline)
         if policy.verification:
-            effective["verification"] = {
-                "test_commands": [
-                    {"command": command, "ci_check": None}
-                    for command in policy.verification.test_commands
-                ],
-                "lint_commands": [
-                    {"command": command, "ci_check": None}
-                    for command in policy.verification.lint_commands
-                ],
-                "typecheck_commands": [
-                    {"command": command, "ci_check": None}
-                    for command in policy.verification.typecheck_commands
-                ],
-            }
+            effective["verification"] = policy.verification.get_commands(
+                detected=baseline.get("verification") or {}
+            )
         project_repo.set_profile(baseline=baseline, effective=effective)
 
     async def get_workspace_kwargs(self, sandbox: "Sandbox") -> dict[str, Any]:

--- a/backend/tests/ship/test_profiling.py
+++ b/backend/tests/ship/test_profiling.py
@@ -143,6 +143,28 @@ class TestProfileRun:
             {"command": "ruff check .", "ci_check": "Backend / lint"}
         ]
 
+    async def test_pinned_command_keeps_the_check_detected_for_it(self, druks_db, monkeypatch):
+        repo = _seed_repo()
+
+        async def _profiler(*, repo: str):
+            return _profiled()
+
+        async def _pinning_policy(repo):
+            return RepoPolicy(
+                verification=VerificationProfile(test_commands=("pytest", "make e2e"))
+            )
+
+        monkeypatch.setattr(Ship, "repo_profiler", _profiler)
+        monkeypatch.setattr(RepoPolicy, "resolve", staticmethod(_pinning_policy))
+
+        await Profile().run(repo_id=repo.id)
+        repo = ProjectRepo.get(repo.id)
+
+        assert repo.effective_profile["verification"]["test_commands"] == [
+            {"command": "pytest", "ci_check": "Backend / tests"},
+            {"command": "make e2e", "ci_check": None},
+        ]
+
 
 class TestRefreshOnly:
     async def test_skips_the_agent_and_reapplies_the_pin(self, druks_db, monkeypatch):


### PR DESCRIPTION
Building the effective profile from the operator's pinned commands hardcoded `ci_check` to `None` on every one, discarding what the profiler detected. The evaluator runs any command that names no check — "A configured command with no CI check name runs locally. Never infer that another check covers it." So a repo pinning its verification in `.druks/ship/config.yml` ran every command in the sandbox on every evaluation and could never read its own CI, however often it was re-profiled.

`VerificationProfile.with_ci_checks` pairs each pinned command with the check detected for that same command. Pinning chooses which commands gate a PR; it no longer decides what proves them.

## Acceptance criteria

- AC1: A pinned command matching a detected command carries that command's `ci_check` in the stored effective profile.
  - Verification: `test_pinned_command_keeps_the_check_detected_for_it` pins `("pytest", "make e2e")` against a profile that detected `pytest` under `Backend / tests`, and asserts the stored entries.
- AC2: A pinned command with no matching detected command carries `ci_check: null`.
  - Verification: the same test's `make e2e` entry, plus `test_pinned_verification_replaces_the_detected_one` and `test_skips_the_agent_and_reapplies_the_pin`, which pass unchanged.
- AC3: With no pinned verification, the effective profile is the profiler's own output, unchanged.
  - Verification: `test_persists_baseline_and_effective`, unchanged.

Closes ENG-825.

🤖 Generated with [Claude Code](https://claude.com/claude-code)