### PR TITLE
The route is an agent tool's single declaration

### DIFF
--- a/backend/druks/api/runs.py
+++ b/backend/druks/api/runs.py
@@ -38,6 +38,7 @@ async def resume_run(run_id: str, body: ResumeRequest) -> None:
     "/{run_id}/cancel",
     operation_id="cancel_run",
     tags=["agent"],
+    openapi_extra={"x-idempotent": True},
     response_model=CancelRunResponse,
     response_model_by_alias=True,
 )
@@ -50,17 +51,18 @@ async def cancel_run(
     if not run:
         raise RunNotFound(run_id)
     if run.state == RunState.CANCELLED.value:
-        return CancelRunResponse(run_id=run.id, result="already_cancelled")
+        return CancelRunResponse(run=run.id, result="already_cancelled")
     if not run.is_active:
         raise RunNotActive(run_id)
     await run.cancel(failure=reason)
-    return CancelRunResponse(run_id=run.id, result="cancelled")
+    return CancelRunResponse(run=run.id, result="cancelled")
 
 
 @router.post(
     "/{run_id}/retry",
     operation_id="retry_run",
     tags=["agent"],
+    openapi_extra={"x-destructive": False},
     response_model=RetryRunResponse,
     response_model_by_alias=True,
 )
@@ -79,4 +81,4 @@ async def retry_run(run_id: str) -> RetryRunResponse:
         if latest and latest.is_active:
             raise SubjectBusy(latest.id)
 
-    return RetryRunResponse(run_id=await run.retry())
+    return RetryRunResponse(run=await run.retry())

--- a/backend/druks/api/schemas.py
+++ b/backend/druks/api/schemas.py
@@ -19,12 +19,12 @@ class ResumeRequest(BaseModel):
 
 
 class CancelRunResponse(BaseResponse):
-    run_id: str
+    run: str
     result: Literal["cancelled", "already_cancelled"]
 
 
 class RetryRunResponse(BaseResponse):
-    run_id: str
+    run: str
 
 
 class OpenWorkflowResponse(BaseResponse):

--- a/backend/druks/contrib/review/routes.py
+++ b/backend/druks/contrib/review/routes.py
@@ -2,21 +2,37 @@ from fastapi import APIRouter, Body, Depends, HTTPException, status
 
 from druks.accounts.dependencies import current_account
 from druks.accounts.models import Account
+from druks.contrib.review.schemas import ReviewRequestedResponse
 from druks.contrib.review.workflows import PullRequestReview
 from druks.contrib.ship.models import ProjectRepo
 
 router = APIRouter(prefix="/reviews")
 
 
-@router.post("", status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "",
+    status_code=status.HTTP_202_ACCEPTED,
+    operation_id="review_request",
+    tags=["agent"],
+    response_model=ReviewRequestedResponse,
+    response_model_by_alias=True,
+)
 async def request_review(
     repo: str = Body(..., embed=True),
     pr_number: int = Body(..., embed=True, alias="prNumber", gt=0),
     account: Account = Depends(current_account),
-) -> None:
+) -> ReviewRequestedResponse:
+    """Start a pull request review. The returned run feeds the run tools and
+    is what list_open_subjects shows for the pull request; requesting again
+    while the review is live returns the same run."""
     if not ProjectRepo.get_for_repo(repo):
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
             f"{repo} is not a registered project repo — add it to a project first",
         )
-    await PullRequestReview.dispatch(repo=repo, pr_number=pr_number, requested_by=account.username)
+    run_id = await PullRequestReview.dispatch(
+        repo=repo,
+        pr_number=pr_number,
+        requested_by=account.username,
+    )
+    return ReviewRequestedResponse(run=run_id)

--- a/backend/druks/contrib/review/schemas.py
+++ b/backend/druks/contrib/review/schemas.py
@@ -1,4 +1,9 @@
+from druks.schemas import BaseResponse
 from druks.workflows import SubjectSummary
+
+
+class ReviewRequestedResponse(BaseResponse):
+    run: str
 
 
 class ReviewSummary(SubjectSummary):

--- a/backend/druks/mcp/app.py
+++ b/backend/druks/mcp/app.py
@@ -2,20 +2,25 @@
 # Its tools are derived from the routes tagged "agent": the route is an
 # operation's single declaration — schema, docstring, operation_id — and a
 # tagged extension route joins the surface the same way.
