### PR TITLE
Ship contributes ship_start to the agent surface

### DIFF
--- a/backend/druks/contrib/review/routes.py
+++ b/backend/druks/contrib/review/routes.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter, Body, Depends, HTTPException, status
 
 from druks.accounts.dependencies import current_account
 from druks.accounts.models import Account
-from druks.contrib.review.schemas import ReviewRequestedResponse
 from druks.contrib.review.workflows import PullRequestReview
 from druks.contrib.ship.models import ProjectRepo
 
@@ -14,8 +13,6 @@ router = APIRouter(prefix="/reviews")
     status_code=status.HTTP_202_ACCEPTED,
     operation_id="review_request",
     tags=["agent"],
-    response_model=ReviewRequestedResponse,
-    response_model_by_alias=True,
     responses={
         404: {
             "description": "The repository is not registered.",
@@ -47,18 +44,13 @@ async def request_review(
         description="The pull request number in that repository.",
     ),
     account: Account = Depends(current_account),
-) -> ReviewRequestedResponse:
-    """Start a pull request review. The returned run feeds the run tools and
-    is what list_open_subjects shows for the pull request; requesting again
-    while the review is live returns the same run."""
+) -> str:
+    """Start a pull request review."""
     if not ProjectRepo.get_for_repo(repo):
         raise HTTPException(
             status.HTTP_404_NOT_FOUND,
             f"{repo} is not a registered project repo — add it to a project first",
         )
-    run_id = await PullRequestReview.dispatch(
-        repo=repo,
-        pr_number=pr_number,
-        requested_by=account.username,
+    return await PullRequestReview.dispatch(
+        repo=repo, pr_number=pr_number, requested_by=account.username
     )
-    return ReviewRequestedResponse(run=run_id)

--- a/backend/druks/contrib/review/schemas.py
+++ b/backend/druks/contrib/review/schemas.py
@@ -1,9 +1,4 @@
-from druks.schemas import BaseResponse
 from druks.workflows import SubjectSummary
-
-
-class ReviewRequestedResponse(BaseResponse):
-    run: str
 
 
 class ReviewSummary(SubjectSummary):

--- a/backend/druks/contrib/ship/models.py
+++ b/backend/druks/contrib/ship/models.py
@@ -342,10 +342,8 @@ class WorkItem(StoredSubject):
         source: str,
         ticket_key: str,
     ) -> "WorkItem | None":
-        """Look up a WorkItem by its source + ticket_key pair.
-
-        The (source, ticket_key) unique constraint guarantees at most
-        one live row; we return that row or None if no match exists."""
+        """The item a ticket names in its tracker — (source, ticket_key) is the
+        row's identity."""
         stmt = select(cls).where(cls.source == source, cls.ticket_key == ticket_key).limit(1)
         return db_session().scalars(stmt).first()
 

--- a/backend/druks/contrib/ship/routes.py
+++ b/backend/druks/contrib/ship/routes.py
@@ -1,8 +1,11 @@
 import logging
 
-from fastapi import APIRouter, Body, HTTPException, Query, Response, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Response, status
 from sqlalchemy import func, select, update
 
