### PR TITLE
Move agent-call file stats out of the schema into the read side

### DIFF
--- a/backend/druks/durable/reads.py
+++ b/backend/druks/durable/reads.py
@@ -2,6 +2,7 @@
 # Schemas stay pure projections; routes call in here.
 import asyncio
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -17,6 +18,8 @@ from .models import AgentCall, Artifact, Run
 from .schemas import (
     AgentCallFiles,
     AgentCallResponse,
+    ArtifactDescriptor,
+    ArtifactFile,
     RunResponse,
     SubjectActivity,
     SubjectResponse,
@@ -36,7 +39,32 @@ _TERMINAL_CALL_STATES = {"succeeded", "failed", "abandoned"}
 
 def get_agent_call_files(call_id: str) -> AgentCallFiles:
     call = AgentCall.get(call_id)
-    return AgentCallFiles.from_call(call, Artifact.get_for_call(call.id))
+    artifact = Artifact.get_for_call(call.id)
+    layout = call.artifact_layout
+
+    def named(path: Path) -> ArtifactFile | None:
+        if path.is_file():
+            stat = path.stat()
+            return ArtifactFile(
+                name=path.name,
+                size_bytes=stat.st_size,
+                updated_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
+            )
+
+    descriptor = None
+    if artifact:
+        descriptor = ArtifactDescriptor(
+            kind=artifact.kind, title=artifact.title, name=artifact.path
+        )
+    return AgentCallFiles(
+        prompt=named(layout.prompt),
+        response=named(layout.output),
+        metadata=named(layout.metadata),
+        manifest=named(layout.manifest),
+        stdout=named(layout.transcript),
+        stderr=named(layout.stderr),
+        artifact=descriptor,
+    )
 
 
 def list_subject_timeline(subject_type: str, subject_id: str) -> list[RunResponse]:

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -1,5 +1,4 @@
-from datetime import UTC, datetime
-from pathlib import Path
+from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from pydantic import AliasPath, BeforeValidator, ConfigDict, Field, SerializeAsAny, computed_field
@@ -9,7 +8,7 @@ from druks.schemas import BaseResponse
 from .enums import AgentCallStatus, RunState
 
 if TYPE_CHECKING:
-    from .models import AgentCall, Artifact, Run
+    from .models import AgentCall, Run
 
 
 class TokenUsage(BaseResponse):
@@ -78,34 +77,6 @@ class AgentCallFiles(BaseResponse):
     manifest: ArtifactFile | None = None
     # The call's renderable output, rendered by kind; None unless it produced one.
     artifact: ArtifactDescriptor | None = None
-
-    @classmethod
-    def from_call(cls, call: "AgentCall", artifact: "Artifact | None") -> "AgentCallFiles":
-        layout = call.artifact_layout
-
-        def named(path: Path) -> ArtifactFile | None:
-            if path.is_file():
-                stat = path.stat()
-                return ArtifactFile(
-                    name=path.name,
-                    size_bytes=stat.st_size,
-                    updated_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC),
-                )
-
-        descriptor = None
-        if artifact:
-            descriptor = ArtifactDescriptor(
-                kind=artifact.kind, title=artifact.title, name=artifact.path
-            )
-        return cls(
-            prompt=named(layout.prompt),
-            response=named(layout.output),
-            metadata=named(layout.metadata),
-            manifest=named(layout.manifest),
-            stdout=named(layout.transcript),
-            stderr=named(layout.stderr),
-            artifact=descriptor,
-        )
 
 
 class RunResponse(BaseResponse):

--- a/backend/tests/test_manifest.py
+++ b/backend/tests/test_manifest.py
@@ -1,7 +1,7 @@
 import json
 from unittest import mock
 
-from druks.durable.schemas import AgentCallFiles
+from druks.durable.reads import get_agent_call_files
 from druks.harnesses.artifacts import persist_manifest
 from druks.harnesses.base import Harness
 from druks.harnesses.claude import ClaudeHarness
@@ -229,7 +229,7 @@ def test_manifest_surfaces_in_agent_call_files(tmp_path, druks_db):
     manifest = _build()
     with mock.patch("druks.durable.models.load_settings", return_value=make_settings(tmp_path)):
         persist_manifest(call.call_dir.parent, call_id=call.call_dir.name, manifest=manifest)
-        files = AgentCallFiles.from_call(call, None)
+        files = get_agent_call_files(call.id)
 
     assert files.manifest
     assert files.manifest.name == "manifest.json"


### PR DESCRIPTION
`AgentCallFiles.from_call` was a `from_*` constructor doing filesystem I/O (`is_file`/`stat`) inside `schemas.py` — both shapes the read-side rule bans: a response schema is a pure projection, and the read layer fetches and hands data in.

The stat composition now lives in `get_agent_call_files` in `reads.py`, where its one consumer (the `/transcripts/{call_id}/files` route) already called; `AgentCallFiles` is declared fields only. Wire shape unchanged.