+import inspect
 from collections.abc import Generator
 
 import httpx
 from fastapi import FastAPI
+from fastapi.routing import APIRoute, iter_route_contexts
 from fastmcp import FastMCP
 from fastmcp.server.auth import AccessToken, TokenVerifier
 from fastmcp.server.dependencies import get_http_request
 from fastmcp.server.http import StarletteWithLifespan
 from fastmcp.server.providers.openapi import MCPType, OpenAPIProvider, OpenAPITool, RouteMap
+from fastmcp.utilities.openapi import HTTPRoute
 from mcp.types import ToolAnnotations
 
 from druks.accounts.exceptions import InvalidPatError
 from druks.accounts.models import PersonalAccessToken
 from druks.database import db_session
+from druks.extensions.loader import iter_extensions
+from druks.mcp.exceptions import InvalidAgentToolError
 
 _INSTRUCTIONS = """\
 Druks coordinates durable agent runs over shared work items. Start with
@@ -30,18 +35,6 @@ the step that killed it. get_usage is the caller's quota and today's spend.
 There is no push channel; poll. Tool failures embed {code, message, retryable}
 from the HTTP surface.
 """
-
-# FastMCP logs component-fn errors instead of raising, so the tools/list
-# test is the guard: an unmapped tagged route ships unannotated and fails CI.
-_TOOL_ANNOTATIONS = {
-    "get_gate": ToolAnnotations(readOnlyHint=True),
-    "answer_gate": ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True),
-    "get_agent_call": ToolAnnotations(readOnlyHint=True),
-    "cancel_run": ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=True),
-    "retry_run": ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False),
-    "list_open_subjects": ToolAnnotations(readOnlyHint=True),
-    "get_usage": ToolAnnotations(readOnlyHint=True),
-}
 
 
 class PatTokenVerifier(TokenVerifier):
@@ -79,12 +72,43 @@ class CallerPat(httpx.Auth):
         yield request
 
 
-def _annotate(route: object, component: object) -> None:
+def _validate_agent_tools(api: FastAPI) -> None:
+    # The provider logs component-fn errors instead of raising, so derived tools
+    # cannot refuse boot; validate the routes before derivation. Inclusion is
+    # deferred (api.routes holds unresolved routers), so the contexts iterator
+    # is the one view with every route's merged tags — and the loader tags each
+    # extension route with its extension's name, so the tag names the owner.
+    extension_names = {extension.name for extension in iter_extensions()}
+
+    for route in iter_route_contexts(api.routes):
+        if not isinstance(route.original_route, APIRoute) or "agent" not in route.tags:
+            continue
+
+        where = f"{'/'.join(sorted(route.methods or ()))} {route.path}"
+        operation_id = route.operation_id
+        if not operation_id:
+            raise InvalidAgentToolError(where, "an explicit operation_id is required")
+        if not inspect.getdoc(route.endpoint):
+            raise InvalidAgentToolError(where, "a non-empty endpoint docstring is required")
+        extension = next((tag for tag in route.tags if tag in extension_names), None)
+        if extension and not operation_id.startswith(f"{extension}_"):
+            raise InvalidAgentToolError(
+                where, f"operation_id {operation_id!r} must start with {extension + '_'!r}"
+            )
+
+
+def _annotate(route: HTTPRoute, component: object) -> None:
     if isinstance(component, OpenAPITool):
-        component.annotations = _TOOL_ANNOTATIONS[component.name]
+        is_read = route.method == "GET"
+        component.annotations = ToolAnnotations(
+            readOnlyHint=is_read,
+            destructiveHint=not is_read and route.extensions.get("x-destructive", True),
+            idempotentHint=route.extensions.get("x-idempotent", False),
+        )
 
 
 def create_mcp_app(api: FastAPI) -> StarletteWithLifespan:
+    _validate_agent_tools(api)
     # Built directly rather than via from_fastapi, which owns the transport:
     # raise_app_exceptions=False makes an app crash reach the tool as the
     # app's sanitized 500, so no masking is needed and the taxonomy travels.

