### PR TITLE
Plans are briefings: one critic pass, outcome-level altitude, adaptive confidence gate

### DIFF
--- a/backend/druks/contrib/ship/constants.py
+++ b/backend/druks/contrib/ship/constants.py
@@ -4,5 +4,3 @@
 # act as (druks.contrib.review.github).
 GITHUB_MCP_NAME = "github"
 GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
-
-PLAN_DRAFTS_PER_ROUND = 2

--- a/backend/druks/contrib/ship/contracts.py
+++ b/backend/druks/contrib/ship/contracts.py
@@ -184,10 +184,17 @@ class ContractRevisionOutput(AgentOutput):
 
 
 class ReviewOutput(AgentOutput):
-    # No get_artifact: the plan must stay the parked ask's resolved document;
-    # the fallback park sends the critique as ask context instead.
+    # No get_artifact: the plan must stay the parked ask's resolved document.
     decision: Literal[ReviewDecision.APPROVE, ReviewDecision.REQUEST_CHANGES]
     body: str
+
+    @model_validator(mode="after")
+    def _request_changes_carries_the_critique(self) -> "ReviewOutput":
+        # An empty critique would redraft blind — the planner regenerates with
+        # no guidance and the result proceeds unreviewed.
+        if self.decision == ReviewDecision.REQUEST_CHANGES and not self.body.strip():
+            raise ValueError("REQUEST_CHANGES needs the critique in body")
+        return self
 
 
 class TriageOutput(AgentOutput):

--- a/backend/druks/contrib/ship/contracts.py
+++ b/backend/druks/contrib/ship/contracts.py
@@ -108,6 +108,9 @@ class PlanData(BaseModel):
     # Approaches the planner dropped — the judgment that otherwise dies at the
     # plan-review park and gets re-proposed downstream.
     rejected_approaches: list[str] = Field(default_factory=list)
+    # The planner's self-reported calibration; "medium" for producers that
+    # don't assert one (a contract revision), which never skips a park.
+    confidence: Literal["high", "medium", "low"] = "medium"
     # Resolved by the planner; a revision carries None.
     assignee_github_login: str | None = None
 
@@ -143,6 +146,7 @@ class PlanOutput(AgentOutput):
     acceptance_criteria: list[AcceptanceCriterionOutput]
     questions: list[QuestionOutput] = Field(max_length=8)
     rejected_approaches: list[str]
+    confidence: Literal["high", "medium", "low"]
     # Required but nullable: the planner always reports the field, null when it
     # resolved no assignee login convincingly.
     assignee_github_login: str | None
@@ -156,6 +160,7 @@ class PlanOutput(AgentOutput):
             acceptance_criteria=self.acceptance_criteria,
             questions=self.questions,
             rejected_approaches=self.rejected_approaches,
+            confidence=self.confidence,
             assignee_github_login=self.assignee_github_login,
         )
 

--- a/backend/druks/contrib/ship/policy.py
+++ b/backend/druks/contrib/ship/policy.py
@@ -7,7 +7,7 @@ from druks.prompts import render_prompt
 from druks.sandbox.datastructures import Profile
 
 GateValue = Literal["human", "none"]
-PlanGate = Literal["human", "machine", "machine_then_human"]
+PlanGate = Literal["human", "machine", "machine_then_human", "adaptive"]
 
 
 class Gates(BaseModel):

--- a/backend/druks/contrib/ship/templates/build/generate_plan.md
+++ b/backend/druks/contrib/ship/templates/build/generate_plan.md
@@ -19,19 +19,25 @@ your acceptance criteria. Wrong shape here compounds into every step that follow
 - **Verify what the ticket claims.** A named call site may have moved or gone since it was
   written, so confirm each one at HEAD before you plan on it. Read the cited regions rather
   than whole files — a whole file is re-processed on every turn.
-- **Preserve operator contracts verbatim.** Copy exact field shapes, JSON and endpoint
-  contracts, template strings, do/don't decisions, and dependency nuance from the description
-  and especially operator refinement comments into the plan. When in doubt, copy more.
-  Verbatim preservation covers the operator's decisions, not designs you can shrink: when a
-  meaningfully smaller mechanism meets the ticket's stated goal, raise it as one question
-  with the smaller shape `recommended: true` rather than silently building the heavier one —
-  and never silently substitute your own design either.
-- **ACs are written for a machine, not a human.** Every acceptance criterion will be verified
+- **Preserve operator decisions verbatim; author none of your own.** Exact field shapes,
+  endpoint contracts, template strings, and do/don't decisions stated in the description and
+  especially operator refinement comments are binding — copy them into the plan as written.
+  Everything the operator did not pin is the implementer's to decide with the code in front
+  of them: never author your own wire examples, message strings, docstrings, query documents,
+  or code snippets. A literal you invent is a decision made blind — it locks the implementer
+  out of the better fit the code would suggest, and every pinned string becomes a test that
+  pins it again. Verbatim preservation covers the operator's decisions, not designs you can
+  shrink: when a meaningfully smaller mechanism meets the ticket's stated goal, raise it as
+  one question with the smaller shape `recommended: true` rather than silently building the
+  heavier one — and never silently substitute your own design either.
+- **ACs pin observable outcomes, never wording.** Every acceptance criterion will be verified
   by a code-reading evaluator who cannot run a browser, eyeball rendered output, or call
   external services. If you cannot express it as a machine-checkable assertion — diff exists,
   test passes, column present in migration, function has this signature — it is not an AC yet.
