### PR TITLE
Agent call page surfaces the call's artifact

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -152,6 +152,15 @@ export interface ArtifactFile {
   updatedAt: string
 }
 
+// A call's renderable output (a plan's markdown), rendered by kind — distinct
+// from the raw files. name is its file in the call dir, downloadable from the
+// transcript files route like any other.
+export interface ArtifactDescriptor {
+  kind: string
+  title: string
+  name: string
+}
+
 // A call's on-disk artifacts by role. Each carries its file name; the client
 // composes the download URL from the transcript route it fetched this listing
 // from (subjectApi.transcriptFile).
@@ -161,6 +170,7 @@ export interface AgentCallFiles {
   stderr?: ArtifactFile | null
   response?: ArtifactFile | null
   metadata?: ArtifactFile | null
+  artifact?: ArtifactDescriptor | null
 }
 
 export interface TranscriptChunk {

--- a/frontend/src/extensions/ship/AgentCallPage.tsx
+++ b/frontend/src/extensions/ship/AgentCallPage.tsx
@@ -6,6 +6,7 @@ import { buildApi } from './api'
 import type { WorkItemSummary } from './api'
 import type { AgentCallFiles, AgentCallSummary } from '../../api/types'
 import { Cost, Kebab, SectionHead, TokenBreakdown, Tokens } from '../../components/Common'
+import { Markdown } from '../../components/Markdown'
 import { Page } from '../../components/Page'
 import { queryGate } from '../../components/QueryGate'
 import { RunTranscript } from '../../components/RunTranscript'
@@ -80,11 +81,18 @@ function RunView({
           : 'running'
   }`
 
-  type LeftTab = 'prompt' | 'response'
+  type LeftTab = 'artifact' | 'prompt' | 'response'
 
-  const initialLeft: LeftTab = files.prompt ? 'prompt' : 'response'
+  // The artifact is the call's headline output (a plan's markdown) — front it
+  // when the call produced one.
+  const initialLeft: LeftTab = files.artifact ? 'artifact' : files.prompt ? 'prompt' : 'response'
   const [leftTab, setLeftTab] = useState<LeftTab>(initialLeft)
-  const activeFile = leftTab === 'prompt' ? files.prompt : files.response
+  const activeName =
+    leftTab === 'artifact'
+      ? files.artifact?.name
+      : leftTab === 'prompt'
+        ? files.prompt?.name
+        : files.response?.name
 
   return (
     <Page scroll="internal" className="page-run">
@@ -127,6 +135,15 @@ function RunView({
       <div className="run-body">
         <section className="run-col run-col-left">
           <div className="run-col-tabs">
+            {files.artifact && (
+              <button
+                className={`run-tab mono ${leftTab === 'artifact' ? 'active' : ''}`}
+                onClick={() => setLeftTab('artifact')}
+                type="button"
+              >
+                artifact
+              </button>
+            )}
             <button
               className={`run-tab mono ${leftTab === 'prompt' ? 'active' : ''}`}
               onClick={() => setLeftTab('prompt')}
@@ -144,7 +161,10 @@ function RunView({
               response
             </button>
           </div>
-          <FilePane url={activeFile ? buildApi.transcriptFile(call.id, activeFile.name) : null} />
+          <FilePane
+            url={activeName ? buildApi.transcriptFile(call.id, activeName) : null}
+            markdown={leftTab === 'artifact' && files.artifact?.kind === 'markdown'}
+          />
         </section>
 
         <section className="run-col run-col-right">
@@ -202,7 +222,7 @@ function TokensStat({ call }: { call: AgentCallSummary }) {
   )
 }
 
-function FilePane({ url }: { url: string | null }) {
+function FilePane({ url, markdown = false }: { url: string | null; markdown?: boolean }) {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['file', url],
     queryFn: async () => {
@@ -216,5 +236,12 @@ function FilePane({ url }: { url: string | null }) {
   if (!url) return <pre className="run-pre mono dim">no file</pre>
   if (isLoading) return <pre className="run-pre mono dim">loading…</pre>
   if (isError) return <pre className="run-pre mono dim">could not load file</pre>
+  if (markdown) {
+    return (
+      <div className="run-markdown">
+        <Markdown source={data ?? ''} />
+      </div>
+    )
+  }
   return <pre className="run-pre mono">{data}</pre>
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -558,6 +558,13 @@ button { background: none; border: none; color: inherit; cursor: pointer; font: 
   white-space: pre-wrap; word-break: break-word;
   background: var(--bg);
 }
+.run-markdown {
+  padding: 16px 20px;
+  flex: 1; overflow: auto;
+  font-size: 13px; line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+}
 
 /* Structured rendering of Claude's --output-format stream-json
  * transcript. Each row is one event from Claude's NDJSON stream;


### PR DESCRIPTION
## What changes

The backend's per-call files listing already ships an `artifact` descriptor (kind, title, file name) — `AgentCallFiles.from_call` populates it from `Artifact.get_for_call`, and every `transcriptFiles` fetch carries it. The hand-written frontend mirror never declared the field, so no component consumed it: a `generate_plan` call's plan was visible only while its run sat parked on an in-app ask, and never again after approval (or at all under a machine-gated run).

- `AgentCallFiles` in [types.ts](https://github.com/czpython/druks/blob/call-artifact/frontend/src/api/types.ts) gains the `artifact` descriptor the wire already sends.
- The agent call page fronts an **artifact** tab (before prompt/response) when the call produced one, defaulting to it — the artifact is the call's headline output. Markdown artifacts render through the shared `Markdown` component; content loads through the existing per-call transcript file route. Calls without an artifact see no new tab.

Frontend-only; no backend change. Verified with tsc, eslint, and a production build — visual check needs a deployment with real run data.