### PR TITLE
The agent surface teaches its own contract

### DIFF
--- a/backend/druks/api/exceptions.py
+++ b/backend/druks/api/exceptions.py
@@ -12,6 +12,28 @@ class AgentApiError(Exception):
     retryable: ClassVar[bool] = False
 
 
+def agent_error_responses(*errors: AgentApiError) -> dict:
+    # One response per status; the first error listed for a status is the example.
+    by_status: dict[int, list[AgentApiError]] = {}
+    for error in errors:
+        by_status.setdefault(error.status_code, []).append(error)
+    return {
+        status: {
+            "description": ", ".join(error.code for error in grouped) + ".",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "code": grouped[0].code,
+                        "message": str(grouped[0]),
+                        "retryable": grouped[0].retryable,
+                    }
+                }
+            },
+        }
+        for status, grouped in by_status.items()
+    }
+
+
 class RunNotFound(AgentApiError):
     status_code = 404
     code = "RUN_NOT_FOUND"

--- a/backend/druks/api/runs.py
+++ b/backend/druks/api/runs.py
@@ -1,8 +1,14 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Body, HTTPException, status
+from fastapi import APIRouter, Body, HTTPException, Path, status
 
-from druks.api.exceptions import RunNotActive, RunNotFailed, RunNotFound, SubjectBusy
+from druks.api.exceptions import (
+    RunNotActive,
+    RunNotFailed,
+    RunNotFound,
+    SubjectBusy,
+    agent_error_responses,
+)
 from druks.api.schemas import CancelRunResponse, ResumeRequest, RetryRunResponse
 from druks.durable.enums import RunState
 from druks.durable.models import Run
@@ -41,9 +47,19 @@ async def resume_run(run_id: str, body: ResumeRequest) -> None:
     openapi_extra={"x-idempotent": True},
     response_model=CancelRunResponse,
     response_model_by_alias=True,
+    responses=agent_error_responses(RunNotFound("run-123"), RunNotActive("run-123")),
 )
 async def cancel_run(
-    run_id: str, reason: Annotated[str, Body(embed=True, min_length=1, max_length=500)]
+    run_id: Annotated[str, Path(description="The active run's id, run in list_open_subjects.")],
+    reason: Annotated[
+        str,
+        Body(
+            embed=True,
+            min_length=1,
+            max_length=500,
+            description="The failure reason to record on the cancelled run.",
+        ),
+    ],
 ) -> CancelRunResponse:
     """Cancel an active run, recording the reason as its failure; a repeat
     cancel reports already_cancelled."""
@@ -65,8 +81,13 @@ async def cancel_run(
     openapi_extra={"x-destructive": False},
     response_model=RetryRunResponse,
     response_model_by_alias=True,
+    responses=agent_error_responses(
+        RunNotFound("run-123"), RunNotFailed("run-123"), SubjectBusy("run-456")
+    ),
 )
-async def retry_run(run_id: str) -> RetryRunResponse:
+async def retry_run(
+    run_id: Annotated[str, Path(description="The failed run's id, run in list_open_subjects.")],
+) -> RetryRunResponse:
     """Rerun a failed run from the step that killed it, reusing every
     completed step."""
     run = Run.get(run_id)

--- a/backend/druks/contrib/review/routes.py
+++ b/backend/druks/contrib/review/routes.py
@@ -16,10 +16,36 @@ router = APIRouter(prefix="/reviews")
     tags=["agent"],
     response_model=ReviewRequestedResponse,
     response_model_by_alias=True,
