### PR TITLE
The agent surface lists open subjects

### DIFF
--- a/backend/druks/api/app.py
+++ b/backend/druks/api/app.py
@@ -17,6 +17,7 @@ from druks.accounts.routes import router as auth_router
 from druks.api.artifacts import router as artifacts_router
 from druks.api.exceptions import AgentApiError
 from druks.api.runs import router as runs_router
+from druks.api.subjects import router as subjects_router
 from druks.database import configure_session, create_engine_from_url, db_session, session_scope
 from druks.durable.engine import init_dbos, launch, shutdown
 from druks.events.routes import router as events_router
@@ -225,6 +226,7 @@ app.include_router(mcp_router, dependencies=_identity_gate)
 app.include_router(notifications_router, dependencies=_identity_gate)
 app.include_router(events_router, dependencies=_identity_gate)
 app.include_router(runs_router, dependencies=_identity_gate)
+app.include_router(subjects_router, dependencies=_identity_gate)
 app.include_router(gateway_router, dependencies=_identity_gate)
 app.include_router(artifacts_router, dependencies=_identity_gate)
 load(app)

--- a/backend/druks/api/schemas.py
+++ b/backend/druks/api/schemas.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from druks.durable.enums import RunState
 from druks.schemas import BaseResponse
 
 
@@ -24,6 +25,28 @@ class CancelRunResponse(BaseResponse):
 
 class RetryRunResponse(BaseResponse):
     run_id: str
+
+
+class OpenWorkflowResponse(BaseResponse):
+    extension: str
+    state: RunState
+    run: str = Field(description="What get_gate, cancel_run, and retry_run take.")
+    latest_agent_call: str | None = Field(
+        description="What get_agent_call takes; null before the first call."
+    )
+    failure: str | None
+    created_at: datetime
+
+
+class OpenSubjectResponse(BaseResponse):
+    subject_type: str
+    subject_id: str
+    subject_label: str
+    workflows: list[OpenWorkflowResponse]
+
+
+class OpenSubjectsResponse(BaseResponse):
+    subjects: list[OpenSubjectResponse]
 
 
 class ArtifactContent(BaseResponse):

--- a/backend/druks/api/subjects.py
+++ b/backend/druks/api/subjects.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter
+
+from druks.api.schemas import OpenSubjectResponse, OpenSubjectsResponse, OpenWorkflowResponse
+from druks.database import db_session
+from druks.durable.enums import RunState
+from druks.durable.models import Run
+
+_WORKFLOW_ROWS = 50
+_FAILURE_TAIL_BYTES = 512
+
+router = APIRouter(prefix="/api", tags=["agent"])
+
+
+@router.get(
+    "/open-subjects",
+    operation_id="list_open_subjects",
+    response_model=OpenSubjectsResponse,
+    response_model_by_alias=True,
+)
+async def list_open_subjects() -> OpenSubjectsResponse:
+    """Every subject with open work — each nesting its open workflows, the
+    newest run of one kind that is scheduled, running, parked, or failed.
+    At most 50 workflows."""
+    rows = db_session().execute(Run.get_open_subjects().limit(_WORKFLOW_ROWS)).all()
+    grouped = {}
+    for row in rows:
+        grouped.setdefault(row.subject_type, {}).setdefault(row.subject_id, []).append(row)
+    subjects = []
+    for subject_type, rows_by_id in grouped.items():
+        for subject_id, workflow_rows in rows_by_id.items():
+            workflows = []
+            for row in workflow_rows:
+                failure = row.failure
+                if failure:
+                    failure = failure.encode()[-_FAILURE_TAIL_BYTES:].decode(errors="ignore")
+                workflows.append(
+                    OpenWorkflowResponse(
+                        extension=row.kind.partition(".")[0],
+                        state=RunState(row.state),
+                        run=row.run_id,
+                        latest_agent_call=row.latest_call_id,
+                        failure=failure,
+                        created_at=row.created_at,
+                    )
+                )
+            newest = workflow_rows[0]
+            subjects.append(
+                OpenSubjectResponse(
+                    subject_type=subject_type,
+                    subject_id=subject_id,
+                    subject_label=newest.subject_label,
+                    workflows=workflows,
+                )
+            )
+    return OpenSubjectsResponse(subjects=subjects)

--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -181,6 +181,53 @@ class Run(Base):
             .order_by(driving.c.created_at.desc())
         )
 