+  "An unknown ticket returns 404 naming the tracker" is an AC; the 404 body's exact phrasing
+  is the implementer's, judged in the diff.
 - **A confident answer is a decision, not a question.** Make it, plan with it, and note it in
-  the plan. Ask only when no confident decision can make the plan decision-complete.
+  the plan. Ask only when the plan cannot proceed without the operator's decision.
 - **One PR, one coherent change.** If the work bundles independent surfaces that could ship
   separately, a refactor with a feature, or independently shippable AC groups, ask one question
   naming the split seam and let the operator decide. Do not ask for a single feature spanning
@@ -40,8 +46,13 @@ your acceptance criteria. Wrong shape here compounds into every step that follow
 
 ## Boundaries
 
-- You are not a project manager listing requirements. Specify the change precisely enough that
-  the implementer can execute without you in the room.
+- The plan is a briefing, not a spec: the decisions made, the shape (files, layers, data),
+  the risks, and the scope boundaries. The implementer is a capable engineer with the repo in
+  front of them — brief them, don't transcribe for them.
+- Keep the plan the length its reviewers can actually read: target one screenful, around
+  fifty lines. Growth pressure is a signal to cut detail, not to add sections. When the plan
+  implies a change far larger than the ticket's apparent size, say so in the plan and
+  question the scope instead of specifying the bloat.
 - Do not write ACs that require a browser, live API call, visual check, or operator action
   post-merge. If it cannot be code-verified, move it to out-of-scope as a post-merge note.
 - **Keep verification profile checks out of ACs.** The profile is the evaluator's check set.
@@ -76,7 +87,7 @@ The operator requested changes on your previous plan in their own words. The blo
 {% if reviewer_notes %}
 ## Plan reviewer critique
 
-The plan reviewer rejected your previous draft with the critique below. Fold every point into this redraft — the reviewer never edits the plan; you produce the complete corrected plan yourself. If the redraft still fails review, the run parks for the operator — resolve every point now:
+The plan reviewer rejected your previous draft with the critique below. Fold every point into this redraft — the reviewer never edits the plan; you produce the complete corrected plan yourself. This redraft is the one that proceeds; there is no second review, so resolve every point now:
 Where the operator's note conflicts with this critique, the operator's note wins.
 
 > {{ reviewer_notes | replace("\n", "\n> ") }}
@@ -103,7 +114,7 @@ two or three sentences stating what druks understood the work to be.
 {% endif %}Never edit the ticket description and never post the plan itself.
 
 {% endif %}
-Generate the initial implementation plan. For each unavoidable question, set `recommended: true` on exactly one option. Return specific acceptance criteria describing what must be true for this PR to pass. When the work changes a protocol or wire contract, include exact request/response examples in the plan or acceptance criteria. Do not add standalone lint, test, or type-check acceptance criteria from the verification profile. A test explicitly requested by the issue remains a valid AC. A behavioral AC may include a `Verification:` note describing how the evaluator confirms that specific criterion.
+Generate the initial implementation plan. For each unavoidable question, set `recommended: true` on exactly one option. Return specific acceptance criteria describing what must be true for this PR to pass. When the work changes a protocol or wire contract, state the change as observable behavior — verb, status, outcome vocabulary; include exact payloads only when the operator pinned them. Do not add standalone lint, test, or type-check acceptance criteria from the verification profile. A test explicitly requested by the issue remains a valid AC. A behavioral AC may include a `Verification:` note describing how the evaluator confirms that specific criterion.
 
 ACCEPTANCE CRITERIA MUST BE CODE-VERIFIABLE. Druks's evaluator inspects the diff and reads tests. It runs the configured verification profile as its own check set, separate from the binding acceptance criteria the implementer must satisfy. It cannot drive a browser, click through a UI, eyeball rendered output, exercise a real third-party API, or otherwise perform a runtime/visual smoke. Any criterion phrased as "manually smoke X", "load the app locally", "verify visually", "click through Y", "confirm in production", or "exercise the live N integration" is unfulfillable in this pipeline and will lock the PR in revision loops forever.
 
@@ -113,6 +124,14 @@ When the source ticket asks for a manual smoke or visual check, do ONE of these 
 - **Move the request to ``out_of_scope`` as a post-merge note**: the operator does the smoke after merge with their own eyes, not as a precondition to merge. Phrase it explicitly: "Out of scope: post-merge smoke of X (operator-driven; not gated by this PR)".
 
 Smoke / manual-verify requests in the source are operator concerns, not implementer concerns. Honor the intent (the operator wants to test the UX) without making the agent loop block on something it can't satisfy.