+from druks.accounts.dependencies import current_account
+from druks.accounts.models import Account
+from druks.contrib.ship.extension import Ship
 from druks.contrib.ship.models import Project, ProjectRepo, WorkItem
 from druks.contrib.ship.schemas import (
     AddProjectRepoRequest,
@@ -15,7 +18,7 @@ from druks.contrib.ship.schemas import (
     ProjectSummary,
     WorkItemsHistoryResponse,
 )
-from druks.contrib.ship.workflows import Profile
+from druks.contrib.ship.workflows import Build, Profile
 from druks.core.apis.github import get_github_client
 from druks.db import db_session
 from druks.settings import load_settings
@@ -253,3 +256,56 @@ async def list_work_items_history(
     # Recent history: the PRs GitHub has resolved, its verdict newest first.
     items = [DashboardItem.model_validate(wi) for wi in WorkItem.list_handoff(limit=clamped)]
     return WorkItemsHistoryResponse(items=items)
+
+
+@work_items_router.post(
+    "/{ticket}/start",
+    status_code=status.HTTP_202_ACCEPTED,
+    operation_id="ship_start",
+    tags=["agent"],
+    responses={
+        404: {
+            "description": "Unknown ticket.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": "HTTP_404",
+                        "detail": "no work item for ticket ENG-831",
+                    }
+                }
+            },
+        },
+        409: {
+            "description": "The work item has no registered target repository.",
+            "content": {
+                "application/json": {
+                    "example": {
+                        "error": "HTTP_409",
+                        "detail": (
+                            "acme/app is not a registered project repo — add it to a project first"
+                        ),
+                    }
+                }
+            },
+        },
+    },
+)
+async def start_work_item(
+    ticket: str = Path(
+        ...,
+        description=(
+            "The work item's ticket key, e.g. ENG-831 — its subjectLabel in list_open_subjects."
+        ),
+    ),
+    account: Account = Depends(current_account),
+) -> str:
+    """Start agents building the ticket's work item."""
+    item = WorkItem.get_for_ticket_key(source=Ship.settings().tracker, ticket_key=ticket)
+    if not item:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, f"no work item for ticket {ticket}")
+    if not ProjectRepo.get_for_repo(item.repo):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"{item.repo} is not a registered project repo — add it to a project first",
+        )
+    return await Build.start(subject=item, account_id=account.id)

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -125,17 +125,13 @@ class Build(Workflow):
         return await cls.start(
             subject=item,
             account_id=assignee.id if assignee else None,
-            repo=item.repo,
-            source=item.source,
             task_owner_email=email,
             task_owner_name=ticket["assignee_name"],
         )
 
     async def run_multistep(
         self,
-        repo: str,
         issue_number: int | None = None,
-        source: str = "github",
         task_owner_email: str | None = None,
         task_owner_name: str | None = None,
     ) -> None:
@@ -160,7 +156,7 @@ class Build(Workflow):
         # ones they actually need under get_related_root (the prompt names them, the
         # credential helper handles auth). The mkdir keeps Claude's --add-dir target
         # valid before the first on-demand clone.
-        repo = self.input.repo
+        repo = self.subject.repo
         # Planning agents run before the first implement provisions the branch — their
         # VMs clone the default branch; every agent after delivery gets the PR branch.
         branch = self.branch
@@ -197,16 +193,16 @@ class Build(Workflow):
 
     async def get_prompt_context(self, **context: Any) -> dict[str, Any]:
         work_item = self.subject
