### PR TITLE
The review extension owns the identity reviews act as; ship borrows it, never the credentials

### DIFF
--- a/backend/druks/contrib/review/github.py
+++ b/backend/druks/contrib/review/github.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from druks.core.apis.github import GitHubClient, get_github_client
+from druks.settings import load_settings
+
+
+@dataclass(frozen=True)
+class ReviewActor:
+    """Who reviews act as, and how they may post. ``approve`` — a review
+    identity distinct from the operator, so GitHub accepts its verdict reviews
+    on operator-authored pull requests. ``comment`` — the operator itself,
+    which GitHub bars from approving its own pull requests, so reviews publish
+    as comment events with the verdict in the body."""
+
+    client: GitHubClient
+    mode: Literal["approve", "comment"]
+
+
+def get_review_actor() -> ReviewActor:
+    settings = load_settings()
+    if settings.github.reviewer_app_id and settings.github_reviewer_private_key_path:
+        return ReviewActor(
+            client=GitHubClient(
+                app_id=settings.github.reviewer_app_id,
+                private_key=settings.github_reviewer_private_key_path.read_text(),
+                base_url=settings.github_api_url,
+            ),
+            mode="approve",
+        )
+    return ReviewActor(client=get_github_client(settings), mode="comment")

--- a/backend/druks/contrib/review/subscribers.py
+++ b/backend/druks/contrib/review/subscribers.py
@@ -1,15 +1,14 @@
+from druks.contrib.review.github import get_review_actor
 from druks.contrib.review.workflows import PullRequestReview
 from druks.contrib.ship.models import ProjectRepo
-from druks.core.apis.github import get_reviewer_github_client
-from druks.settings import load_settings
 from druks.signals import subscribe
 
 
 @subscribe("pr.commented", payload__author_can_write=True)
 async def mention_asks_for_a_review(*, repo: str, pr_number: int, payload: dict) -> None:
-    """Addressing the reviewer app asks it to review that pull request, and only someone
+    """Addressing the review actor asks it to review that pull request, and only someone
     who writes to the repo may ask — a review is the account's to spend."""