+
+CONFIDENCE — the `confidence` schema field. Report how confident you are that this plan is
+the change the operator wants: `high` only when the ticket is unambiguous, the repo told you
+the shape, and the blast radius is small enough that an operator skimming the diff would
+approve it without questions; `medium` when any of those took a judgment call; `low` when
+you made a real bet the operator should see. Under the adaptive gate a `high` plan can skip
+the operator park entirely — calibrate accordingly: a wrong `high` costs an unwanted PR, a
+wrong `low` only costs a park.
 
 RULED OUT — the `rejected_approaches` schema field. Name each approach you considered and
 dropped, with the reason you dropped it. Every agent after you reads the list and takes it as

--- a/backend/druks/contrib/ship/templates/build/review_plan.md
+++ b/backend/druks/contrib/ship/templates/build/review_plan.md
@@ -2,8 +2,8 @@
 
 You are the principal engineer doing the gate review before implementation starts. The planner
 thinks this plan is ready. Your job is to catch the shape problems that are cheap to fix now
-and catastrophically expensive after implementation starts. No human will see this plan before
-implementation — your verdict is the gate.
+and catastrophically expensive after implementation starts. On the machine-gated paths your
+verdict is the gate; on the human-gated paths the operator judges the redraft it produces.
 
 ## Core truths
 
@@ -18,9 +18,14 @@ implementation — your verdict is the gate.
   critique, grep the repo for prior usage or read adjacent code that does similar work. If you
   cannot verify it exists in this codebase, write the behavior instead: "read the
   request body asynchronously" not "use `await request.abody()`".
-- **One shot, then a human.** If the redrafted plan still doesn't pass your re-review, the run
-  parks for the operator with your critique attached. Make every point concrete and
-  self-contained — both the planner and, on the fallback, a human will act on it directly.
+- **One pass, period.** You review once per run. The planner folds your critique into one
+  redraft and the run proceeds on it — there is no re-review, and a vague point ships vague.
+  Make every point concrete and self-contained; on the human-gated paths the operator judges
+  the redraft your critique produced.
+- **The plan is a briefing, not a spec.** Detail the plan leaves open — wire payloads, message
+  wording, error taxonomies, test enumerations — is the implementer's to decide in code and
+  the diff review's to judge. A plan is not incomplete for leaving them open; it is at the
+  wrong altitude when it pins them.
 
 ## Boundaries
 
@@ -41,7 +46,7 @@ not a line-level finding for later.
 {% include "ship/build/_contract.md" %}
 {% include "ship/build/_related_repos.md" %}
 {% include "ship/build/_skills.md" %}
-Review the current plan in one complete pass. Batch every blocking issue and every required clarification into a single response — there is no second automatic round.
+Review the current plan in one complete pass. Batch every blocking issue into a single response — there is no second round of any kind.
 
 SCOPE & APPROACH REVIEW — do this BEFORE evaluating contract details. These are the holistic checks that, if missed, cost the most downstream: a wrong shape at the plan stage burns implementation + evaluation rounds that no amount of polishing recovers.
 - Scope shape: is this one coherent PR, or does it bundle two/three unrelated changes that should ship separately? Mixed concerns (refactor + new feature, schema migration + UI, multiple bug fixes) almost always review better as separate PRs. If you'd want to merge half of this and revisit the rest, the plan should be split — flag it.
@@ -50,10 +55,18 @@ SCOPE & APPROACH REVIEW — do this BEFORE evaluating contract details. These ar
 - Implied follow-ups the plan didn't mention: does this change require docs, a migration, an admin/CLI affordance, a feature flag, or a backfill that the plan silently omitted? Either fold them in or call them out as explicit out-of-scope so the operator can decide.
 
 Pick exactly one decision:
-- APPROVE: the plan is decision-complete, correctly scoped, approach matches repo patterns, and is implementable with no required edits. Implementation starts immediately on your approval.
-- REQUEST_CHANGES: anything less. Your body is the complete critique — every shape problem, every binding clarification the plan is missing (exact wire schemas, parser boundaries, error code taxonomy, side-effect boundaries, malformed-payload behavior), every nudge toward an existing repo pattern. The planner redrafts the plan once, folding your critique; you then re-review the redraft. Batch everything — a point you omit now either ships unreviewed or costs the operator fallback.
+- APPROVE: the shape is right — correctly scoped, the approach matches repo patterns, the
+  surface is sized to the ticket, and nothing in it breaks an existing behavior or checklist
+  rule. Open low-level detail is not a reason to withhold approval.
+- REQUEST_CHANGES: a shape problem — wrong scope, wrong layer, wrong approach, a checklist
+  violation, a contradiction, or an unsatisfiable requirement. Your body is the complete
+  critique; the planner folds it into one redraft that proceeds without re-review, so batch
+  everything. Missing low-level detail is never a shape problem: do not demand wire schemas,
+  error taxonomies, message wording, or test enumerations — those are decided in code.
+  Over-specification IS a finding: a plan that quotes docstrings, wire payloads, or code the
+  implementer should write is planning at the wrong altitude — name the sections to cut.
 