+    @classmethod
+    def get_open_subjects(cls) -> Select:
+        """Every open workflow — the newest run of each kind on each subject, still
+        going or failed — newest first across every installed extension."""
+        state = state_expression(cls.id, cls.input_gate, cls.created_at).label("state")
+        attributes = workflow_status.c.attributes
+        subject_type = attributes["subject_type"].as_string().label("subject_type")
+        subject_id = attributes["subject_id"].as_string().label("subject_id")
+        subject_label = attributes["subject_label"].as_string().label("subject_label")
+        driving = (
+            select(
+                subject_type,
+                subject_id,
+                subject_label,
+                cls.id.label("run_id"),
+                cls.kind,
+                cls.failure,
+                cls.created_at,
+                state,
+                func.row_number()
+                .over(
+                    partition_by=(cls.kind, subject_type, subject_id),
+                    order_by=(cls.created_at.desc(), cls.id.desc()),
+                )
+                .label("rank"),
+            )
+            .join_from(cls, workflow_status, workflow_status.c.workflow_uuid == cls.id)
+            .where(subject_id.is_not(None))
+            .subquery()
+        )
+        latest_call_id = (
+            select(AgentCall.id)
+            .where(AgentCall.run_id == driving.c.run_id)
+            .order_by(AgentCall.created_at.desc(), AgentCall.id.desc())
+            .limit(1)
+            .scalar_subquery()
+            .label("latest_call_id")
+        )
+        return (
+            select(driving, latest_call_id)
+            .where(
+                driving.c.rank == 1,
+                driving.c.state.in_([run_state.value for run_state in OPEN_STATES]),
+            )
+            .order_by(driving.c.created_at.desc(), driving.c.run_id.desc())
+        )
+
     def get_ask(self) -> dict[str, Any]:
         # The parked ask, ready to serve. An in-app review's ask names neither
         # label nor artifact — a parked run can't produce new artifacts, so the
@@ -500,7 +547,7 @@ class AgentCall(Base, Uuid7Pk):
         return list(db_session().scalars(stmt))
 
     @classmethod
-    def by_run(cls, run_ids: list[str]) -> dict[str, list["AgentCall"]]:
+    def get_by_run(cls, run_ids: list[str]) -> dict[str, list["AgentCall"]]:
         # The calls under each run, in execution order — one query for a timeline.
         stmt = select(cls).where(cls.run_id.in_(run_ids)).order_by(cls.created_at, cls.id)
         grouped: dict[str, list[AgentCall]] = {run_id: [] for run_id in run_ids}