-    handle = await get_reviewer_github_client(load_settings()).get_mention_handle()
+    handle = await get_review_actor().client.get_mention_handle()
     is_mentioned = handle and f"@{handle}".casefold() in payload["body"].casefold()
     if is_mentioned and ProjectRepo.get_for_repo(repo):
         await PullRequestReview.dispatch(

--- a/backend/druks/contrib/review/templates/review_pull_request.md
+++ b/backend/druks/contrib/review/templates/review_pull_request.md
@@ -3,10 +3,9 @@
 You are reviewing pull request #{{ workflow.subject.number }} on `{{ workflow.subject.repo }}`,
 at {{ workflow.input.requested_by }}'s request.
 
-The repo is cloned at `{{ workspace.repo_path }}`, and `gh` is authenticated there as the
-reviewer app — that is the identity your review will be published under. Only your FINAL
-response must be the JSON matching the requested schema; everything before it is free-form and
-never parsed.
+The repo is cloned at `{{ workspace.repo_path }}`, and `gh` is authenticated there — that is
+the identity your review will be published under. Only your FINAL response must be the JSON
+matching the requested schema; everything before it is free-form and never parsed.
 
 ## How to review
 
@@ -91,6 +90,13 @@ Publish it on the pull request yourself, as one review carrying all three parts 
 verdict — approve, request changes, or comment without blocking — your prose addressed to the
 author, and an inline comment on each line you have something to say about, anchored to the
 diff's post-image (the `+` side). Anything you cannot anchor to a line belongs in the prose.
+{% if review_mode == "comment" %}
+
+You share the identity that authors druks's own pull requests, and GitHub refuses `APPROVE`
+and `REQUEST_CHANGES` reviews from a pull request's author. Publish every review as a
+`COMMENT` event and open its prose by stating the verdict plainly ("Verdict: approve" /
+"Verdict: request changes"). The `decision` you return is your real verdict either way.
+{% endif %}
 
 Post exactly once. If GitHub refuses an anchor, move that remark into the prose and post the
 review again — never leave the pull request without a review.

--- a/backend/druks/contrib/review/workflows.py
+++ b/backend/druks/contrib/review/workflows.py
@@ -3,12 +3,11 @@ from typing import TYPE_CHECKING, Any
 from druks.accounts.models import Account
 from druks.contrib.review.datastructures import PullRequest
 from druks.contrib.review.extension import Review
+from druks.contrib.review.github import get_review_actor
 from druks.contrib.ship.models import ProjectRepo
 from druks.contrib.ship.workspace import RepoWorkspace
-from druks.core.apis.github import get_reviewer_github_client
 from druks.sandbox import repo as _repo
 from druks.sandbox.layout import get_github_token_remote_path, get_related_root, get_repo_root
-from druks.settings import load_settings
 from druks.workflows import Workflow
 
 if TYPE_CHECKING:
@@ -53,11 +52,11 @@ class PullRequestReview(Workflow):
 
     async def get_workspace_kwargs(self, sandbox: "Sandbox") -> dict[str, Any]:
         # Cloned at the default branch — the reviewer checks the pull request out itself.
-        # The token is the reviewer app's: it authenticates the clone and ``gh``, so the
+        # The token is the review actor's: it authenticates the clone and ``gh``, so the
         # review is authored under that identity. Siblings stay uncloned — the reviewer
         # clones the ones it opens, into a directory that must exist for the grant to hold.
         repo = self.subject.repo
-        github_token = await get_reviewer_github_client(load_settings()).token_for_repo(repo)
+        github_token = await get_review_actor().client.token_for_repo(repo)
         await sandbox.write_secret(
             secret=github_token, remote=get_github_token_remote_path(sandbox.ssh_username)
         )
@@ -78,5 +77,6 @@ class PullRequestReview(Workflow):
         target = ProjectRepo.get_for_repo(self.subject.repo, raise_on_missing=True)
         return {
             "siblings": target.siblings(),
+            "review_mode": get_review_actor().mode,
             **await super().get_prompt_context(**context),
         }

--- a/backend/druks/contrib/ship/constants.py
+++ b/backend/druks/contrib/ship/constants.py
@@ -1,6 +1,7 @@
 # The github MCP server build ships into its own runs — build's requirement
 # (there is no build without github), not an operator-facing catalog entry.
-# Its token is per-repo, minted from the reviewer app at workspace setup.
+# Its token is per-repo, minted at workspace setup from the identity reviews
+# act as (druks.contrib.review.github).
 GITHUB_MCP_NAME = "github"
 GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
 

--- a/backend/druks/contrib/ship/prompt_context.py
+++ b/backend/druks/contrib/ship/prompt_context.py
@@ -26,4 +26,8 @@ class BuildPromptContext:
     task_owner_email: str | None
     related_repos: list[ProjectRepo]
     skills: list[Skill]
+    # How the github MCP identity may post reviews: "approve" (distinct
+    # review identity) or "comment" (the operator, barred from approving its
+    # own pull requests).
+    review_mode: str
     journal: BuildJournal

--- a/backend/druks/contrib/ship/templates/build/_github_review.md
+++ b/backend/druks/contrib/ship/templates/build/_github_review.md
@@ -6,10 +6,19 @@ through it — every time, not optionally. This is in addition to the JSON you
 return: the JSON drives the build; the GitHub review is what the human sees on
 the PR.
 
+{% if build.review_mode == "approve" %}
 - Review event from your verdict: an **approving** verdict → `APPROVE`; a
   **changes-requested / failing** verdict → `REQUEST_CHANGES`; a **blocked /
   could-not-evaluate** verdict → skip the GitHub review. When you approve *with
   required changes*, post `APPROVE` and put the required changes in the body.
+{% else %}
+- Submit every review as a `COMMENT` event — you share the identity that authored
+  this PR, and GitHub refuses `APPROVE` and `REQUEST_CHANGES` from a pull
+  request's author. Open the body by stating your verdict plainly ("Verdict:
+  approve" / "Verdict: request changes"); a **blocked / could-not-evaluate**
+  verdict → skip the GitHub review. When you approve *with required changes*,
+  state the verdict and put the required changes in the body.
+{% endif %}
 - Use your review body as the GitHub review body; attach each finding that maps
   to a file and line as an inline review comment on that line.
 - Do not request reviewers on the PR — druks requests the assignee's review

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel, Field
 
 from druks.accounts.models import Account
+from druks.contrib.review.github import get_review_actor
 from druks.contrib.ship.contracts import ImplementationOutput, ReviewWork
 from druks.contrib.ship.enums import (
     EvaluationVerdict,
@@ -12,7 +13,7 @@ from druks.contrib.ship.enums import (
     ReviewDecision,
 )
 from druks.contrib.ship.models import ProjectRepo, WorkItem
-from druks.core.apis.github import get_github_client, get_reviewer_github_client
+from druks.core.apis.github import get_github_client
 from druks.sandbox import repo as _repo
 from druks.sandbox.datastructures import RequiredMcpServer
 from druks.sandbox.layout import (
@@ -41,12 +42,11 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True, kw_only=True)
 class BuildWorkspace(RepoWorkspace):
     # The base RepoWorkspace brings the cloned repo + token; a build run adds its
-    # curated skills, PR branch, and reviewer MCP token.
+    # curated skills, PR branch, and github MCP token.
     skills: tuple[str, ...]
     branch: str | None = None
-    # Reviewer-extension installation token for build's github MCP server,
-    # minted per repo from the reviewer GitHub App. Required — there is no
-    # build without github.
+    # Installation token for build's github MCP server, minted per repo from
+    # the identity reviews act as. Required — there is no build without github.
     mcp_token: str
 
     @property
@@ -177,15 +177,14 @@ class Build(Workflow):
         )
         await sandbox.exec(["mkdir", "-p", get_related_root(sandbox.ssh_username)], timeout=10.0)
         try:
-            mcp_token = await get_reviewer_github_client(load_settings()).token_for_repo(repo)
+            mcp_token = await get_review_actor().client.token_for_repo(repo)
         except Exception as error:
             # There is no build without github: agents push and review through
             # the github MCP, so a run that can't mint its token fails here,
             # loudly, instead of degrading mid-run.
             raise FatalError(
-                f"Could not mint the reviewer GitHub App token for {repo}; build "
-                "requires it for its github MCP server. Configure "
-                "github.reviewer_app_id and its private key."
+                f"Could not mint the GitHub token for {repo}; build requires it "
+                "for its github MCP server."
             ) from error
         return {
             **await super().get_workspace_kwargs(sandbox),
@@ -213,6 +212,7 @@ class Build(Workflow):
             task_owner_email=self.input.task_owner_email,
             related_repos=target_repo.siblings(),
             skills=Skill.list_delivered(self._profile.get("recommended_skills", [])),
+            review_mode=get_review_actor().mode,
             journal=self.journal,
         )
         return {

--- a/backend/druks/contrib/ship/workspace.py
+++ b/backend/druks/contrib/ship/workspace.py
@@ -9,7 +9,7 @@ from druks.sandbox.layout import get_repo_root
 class RepoWorkspace(Workspace):
     # A VM with the target repo cloned in and a short-lived token its agent
     # pushes/reads through. Build's workspace extends this with the PR branch
-    # and the reviewer MCP token; the profiler uses it as-is.
+    # and the github MCP token; the profiler uses it as-is.
     repo: str
     github_token: str
 

--- a/backend/druks/core/apis/github.py
+++ b/backend/druks/core/apis/github.py
@@ -510,16 +510,3 @@ def get_github_client(settings: Settings) -> GitHubClient:
         "Operator GitHub App credentials are required: set github.operator_app_id and "
         "GITHUB_OPERATOR_PRIVATE_KEY_PATH."
     )
-
-
-def get_reviewer_github_client(settings: Settings) -> GitHubClient:
-    if settings.github.reviewer_app_id and settings.github_reviewer_private_key_path:
-        return GitHubClient(
-            app_id=settings.github.reviewer_app_id,
-            private_key=settings.github_reviewer_private_key_path.read_text(),
-            base_url=settings.github_api_url,
-        )
-    raise GitHubAppNotConfiguredError(
-        "Reviewer GitHub App credentials are required: set github.reviewer_app_id and "
-        "GITHUB_REVIEWER_PRIVATE_KEY_PATH."
-    )

--- a/backend/tests/ship/test_build_prompts.py
+++ b/backend/tests/ship/test_build_prompts.py
@@ -49,6 +49,7 @@ def _build() -> SimpleNamespace:
                 description="Apply the Python house rules.",
             )
         ],