-Include concise review body text. For REQUEST_CHANGES, the body must contain the full critique as plain prose or a bulleted list — the planner folds it into the redraft directly, and if the redraft still fails, the operator reads it at the park.
+Include concise review body text. For REQUEST_CHANGES, the body must contain the full critique as plain prose or a bulleted list — the planner folds it into the redraft directly.
 
 LOW-LEVEL API CONTRACT RULE: When your critique specifies a low-level contract — an exact method call, function signature, library API, or framework internal (e.g. `await request.abody()`, `Model.objects.abulk_create(...)`, a specific Django/DRF/Ninja method) — you MUST verify the framework actually supports it before making it binding. Verify by: grepping the repo for prior usage (`rg "method_name" backend/`), reading adjacent code that does similar work, or confirming against the repo's pinned dependency versions. If you cannot verify framework support, express the point as BEHAVIOR rather than an exact call — write "read the request body asynchronously without blocking the event loop" not "use `await request.abody()`". An unverified low-level call in the critique poisons the redrafted plan: the implementer either blindly complies and ships a runtime error, or spends multiple rounds discovering the call doesn't exist. When in doubt, state the intent and leave the implementer to pick the correct API.
 

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -26,7 +26,7 @@ from druks.settings import load_settings
 from druks.skills.models import Skill
 from druks.workflows import FatalError, Workflow, step
 
-from .constants import GITHUB_MCP_NAME, GITHUB_MCP_URL, PLAN_DRAFTS_PER_ROUND
+from .constants import GITHUB_MCP_NAME, GITHUB_MCP_URL
 from .extension import Ship
 from .journal import BuildJournal
 from .policy import PlanGate, RepoPolicy
@@ -80,10 +80,11 @@ class Build(Workflow):
             title="Plan gate",
             description=(
                 "human — Operator reviews every plan; the machine reviewer never runs. "
-                "machine — The machine reviewer approves for implementation; the operator is the "
-                "fallback after the draft bound. machine_then_human — The machine reviewer "
-                "critiques first, then the operator approves; the operator also receives the "
-                "standing critique after the draft bound."
+                "machine — The machine reviewer critiques once; the plan implements without "
+                "operator review. machine_then_human — The machine reviewer critiques once, "
+                "then the operator approves every plan. adaptive — The machine reviewer "
+                "critiques once; a high-confidence plan it approved implements directly, "
+                "anything less parks for the operator."
             ),
         )
         max_implementation_revisions: int = Field(
@@ -244,28 +245,31 @@ class Build(Workflow):
         plan_gate = self._policy.plan_approval_gate(self._settings.plan_gate)
         answered_questions: list[dict[str, str]] = []
         operator_note = ""
-        unresolved_critique = ""
+        critique = ""
+        reviewed = False
         while True:
-            for _ in range(PLAN_DRAFTS_PER_ROUND):
-                draft_guidance = unresolved_critique
-                unresolved_critique = ""
-                plan = await Ship.generate_plan(
-                    answered_questions=answered_questions,
-                    operator_note=operator_note,
-                    reviewer_notes=draft_guidance,
-                )
-                if plan_gate == "human" or plan.questions:
-                    break
-                machine_review = await Ship.review_plan()
-                if machine_review.decision == ReviewDecision.APPROVE:
+            plan = await Ship.generate_plan(
+                answered_questions=answered_questions,
+                operator_note=operator_note,
+                reviewer_notes=critique,
+            )
+            critique = ""
+            if not plan.questions:
+                if plan_gate != "human" and not reviewed:
+                    # The machine reviewer gets one pass per run; a critique is
+                    # folded into one redraft that proceeds without re-review.
+                    reviewed = True
+                    machine_review = await Ship.review_plan()
+                    if machine_review.decision == ReviewDecision.REQUEST_CHANGES:
+                        critique = machine_review.body
+                        continue
                     if plan_gate == "machine":
                         return True
-                    break
-                unresolved_critique = machine_review.body
-            operator_reply = await self.review(
-                questions=plan.questions,
-                context=unresolved_critique,
-            )
+                    if plan_gate == "adaptive" and plan.confidence == "high":
+                        return True
+                elif plan_gate == "machine":
+                    return True
+            operator_reply = await self.review(questions=plan.questions)
             if plan.is_confirmed_by(operator_reply):
                 return True
             answered_questions = plan.get_answered_questions(operator_reply.answers)

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -265,7 +265,11 @@ class Build(Workflow):
                         continue
                     if plan_gate == "machine":
                         return True
-                    if plan_gate == "adaptive" and plan.confidence == "high":
+                    if (
+                        plan_gate == "adaptive"
+                        and plan.confidence == "high"
+                        and plan.acceptance_criteria
+                    ):
                         return True
                 elif plan_gate == "machine":
                     return True

--- a/backend/tests/ship/test_build_plan_phase.py
+++ b/backend/tests/ship/test_build_plan_phase.py
@@ -263,17 +263,17 @@ async def test_approve_with_note_redrafts(monkeypatch):
 
 async def test_machine_mode_folds_the_critique_into_one_redraft(monkeypatch):
     """Machine mode, no questions: REQUEST_CHANGES routes the critique into one
-    redraft (reviewer_notes), the re-review approves, and nothing parks."""
+    redraft (reviewer_notes) that implements without re-review, and nothing
+    parks — the reviewer's single grade is all the loop may consume."""
     flow = _flow(plan_gate="machine")
     passes = _fake_plans(monkeypatch, PlanData(plan_markdown="v1"), PlanData(plan_markdown="v2"))
     _fake_grades(
         monkeypatch,
         ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="name the wire schema"),
-        ReviewOutput(decision=ReviewDecision.APPROVE, body=""),
     )
 
     async def fail_park(*, questions=None, context=""):