+    responses={
+        404: {
+            "description": "The repository is not registered.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": "HTTP_404",
+                        "detail": (
+                            "owner/name is not a registered project repo — "
+                            "add it to a project first"
+                        ),
+                    }
+                }
+            },
+        }
+    },
 )
 async def request_review(
-    repo: str = Body(..., embed=True),
-    pr_number: int = Body(..., embed=True, alias="prNumber", gt=0),
+    repo: str = Body(
+        ...,
+        embed=True,
+        description="A registered project repository in owner/name form.",
+    ),
+    pr_number: int = Body(
+        ...,
+        embed=True,
+        alias="prNumber",
+        gt=0,
+        description="The pull request number in that repository.",
+    ),
     account: Account = Depends(current_account),
 ) -> ReviewRequestedResponse:
     """Start a pull request review. The returned run feeds the run tools and

--- a/backend/druks/mcp/app.py
+++ b/backend/druks/mcp/app.py
@@ -32,8 +32,9 @@ being answered, and a repeat answer reports already_answered. get_agent_call
 returns bounded transcript and stderr tails, never full payloads. cancel_run
 records its reason as the run's failure. retry_run reruns a failed run from
 the step that killed it. get_usage is the caller's quota and today's spend.
-There is no push channel; poll. Tool failures embed {code, message, retryable}
-from the HTTP surface.
+There is no push channel; poll list_open_subjects at ~30s intervals while
+waiting. Tool failures embed {code, message, retryable} from the HTTP
+surface.
 """
 
 

--- a/backend/druks/mcp/gateway/routes.py
+++ b/backend/druks/mcp/gateway/routes.py
@@ -1,7 +1,11 @@
-from fastapi import APIRouter, Depends
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path
 
 from druks.accounts.dependencies import current_account
 from druks.accounts.models import Account
+from druks.api.exceptions import RunNotFound, agent_error_responses
+from druks.mcp.gateway import exceptions as gate_errors
 from druks.mcp.gateway import schemas, services
 
 # Docstrings here are the derived tool descriptions and operation_id is the
@@ -14,8 +18,15 @@ router = APIRouter(prefix="/api", tags=["agent"])
     operation_id="get_gate",
     response_model=schemas.GateResponse,
     response_model_by_alias=True,
+    responses=agent_error_responses(
+        RunNotFound("run-123"),
+        gate_errors.GateNotOpen("run-123"),
+        gate_errors.GateNotAnswerable("run-123"),
+    ),
 )
-async def get_gate(run_id: str) -> schemas.GateResponse:
+async def get_gate(
+    run_id: Annotated[str, Path(description="The parked run's id, run in list_open_subjects.")],
+) -> schemas.GateResponse:
     """A parked run's open gate: the ask, a bounded artifact chunk, and
     parkedAt — echo parkedAt unchanged to answer_gate."""
     return services.get_gate(run_id)
@@ -27,8 +38,18 @@ async def get_gate(run_id: str) -> schemas.GateResponse:
     openapi_extra={"x-destructive": False, "x-idempotent": True},
     response_model=schemas.GateAnswerResponse,
     response_model_by_alias=True,
+    responses=agent_error_responses(
+        gate_errors.InvalidGateAnswer("unknown control 'merge'"),
+        RunNotFound("run-123"),
+        gate_errors.GateRoundStale("run-123"),
+        gate_errors.GateNotOpen("run-123"),
+        gate_errors.GateNotAnswerable("run-123"),
+    ),
 )
-async def answer_gate(run_id: str, body: schemas.AnswerGateRequest) -> schemas.GateAnswerResponse:
+async def answer_gate(
+    run_id: Annotated[str, Path(description="The parked run's id from get_gate.")],
+    body: schemas.AnswerGateRequest,
+) -> schemas.GateAnswerResponse:
     """Answer the gate get_gate showed, resuming the run. parkedAt must echo
     get_gate's value unchanged; a repeat answer to the same parkedAt reports
     already_answered."""
@@ -46,8 +67,13 @@ async def answer_gate(run_id: str, body: schemas.AnswerGateRequest) -> schemas.G
     operation_id="get_agent_call",
     response_model=schemas.AgentCallDetailResponse,
     response_model_by_alias=True,
+    responses=agent_error_responses(gate_errors.AgentCallNotFound("call-123")),
 )
-async def get_agent_call(call_id: str) -> schemas.AgentCallDetailResponse:
+async def get_agent_call(
+    call_id: Annotated[
+        str, Path(description="An agent call id, latestAgentCall in list_open_subjects.")
+    ],
+) -> schemas.AgentCallDetailResponse:
     """One agent call's metadata with bounded transcript and stderr tails and
     an artifact chunk."""
     return services.get_agent_call(call_id)

