### PR TITLE
Both review seats read the repo checklist, and the PR names its scrutiny

### DIFF
--- a/.druks/review/checklist.md
+++ b/.druks/review/checklist.md
@@ -66,6 +66,9 @@ the code is wrong: fix the code, delete the explanation.
 - Prefer no new surface. A parameter or an inline beats a new function; a new
   function beats a new class; a new class beats a new package. Cheap to write is
   not a reason to exist.
+- Before adding a layer, name the existing mechanism that already does the job
+  and why it falls short — a second copy of one the repo already runs is the
+  finding.
 
 The author-facing surface (extensions/SDK) is the product, not the plumbing.
 Design it by writing the example first: the obvious call is the correct one, the

--- a/backend/druks/contrib/ship/journal.py
+++ b/backend/druks/contrib/ship/journal.py
@@ -4,6 +4,7 @@ from druks.contrib.ship.contracts import (
     EvaluationOutput,
     ImplementationOutput,
     PlanData,
+    ReviewOutput,
     ReviewWork,
     TriageOutput,
 )
@@ -42,6 +43,10 @@ class BuildJournal(Journal):
     @property
     def evaluations(self) -> list[EvaluationOutput]:
         return self.filter(EvaluationOutput)
+
+    @property
+    def plan_reviews(self) -> list[ReviewOutput]:
+        return self.filter(ReviewOutput)
 
     @property
     def assignee_github_login(self) -> str | None:

--- a/backend/druks/contrib/ship/templates/build/review_code.md
+++ b/backend/druks/contrib/ship/templates/build/review_code.md
@@ -71,13 +71,23 @@ You do the writing yourself — druks records only your one-line `summary`.
 
 1. **Decide.** If the diff is clean — no medium- or high-severity finding — you file no sub-issue. Low-severity findings alone never justify one. Otherwise you have real follow-up work.
 
-2. **Post one PR comment** on PR #{{ build.pr_number }} (`gh pr comment {{ build.pr_number }} --body ...`; the checkout is authenticated): `Code review: <your one-sentence summary, verbatim>`.
-
-3. **File a follow-up sub-issue — only when step 1 found real work.** Open it on the same tracker as the parent ticket named in **Workflow context**, as a child of that ticket, using the same tracker tools. Give it a concise verb-first title (e.g. "Extract duplicate validation helper", "Add integration test for refund path"). In the body write one section per finding — the follow-up implementer reads it as spec — each covering:
+2. **File a follow-up sub-issue — only when step 1 found real work.** Open it on the same tracker as the parent ticket named in **Workflow context**, as a child of that ticket, using the same tracker tools. Give it a concise verb-first title (e.g. "Extract duplicate validation helper", "Add integration test for refund path"). In the body write one section per finding — the follow-up implementer reads it as spec — each covering:
    - severity: high / medium / low
    - what's wrong, why it matters, and what good would look like
    - the file path and anchor line it applies to, when it has one
 
-   The sub-issue is separate work for later; it does not loop the current implementer.
+   The sub-issue is separate work for later; it does not loop the current implementer. It records
+   what you observed and where; whoever picks it up decides the mechanism. This PR is an
+   unmerged proposal — never cite its approach as precedent or prescribe extending it.
+
+3. **Post one PR comment** on PR #{{ build.pr_number }} (`gh pr comment {{ build.pr_number }} --body ...`; the checkout is authenticated) — file any sub-issue first, so the comment can name it:
+
+   ```
+   Code review: <your one-sentence summary, verbatim>
+   Scrutiny: plan critic {{ "ran (" ~ (build.journal.plan_reviews | length) ~ ")" if build.journal.plan_reviews else "skipped" }} · evaluation rounds: {{ build.journal.evaluations | length }} · line review ran
+   Follow-up: <sub-issue key> — <its title>
+   ```
+
+   Copy the Scrutiny line as rendered. One Follow-up line per sub-issue you filed; omit the line when you filed none.
 
 4. **Return** the JSON: just `{ "summary": "<your one sentence describing what this PR ships>" }`, e.g. "Adds X endpoint with Y validation; cleanly factored."