-        raise AssertionError("an approved machine-mode plan must not park")
+        raise AssertionError("a machine-mode plan must not park")
 
     flow.review = fail_park
 
@@ -282,7 +282,8 @@ async def test_machine_mode_folds_the_critique_into_one_redraft(monkeypatch):
 
 
 async def test_machine_mode_redraft_questions_park_without_the_folded_critique(monkeypatch):
-    """A redraft's questions park without repeating the critique already folded into it."""
+    """A redraft's questions park without repeating the critique already folded
+    into it; the answered redraft implements without a second review."""
     flow = _flow(plan_gate="machine")
     passes = _fake_plans(
         monkeypatch,
@@ -296,20 +297,18 @@ async def test_machine_mode_redraft_questions_park_without_the_folded_critique(m
     _fake_grades(
         monkeypatch,
         ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="name the rollout boundary"),
-        ReviewOutput(decision=ReviewDecision.APPROVE, body=""),
     )
-    parks: list[tuple[list, str]] = []
+    parks: list[list[QuestionOutput]] = []
 
     async def fake_review(*, questions=None, context=""):
-        parks.append((list(questions or []), context))
+        parks.append(list(questions or []))
         return OperatorReply(action="request_changes", answers={"q1": "behind a flag"})
 
     flow.review = fake_review
 
     assert await flow._plan_phase() is True
     assert len(parks) == 1
-    assert [question.id for question in parks[0][0]] == ["q1"]
-    assert parks[0][1] == ""
+    assert [question.id for question in parks[0]] == ["q1"]
     assert [p["reviewer_notes"] for p in passes] == [
         "",
         "name the rollout boundary",
@@ -317,121 +316,84 @@ async def test_machine_mode_redraft_questions_park_without_the_folded_critique(m
     ]
 
 
-@pytest.mark.parametrize("plan_gate", ["machine", "machine_then_human"])
-@pytest.mark.parametrize(
-    ("operator_reply", "operator_note"),
-    [
-        pytest.param(OperatorReply(action="request_changes"), "", id="empty-request-changes"),
-        pytest.param(
-            OperatorReply(action="request_changes", note="steer left"),
-            "steer left",
-            id="guided-request-changes",
-        ),
-        pytest.param(
-            OperatorReply(action="approve", note="steer left"),
-            "steer left",
-            id="approve-with-guidance",
-        ),
-    ],
-)
-async def test_machine_gate_preserves_bounded_critique_across_operator_park(
-    monkeypatch, plan_gate, operator_reply, operator_note
-):
-    """The parked critique guides the first next-round draft before machine review."""
-    flow = _flow(plan_gate=plan_gate)
-    passes = _fake_plans(
+async def test_adaptive_high_confidence_approved_plan_implements_without_parking(monkeypatch):
+    """Adaptive: the critic's approval plus the planner's own high confidence
+    skip the operator entirely."""
+    flow = _flow(plan_gate="adaptive")
+    _fake_plans(
         monkeypatch,
-        PlanData(plan_markdown="v1"),
-        PlanData(plan_markdown="v2"),
-        PlanData(plan_markdown="v3"),
-        PlanData(plan_markdown="v4", acceptance_criteria=_acceptance_criteria()),
-    )
-    _fake_grades(
-        monkeypatch,
-        ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="critique-1"),
-        ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="critique-2"),
-        ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="critique-3"),
-        ReviewOutput(decision=ReviewDecision.APPROVE, body=""),
-    )
-    parks: list[tuple[list, str]] = []
-    replies = iter(
-        [operator_reply]
-        + ([OperatorReply(action="approve")] if plan_gate == "machine_then_human" else [])
-    )
-
-    async def fake_review(*, questions=None, context=""):
-        parks.append((list(questions or []), context))
-        return next(replies)
-
-    flow.review = fake_review
-
-    assert await flow._plan_phase() is True
-    expected_parks = [([], "critique-2")]
-    if plan_gate == "machine_then_human":
-        expected_parks.append(([], ""))
-    assert parks == expected_parks
-    assert [passing["reviewer_notes"] for passing in passes] == [
-        "",
-        "critique-1",
-        "critique-2",
-        "critique-3",
-    ]
-    assert [passing["operator_note"] for passing in passes] == [
-        "",
-        "",
-        operator_note,
-        operator_note,
-    ]
-
-
-async def test_bounded_critique_is_consumed_when_the_post_park_redraft_asks_a_question(
-    monkeypatch,
-):
-    """A question emitted after the critique-backed park does not repeat that critique."""
-    flow = _flow(plan_gate="machine")
-    passes = _fake_plans(
-        monkeypatch,
-        PlanData(plan_markdown="v1"),
-        PlanData(plan_markdown="v2"),
         PlanData(
-            plan_markdown="v3",
-            questions=[QuestionOutput(id="q1", prompt="Feature flag?", options=[])],
+            plan_markdown="v1",
+            acceptance_criteria=_acceptance_criteria(),
+            confidence="high",
         ),
-        PlanData(plan_markdown="v4", acceptance_criteria=_acceptance_criteria()),
     )