-        target_repo = ProjectRepo.get_for_repo(self.input.repo, raise_on_missing=True)
+        target_repo = ProjectRepo.get_for_repo(work_item.repo, raise_on_missing=True)
         endpoint = load_settings().urls.endpoint.rstrip("/")
         work_item_url = f"{endpoint}/work-items/{work_item.id}" if endpoint else ""
         prompt_context = BuildPromptContext(
-            repo=self.input.repo,
+            repo=work_item.repo,
             work_item_url=work_item_url,
             branch=self.branch,
             pr_number=self.pr_number,
             ticket_ref=work_item.ticket_key,
-            source=self.input.source,
+            source=work_item.source,
             issue_number=self.input.issue_number,
             task_owner_name=self.input.task_owner_name,
             task_owner_email=self.input.task_owner_email,
@@ -216,7 +212,7 @@ class Build(Workflow):
         )
         return {
             "verification": await self._policy.verification_block(
-                profile=self._profile, repo=self.input.repo
+                profile=self._profile, repo=work_item.repo
             ),
             "build": prompt_context,
             **await super().get_prompt_context(**context),
@@ -224,9 +220,10 @@ class Build(Workflow):
 
     @step
     async def _load_policy_and_profile(self) -> dict[str, Any]:
-        # One memoized read: the live policy + the repo's profiled facts.
-        policy = await RepoPolicy.resolve(self.input.repo)
-        target = ProjectRepo.get_for_repo(self.input.repo, raise_on_missing=True)
+        # One memoized read: the live policy + the work item's repo profiled facts.
+        repo = self.subject.repo
+        policy = await RepoPolicy.resolve(repo)
+        target = ProjectRepo.get_for_repo(repo, raise_on_missing=True)
         return {
             "policy": policy.model_dump(mode="json"),
             "profile": target.effective_profile,
@@ -343,7 +340,7 @@ class Build(Workflow):
     async def declare_merge_intent(self) -> bool:
         """Whether GitHub accepted ownership of the merge."""
         github = get_github_client(load_settings())
-        return await github.merge_when_ready(self.input.repo, self.pr_number)
+        return await github.merge_when_ready(self.subject.repo, self.pr_number)
 
     # The provisioned branch + PR, pinned to the FIRST delivery — None until then
     # (planning runs against the default branch, and there is no PR to point at).
@@ -365,29 +362,29 @@ class Build(Workflow):
 
     async def request_assignee_review(self) -> None:
         login = self.journal.assignee_github_login
-        if login and self.input.repo and self.pr_number:
+        repo = self.subject.repo
+        if login and self.pr_number:
             try:
                 await get_github_client(load_settings()).request_pull_request_reviewers(
-                    self.input.repo, self.pr_number, [login]
+                    repo, self.pr_number, [login]
                 )
             except Exception:  # noqa: BLE001 — a missed ping must not fail the park
                 logger.warning(
                     "could not request review from %s on %s#%s",
                     login,
-                    self.input.repo,
+                    repo,
                     self.pr_number,
                 )
 
     async def set_pr_draft(self, *, draft: bool) -> None:
-        if self.input.repo and self.pr_number:
+        repo = self.subject.repo
+        if self.pr_number:
             try:
                 await get_github_client(load_settings()).set_pull_request_draft_state(
-                    self.input.repo, self.pr_number, draft=draft
+                    repo, self.pr_number, draft=draft
                 )
             except Exception:  # noqa: BLE001 — a draft merge fails loudly anyway
-                logger.warning(
-                    "Could not set draft=%s on %s#%s.", draft, self.input.repo, self.pr_number
-                )
+                logger.warning("Could not set draft=%s on %s#%s.", draft, repo, self.pr_number)
 
 
 class Profile(Workflow):

--- a/backend/tests/ship/test_build_durable.py
+++ b/backend/tests/ship/test_build_durable.py
@@ -219,7 +219,7 @@ def _stub(
 
 
 async def _start_to_work_gate(rt, item):
-    workflow_id = await rt.flow.start(repo=item.repo, subject=item)
+    workflow_id = await rt.flow.start(subject=item)
     # The claim rides the dispatcher's transaction, so its row lock releases at
     # the request boundary — which the harness has to stand in for.
     db_session().commit()
@@ -300,10 +300,7 @@ async def test_machine_mode_reaches_work_gate_without_a_plan_park(rt, monkeypatc
     invoked, _ = _stub(monkeypatch, rt, plan_approval=None, plan_gate="machine")
 
     item = _seed_work_item(rt.engine, repo="acme/gizmo")
-    workflow_id = await rt.flow.start(
-        repo="acme/gizmo",
-        subject=item,
-    )
+    workflow_id = await rt.flow.start(subject=item)
 
     parked = await _wait(
         rt.engine,

--- a/backend/tests/ship/test_build_workspace.py
+++ b/backend/tests/ship/test_build_workspace.py
@@ -99,7 +99,8 @@ async def test_get_workspace_kwargs_clones_primary_only(monkeypatch: pytest.Monk
     sandbox = host_mod.Sandbox(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
 
     workflow = Build()
-    workflow.input = Build._run_input_model(repo="o/extension")
+    workflow.input = Build._run_input_model()
+    workflow.subject = SimpleNamespace(repo="o/extension")
     workflow._profile = {"recommended_skills": ["python-house-rules"]}
     kwargs = await workflow.get_workspace_kwargs(sandbox)
 
@@ -123,7 +124,8 @@ async def test_get_workspace_kwargs_fails_loudly_without_the_reviewer_app(
     sandbox = host_mod.Sandbox(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
 
     workflow = Build()
-    workflow.input = Build._run_input_model(repo="o/extension")
+    workflow.input = Build._run_input_model()
+    workflow.subject = SimpleNamespace(repo="o/extension")
     workflow._profile = {"recommended_skills": ["python-house-rules"]}
 
     with pytest.raises(FatalError, match="reviewer GitHub App"):

--- a/backend/tests/ship/test_extension_config.py
+++ b/backend/tests/ship/test_extension_config.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from druks.contrib.ship.policy import RepoPolicy
 from druks.extensions.config import resolve_extension_config
@@ -147,7 +149,8 @@ class TestLoadPolicyAndProfile:
         from druks.contrib.ship.workflows import Build
 
         flow = Build()
-        flow.input = Build._run_input_model(repo=repo, pr_number=1, branch="agent/x")
+        flow.input = Build._run_input_model()
+        flow.subject = SimpleNamespace(repo=repo)
         return flow
 
     async def test_resolves_live(self, druks_db, monkeypatch):

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -2,10 +2,11 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
-from druks.accounts.models import Account
+from druks.accounts.models import Account, PersonalAccessToken
 from druks.api.app import app
 from druks.contrib.review.workflows import PullRequestReview
-from druks.contrib.ship.models import Project, ProjectRepo
+from druks.contrib.ship.models import Project, ProjectRepo, WorkItem
+from druks.contrib.ship.workflows import Build
 from druks.durable.dbos_state import workflow_status
 from druks.durable.models import AgentCall, Run
 from druks.durable.reads import read_transcript_chunk
@@ -71,7 +72,7 @@ def _park(druks_db, note):
     return run
 
 
-def test_openapi_pins_platform_routes_and_review_request(client: TestClient):
+def test_openapi_pins_platform_and_extension_agent_routes(client: TestClient):
     schema = app.openapi()
     found = {
         (method, path): operation
@@ -81,6 +82,7 @@ def test_openapi_pins_platform_routes_and_review_request(client: TestClient):
     }
     assert {key: found[key]["operationId"] for key in _MCP_ROUTES} == _MCP_ROUTES
     assert found[("post", "/api/review/reviews")]["operationId"] == "review_request"
+    assert found[("post", "/api/ship/work-items/{ticket}/start")]["operationId"] == "ship_start"
 
     extensions = {
         key: {name: value for name, value in found[key].items() if name.startswith("x-")}
@@ -99,6 +101,11 @@ def test_openapi_pins_platform_routes_and_review_request(client: TestClient):
         ("get", "/api/usage/summary"): {},
     }
     assert not {name for name in found[("post", "/api/review/reviews")] if name.startswith("x-")}
+    assert not {
+        name
+        for name in found[("post", "/api/ship/work-items/{ticket}/start")]
+        if name.startswith("x-")
+    }
 
 
 def test_review_request_returns_the_run_id_start_hands_back(
@@ -124,15 +131,81 @@ def test_review_request_returns_the_run_id_start_hands_back(
     ]
 
     assert [response.status_code for response in responses] == [202, 202]
-    assert [response.json() for response in responses] == [
-        {"run": live_run_id},
-        {"run": live_run_id},
-    ]
+    assert [response.json() for response in responses] == [live_run_id, live_run_id]
     assert [call["subject"].identity for call in starts] == [
         {"type": "pull_request", "id": "acme/app#7"},
         {"type": "pull_request", "id": "acme/app#7"},
     ]
     assert {call["account_id"] for call in starts} == {account.id}
+
+
+def test_ship_start_returns_the_live_run_and_attributes_the_pat_account(
+    client: TestClient, account: Account, monkeypatch
+):
+    project = Project.create(name="Acme")
+    ProjectRepo.create(project_id=project.id, full_name="acme/app")
+    item = WorkItem.create(
+        project_id=project.id,
+        source="linear",
+        title="Build the agent route",
+        ticket_key="ENG-831",
+        repo="acme/app",
+    )
+    _, pat_token = PersonalAccessToken.create(account_id=account.id, name="agent")
+    live_run_id = "build-run-id"
+    starts = []
+
+    async def start(cls, **kwargs):
+        # The subject detaches with the request's session; keep its identity.
+        starts.append({**kwargs, "subject": kwargs["subject"].id})
+        return live_run_id
+
+    monkeypatch.setattr(Build, "start", classmethod(start))
+
+    responses = [
+        client.post(
+            f"/api/ship/work-items/{item.ticket_key}/start",
+            headers={"Authorization": f"Bearer {pat_token}"},
+        )
+        for _ in range(2)
+    ]
+
+    assert [response.status_code for response in responses] == [202, 202]
+    assert [response.json() for response in responses] == [live_run_id, live_run_id]
+    assert [call["subject"] for call in starts] == [item.id, item.id]
+    assert {call["account_id"] for call in starts} == {account.id}
+    assert all("repo" not in call for call in starts)
+    assert all("task_owner_email" not in call for call in starts)
+    assert all("task_owner_name" not in call for call in starts)
+
+
+def test_ship_start_rejects_an_unknown_ticket(client: TestClient):
+    response = client.post("/api/ship/work-items/ENG-000/start")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": "HTTP_404",
+        "detail": "no work item for ticket ENG-000",
+    }
+
+
+def test_ship_start_rejects_a_work_item_without_a_registered_repo(client: TestClient):
+    project = Project.create(name="Acme")
+    item = WorkItem.create(
+        project_id=project.id,
+        source="linear",
+        title="Unroutable work",
+        ticket_key="ENG-832",
+        repo="acme/missing",
+    )
+
+    response = client.post(f"/api/ship/work-items/{item.ticket_key}/start")
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "error": "HTTP_409",
+        "detail": "acme/missing is not a registered project repo — add it to a project first",
+    }
 
 
 def test_agent_routes_sit_behind_the_gate(tmp_path, druks_db):

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -155,14 +155,14 @@ async def test_mcp_subpaths_never_reach_the_spa(app):
             assert stray.headers["content-type"].startswith("application/json")
 
 
-async def test_tools_list_pins_platform_tools_and_review_request(app, pat_token):
+async def test_tools_list_pins_platform_and_extension_tools(app, pat_token):
     async with live(app), _client(app, pat_token) as client:
         assert "list_open_subjects" in (client.initialize_result.instructions or "")
         assert "parkedAt" in (client.initialize_result.instructions or "")
         tools = {tool.name: tool for tool in await client.list_tools()}
 
     assert list(tools)[:7] == _TOOL_NAMES
-    assert list(tools)[7:] == ["review_request"]
+    assert list(tools)[7:] == ["review_request", "ship_start"]
 
     expected_annotations = {
         "cancel_run": (False, True, True),
@@ -182,13 +182,14 @@ async def test_tools_list_pins_platform_tools_and_review_request(app, pat_token)
         ) == expected
         assert tools[name].description
 
-    review_request = tools["review_request"]
-    assert (
-        review_request.annotations.readOnlyHint,
-        review_request.annotations.destructiveHint,
-        review_request.annotations.idempotentHint,
-    ) == (False, True, False)
-    assert review_request.description
+    for name in ("review_request", "ship_start"):
+        extension_tool = tools[name]
+        assert (
+            extension_tool.annotations.readOnlyHint,
+            extension_tool.annotations.destructiveHint,
+            extension_tool.annotations.idempotentHint,
+        ) == (False, True, False)
+        assert extension_tool.description
 
     # Derived schemas keep the routes' own shapes and constraints.
     assert tools["answer_gate"].inputSchema["required"] == ["run_id", "parkedAt", "control"]
@@ -197,6 +198,9 @@ async def test_tools_list_pins_platform_tools_and_review_request(app, pat_token)
     )
     reason = tools["cancel_run"].inputSchema["properties"]["reason"]
     assert (reason["minLength"], reason["maxLength"]) == (1, 500)
+    assert tools["ship_start"].inputSchema["properties"]["ticket"]["description"] == (
+        "The work item's ticket key, e.g. ENG-831 — its subjectLabel in list_open_subjects."
+    )
     assert not tools["list_open_subjects"].inputSchema.get("required")
     assert not tools["get_usage"].inputSchema.get("required")
 


### PR DESCRIPTION
Ship was the one extension with no HTTP dispatch door — builds started only from the tracker webhook. `Build.dispatch` takes a tracker payload and resolves attribution from the ticket's assignee, so a wire caller could not use it.

`ship_start` names a work item by its ticket key — the handle the operator speaks and the listing's `subjectLabel` for work_item subjects — and starts its build with the calling account's attribution. Resolve-or-create stays the tracker funnel's job: an unknown ticket is a 404, an item whose repo is not registered to a project is a 409.

A workflow that declares a subject owns what the subject knows: `repo` and `source` leave Build's input and resolve once, memoized, in the same step that loads policy and profile — so input carries only caller knowledge (`issue_number`, task owner). A dispatch route returns what `start()` returns, and the author's whole body is look up, refuse, `return await Build.start(subject=item, account_id=account.id)`. `review_request` shares the shape.

Deploy note: drain in-flight `ship.build` runs before rolling this out — their stored input carries the removed `repo`/`source` fields and cannot replay into the new signature.

Closes ENG-831.
