### PR TITLE
The mode-claim test completes its connects sequentially instead of racing them

### DIFF
--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -347,7 +347,7 @@ async def test_two_per_user_connects_store_two_grants(auth_server, druks_db):
     assert {grant.account_id for grant in grants} == {first.id, second.id}
 
 
-async def test_concurrent_first_connects_converge_on_the_claimed_mode(auth_server, druks_db):
+async def test_a_later_connect_stores_under_the_claimed_mode(auth_server, druks_db):
     first = Account.get_or_create("first@example.com")
     second = Account.get_or_create("second@example.com")
     first_url = await oauth.begin_connect(
@@ -367,18 +367,12 @@ async def test_concurrent_first_connects_converge_on_the_claimed_mode(auth_serve
     first_state = dict(parse_qsl(urlparse(first_url).query))["state"]
     second_state = dict(parse_qsl(urlparse(second_url).query))["state"]
 
-    await asyncio.gather(
-        oauth.complete_connect(state=first_state, code="first"),
-        oauth.complete_connect(state=second_state, code="second"),
-    )
+    await oauth.complete_connect(state=first_state, code="first")
+    await oauth.complete_connect(state=second_state, code="second")
 
-    identity_mode = McpServer.get_for_name(_NAME).identity_mode
+    assert McpServer.get_for_name(_NAME).identity_mode == IdentityMode.SHARED
     grant_accounts = {grant.account_id for grant in McpOauthGrant.list_for_server(_NAME)}
-    assert identity_mode in {IdentityMode.SHARED, IdentityMode.PER_USER}
-    if identity_mode == IdentityMode.SHARED:
-        assert grant_accounts == {SYSTEM_ACCOUNT_ID}
-    else:
-        assert grant_accounts == {first.id, second.id}
+    assert grant_accounts == {SYSTEM_ACCOUNT_ID}
 
 
 # --- mint: cache, refresh, rotation, eviction -------------------------------


### PR DESCRIPTION
Removes the `asyncio.gather` from `test_concurrent_first_connects_converge_on_the_claimed_mode` — the same latent savepoint hazard #199 fixed in the rotation test, caught before it started flaking.

## The hazard

The test fixture binds every session to one shared connection inside one outer transaction, with `join_transaction_mode="create_savepoint"`. `db_session` is task-scoped, so gathering two `complete_connect` calls gives each task its own session, and both stack savepoints on the connection's single nested-transaction stack. Postgres destroys every later savepoint when an earlier one is released, and SQLAlchemy's per-connection tracking can't see across sessions — the #199 mechanism. `complete_connect` doesn't commit today, which is the only reason this instance hasn't escalated; the two abandoned task sessions still leave interleaved savepoints for teardown and GC to trip over, and any future commit on the path arms it.

## What the gather was buying

Nothing provable. The claim `complete_connect` makes — a concurrent claim serializes on the `McpServer` row lock — is a cross-connection property, and both gathered tasks ride one connection in one transaction, so the staged race never exercises it. The old assertions admitted it: they accepted either mode winning.

## The fix

Sequential completes make the property deterministic: the first connect claims SHARED, and the second — asking PER_USER — stores its grant under the claimed mode instead, landing on the system account. Renamed to `test_a_later_connect_stores_under_the_claimed_mode` to match what it now proves. The row-lock serialization itself is Postgres's contract, per the repo's rule that primitives' contracts aren't ours to re-prove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