-    _fake_grades(
+    _fake_grades(monkeypatch, ReviewOutput(decision=ReviewDecision.APPROVE, body=""))
+
+    async def fail_park(*, questions=None, context=""):
+        raise AssertionError("a high-confidence approved plan must not park")
+
+    flow.review = fail_park
+
+    assert await flow._plan_phase() is True
+
+
+@pytest.mark.parametrize("confidence", ["medium", "low"])
+async def test_adaptive_parks_unless_the_planner_is_confident(monkeypatch, confidence):
+    """Adaptive: a critic-approved plan still parks when the planner hedges."""
+    flow = _flow(plan_gate="adaptive")
+    _fake_plans(
         monkeypatch,
-        ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="critique-1"),
-        ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="critique-2"),
-        ReviewOutput(decision=ReviewDecision.APPROVE, body=""),
+        PlanData(
+            plan_markdown="v1",
+            acceptance_criteria=_acceptance_criteria(),
+            confidence=confidence,
+        ),
     )
-    replies = iter(
-        [
-            OperatorReply(action="request_changes"),
-            OperatorReply(action="request_changes", answers={"q1": "behind a flag"}),
-        ]
-    )
-    parks: list[tuple[list[QuestionOutput], str]] = []
+    _fake_grades(monkeypatch, ReviewOutput(decision=ReviewDecision.APPROVE, body=""))
+    parks: list[list[QuestionOutput]] = []
 
     async def fake_review(*, questions=None, context=""):
-        parks.append((list(questions or []), context))
-        return next(replies)
+        parks.append(list(questions or []))
+        return OperatorReply(action="approve")
 
     flow.review = fake_review
 
     assert await flow._plan_phase() is True
-    assert [passing["reviewer_notes"] for passing in passes] == [
-        "",
-        "critique-1",
-        "critique-2",
-        "",
-    ]
-    assert parks[0] == ([], "critique-2")
-    assert [question.id for question in parks[1][0]] == ["q1"]
-    assert parks[1][1] == ""
+    assert parks == [[]]
 
 
-@pytest.mark.parametrize("plan_gate", ["machine", "machine_then_human"])
+async def test_adaptive_critic_concerns_park_even_at_high_confidence(monkeypatch):
+    """Adaptive: a critique means the operator looks — the folded redraft parks
+    no matter how confident it claims to be."""
+    flow = _flow(plan_gate="adaptive")
+    passes = _fake_plans(
+        monkeypatch,
+        PlanData(plan_markdown="v1", confidence="high"),
+        PlanData(
+            plan_markdown="v2",
+            acceptance_criteria=_acceptance_criteria(),
+            confidence="high",
+        ),
+    )
+    _fake_grades(
+        monkeypatch,
+        ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="wrong layer"),
+    )
+    parks: list[list[QuestionOutput]] = []
+
+    async def fake_review(*, questions=None, context=""):
+        parks.append(list(questions or []))
+        return OperatorReply(action="approve")
+
+    flow.review = fake_review
+
+    assert await flow._plan_phase() is True
+    assert [p["reviewer_notes"] for p in passes] == ["", "wrong layer"]
+    assert parks == [[]]
+
+
+@pytest.mark.parametrize("plan_gate", ["machine", "machine_then_human", "adaptive"])
 async def test_questions_park_before_machine_review(monkeypatch, plan_gate):
     """Open questions always park for the operator — the machine reviewer only
     ever sees a question-free plan."""