--- a/backend/druks/contrib/ship/templates/build/review_plan.md
+++ b/backend/druks/contrib/ship/templates/build/review_plan.md
@@ -30,6 +30,13 @@ implementation — your verdict is the gate.
   output, and the planner folds it.
 - Do not require changes beyond what the issue and the existing codebase support.
 
+## What this repo asks of its reviewers
+
+`.druks/review/checklist.md`, when the checkout has one, is the repo's standing rules and
+the last word: where it and anything else in this prompt disagree, it wins. Its rules bind
+the plan's choices too — a mechanism the checklist forbids is a shape problem to raise now,
+not a line-level finding for later.
+
 {% include "ship/build/_header.md" %}
 {% include "ship/build/_contract.md" %}
 {% include "ship/build/_related_repos.md" %}

--- a/backend/tests/ship/test_build_prompts.py
+++ b/backend/tests/ship/test_build_prompts.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 
 import pytest
 from druks.contrib import ship
+from druks.contrib.ship.contracts import ReviewOutput
+from druks.contrib.ship.enums import ReviewDecision
 from druks.contrib.ship.journal import BuildJournal
 from druks.contrib.ship.models import Project, ProjectRepo
 from druks.contrib.ship.policy import RepoPolicy
@@ -89,6 +91,32 @@ async def test_verification_profile_renders_ci_provenance_per_command():
         "**Tests:**",
         "- `pytest`",
     ]
+
+
+async def test_reviewer_scrutiny_line_reports_each_seat():
+    async def scrutiny(build) -> str:
+        prompt = await render_prompt(
+            "ship/build/review_code.md",
+            build=build,
+            verification="VERIFICATION-BLOCK",
+            workspace=_workspace(),
+        )
+        lines = (line.strip() for line in prompt.splitlines())
+        return next(line for line in lines if line.startswith("Scrutiny:"))
+
+    unreviewed = _build()
+    assert (
+        await scrutiny(unreviewed)
+        == "Scrutiny: plan critic skipped · evaluation rounds: 0 · line review ran"
+    )
+
+    reviewed = _build()
+    reviewed.journal.add(ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="split it"))
+    reviewed.journal.add(ReviewOutput(decision=ReviewDecision.APPROVE, body="clean"))
+    assert (
+        await scrutiny(reviewed)
+        == "Scrutiny: plan critic ran (2) · evaluation rounds: 0 · line review ran"
+    )
 
 
 def test_build_prompt_context_covers_template_attrs():


### PR DESCRIPTION
The plan critic reviews the mechanism choice — the stage where an overengineered shape is cheapest to catch — but only the line reviewer carried the repo checklist's authority, and it reviews after the plan and evaluator have already framed the diff as correct. `review_plan.md` now carries the same paragraph: `.druks/review/checklist.md` is the repo's standing rules and the last word, binding the plan's choices too.

The checklist gains one craft rule: before adding a layer, name the existing mechanism that already does the job and why it falls short — a second copy of one the repo already runs is the finding.

The code reviewer's outputs are reordered so its PR comment can tell the truth: any follow-up sub-issue is filed first, the comment names each one, and the sub-issue records what was observed rather than prescribing a mechanism off an unmerged proposal. The comment also opens with a scrutiny line rendered from the journal — whether the plan critic ran and how many evaluation rounds the diff survived — so a seat that is off shows on every PR instead of staying silent.

`BuildJournal.plan_reviews` backs the render; `test_reviewer_scrutiny_line_reports_each_seat` pins the line for a reviewed and an unreviewed plan.

Example of the comment shape:

```
Code review: Adds X endpoint with Y validation; cleanly factored.
Scrutiny: plan critic ran (2) · evaluation rounds: 1 · line review ran
Follow-up: ENG-999 — Extract duplicate validation helper
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
