### PR TITLE
The agent guide names the platform's seven and defers the rest to tools/list

### DIFF
--- a/docs/connect-your-agent.md
+++ b/docs/connect-your-agent.md
@@ -1,10 +1,12 @@
 # Connect your agent
 
 Druks serves an MCP endpoint at `/mcp` (streamable HTTP, stateless). Its
-tools are derived from the agent-tagged API routes — the same eight operations,
-one contract: `list_open_subjects`, `get_gate`, `answer_gate`, `get_agent_call`,
-`cancel_run`, `retry_run`, `get_usage`, `review_request` — authenticated per
-request with a personal access token sent as `Authorization: Bearer <token>`.
+tools are derived from the agent-tagged API routes. The platform contributes
+seven — `list_open_subjects`, `get_gate`, `answer_gate`, `get_agent_call`,
+`cancel_run`, `retry_run`, `get_usage` — and each installed extension
+contributes its own verbs beside them; `tools/list` is the live catalog.
+Every request authenticates with a personal access token sent as
+`Authorization: Bearer <token>`.
 Mint and revoke tokens in **Settings → Tokens**; see
 [personal access tokens](configuration.md#personal-access-tokens) for
 lifecycle and compromise handling.
@@ -40,7 +42,7 @@ bearer_token_env_var = "DRUKS_PAT"
 - **Discovery first.** There is no push channel. Call `list_open_subjects`
   first and poll it about every 30 seconds while waiting. Each workflow's `run` feeds
   the gate and run tools, and `latestAgentCall` feeds `get_agent_call`;
-  `review_request` starts or reuses a review run that enters the same flow.
+  An extension's verbs open work whose run enters the same flow.
   Call `get_gate` before `answer_gate` and echo its `parkedAt`
   value unchanged; it names the exact question being answered, and a repeat
   answer to the same `parkedAt` reports `already_answered` instead of
@@ -51,6 +53,6 @@ bearer_token_env_var = "DRUKS_PAT"
 - **Stable error shapes.** Gateway and run tool failures embed the agent
   routes' `{"code", "message", "retryable"}` body in their error text — the
   codes (`GATE_ROUND_STALE`, `RUN_NOT_ACTIVE`, …) are stable and safe to match
-  on. `review_request` uses the API's `{"error", "detail"}` shape for an
-  unregistered-repository 404. Requests that fail shape validation carry
+  on. Extension verbs use the API's `{"error", "detail"}` shape for their
+  refusals. Requests that fail shape validation carry
   `VALIDATION_ERROR` detail instead.


### PR DESCRIPTION
The guide enumerated extension tools in the core contract, so it drifted every time an extension verb landed — ship_start merged and the guide said eight. Now it names the platform's seven, states that installed extensions contribute their own verbs, and points at tools/list as the live catalog. No extension tool is named in core docs again.