@@ -484,8 +446,9 @@ async def test_machine_then_human_approval_parks_for_operator_approval(monkeypat
     assert parks == [([], "")]
 
 
-async def test_machine_then_human_critiques_force_redrafts_before_the_park(monkeypatch):
-    """Machine critique is folded into a redraft before operator approval."""
+async def test_machine_then_human_critiques_force_one_redraft_before_the_park(monkeypatch):
+    """The machine critique is folded into one redraft that parks for the
+    operator without a re-review."""
     flow = _flow(plan_gate="machine_then_human")
     passes = _fake_plans(
         monkeypatch,
@@ -495,44 +458,53 @@ async def test_machine_then_human_critiques_force_redrafts_before_the_park(monke
     _fake_grades(
         monkeypatch,
         ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="name the wire schema"),
-        ReviewOutput(decision=ReviewDecision.APPROVE, body=""),
     )
-    parks: list[tuple[list, str]] = []
+    parks: list[list[QuestionOutput]] = []
 
     async def fake_review(*, questions=None, context=""):
-        parks.append((list(questions or []), context))
+        parks.append(list(questions or []))
         return OperatorReply(action="approve")
 
     flow.review = fake_review
 
     assert await flow._plan_phase() is True
     assert [passing["reviewer_notes"] for passing in passes] == ["", "name the wire schema"]
-    assert parks == [([], "")]
+    assert parks == [[]]
 
 
-async def test_machine_then_human_exhaustion_parks_with_the_standing_critique(monkeypatch):
-    """The final machine critique remains attached when the draft bound parks."""
+async def test_operator_rounds_after_the_critique_never_rerun_the_reviewer(monkeypatch):
+    """The reviewer's pass is spent: operator request_changes rounds redraft
+    and re-park on the operator alone."""
     flow = _flow(plan_gate="machine_then_human")
-    _fake_plans(
+    passes = _fake_plans(
         monkeypatch,
         PlanData(plan_markdown="v1"),
         PlanData(plan_markdown="v2", acceptance_criteria=_acceptance_criteria()),
+        PlanData(plan_markdown="v3", acceptance_criteria=_acceptance_criteria()),
     )
     _fake_grades(
         monkeypatch,
-        ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="critique-1"),
-        ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="critique-2"),
+        ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="wrong layer"),
     )
-    parks: list[tuple[list, str]] = []
+    replies = iter(
+        [
+            OperatorReply(action="request_changes", note="steer left"),
+            OperatorReply(action="approve"),
+        ]
+    )
+    parks = 0
 
     async def fake_review(*, questions=None, context=""):
-        parks.append((list(questions or []), context))
-        return OperatorReply(action="approve")
+        nonlocal parks
+        parks += 1
+        return next(replies)
 
     flow.review = fake_review
 
     assert await flow._plan_phase() is True
-    assert parks == [([], "critique-2")]
+    assert parks == 2
+    assert [passing["reviewer_notes"] for passing in passes] == ["", "wrong layer", ""]
+    assert [passing["operator_note"] for passing in passes] == ["", "", "steer left"]
 
 
 async def test_review_work_ask_renders_a_notification_body(monkeypatch):

--- a/backend/tests/ship/test_build_plan_phase.py
+++ b/backend/tests/ship/test_build_plan_phase.py
@@ -338,6 +338,68 @@ async def test_adaptive_high_confidence_approved_plan_implements_without_parking
     assert await flow._plan_phase() is True
 
 
+async def test_adaptive_questions_park_before_confidence_counts(monkeypatch):
+    """Adaptive: open questions always park — confidence never outranks them."""
+    flow = _flow(plan_gate="adaptive")
+    _fake_plans(
+        monkeypatch,
+        PlanData(
+            plan_markdown="v1",
+            confidence="high",
+            questions=[QuestionOutput(id="q1", prompt="Feature flag?", options=[])],
+        ),
+        PlanData(
+            plan_markdown="v2",
+            acceptance_criteria=_acceptance_criteria(),
+            confidence="high",
+        ),
+    )
+    _fake_grades(monkeypatch, ReviewOutput(decision=ReviewDecision.APPROVE, body=""))
+    parks: list[list[QuestionOutput]] = []
+    replies = iter(
+        [
+            OperatorReply(action="request_changes", answers={"q1": "behind a flag"}),
+        ]
+    )
+
+    async def fake_review(*, questions=None, context=""):
+        parks.append(list(questions or []))
+        return next(replies)
+
+    flow.review = fake_review
+
+    assert await flow._plan_phase() is True
+    assert [question.id for question in parks[0]] == ["q1"]
+    assert len(parks) == 1
+
+
+async def test_adaptive_confident_plan_without_acceptance_criteria_parks(monkeypatch):
+    """Adaptive: skipping the operator takes the same bar the human path holds —
+    no acceptance criteria, no auto-proceed."""
+    flow = _flow(plan_gate="adaptive")
+    _fake_plans(
+        monkeypatch,
+        PlanData(plan_markdown="v1", confidence="high"),
+        PlanData(
+            plan_markdown="v2",
+            acceptance_criteria=_acceptance_criteria(),
+            confidence="high",
+        ),
+    )
+    _fake_grades(monkeypatch, ReviewOutput(decision=ReviewDecision.APPROVE, body=""))
+    parks = 0
+
+    async def fake_review(*, questions=None, context=""):
+        nonlocal parks
+        parks += 1
+        return OperatorReply(action="approve")
+
+    flow.review = fake_review
+
+    assert await flow._plan_phase() is True
+    assert parks == 2
+
+
 @pytest.mark.parametrize("confidence", ["medium", "low"])
 async def test_adaptive_parks_unless_the_planner_is_confident(monkeypatch, confidence):
     """Adaptive: a critic-approved plan still parks when the planner hedges."""

