### PR TITLE
Agent tool params speak the surface vocabulary: run and call, never run_id

### DIFF
--- a/backend/druks/api/runs.py
+++ b/backend/druks/api/runs.py
@@ -18,8 +18,8 @@ from druks.notifications.services import validate_in_app_answer
 router = APIRouter(prefix="/api/runs", tags=["runs"])
 
 
-@router.post("/{run_id}/resume", status_code=status.HTTP_204_NO_CONTENT)
-async def resume_run(run_id: str, body: ResumeRequest) -> None:
+@router.post("/{run}/resume", status_code=status.HTTP_204_NO_CONTENT)
+async def resume_run(run_id: Annotated[str, Path(alias="run")], body: ResumeRequest) -> None:
     # The in-app half of a gate: the operator answers the parked run from Druks
     # (external gates resume through their own webhook).
     run = Run.get(run_id)
@@ -41,7 +41,7 @@ async def resume_run(run_id: str, body: ResumeRequest) -> None:
 
 
 @router.post(
-    "/{run_id}/cancel",
+    "/{run}/cancel",
     operation_id="cancel_run",
     tags=["agent"],
     openapi_extra={"x-idempotent": True},
@@ -50,7 +50,9 @@ async def resume_run(run_id: str, body: ResumeRequest) -> None:
     responses=agent_error_responses(RunNotFound("run-123"), RunNotActive("run-123")),
 )
 async def cancel_run(
-    run_id: Annotated[str, Path(description="The active run's id, run in list_open_subjects.")],
+    run_id: Annotated[
+        str, Path(alias="run", description="The active run, from list_open_subjects.")
+    ],
     reason: Annotated[
         str,
         Body(
@@ -75,7 +77,7 @@ async def cancel_run(
 
 
 @router.post(
-    "/{run_id}/retry",
+    "/{run}/retry",
     operation_id="retry_run",
     tags=["agent"],
     openapi_extra={"x-destructive": False},
@@ -86,7 +88,9 @@ async def cancel_run(
     ),
 )
 async def retry_run(
-    run_id: Annotated[str, Path(description="The failed run's id, run in list_open_subjects.")],
+    run_id: Annotated[
+        str, Path(alias="run", description="The failed run, from list_open_subjects.")
+    ],
 ) -> RetryRunResponse:
     """Rerun a failed run from the step that killed it, reusing every
     completed step."""

--- a/backend/druks/mcp/gateway/routes.py
+++ b/backend/druks/mcp/gateway/routes.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="/api", tags=["agent"])
 
 
 @router.get(
-    "/gates/{run_id}",
+    "/gates/{run}",
     operation_id="get_gate",
     response_model=schemas.GateResponse,
     response_model_by_alias=True,
@@ -25,15 +25,15 @@ router = APIRouter(prefix="/api", tags=["agent"])
     ),
 )
 async def get_gate(
-    run_id: Annotated[str, Path(description="The parked run's id, run in list_open_subjects.")],
+    run: Annotated[str, Path(description="The parked run, from list_open_subjects.")],
 ) -> schemas.GateResponse:
     """A parked run's open gate: the ask, a bounded artifact chunk, and
     parkedAt — echo parkedAt unchanged to answer_gate."""
-    return services.get_gate(run_id)
+    return services.get_gate(run)
 
 
 @router.post(
-    "/gates/{run_id}/answer",
+    "/gates/{run}/answer",
     operation_id="answer_gate",
     openapi_extra={"x-destructive": False, "x-idempotent": True},
     response_model=schemas.GateAnswerResponse,
@@ -47,14 +47,14 @@ async def get_gate(
     ),
 )
 async def answer_gate(
-    run_id: Annotated[str, Path(description="The parked run's id from get_gate.")],
+    run: Annotated[str, Path(description="The parked run from get_gate.")],
     body: schemas.AnswerGateRequest,
 ) -> schemas.GateAnswerResponse:
     """Answer the gate get_gate showed, resuming the run. parkedAt must echo
     get_gate's value unchanged; a repeat answer to the same parkedAt reports
     already_answered."""
     return await services.answer_gate(
-        run_id,
+        run,
         parked_at=body.parked_at,
         control=body.control,
         answers=body.answers,
@@ -63,20 +63,18 @@ async def answer_gate(
 
 
 @router.get(
-    "/agent-calls/{call_id}",
+    "/agent-calls/{call}",
     operation_id="get_agent_call",
     response_model=schemas.AgentCallDetailResponse,
     response_model_by_alias=True,
     responses=agent_error_responses(gate_errors.AgentCallNotFound("call-123")),
 )
 async def get_agent_call(
-    call_id: Annotated[
-        str, Path(description="An agent call id, latestAgentCall in list_open_subjects.")
-    ],
+    call: Annotated[str, Path(description="An agent call, latestAgentCall in list_open_subjects.")],
 ) -> schemas.AgentCallDetailResponse:
     """One agent call's metadata with bounded transcript and stderr tails and
     an artifact chunk."""
-    return services.get_agent_call(call_id)
+    return services.get_agent_call(call)
 
 
 @router.get(

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -23,11 +23,11 @@ _IN_APP_ASK = {
 }
 
 _MCP_ROUTES = {
-    ("get", "/api/gates/{run_id}"): "get_gate",
-    ("post", "/api/gates/{run_id}/answer"): "answer_gate",
-    ("get", "/api/agent-calls/{call_id}"): "get_agent_call",
-    ("post", "/api/runs/{run_id}/cancel"): "cancel_run",
-    ("post", "/api/runs/{run_id}/retry"): "retry_run",
+    ("get", "/api/gates/{run}"): "get_gate",
+    ("post", "/api/gates/{run}/answer"): "answer_gate",
+    ("get", "/api/agent-calls/{call}"): "get_agent_call",
+    ("post", "/api/runs/{run}/cancel"): "cancel_run",
+    ("post", "/api/runs/{run}/retry"): "retry_run",
     ("get", "/api/open-subjects"): "list_open_subjects",
     ("get", "/api/usage/summary"): "get_usage",
 }
@@ -89,14 +89,14 @@ def test_openapi_pins_platform_and_extension_agent_routes(client: TestClient):
         for key in _MCP_ROUTES
     }
     assert extensions == {
-        ("get", "/api/gates/{run_id}"): {},
-        ("post", "/api/gates/{run_id}/answer"): {
+        ("get", "/api/gates/{run}"): {},
+        ("post", "/api/gates/{run}/answer"): {
             "x-destructive": False,
             "x-idempotent": True,
         },
-        ("get", "/api/agent-calls/{call_id}"): {},
-        ("post", "/api/runs/{run_id}/cancel"): {"x-idempotent": True},
-        ("post", "/api/runs/{run_id}/retry"): {"x-destructive": False},
+        ("get", "/api/agent-calls/{call}"): {},
+        ("post", "/api/runs/{run}/cancel"): {"x-idempotent": True},
+        ("post", "/api/runs/{run}/retry"): {"x-destructive": False},
         ("get", "/api/open-subjects"): {},
         ("get", "/api/usage/summary"): {},
     }

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -192,7 +192,7 @@ async def test_tools_list_pins_platform_and_extension_tools(app, pat_token):
         assert extension_tool.description
 
     # Derived schemas keep the routes' own shapes and constraints.
-    assert tools["answer_gate"].inputSchema["required"] == ["run_id", "parkedAt", "control"]
+    assert tools["answer_gate"].inputSchema["required"] == ["run", "parkedAt", "control"]
     assert tools["answer_gate"].inputSchema["properties"]["control"]["description"] == (
         "The decision to take: one of the ids the ask offers as controls, e.g. approve."
     )
@@ -276,14 +276,14 @@ async def test_gate_cycle_reads_answers_and_reports_stale_rounds(
     druks_db.flush()
 
     async with live(app), _client(app, pat_token) as client:
-        gate = (await client.call_tool("get_gate", {"run_id": run.id})).structured_content
+        gate = (await client.call_tool("get_gate", {"run": run.id})).structured_content
         assert gate["run"] == run.id
         assert gate["ask"]["controls"] == ["approve", "request_changes"]
 
         stale = await _call_error(
             client,
             "answer_gate",
-            {"run_id": run.id, "parkedAt": "2020-01-01T00:00:00+00:00", "control": "approve"},
+            {"run": run.id, "parkedAt": "2020-01-01T00:00:00+00:00", "control": "approve"},
         )
         assert stale["code"] == "GATE_ROUND_STALE"
         assert stale["retryable"] is True
@@ -291,7 +291,7 @@ async def test_gate_cycle_reads_answers_and_reports_stale_rounds(
         answered = (
             await client.call_tool(
                 "answer_gate",
-                {"run_id": run.id, "parkedAt": gate["parkedAt"], "control": "approve"},
+                {"run": run.id, "parkedAt": gate["parkedAt"], "control": "approve"},
             )
         ).structured_content
         assert answered["result"] == "answered"
@@ -302,7 +302,7 @@ async def test_gate_cycle_reads_answers_and_reports_stale_rounds(
         repeat = (
             await client.call_tool(
                 "answer_gate",
-                {"run_id": run.id, "parkedAt": gate["parkedAt"], "control": "approve"},
+                {"run": run.id, "parkedAt": gate["parkedAt"], "control": "approve"},
             )
         ).structured_content
         assert repeat["result"] == "already_answered"
@@ -310,7 +310,7 @@ async def test_gate_cycle_reads_answers_and_reports_stale_rounds(
         missing = await _call_error(
             client,
             "answer_gate",
-            {"run_id": "no-such-run", "parkedAt": gate["parkedAt"], "control": "approve"},
+            {"run": "no-such-run", "parkedAt": gate["parkedAt"], "control": "approve"},
         )
         assert missing["code"] == "RUN_NOT_FOUND"
 
@@ -324,7 +324,7 @@ async def test_gate_cycle_reads_answers_and_reports_stale_rounds(
         )
         external.input_requested_at = datetime.now(UTC)
         druks_db.flush()
-        unanswerable = await _call_error(client, "get_gate", {"run_id": external.id})
+        unanswerable = await _call_error(client, "get_gate", {"run": external.id})
     assert unanswerable["code"] == "GATE_NOT_ANSWERABLE"
 
 
@@ -340,14 +340,14 @@ async def test_get_agent_call_serves_bounded_tails(app, pat_token, druks_db):
     )
 
     async with live(app), _client(app, pat_token) as client:
-        detail = (await client.call_tool("get_agent_call", {"call_id": call.id})).structured_content
+        detail = (await client.call_tool("get_agent_call", {"call": call.id})).structured_content
         assert detail["run"] == call.run_id
         assert len(detail["transcript"].encode()) <= 8 * 1024
         assert len(detail["stderr"].encode()) <= 4 * 1024
         assert len(detail["artifact"]["content"].encode()) <= 4 * 1024
         assert _wire_size(detail) <= 20 * 1024
 
-        error = await _call_error(client, "get_agent_call", {"call_id": "missing"})
+        error = await _call_error(client, "get_agent_call", {"call": "missing"})
     assert error == {
         "code": "AGENT_CALL_NOT_FOUND",
         "message": "No agent call missing.",
@@ -371,24 +371,22 @@ async def test_cancel_run_is_destructive_but_repeatable(app, pat_token, druks_db
 
     async with live(app), _client(app, pat_token) as client:
         cancelled = (
-            await client.call_tool("cancel_run", {"run_id": active.id, "reason": "wrong branch"})
+            await client.call_tool("cancel_run", {"run": active.id, "reason": "wrong branch"})
         ).structured_content
         assert cancelled == {"run": active.id, "result": "cancelled"}
         assert cancels == [{"id": active.id, "failure": "wrong branch"}]
 
         repeat = (
-            await client.call_tool("cancel_run", {"run_id": gone.id, "reason": "again"})
+            await client.call_tool("cancel_run", {"run": gone.id, "reason": "again"})
         ).structured_content
         assert repeat["result"] == "already_cancelled"
 
-        terminal = await _call_error(
-            client, "cancel_run", {"run_id": done.id, "reason": "too late"}
-        )
+        terminal = await _call_error(client, "cancel_run", {"run": done.id, "reason": "too late"})
         assert terminal["code"] == "RUN_NOT_ACTIVE"
 
         # A blank reason dies at route validation (422), before the service.
         blank = await client.call_tool(
-            "cancel_run", {"run_id": active.id, "reason": ""}, raise_on_error=False
+            "cancel_run", {"run": active.id, "reason": ""}, raise_on_error=False
         )
     assert blank.is_error
     assert cancels == [{"id": active.id, "failure": "wrong branch"}]


### PR DESCRIPTION
list_open_subjects hands back `run` and `latestAgentCall`, but the id-keyed agent tools took `run_id` / `call_id` — two names for the same value, and a caller passing the vocabulary word got a 404 instead of a bound param. ENG-827 renamed the wire fields; the path params were left behind.

Every agent-surface path param now uses the one-word vocabulary:

- `get_gate`, `answer_gate`, `cancel_run`, `retry_run` take `run`
- `get_agent_call` takes `call`
- `/api/runs/{run}/resume` renames its template for consistency (dashboard-only, name never crosses the wire)

The wire vocabulary and Python's naming are two namespaces: on the wire `run` is the run pointer; in code `run` is the fetched `Run` and `run_id` the id string. Where a handler holds both, `Path(alias="run")` translates at the boundary — the same move `parked_at` ⇄ `parkedAt` already makes via the camel-case alias generator — so the bodies keep their natural `run = Run.get(run_id)`. Handlers with no fetched model (the gateway pass-throughs) just name the param `run`.

URLs are unchanged in shape, so HTTP clients are unaffected; the derived MCP tool input schemas are the visible change. Tests pinning the old names are updated.