+        review_mode="approve",
         journal=BuildJournal(),
     )
 
@@ -163,6 +164,35 @@ async def test_reviewer_scrutiny_line_reports_each_seat():
         await scrutiny(reviewed)
         == "Scrutiny: plan critic ran (2) · evaluation rounds: 0 · line review ran"
     )
+
+
+async def test_approve_mode_posts_verdict_reviews():
+    prompt = await render_prompt(
+        "ship/build/evaluate_implementation.md",
+        build=_build(),
+        verification="VERIFICATION-BLOCK",
+        workspace=_workspace(),
+    )
+
+    assert "an **approving** verdict → `APPROVE`" in prompt
+    assert "Submit every review as a `COMMENT` event" not in prompt
+
+
+async def test_comment_mode_swaps_the_review_event_mapping():
+    # The operator authored the PR, and GitHub refuses an author's APPROVE /
+    # REQUEST_CHANGES — the prompt swaps the event mapping for comment-mode.
+    build = _build()
+    build.review_mode = "comment"
+
+    prompt = await render_prompt(
+        "ship/build/evaluate_implementation.md",
+        build=build,
+        verification="VERIFICATION-BLOCK",
+        workspace=_workspace(),
+    )
+
+    assert "Submit every review as a `COMMENT` event" in prompt
+    assert "an **approving** verdict → `APPROVE`" not in prompt
 
 
 def test_build_prompt_context_covers_template_attrs():