--- a/backend/tests/ship/test_contracts.py
+++ b/backend/tests/ship/test_contracts.py
@@ -211,3 +211,11 @@ def test_review_output_records_no_artifact():
     # An artifact would displace the plan as the parked ask's document.
     grade = O.ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body="name the wire schema")
     assert grade.get_artifact() == {}
+
+
+@pytest.mark.parametrize("body", ["", "   \n"])
+def test_request_changes_requires_a_critique_body(body):
+    # The critique is the redraft's only guidance; empty would redraft blind.
+    with pytest.raises(ValidationError, match="critique"):
+        O.ReviewOutput(decision=ReviewDecision.REQUEST_CHANGES, body=body)
+    assert O.ReviewOutput(decision=ReviewDecision.APPROVE, body=body).body == body

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -227,15 +227,16 @@ def test_extensions_surface_build_agents_and_workflow_defaults(tmp_path: Path):
         "label": "Plan gate",
         "help": (
             "human — Operator reviews every plan; the machine reviewer never runs. "
-            "machine — The machine reviewer approves for implementation; the operator is the "
-            "fallback after the draft bound. machine_then_human — The machine reviewer "
-            "critiques first, then the operator approves; the operator also receives the "
-            "standing critique after the draft bound."
+            "machine — The machine reviewer critiques once; the plan implements without "
+            "operator review. machine_then_human — The machine reviewer critiques once, "
+            "then the operator approves every plan. adaptive — The machine reviewer "
+            "critiques once; a high-confidence plan it approved implements directly, "
+            "anything less parks for the operator."
         ),
         "type": "enum",
         "value": "human",
         "default": "human",
-        "choices": ["human", "machine", "machine_then_human"],
+        "choices": ["human", "machine", "machine_then_human", "adaptive"],
         "section": "",
         "visibleWhenField": "",
         "visibleWhenValue": None,


### PR DESCRIPTION
## What changes

**Plan altitude** ([generate_plan.md](https://github.com/czpython/druks/blob/plan-altitude/backend/druks/contrib/ship/templates/build/generate_plan.md)): the planner briefs, it does not transcribe. Operator-stated contracts remain binding verbatim, but the plan no longer authors its own wire examples, message strings, docstrings, query documents, or code snippets — those are the implementer's to decide with the code in front of them, judged in the diff. ACs pin observable outcomes ("an unknown ticket returns 404 naming the tracker"), never wording. Plans target one screenful, and a plan implying a change far larger than the ticket must say so instead of specifying the bloat.

**One critic pass per run** ([review_plan.md](https://github.com/czpython/druks/blob/plan-altitude/backend/druks/contrib/ship/templates/build/review_plan.md), `_plan_phase`): the machine reviewer reviews once. A REQUEST_CHANGES critique folds into one redraft that proceeds without re-review, and operator rounds never re-run the reviewer. APPROVE means the shape is right — scope, layer, repo patterns, checklist fit; missing low-level detail is never a blocker, and over-specification is now itself a finding. The draft-bound loop (`PLAN_DRAFTS_PER_ROUND`) and its exhaustion park are removed, so a park never carries unresolved critique context — the empty-handed `request_changes` allowance for context-bearing asks stays for any surface that still sends context.

**Adaptive gate** (new `plan_gate` value): the planner self-reports `confidence` (`high`/`medium`/`low`, stamped on `PlanData`). Under `adaptive`, a high-confidence plan the critic approved implements without parking; lower confidence, a critique, or open questions park for the operator. A contract revision defaults to `medium` and never skips a park.

## Why

A plan that pins literals turns the implementer into a transcriber and every pinned string into a test that pins it again, while a critic asked for decision-completeness can always find another unpinned decision — the loop accretes instead of converging. Shape review has one pass of value; everything after is spent better in the diff.

## Behavior notes

- `machine` gate: a critic rejection now folds and implements (previously it could park on the draft bound). The operator fallback for machine-gated runs is the questions path and the implementation gates.
- `machine_then_human` parks always present a critique-folded plan with empty ask context.
- Existing journals: `PlanData.confidence` defaults to `medium`, which never skips a park.