--- a/backend/druks/durable/reads.py
+++ b/backend/druks/durable/reads.py
@@ -44,7 +44,7 @@ def list_subject_timeline(subject_type: str, subject_id: str) -> list[RunRespons
     # The subject's whole timeline: every run about it, oldest first, each
     # with its agent calls.
     runs = Run.list_for_subject(subject_type, subject_id)
-    return _timeline(runs, AgentCall.by_run([run.id for run in runs]))
+    return _timeline(runs, AgentCall.get_by_run([run.id for run in runs]))
 
 
 def get_subject_status(
@@ -71,7 +71,7 @@ def get_subject_response(
     activity: SubjectActivity | None = None,
 ) -> SubjectResponse:
     runs = Run.list_for_subject(subject_type, subject_id)
-    calls_by_run = AgentCall.by_run([run.id for run in runs])
+    calls_by_run = AgentCall.get_by_run([run.id for run in runs])
     latest = Run.get_latest_for_subject(subject_type, subject_id)
     return SubjectResponse(
         summary=summary,
@@ -82,7 +82,7 @@ def get_subject_response(
 
 
 def _timeline(runs: list[Run], calls_by_run: dict[str, list[AgentCall]]) -> list[RunResponse]:
-    # by_run keys every run id, so the lookup is total.
+    # get_by_run keys every run id, so the lookup is total.
     ordered = sorted(runs, key=lambda run: (run.created_at, run.id))
     return [
         RunResponse.from_run(

--- a/backend/druks/mcp/app.py
+++ b/backend/druks/mcp/app.py
@@ -18,15 +18,17 @@ from druks.accounts.models import PersonalAccessToken
 from druks.database import db_session
 
 _INSTRUCTIONS = """\
-Druks coordinates durable agent runs over shared work items. This surface
-answers gates: get_gate returns a parked run's ask, a bounded artifact
-chunk, and parkedAt; answer_gate must echo that parkedAt unchanged — it
-names the exact question being answered, and a repeat answer reports
-already_answered. get_agent_call returns bounded transcript and stderr
-tails, never full payloads. cancel_run records its reason as the run's
-failure. retry_run reruns a failed run from the step that killed it.
-get_usage is the caller's quota and today's spend. There is no push channel;
-poll. Tool failures embed {code, message, retryable} from the HTTP surface.
+Druks coordinates durable agent runs over shared work items. Start with
+list_open_subjects; each workflow's run and latestAgentCall ids feed the
+id-keyed tools.
+get_gate returns a parked run's ask, a bounded artifact chunk, and parkedAt;
+answer_gate must echo that parkedAt unchanged — it names the exact question
+being answered, and a repeat answer reports already_answered. get_agent_call
+returns bounded transcript and stderr tails, never full payloads. cancel_run
+records its reason as the run's failure. retry_run reruns a failed run from
+the step that killed it. get_usage is the caller's quota and today's spend.
+There is no push channel; poll. Tool failures embed {code, message, retryable}
+from the HTTP surface.
 """
 
 # FastMCP logs component-fn errors instead of raising, so the tools/list
@@ -37,6 +39,7 @@ _TOOL_ANNOTATIONS = {
     "get_agent_call": ToolAnnotations(readOnlyHint=True),
     "cancel_run": ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True),
     "retry_run": ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False),
+    "list_open_subjects": ToolAnnotations(readOnlyHint=True),
     "get_usage": ToolAnnotations(readOnlyHint=True),
 }
 

--- a/backend/druks/testing.py
+++ b/backend/druks/testing.py
@@ -319,7 +319,7 @@ def seed_run(
     session.flush()
     identity = None
     if subject:
-        identity = subject.identity
+        identity = {**subject.identity, "label": subject.label}
     seed_dbos_status(session, run.id, state, subject=identity)
     session.expire(run, ["state", "updated_at"])
     return run
@@ -344,7 +344,13 @@ def seed_dbos_status(
     }[state]
     attributes = None
     if subject:
-        attributes = {"subject_type": subject["type"], "subject_id": str(subject["id"])}
+        attributes = {
+            "subject_type": subject["type"],
+            "subject_id": str(subject["id"]),
+            # start() always stamps a label; an identity dict without one labels
+            # itself by its id — Subject.label's own rule.
+            "subject_label": subject.get("label") or str(subject["id"]),
+        }
     session.execute(
         workflow_status.insert().values(
             workflow_uuid=run_id,

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -1,10 +1,11 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 from druks.accounts.models import Account
 from druks.api.app import app
-from druks.durable.models import Run
+from druks.durable.dbos_state import workflow_status
+from druks.durable.models import AgentCall, Run
 from druks.durable.reads import read_transcript_chunk
 from druks.mcp.gateway import services
 from druks.testing import configure_app_for_test, make_settings, seed_call, seed_run
@@ -24,6 +25,7 @@ _MCP_ROUTES = {
     ("get", "/api/agent-calls/{call_id}"): "get_agent_call",
     ("post", "/api/runs/{run_id}/cancel"): "cancel_run",
     ("post", "/api/runs/{run_id}/retry"): "retry_run",
+    ("get", "/api/open-subjects"): "list_open_subjects",
     ("get", "/api/usage/summary"): "get_usage",
 }
 
@@ -67,7 +69,7 @@ def _park(druks_db, note):
     return run
 
 
-def test_openapi_pins_the_six_agent_routes(client: TestClient):
+def test_openapi_pins_the_seven_agent_routes(client: TestClient):
     schema = app.openapi()
     found = {
         (method, path): operation
@@ -89,6 +91,7 @@ def test_agent_routes_sit_behind_the_gate(tmp_path, druks_db):
     )
     with TestClient(app) as anonymous:
         assert anonymous.get("/api/gates/x").status_code == 401
+        assert anonymous.get("/api/open-subjects").status_code == 401
         assert anonymous.get("/api/usage/summary").status_code == 401
 
 
@@ -111,6 +114,151 @@ def test_agent_errors_share_one_shape(client: TestClient, druks_db):
     body = stale.json()
     assert body["code"] == "GATE_ROUND_STALE"
     assert body["retryable"] is True
+
+
+def test_list_open_subjects_returns_newest_open_work_and_latest_calls(client: TestClient, druks_db):
+    finished_note = Note.create(body="finished")
+    seed_run(druks_db, kind=Summarize.kind, subject=finished_note, state="finished")
+
+    failed_note = Note.create(body="failed")
+    older = seed_run(druks_db, kind=Summarize.kind, subject=failed_note)
+    older.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    seed_call(druks_db, older, "older")
+    failure = "discarded failure prefix " + "f" * 512
+    newest = seed_run(
+        druks_db,
+        kind=Summarize.kind,
+        subject=failed_note,
+        state="failed",
+        failure=failure,
+    )
+    newest.created_at = older.created_at + timedelta(days=1)
+    seed_call(druks_db, newest, "first")
+    latest_call = seed_call(druks_db, newest, "latest")
+    subject_label = "long label kept whole " + "l" * 512
+    druks_db.execute(
+        workflow_status.update()
+        .where(workflow_status.c.workflow_uuid == newest.id)
+        .values(
+            attributes={
+                "subject_type": failed_note.subject_type,
+                "subject_id": str(failed_note.id),
+                "subject_label": subject_label,
+            }
+        )
+    )
+
+    callless_note = Note.create(body="callless")
+    seed_run(druks_db, kind="field_notes.audit", subject=callless_note)
+    seed_run(druks_db, kind="usage.scrape")
+
+    response = client.get("/api/open-subjects")
+
+    assert response.status_code == 200
+    body = response.json()
+    subjects = {subject["subjectId"]: subject for subject in body["subjects"]}
+    assert set(subjects) == {str(failed_note.id), str(callless_note.id)}
+    assert subjects[str(failed_note.id)] == {
+        "subjectType": failed_note.subject_type,
+        "subjectId": str(failed_note.id),
+        "subjectLabel": subject_label,
+        "workflows": [
+            {
+                "extension": "field_notes",
+                "state": "failed",
+                "run": newest.id,
+                "latestAgentCall": latest_call.id,
+                "failure": "f" * 512,
+                "createdAt": newest.created_at.isoformat().replace("+00:00", "Z"),
+            }
+        ],
+    }
+    assert subjects[str(callless_note.id)]["workflows"][0]["latestAgentCall"] is None
+
+
+def test_list_open_subjects_keeps_type_and_kind_partitions(client: TestClient, druks_db):
+    typed_note = Note.create(body="two types")
+    note_run = seed_run(druks_db, kind=Summarize.kind, subject=typed_note)
+    ticket_run = seed_run(druks_db, kind=Summarize.kind, subject=typed_note)
+    druks_db.execute(
+        workflow_status.update()
+        .where(workflow_status.c.workflow_uuid == ticket_run.id)
+        .values(
+            attributes={
+                "subject_type": "ticket",
+                "subject_id": str(typed_note.id),
+                "subject_label": "T-1",
+            }
+        )
+    )
+
+    multi_kind_note = Note.create(body="two kinds")
+    scan = seed_run(druks_db, kind="field_notes.scan", subject=multi_kind_note)
+    audit = seed_run(druks_db, kind="field_notes.audit", subject=multi_kind_note)
+
+    terminal_sibling_note = Note.create(body="terminal sibling")
+    failed_scan = seed_run(
+        druks_db,
+        kind="field_notes.scan",
+        subject=terminal_sibling_note,
+        state="failed",
+    )
+    failed_scan.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    finished_audit = seed_run(
+        druks_db,
+        kind="field_notes.audit",
+        subject=terminal_sibling_note,
+        state="finished",
+    )
+    finished_audit.created_at = failed_scan.created_at + timedelta(days=1)
+    druks_db.flush()
+
+    body = client.get("/api/open-subjects").json()
+
+    assert len(body["subjects"]) == 4
+    run_ids = {workflow["run"] for subject in body["subjects"] for workflow in subject["workflows"]}
+    assert run_ids == {note_run.id, ticket_run.id, scan.id, audit.id, failed_scan.id}
+    assert finished_audit.id not in run_ids
+    multi_kind = next(
+        subject
+        for subject in body["subjects"]
+        if subject["subjectId"] == str(multi_kind_note.id)
+        and subject["subjectType"] == multi_kind_note.subject_type
+    )
+    assert {workflow["run"] for workflow in multi_kind["workflows"]} == {scan.id, audit.id}
+    shared_id_types = {
+        subject["subjectType"]
+        for subject in body["subjects"]
+        if subject["subjectId"] == str(typed_note.id)
+    }
+    assert shared_id_types == {typed_note.subject_type, "ticket"}
+
+
+def test_list_open_subjects_excludes_historical_runs(client: TestClient, druks_db):
+    note = Note.create(body="one open subject")
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    for number in range(10):
+        historical = seed_run(druks_db, kind=Summarize.kind, subject=note, state="finished")
+        historical.created_at = start + timedelta(seconds=number)
+    current = seed_run(druks_db, kind=Summarize.kind, subject=note)
+    current.created_at = start + timedelta(seconds=10)
+    druks_db.flush()
+
+    body = client.get("/api/open-subjects").json()
+
+    assert [
+        workflow["run"] for subject in body["subjects"] for workflow in subject["workflows"]
+    ] == [current.id]
+
+
+def test_list_open_subjects_caps_the_workflows(client: TestClient, druks_db):
+    for number in range(51):
+        note = Note.create(body=f"open {number}")
+        seed_run(druks_db, kind=Summarize.kind, subject=note)
+
+    body = client.get("/api/open-subjects").json()
+
+    assert len(body["subjects"]) == 50
 
 
 def test_get_gate_then_answer_roundtrip(client: TestClient, druks_db, resume_spy):
@@ -245,8 +393,6 @@ def test_resume_route_contract_is_preserved(client: TestClient, druks_db, resume
 
 
 def test_usage_agent_route_matches_the_service(client: TestClient, druks_db, account):
-    from druks.durable.models import AgentCall
-
     note = Note.create(body="usage route")
     run = seed_run(
         druks_db,

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -36,11 +36,12 @@ _WIRE_HEADERS = {
     "Content-Type": "application/json",
 }
 
-# tools/list order is route declaration order: the runs router mounts before
-# the gateway router.
+# tools/list order is route declaration order: the subjects router mounts
+# between the runs and gateway routers.
 _TOOL_NAMES = [
     "cancel_run",
     "retry_run",
+    "list_open_subjects",
     "get_gate",
     "answer_gate",
     "get_agent_call",
@@ -164,13 +165,14 @@ async def test_mcp_subpaths_never_reach_the_spa(app):
             assert stray.headers["content-type"].startswith("application/json")
 
 
-async def test_tools_list_pins_the_six_derived_from_agent_routes(app, pat_token):
+async def test_tools_list_pins_the_seven_derived_from_agent_routes(app, pat_token):
     async with live(app), _client(app, pat_token) as client:
+        assert "list_open_subjects" in (client.initialize_result.instructions or "")
         assert "parkedAt" in (client.initialize_result.instructions or "")
         tools = {tool.name: tool for tool in await client.list_tools()}
 
     assert list(tools) == _TOOL_NAMES
-    read_only = {"get_gate", "get_agent_call", "get_usage"}
+    read_only = {"list_open_subjects", "get_gate", "get_agent_call", "get_usage"}
     for name, tool in tools.items():
         annotations = tool.annotations
         assert annotations.readOnlyHint == (name in read_only)
@@ -183,6 +185,7 @@ async def test_tools_list_pins_the_six_derived_from_agent_routes(app, pat_token)
     assert tools["answer_gate"].inputSchema["required"] == ["run_id", "parkedAt", "control"]
     reason = tools["cancel_run"].inputSchema["properties"]["reason"]
     assert (reason["minLength"], reason["maxLength"]) == (1, 500)
+    assert not tools["list_open_subjects"].inputSchema.get("required")
     assert not tools["get_usage"].inputSchema.get("required")
 
 


### PR DESCRIPTION
An agent holding a PAT and the MCP endpoint had one legal cold call, and it answered a billing question — every other tool takes an id that nothing on the surface produces.

`list_open_subjects` closes that: every subject with open work, its open workflows nested — each the newest run of one kind that is scheduled, running, parked, or failed — carrying the `run` and `latestAgentCall` ids the other tools take. A subject with several workflows in flight is one entry; a newer terminal run of one kind never hides an older open run of another. Subjectless runs never appear. At most 50 workflows; `failure` is tail-bounded, identity never is.

Server instructions open with the discovery call. The six existing tools are untouched.

Closes ENG-828.