--- a/backend/druks/mcp/exceptions.py
+++ b/backend/druks/mcp/exceptions.py
@@ -5,6 +5,13 @@ class McpServerError(Exception):
     pass
 
 
+class InvalidAgentToolError(McpServerError):
+    def __init__(self, route: str, reason: str):
+        super().__init__(f"Invalid agent tool route {route}: {reason}.")
+        self.route = route
+        self.reason = reason
+
+
 class InvalidServerNameError(McpServerError):
     # The name is one identifier reused as the MCP config key and the bearer
     # env-var stem, so it must be a lowercase shell/TOML-safe token — reject

--- a/backend/druks/mcp/gateway/routes.py
+++ b/backend/druks/mcp/gateway/routes.py
@@ -24,6 +24,7 @@ async def get_gate(run_id: str) -> schemas.GateResponse:
 @router.post(
     "/gates/{run_id}/answer",
     operation_id="answer_gate",
+    openapi_extra={"x-destructive": False, "x-idempotent": True},
     response_model=schemas.GateAnswerResponse,
     response_model_by_alias=True,
 )

--- a/backend/druks/mcp/gateway/schemas.py
+++ b/backend/druks/mcp/gateway/schemas.py
@@ -18,7 +18,7 @@ class ArtifactContent(BaseResponse):
 
 class GateResponse(BaseResponse):
     # parked_at is the park identity answer_gate must echo back.
-    run_id: str
+    run: str
     gate: str
     parked_at: datetime
     ask: dict[str, Any]
@@ -26,7 +26,7 @@ class GateResponse(BaseResponse):
 
 
 class GateAnswerResponse(BaseResponse):
-    run_id: str
+    run: str
     parked_at: datetime
     result: Literal["answered", "already_answered"]
 
@@ -41,7 +41,7 @@ class AnswerGateRequest(BaseModel):
 
 
 class AgentCallDetailResponse(BaseResponse):
-    run_id: str
+    run: str
     call: AgentCallResponse
     transcript: str
     stderr: str