--- a/backend/tests/ship/test_build_workspace.py
+++ b/backend/tests/ship/test_build_workspace.py
@@ -23,7 +23,7 @@ def test_build_workspace_grants_related_root_add_dir():
         repo="o/main",
         branch="b",
         github_token="t",
-        mcp_token="ghs_reviewer",
+        mcp_token="ghs_review",
         skills=("python-house-rules",),
     )
     kwargs = workspace.get_agent_run_kwargs(model="m")
@@ -38,7 +38,7 @@ def test_build_workspace_grants_related_root_add_dir():
 
 async def test_build_workspace_declares_its_github_mcp(druks_db):
     # The github MCP is build's own declaration, credentialed with the per-repo
-    # reviewer token — never an operator catalog entry, never optional (there
+    # review-actor token — never an operator catalog entry, never optional (there
     # is no build without github). Delivery ships it whole: wire shape + token
     # in the run env.
     workspace = BuildWorkspace(
@@ -46,18 +46,18 @@ async def test_build_workspace_declares_its_github_mcp(druks_db):
         repo="o/main",
         branch="b",
         github_token="t",
-        mcp_token="ghs_reviewer",
+        mcp_token="ghs_review",
         skills=("python-house-rules",),
     )
     kwargs = await workspace.with_mcp_servers(None, **workspace.get_agent_run_kwargs())
 
-    assert kwargs["extra_env"] == {get_bearer_token_env_var(GITHUB_MCP_NAME): "ghs_reviewer"}
+    assert kwargs["extra_env"] == {get_bearer_token_env_var(GITHUB_MCP_NAME): "ghs_review"}
     github = next(s for s in kwargs["mcp_servers"] if s.name == GITHUB_MCP_NAME)
     assert github.url == GITHUB_MCP_URL