--- a/backend/druks/mcp/gateway/schemas.py
+++ b/backend/druks/mcp/gateway/schemas.py
@@ -34,10 +34,18 @@ class GateAnswerResponse(BaseResponse):
 class AnswerGateRequest(BaseModel):
     # parked_at echoes get_gate's value unchanged.
     model_config = ConfigDict(str_strip_whitespace=True, alias_generator=to_camel)
-    parked_at: AwareDatetime
-    control: str
-    answers: dict[str, str] = Field(default_factory=dict)
-    note: str = ""
+    parked_at: AwareDatetime = Field(
+        description="When the run parked, echoed from get_gate unchanged — it names the "
+        "exact question being answered."
+    )
+    control: str = Field(
+        description="The decision to take: one of the ids the ask offers as controls, e.g. approve."
+    )
+    answers: dict[str, str] = Field(
+        default_factory=dict,
+        description="One answer per ask question, keyed by the question's id.",
+    )
+    note: str = Field(default="", description="The optional note to submit with this answer.")
 
 
 class AgentCallDetailResponse(BaseResponse):

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -115,19 +115,6 @@ def _wire_size(structured: dict) -> int:
     return len(json.dumps(structured, separators=(",", ":"), default=str).encode())
 
 
-def _park(druks_db, note):
-    run = seed_note_run(
-        druks_db,
-        note=note,
-        state="parked",
-        input_gate="review",
-        input_request=dict(_IN_APP_ASK),
-    )
-    run.input_requested_at = datetime.now(UTC)
-    druks_db.flush()
-    return run
-
-
 async def test_mcp_rejects_missing_and_dead_tokens(app, account, druks_db):
     row, token = PersonalAccessToken.create(account_id=account.id, name="agent")
     async with httpx.AsyncClient(
@@ -205,6 +192,9 @@ async def test_tools_list_pins_platform_tools_and_review_request(app, pat_token)
 
     # Derived schemas keep the routes' own shapes and constraints.
     assert tools["answer_gate"].inputSchema["required"] == ["run_id", "parkedAt", "control"]
+    assert tools["answer_gate"].inputSchema["properties"]["control"]["description"] == (
+        "The decision to take: one of the ids the ask offers as controls, e.g. approve."
+    )
     reason = tools["cancel_run"].inputSchema["properties"]["reason"]
     assert (reason["minLength"], reason["maxLength"]) == (1, 500)
     assert not tools["list_open_subjects"].inputSchema.get("required")
@@ -271,7 +261,15 @@ async def test_gate_cycle_reads_answers_and_reports_stale_rounds(
     app, pat_token, druks_db, resume_spy
 ):
     item = make_test_note()
-    run = _park(druks_db, item)
+    run = seed_note_run(
+        druks_db,
+        note=item,
+        state="parked",
+        input_gate="review",
+        input_request=dict(_IN_APP_ASK),
+    )
+    run.input_requested_at = datetime.now(UTC)
+    druks_db.flush()
 
     async with live(app), _client(app, pat_token) as client:
         gate = (await client.call_tool("get_gate", {"run_id": run.id})).structured_content

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ setup state.
 ## Personal access tokens
 
 Agents and other non-browser clients authenticate the same internal API with
-personal access tokens minted in Settings → Agent access, sent as
+personal access tokens minted in Settings → Tokens, sent as
 `Authorization: Bearer <token>`. A token serializes as
 `druks_pat_<prefix>_<secret>`; Druks stores only the SHA-256 of the full
 token, shows the plaintext exactly once at mint, and expires it 365 days
@@ -153,7 +153,7 @@ after creation. When the header is present it must authenticate — a bad
 token is a 401, never a fall back to edge identity — and token management
 itself accepts the signed-in identity only (edge-asserted, or the none-mode
 operator) and refuses any `Authorization` header, so a leaked token cannot
-mint or revoke tokens. On compromise, revoke the token in Settings → Agent access
+mint or revoke tokens. On compromise, revoke the token in Settings → Tokens
 (immediate; the list shows each token's prefix and last use, tracked hourly,
 to identify it) and mint a replacement — rotation is mint first, revoke
 second. Agents consume the API through the MCP endpoint; see

--- a/docs/connect-your-agent.md
+++ b/docs/connect-your-agent.md
@@ -1,11 +1,11 @@
 # Connect your agent
 
 Druks serves an MCP endpoint at `/mcp` (streamable HTTP, stateless). Its
-tools are derived from the agent-tagged API routes — the same five operations,
-one contract: `get_gate`, `answer_gate`, `get_agent_call`, `cancel_run`,
-`get_usage` — authenticated per request with a personal access token sent
-as `Authorization: Bearer <token>`. Mint and revoke tokens in **Settings →
-Agent access**; see
+tools are derived from the agent-tagged API routes — the same eight operations,
+one contract: `list_open_subjects`, `get_gate`, `answer_gate`, `get_agent_call`,
+`cancel_run`, `retry_run`, `get_usage`, `review_request` — authenticated per
+request with a personal access token sent as `Authorization: Bearer <token>`.
+Mint and revoke tokens in **Settings → Tokens**; see
 [personal access tokens](configuration.md#personal-access-tokens) for
 lifecycle and compromise handling.
 
@@ -37,17 +37,20 @@ bearer_token_env_var = "DRUKS_PAT"
 
 ## What to expect
 
-- **Polling only (v1).** There is no push channel and no discovery tool yet
-  — the parked run's id arrives through the dashboard or the park
-  notification. Call `get_gate` before `answer_gate` and echo its `parkedAt`
+- **Discovery first.** There is no push channel. Call `list_open_subjects`
+  first and poll it about every 30 seconds while waiting. Each workflow's `run` feeds
+  the gate and run tools, and `latestAgentCall` feeds `get_agent_call`;
+  `review_request` starts or reuses a review run that enters the same flow.
+  Call `get_gate` before `answer_gate` and echo its `parkedAt`
   value unchanged; it names the exact question being answered, and a repeat
   answer to the same `parkedAt` reports `already_answered` instead of
   failing.
 - **Bounded responses.** Tool reads are windowed (call detail: 8KiB
   transcript tail + 4KiB stderr tail + 4KiB artifact chunk) — expect tails,
   not full payloads.
-- **One error taxonomy for domain failures.** A failed tool call embeds the
-  agent routes' `{"code", "message", "retryable"}` body in its error text —
-  the codes (`GATE_ROUND_STALE`, `RUN_NOT_ACTIVE`, …) are stable and safe to
-  match on. Requests that fail shape validation carry `VALIDATION_ERROR`
-  detail instead.
+- **Stable error shapes.** Gateway and run tool failures embed the agent
+  routes' `{"code", "message", "retryable"}` body in their error text — the
+  codes (`GATE_ROUND_STALE`, `RUN_NOT_ACTIVE`, …) are stable and safe to match
+  on. `review_request` uses the API's `{"error", "detail"}` shape for an
+  unregistered-repository 404. Requests that fail shape validation carry
+  `VALIDATION_ERROR` detail instead.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -126,7 +126,7 @@ be idempotent.
 ## An agent cannot reach `/mcp`
 
 1. A 401 means the personal access token is missing, malformed, expired, or
-   revoked — mint a fresh one in **Settings → Agent access** and resend it as
+   revoked — mint a fresh one in **Settings → Tokens** and resend it as
    `Authorization: Bearer <token>` ([Connect your agent](connect-your-agent.md)).
 2. A redirect or 404 at the edge means the host's Caddyfile predates the
    `/mcp` handlers: deploys never refresh the host copy, so re-run the


### PR DESCRIPTION
Stacked on #192.

A client that renders `tools/list` instead of the server instructions got bare `{type, title}` schemas: nothing said `answer_gate`'s `control` must be one of the ask's offered control ids, or where a `run_id` comes from.

- Every agent route parameter carries a description written for the calling agent, teaching the id graph in place (`"The runId from list_open_subjects for the parked run"`). These ride the existing derivation into the tool schemas.
- Each route declares the error responses it actually returns: the gateway and run routes their `{code, message, retryable}` codes via one builder beside `AgentApiError`, the review route its `{error, detail}` 404. The rendered OpenAPI for existing declarations is byte-identical.
- The instructions state the poll interval.
- Docs trued up: the connect guide now describes the eight-tool discovery-first surface, and two pages stop pointing at a settings pane that was renamed.

Closes ENG-830.