--- a/backend/druks/mcp/gateway/services.py
+++ b/backend/druks/mcp/gateway/services.py
@@ -36,7 +36,7 @@ def get_gate(run_id: str) -> schemas.GateResponse:
     if not ask or ask.get("presentation") != "in_app":
         raise exceptions.GateNotAnswerable(run_id)
     return schemas.GateResponse(
-        run_id=run.id,
+        run=run.id,
         gate=run.input_gate,  # type: ignore[arg-type]
         parked_at=run.input_requested_at,  # type: ignore[arg-type]
         ask=run.get_ask(),
@@ -53,7 +53,7 @@ async def answer_gate(
     db_session().expire(run)  # the receipt/park comparison must read fresh
     if run.answer_parked_at == parked_at:
         return schemas.GateAnswerResponse(
-            run_id=run.id, parked_at=parked_at, result="already_answered"
+            run=run.id, parked_at=parked_at, result="already_answered"
         )
     if run.state != RunState.PARKED.value:
         raise exceptions.GateNotOpen(run_id)
@@ -67,7 +67,7 @@ async def answer_gate(
     except InvalidChoiceError as error:
         raise exceptions.InvalidGateAnswer(str(error)) from error
     await run.resume(**payload)
-    return schemas.GateAnswerResponse(run_id=run.id, parked_at=parked_at, result="answered")
+    return schemas.GateAnswerResponse(run=run.id, parked_at=parked_at, result="answered")
 
 
 def get_agent_call(call_id: str) -> schemas.AgentCallDetailResponse:
@@ -76,7 +76,7 @@ def get_agent_call(call_id: str) -> schemas.AgentCallDetailResponse:
         raise exceptions.AgentCallNotFound(call_id)
     layout = call.artifact_layout
     return schemas.AgentCallDetailResponse(
-        run_id=call.run_id,
+        run=call.run_id,
         call=AgentCallResponse.model_validate(call),
         transcript=read_slice(
             layout.transcript, offset=-_TRANSCRIPT_TAIL_BYTES, limit=_TRANSCRIPT_TAIL_BYTES

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 from druks.accounts.models import Account
 from druks.api.app import app
+from druks.contrib.review.workflows import PullRequestReview
+from druks.contrib.ship.models import Project, ProjectRepo
 from druks.durable.dbos_state import workflow_status
 from druks.durable.models import AgentCall, Run
 from druks.durable.reads import read_transcript_chunk
@@ -69,7 +71,7 @@ def _park(druks_db, note):
     return run
 
 
-def test_openapi_pins_the_seven_agent_routes(client: TestClient):
+def test_openapi_pins_platform_routes_and_review_request(client: TestClient):
     schema = app.openapi()
     found = {
         (method, path): operation
@@ -77,7 +79,60 @@ def test_openapi_pins_the_seven_agent_routes(client: TestClient):
         for method, operation in operations.items()
         if "agent" in operation.get("tags", [])
     }
-    assert {key: op["operationId"] for key, op in found.items()} == _MCP_ROUTES
+    assert {key: found[key]["operationId"] for key in _MCP_ROUTES} == _MCP_ROUTES
+    assert found[("post", "/api/review/reviews")]["operationId"] == "review_request"
+
+    extensions = {
+        key: {name: value for name, value in found[key].items() if name.startswith("x-")}
+        for key in _MCP_ROUTES
+    }
+    assert extensions == {
+        ("get", "/api/gates/{run_id}"): {},
+        ("post", "/api/gates/{run_id}/answer"): {
+            "x-destructive": False,
+            "x-idempotent": True,
+        },
+        ("get", "/api/agent-calls/{call_id}"): {},
+        ("post", "/api/runs/{run_id}/cancel"): {"x-idempotent": True},
+        ("post", "/api/runs/{run_id}/retry"): {"x-destructive": False},
+        ("get", "/api/open-subjects"): {},
+        ("get", "/api/usage/summary"): {},
+    }
+    assert not {name for name in found[("post", "/api/review/reviews")] if name.startswith("x-")}
+
+
+def test_review_request_returns_the_run_id_start_hands_back(
+    client: TestClient, account: Account, monkeypatch
+):
+    project = Project.create(name="Acme")
+    ProjectRepo.create(project_id=project.id, full_name="acme/app")
+    live_run_id = "review-run-id"
+    starts = []
+
+    async def start(cls, **kwargs):
+        starts.append(kwargs)
+        return live_run_id
+
+    monkeypatch.setattr(PullRequestReview, "start", classmethod(start))
+
+    responses = [
+        client.post(
+            "/api/review/reviews",
+            json={"repo": "acme/app", "prNumber": 7},
+        )
+        for _ in range(2)
+    ]
+
+    assert [response.status_code for response in responses] == [202, 202]
+    assert [response.json() for response in responses] == [
+        {"run": live_run_id},
+        {"run": live_run_id},
+    ]
+    assert [call["subject"].identity for call in starts] == [
+        {"type": "pull_request", "id": "acme/app#7"},
+        {"type": "pull_request", "id": "acme/app#7"},
+    ]
+    assert {call["account_id"] for call in starts} == {account.id}
 
 
 def test_agent_routes_sit_behind_the_gate(tmp_path, druks_db):
@@ -327,7 +382,7 @@ def test_cancel_run_route(client: TestClient, druks_db):
 
     cancelled = client.post(f"/api/runs/{run.id}/cancel", json={"reason": "wrong branch"})
     assert cancelled.status_code == 200
-    assert cancelled.json() == {"runId": run.id, "result": "cancelled"}
+    assert cancelled.json() == {"run": run.id, "result": "cancelled"}
 
     druks_db.expire_all()
     run = druks_db.get(type(run), run.id)

--- a/backend/tests/test_agent_services.py
+++ b/backend/tests/test_agent_services.py
@@ -108,7 +108,7 @@ def test_get_gate_returns_the_ask_and_parked_at(druks_db):
 
     view = services.get_gate(run.id)
 
-    assert view.run_id == run.id
+    assert view.run == run.id
     assert view.gate == "review"
     assert view.parked_at == run.input_requested_at
     assert view.ask["controls"] == ["approve", "request_changes"]
@@ -218,7 +218,7 @@ def test_get_agent_call_serves_bounded_tails(druks_db):
 
     detail = services.get_agent_call(call.id)
 
-    assert detail.run_id == call.run_id
+    assert detail.run == call.run_id
     assert detail.call.id == call.id
     assert detail.call.last_error == "boom " * 100
     assert detail.transcript == "s" * 8192
@@ -368,7 +368,7 @@ async def test_retry_run_retries_a_failed_run(druks_db, monkeypatch):
 
     result = await runs.retry_run(run.id)
 
-    assert result.run_id == "retried-run"
+    assert result.run == "retried-run"
     retry.assert_awaited_once_with()
 
 

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -9,8 +9,11 @@ from conftest import finish_agent_run, make_test_note, seed_note_agent_run, seed
 from druks.accounts.models import Account, PersonalAccessToken
 from druks.api.app import mcp_app
 from druks.durable.models import Artifact, Run
+from druks.mcp.app import create_mcp_app
+from druks.mcp.exceptions import InvalidAgentToolError
 from druks.testing import configure_app_for_test, make_settings
 from druks.usage.models import UsageScrape
+from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient
 from fastmcp.client import Client
 from fastmcp.client.transports import StreamableHttpTransport
@@ -165,21 +168,40 @@ async def test_mcp_subpaths_never_reach_the_spa(app):
             assert stray.headers["content-type"].startswith("application/json")
 
 
-async def test_tools_list_pins_the_seven_derived_from_agent_routes(app, pat_token):
+async def test_tools_list_pins_platform_tools_and_review_request(app, pat_token):
     async with live(app), _client(app, pat_token) as client:
         assert "list_open_subjects" in (client.initialize_result.instructions or "")
         assert "parkedAt" in (client.initialize_result.instructions or "")
         tools = {tool.name: tool for tool in await client.list_tools()}
 
-    assert list(tools) == _TOOL_NAMES
-    read_only = {"list_open_subjects", "get_gate", "get_agent_call", "get_usage"}
-    for name, tool in tools.items():
-        annotations = tool.annotations
-        assert annotations.readOnlyHint == (name in read_only)
-        assert annotations.destructiveHint == (None if name in read_only else name == "cancel_run")
-        # A repeat retry answers SUBJECT_BUSY, so it alone is not idempotent.
-        assert annotations.idempotentHint == (None if name in read_only else name != "retry_run")
-        assert tool.description, name
+    assert list(tools)[:7] == _TOOL_NAMES
+    assert list(tools)[7:] == ["review_request"]
+
+    expected_annotations = {
+        "cancel_run": (False, True, True),
+        "retry_run": (False, False, False),
+        "list_open_subjects": (True, False, False),
+        "get_gate": (True, False, False),
+        "answer_gate": (False, False, True),
+        "get_agent_call": (True, False, False),
+        "get_usage": (True, False, False),
+    }
+    for name, expected in expected_annotations.items():
+        annotations = tools[name].annotations
+        assert (
+            annotations.readOnlyHint,
+            annotations.destructiveHint,
+            annotations.idempotentHint,
+        ) == expected
+        assert tools[name].description
+
+    review_request = tools["review_request"]
+    assert (
+        review_request.annotations.readOnlyHint,
+        review_request.annotations.destructiveHint,
+        review_request.annotations.idempotentHint,
+    ) == (False, True, False)
+    assert review_request.description
 
     # Derived schemas keep the routes' own shapes and constraints.
     assert tools["answer_gate"].inputSchema["required"] == ["run_id", "parkedAt", "control"]
@@ -187,6 +209,35 @@ async def test_tools_list_pins_the_seven_derived_from_agent_routes(app, pat_toke
     assert (reason["minLength"], reason["maxLength"]) == (1, 500)
     assert not tools["list_open_subjects"].inputSchema.get("required")
     assert not tools["get_usage"].inputSchema.get("required")
+
+
+@pytest.mark.parametrize(
+    ("operation_id", "docstring", "message"),
+    [
+        (None, "Start a review.", "explicit operation_id"),
+        ("start_review", "Start a review.", "must start with 'review_'"),
+        ("review_start", None, "docstring"),
+    ],
+)
+def test_invalid_extension_agent_route_stops_boot(operation_id, docstring, message):
+    api = FastAPI()
+    router = APIRouter()
+
+    async def endpoint():
+        pass
+
+    endpoint.__doc__ = docstring
+    router.add_api_route(
+        "/reviews",
+        endpoint,
+        methods=["POST"],
+        operation_id=operation_id,
+        tags=["agent"],
+    )
+    api.include_router(router, prefix="/api/review", tags=["review"])
+
+    with pytest.raises(InvalidAgentToolError, match=message):
+        create_mcp_app(api)
 
 
 async def test_claims_resolve_the_calling_account(app, druks_db):
@@ -224,7 +275,7 @@ async def test_gate_cycle_reads_answers_and_reports_stale_rounds(
 
     async with live(app), _client(app, pat_token) as client:
         gate = (await client.call_tool("get_gate", {"run_id": run.id})).structured_content
-        assert gate["runId"] == run.id
+        assert gate["run"] == run.id
         assert gate["ask"]["controls"] == ["approve", "request_changes"]
 
         stale = await _call_error(
@@ -288,7 +339,7 @@ async def test_get_agent_call_serves_bounded_tails(app, pat_token, druks_db):
 
     async with live(app), _client(app, pat_token) as client:
         detail = (await client.call_tool("get_agent_call", {"call_id": call.id})).structured_content
-        assert detail["runId"] == call.run_id
+        assert detail["run"] == call.run_id
         assert len(detail["transcript"].encode()) <= 8 * 1024
         assert len(detail["stderr"].encode()) <= 4 * 1024
         assert len(detail["artifact"]["content"].encode()) <= 4 * 1024
@@ -316,7 +367,7 @@ async def test_cancel_run_is_destructive_but_repeatable(app, pat_token, druks_db
         cancelled = (
             await client.call_tool("cancel_run", {"run_id": active.id, "reason": "wrong branch"})
         ).structured_content
-        assert cancelled == {"runId": active.id, "result": "cancelled"}
+        assert cancelled == {"run": active.id, "result": "cancelled"}
         assert cancels == [{"id": active.id, "failure": "wrong branch"}]
 
         repeat = (

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -587,6 +587,13 @@ the prefix its own resource is called:
 router = APIRouter(prefix="/reviews")
 ```
 
+Tagging a route `agent` also derives it into an MCP tool: its explicit `operation_id`,
+prefixed with the extension name, is the tool name and its docstring is the description.
+`GET` derives read-only; a write declares `x-destructive: false` or `x-idempotent: true`
+in `openapi_extra` only when that statement is genuinely true, otherwise the safe defaults
+are destructive and non-idempotent. Boot refuses a missing or unprefixed tool name
+and a missing docstring.
+
 Two spellings run through druks, and which one a segment wears says who owns it:
 
 | | |

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -186,9 +186,9 @@ export const api = {
   ) => postNoContent(`/api/runs/${runId}/resume`, body),
   // Cancel is a run-level action, not a review verdict — it ends any active run.
   cancelRun: (runId: string, reason: string) =>
-    postJSON<{ runId: string; result: string }>(`/api/runs/${runId}/cancel`, { reason }),
+    postJSON<{ run: string; result: string }>(`/api/runs/${runId}/cancel`, { reason }),
   retryRun: (runId: string) =>
-    postJSON<{ runId: string }>(`/api/runs/${runId}/retry`, undefined),
+    postJSON<{ run: string }>(`/api/runs/${runId}/retry`, undefined),
   listEvents: (params: { limit?: number; before?: string; extension?: string } = {}) => {
     const query = new URLSearchParams()
     if (params.limit !== undefined) query.set('limit', String(params.limit))


### PR DESCRIPTION
An extension that tagged a destructive route shipped its tool annotated as nothing: annotations came from a closed platform dict, and the provider swallows the lookup failure into a log line. Tool names collided silently across extensions.

Now the route is the whole declaration. `readOnlyHint` derives from the HTTP method; `destructiveHint` / `idempotentHint` read `x-destructive` / `x-idempotent` from the route's `openapi_extra`, defaulting to the protocol's own pessimistic values — a write that declares nothing ships destructive and non-idempotent, so a forgotten declaration fails safe. All seven platform triples are wire-identical to before, pinned per route. Boot refuses a missing or unprefixed tool name and a missing docstring.

`review_request` proves the seam: the existing review dispatch route gains the tag, a name, and a body carrying the run it used to discard — no platform change beyond the seam itself. Re-requesting a live review returns the same run.

Every agent response now spells the run id `run`, matching the listing. The extension author guide documents the contract in one paragraph.

Closes ENG-829.