-    assert "ghs_reviewer" not in repr(github)
+    assert "ghs_review" not in repr(github)
 
 
-def _workspace_kwargs_stubs(monkeypatch: pytest.MonkeyPatch, *, reviewer):
+def _workspace_kwargs_stubs(monkeypatch: pytest.MonkeyPatch, *, review_actor):
     ensured: list[str] = []
     execs: list[list[str]] = []
 
@@ -80,7 +80,7 @@ def _workspace_kwargs_stubs(monkeypatch: pytest.MonkeyPatch, *, reviewer):
         "druks.contrib.ship.workflows.get_github_client",
         lambda _s: SimpleNamespace(token_for_repo=_token),
     )
-    monkeypatch.setattr("druks.contrib.ship.workflows.get_reviewer_github_client", reviewer)
+    monkeypatch.setattr("druks.contrib.ship.workflows.get_review_actor", review_actor)
     monkeypatch.setattr("druks.sandbox.repo.ensure", fake_ensure)
     return ensured, execs
 
@@ -90,11 +90,14 @@ async def test_get_workspace_kwargs_clones_primary_only(monkeypatch: pytest.Monk
     # Only the primary repo is provisioned; related repos are the agents' job.
     # get_related_root is mkdir'd so Claude's --add-dir target exists before the
     # first on-demand clone.
-    async def _reviewer_token(_repo: str) -> str:
-        return "ghs_reviewer"
+    async def _review_token(_repo: str) -> str:
+        return "ghs_review"
 
     ensured, execs = _workspace_kwargs_stubs(
-        monkeypatch, reviewer=lambda _s: SimpleNamespace(token_for_repo=_reviewer_token)
+        monkeypatch,
+        review_actor=lambda: SimpleNamespace(
+            client=SimpleNamespace(token_for_repo=_review_token), mode="approve"
+        ),
     )
     sandbox = host_mod.Sandbox(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
 
@@ -106,21 +109,26 @@ async def test_get_workspace_kwargs_clones_primary_only(monkeypatch: pytest.Monk
 
     assert ensured == ["https://github.com/o/extension"]
     assert ["mkdir", "-p", get_related_root("exedev")] in execs
-    assert kwargs["mcp_token"] == "ghs_reviewer"
+    assert kwargs["mcp_token"] == "ghs_review"
     assert kwargs["skills"] == ("python-house-rules",)
     assert "related" not in kwargs
 
 
 @pytest.mark.asyncio
-async def test_get_workspace_kwargs_fails_loudly_without_the_reviewer_app(
+async def test_get_workspace_kwargs_fails_loudly_when_the_token_wont_mint(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    # There is no build without github: a run that can't mint its reviewer
-    # token fails at workspace setup, never degrades mid-run.
-    def _no_reviewer(_s: Any) -> Any:
-        raise RuntimeError("reviewer app not configured")
+    # There is no build without github: a run that can't mint its MCP token
+    # fails at workspace setup, never degrades mid-run.
+    async def _no_token(_repo: str) -> str:
+        raise RuntimeError("app not installed on this repo")
 
-    _workspace_kwargs_stubs(monkeypatch, reviewer=_no_reviewer)
+    _workspace_kwargs_stubs(
+        monkeypatch,
+        review_actor=lambda: SimpleNamespace(
+            client=SimpleNamespace(token_for_repo=_no_token), mode="comment"
+        ),
+    )
     sandbox = host_mod.Sandbox(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
 
     workflow = Build()
@@ -128,5 +136,5 @@ async def test_get_workspace_kwargs_fails_loudly_without_the_reviewer_app(
     workflow.subject = SimpleNamespace(repo="o/extension")
     workflow._profile = {"recommended_skills": ["python-house-rules"]}
 
-    with pytest.raises(FatalError, match="reviewer GitHub App"):
+    with pytest.raises(FatalError, match="github MCP server"):
         await workflow.get_workspace_kwargs(sandbox)

--- a/backend/tests/test_review.py
+++ b/backend/tests/test_review.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import pytest
 from druks.contrib.review import subscribers  # noqa: F401 — the import registers it
 from druks.contrib.review.datastructures import PullRequest
+from druks.contrib.review.github import get_review_actor
 from druks.contrib.review.workflows import PullRequestReview
 from druks.prompts import render_prompt
 from druks.signals import publish
@@ -94,10 +95,60 @@ async def test_the_reviewer_prompt_names_the_pull_request_it_is_about():
         workflow=workflow,
         workspace=workspace,
         siblings=[],
+        review_mode="approve",
     )
 
     assert "pull request #7 on `acme/app`" in output
     assert "at dev@example.com's request" in output
+    assert "`COMMENT` event" not in output
+
+
+async def test_comment_mode_reviews_publish_as_comments():
+    # Unset review identity: the operator authors druks's own pull requests, so
+    # its reviews publish as comments — the prompt carries that rule.
+    workflow = SimpleNamespace(
+        subject=PullRequest.get("acme/app", 7),
+        input=SimpleNamespace(requested_by="dev@example.com"),
+    )
+    workspace = SimpleNamespace(
+        repo_path="/home/agent/work/repo", related_root="/home/agent/related"
+    )
+
+    output = await render_prompt(
+        "review/review_pull_request.md",
+        workflow=workflow,
+        workspace=workspace,
+        siblings=[],
+        review_mode="comment",
+    )
+
+    assert "`COMMENT` event" in output
+
+
+def test_a_configured_review_identity_approves(tmp_path: Path, monkeypatch):
+    pem = tmp_path / "review.pem"
+    pem.write_text("test-key")
+    settings = make_settings(
+        tmp_path,
+        github={"operator_app_id": "1", "reviewer_app_id": "2"},
+        github_reviewer_private_key_path=pem,
+    )
+    monkeypatch.setattr("druks.contrib.review.github.load_settings", lambda: settings)
+
+    assert get_review_actor().mode == "approve"
+
+
+def test_an_unset_review_identity_means_comment_mode(tmp_path: Path, monkeypatch):
+    pem = tmp_path / "operator.pem"
+    pem.write_text("test-key")
+    settings = make_settings(
+        tmp_path,
+        github={"operator_app_id": "1"},
+        github_operator_private_key_path=pem,
+    )
+    monkeypatch.setattr("druks.contrib.review.github.load_settings", lambda: settings)
+
+    assert get_review_actor().mode == "comment"
 
 
 async def test_a_passer_by_cannot_spend_a_review(monkeypatch):


### PR DESCRIPTION
## What

`get_reviewer_github_client` leaves `core/apis/github.py` for the review extension. Its replacement, `contrib/review/github.py::get_review_actor()`, resolves who reviews act as — the review identity's client when configured, the operator's otherwise — and stamps the actor's posting mode (`mode: "approve" | "comment"`) where credentials resolve.

Build mints its github MCP token through the actor and threads `review_mode` into prompt context. The review-posting prompts branch on it:

- **approve** (distinct review identity) — unchanged: verdict maps to `APPROVE` / `REQUEST_CHANGES`.
- **comment** (the operator itself) — reviews submit as `COMMENT` events with the verdict stated in the body, because GitHub refuses approving reviews from a pull request's own author.

The review extension's own workflow and mention subscriber resolve through the same actor, so an unset review identity now means: builds still run (MCP token rides the operator), reviews post as operator comments, and the trigger mention becomes the operator app's handle — instead of builds refusing to start and reviews crashing at workspace setup.

## Why

Ship had no business holding reviewer credentials: the only thing it ever did with them was hand its sandbox a github MCP token. The review extension is where a distinct reviewing identity means something, so it owns the credential resolution end to end; ship asks who reviews act as and passes the mode through opaquely.

Credential storage is unchanged in this PR (still `github.reviewer_app_id` + PEM path), and the installer, compose, doctor, and docs still require both apps — so the comment-mode fallback is dormant until ENG-835 moves the credentials to their settled homes and relaxes those requirements. This PR is the seam; ENG-835 is the surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
