### PR TITLE
Move the operator GitHub App into an encrypted service_identities row with a paste-in Connect GitHub card

### DIFF
--- a/backend/druks/api/app.py
+++ b/backend/druks/api/app.py
@@ -31,6 +31,8 @@ from druks.mcp.routes import router as mcp_router
 from druks.notifications.routes import external_router as notifications_external_router
 from druks.notifications.routes import router as notifications_router
 from druks.redis import close_client
+from druks.service_identities.exceptions import ServiceNotConnectedError
+from druks.service_identities.routes import router as service_identities_router
 from druks.settings import Settings, ensure_data_dirs, load_settings, setup_logging
 from druks.skills.routes import router as skills_router
 from druks.user_settings.routes import router as settings_router
@@ -174,6 +176,16 @@ async def _auth_configuration_handler(
     return JSONResponse(status_code=503, content={"error": "HTTP_503", "detail": str(exc)})
 
 
+# Any route that resolves a service identity it hasn't connected — directly or
+# through a workflow dispatch — raises this. Map it once so no entry point has
+# to carry its own catch to turn it into a 409.
+@app.exception_handler(ServiceNotConnectedError)
+async def _service_not_connected_handler(
+    request: Request, exc: ServiceNotConnectedError
+) -> JSONResponse:
+    return JSONResponse(status_code=409, content={"error": "HTTP_409", "detail": str(exc)})
+
+
 @app.exception_handler(RequestValidationError)
 async def _validation_exception_handler(
     request: Request,
@@ -230,6 +242,7 @@ app.include_router(webhooks_router)
 app.include_router(auth_router)
 app.include_router(harness_connection_router)
 app.include_router(settings_router, dependencies=_identity_gate)
+app.include_router(service_identities_router, dependencies=_identity_gate)
 app.include_router(skills_router, dependencies=_identity_gate)
 app.include_router(mcp_router, dependencies=_identity_gate)
 app.include_router(notifications_router, dependencies=_identity_gate)

--- a/backend/druks/contrib/review/extension.py
+++ b/backend/druks/contrib/review/extension.py
@@ -1,6 +1,21 @@
+from pydantic import Field
+
 from druks.agents import Agent
 from druks.contrib.review.contracts import ReviewReport
-from druks.extensions import Extension
+from druks.doctor import CheckResult
+from druks.extensions import Extension, ExtensionSettings, Secret
+
+
+def check_review_identity() -> CheckResult:
+    """Set or unset, both healthy: an empty pair is comment mode by design.
+    A half-configured pair is the settings clean's failure (``review:settings``),
+    not this check's."""
+    settings = Review.settings()
+    if settings.app_id and settings.private_key:
+        return CheckResult(
+            name="identity", ok=True, detail="set — reviews approve as the distinct App"
+        )
+    return CheckResult(name="identity", ok=True, detail="unset — reviews post as operator comments")
 
 
 class Review(Extension):
@@ -10,6 +25,31 @@ class Review(Extension):
         "Reviews a pull request and posts the review back to GitHub — the decision, "
         "a summary, and a comment on each line it has something to say about."
     )
+
+    class Settings(ExtensionSettings):
+        # The optional distinct review identity. Empty pair — reviews borrow
+        # the operator client in comment mode; complete pair — verdict reviews
+        # post as this App. Extension-owned by design: a posting identity for
+        # one extension is not a platform service identity.
+        app_id: Secret = Field(
+            title="Review App ID",
+            description="GitHub App ID of the distinct review identity; empty posts as comments.",
+        )
+        private_key: Secret = Field(
+            title="Review App private key",
+            description="PEM private key of the review App, pasted as issued.",
+            json_schema_extra={"multiline": True},
+        )
+
+        def clean(self) -> dict[str, str]:
+            problems: dict[str, str] = {}
+            if self.app_id and not self.private_key:
+                problems["private_key"] = "Required once the review App ID is set."
+            if self.private_key and not self.app_id:
+                problems["app_id"] = "Required once the review App private key is set."
+            return problems
+
+    checks = [check_review_identity]
 
     review_pull_request = Agent(
         description="reads a pull request and writes the review",

--- a/backend/druks/contrib/review/github.py
+++ b/backend/druks/contrib/review/github.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Literal
 
+from druks.contrib.review.extension import Review
 from druks.core.apis.github import GitHubClient, get_github_client
 from druks.settings import load_settings
 
@@ -18,14 +19,16 @@ class ReviewActor:
 
 
 def get_review_actor() -> ReviewActor:
-    settings = load_settings()
-    if settings.github.reviewer_app_id and settings.github_reviewer_private_key_path:
+    settings = Review.settings()
+    if settings.app_id and settings.private_key:
+        # Only a complete pair selects the distinct identity — a half-configured
+        # one (flagged by clean()) still borrows the operator client below.
         return ReviewActor(
             client=GitHubClient(
-                app_id=settings.github.reviewer_app_id,
-                private_key=settings.github_reviewer_private_key_path.read_text(),
-                base_url=settings.github_api_url,
+                app_id=settings.app_id.get_secret_value(),
+                private_key=settings.private_key.get_secret_value(),
+                base_url=load_settings().github_api_url,
             ),
             mode="approve",
         )
-    return ReviewActor(client=get_github_client(settings), mode="comment")
+    return ReviewActor(client=get_github_client(), mode="comment")

--- a/backend/druks/contrib/review/workflows.py
+++ b/backend/druks/contrib/review/workflows.py
@@ -6,8 +6,10 @@ from druks.contrib.review.extension import Review
 from druks.contrib.review.github import get_review_actor
 from druks.contrib.ship.models import ProjectRepo
 from druks.contrib.ship.workspace import RepoWorkspace
+from druks.core.apis.github import GITHUB
 from druks.sandbox import repo as _repo
 from druks.sandbox.layout import get_github_token_remote_path, get_related_root, get_repo_root
+from druks.service_identities.models import ServiceIdentity
 from druks.workflows import Workflow
 
 if TYPE_CHECKING:
@@ -38,6 +40,10 @@ class PullRequestReview(Workflow):
 
     @classmethod
     async def dispatch(cls, *, repo: str, pr_number: int, requested_by: str) -> str:
+        # Even a distinct review identity clones alongside the operator App, so
+        # resolve the operator identity before the start spends a run and
+        # provisions a VM — the raising lookup surfaces the actionable error.
+        ServiceIdentity.get(GITHUB)
         # Attribution follows the requester when druks knows them by that name; a
         # review asked for by someone with no account runs as the system's.
         account = Account.get_for_username(requested_by)

--- a/backend/druks/contrib/ship/models.py
+++ b/backend/druks/contrib/ship/models.py
@@ -11,7 +11,6 @@ from druks.contrib.ship.schemas import ProjectRepoSummary, WorkItemSummary
 from druks.contrib.ship.ticketing.enums import TicketStatus
 from druks.core.apis.github import get_github_client
 from druks.db import Base, StoredSubject, db_session
-from druks.settings import load_settings
 from druks.workflows import FatalError
 
 logger = logging.getLogger(__name__)
@@ -331,7 +330,7 @@ class WorkItem(StoredSubject):
         db_session().flush()
         try:
             if (await RepoPolicy.resolve(self.repo)).delete_branch:
-                await get_github_client(load_settings()).delete_branch(self.repo, self.branch)
+                await get_github_client().delete_branch(self.repo, self.branch)
         except Exception:  # noqa: BLE001 — cleanup only
             logger.warning("Skipped branch cleanup for %s.", self.repo, exc_info=True)
         await self.set_ticket_status(TicketStatus.BACKLOG)

--- a/backend/druks/contrib/ship/routes.py
+++ b/backend/druks/contrib/ship/routes.py
@@ -25,7 +25,7 @@ from druks.contrib.ship.ticketing.exceptions import UnknownTicketError
 from druks.contrib.ship.workflows import Profile
 from druks.core.apis.github import get_github_client
 from druks.db import db_session
-from druks.settings import load_settings
+from druks.service_identities.exceptions import ServiceNotConnectedError
 
 logger = logging.getLogger(__name__)
 
@@ -72,8 +72,7 @@ async def list_github_repos(
         ),
     ),
 ) -> GitHubReposResponse:
-    settings = load_settings()
-    github = get_github_client(settings)
+    github = get_github_client()
     resolved = (owner or "").strip()
     if resolved:
         owners: tuple[str, ...] = (resolved,)
@@ -184,7 +183,12 @@ async def add_project_repo(
         )
         .values(project_id=project.id)
     )
-    await Profile.dispatch(repo)
+    try:
+        await Profile.dispatch(repo)
+    except ServiceNotConnectedError:
+        # Registering the repo is metadata and must survive; profiling needs the
+        # operator App, so defer it — a later push or a manual profile picks it up.
+        logger.info("Registered %s without profiling: GitHub is not connected.", full_name)
     return ProjectRepoSummary.model_validate(repo)
 
 

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -13,7 +13,7 @@ from druks.contrib.ship.enums import (
     ReviewDecision,
 )
 from druks.contrib.ship.models import ProjectRepo, WorkItem
-from druks.core.apis.github import get_github_client
+from druks.core.apis.github import GITHUB, get_github_client
 from druks.sandbox import repo as _repo
 from druks.sandbox.datastructures import RequiredMcpServer
 from druks.sandbox.layout import (
@@ -22,6 +22,8 @@ from druks.sandbox.layout import (
     get_repo_root,
     get_work_root,
 )
+from druks.service_identities.exceptions import ServiceNotConnectedError
+from druks.service_identities.models import ServiceIdentity
 from druks.settings import load_settings
 from druks.skills.models import Skill
 from druks.workflows import FatalError, Workflow, step
@@ -126,6 +128,14 @@ class Build(Workflow):
             else:
                 logger.info("Ticket %s has no routable repo; skipping.", ticket["identifier"])
                 return
+        try:
+            ServiceIdentity.get(GITHUB)
+        except ServiceNotConnectedError as error:
+            # A raise would 5xx the tracker's webhook and put the delivery into
+            # provider redelivery; the delivery itself succeeded. Log the
+            # Connect GitHub direction and stand down without starting.
+            logger.info("Ticket %s cannot start a build: %s", ticket["identifier"], error)
+            return
         email = ticket["assignee_email"]
         assignee = Account.get_for_username(email.strip()) if email else None
         return await cls.start(
@@ -166,7 +176,7 @@ class Build(Workflow):
         # Planning agents run before the first implement provisions the branch — their
         # VMs clone the default branch; every agent after delivery gets the PR branch.
         branch = self.branch
-        github_token = await get_github_client(load_settings()).token_for_repo(repo)
+        github_token = await get_github_client().token_for_repo(repo)
         await sandbox.write_secret(
             secret=github_token, remote=get_github_token_remote_path(sandbox.ssh_username)
         )
@@ -352,7 +362,7 @@ class Build(Workflow):
     @step
     async def declare_merge_intent(self) -> bool:
         """Whether GitHub accepted ownership of the merge."""
-        github = get_github_client(load_settings())
+        github = get_github_client()
         return await github.merge_when_ready(self.subject.repo, self.pr_number)
 
     # The provisioned branch + PR, pinned to the FIRST delivery — None until then
@@ -378,7 +388,7 @@ class Build(Workflow):
         repo = self.subject.repo
         if login and self.pr_number:
             try:
-                await get_github_client(load_settings()).request_pull_request_reviewers(
+                await get_github_client().request_pull_request_reviewers(
                     repo, self.pr_number, [login]
                 )
             except Exception:  # noqa: BLE001 — a missed ping must not fail the park
@@ -393,7 +403,7 @@ class Build(Workflow):
         repo = self.subject.repo
         if self.pr_number:
             try:
-                await get_github_client(load_settings()).set_pull_request_draft_state(
+                await get_github_client().set_pull_request_draft_state(
                     repo, self.pr_number, draft=draft
                 )
             except Exception:  # noqa: BLE001 — a draft merge fails loudly anyway
@@ -412,6 +422,10 @@ class Profile(Workflow):
 
     @classmethod
     async def dispatch(cls, repo: ProjectRepo, *, refresh_only: bool = False) -> str:
+        # The profiler clones with an operator-App token, so resolve the
+        # identity before the start spends a run and provisions a VM — the
+        # raising lookup surfaces the actionable not-connected error.
+        ServiceIdentity.get(GITHUB)
         return await cls.start(
             subject=repo,
             repo_id=repo.id,
@@ -444,7 +458,7 @@ class Profile(Workflow):
 
     async def get_workspace_kwargs(self, sandbox: "Sandbox") -> dict[str, Any]:
         repo = ProjectRepo.get(self.input.repo_id).full_name
-        github_token = await get_github_client(load_settings()).token_for_repo(repo)
+        github_token = await get_github_client().token_for_repo(repo)
         await sandbox.write_secret(
             secret=github_token, remote=get_github_token_remote_path(sandbox.ssh_username)
         )

--- a/backend/druks/core/apis/exceptions.py
+++ b/backend/druks/core/apis/exceptions.py
@@ -10,8 +10,3 @@ class GitHubAppNotInstalledError(Exception):
             "repo (or add it to the installation's selected repositories)."
         )
         self.repo = repo
-
-
-class GitHubAppNotConfiguredError(Exception):
-    """Operator or reviewer GitHub App credentials are absent from settings;
-    the message names the env vars to set."""

--- a/backend/druks/core/apis/github.py
+++ b/backend/druks/core/apis/github.py
@@ -9,10 +9,13 @@ from typing import Any, Literal, TypeVar
 from githubkit import AppAuthStrategy, AppInstallationAuthStrategy, GitHub
 from githubkit.exception import GraphQLFailed, RequestFailed
 
-from druks.core.apis.exceptions import GitHubAppNotConfiguredError, GitHubAppNotInstalledError
-from druks.settings import Settings
+from druks.core.apis.exceptions import GitHubAppNotInstalledError
+from druks.service_identities.models import ServiceIdentity
+from druks.settings import load_settings
 
 logger = logging.getLogger(__name__)
+
+GITHUB = "github"
 
 
 @dataclass(frozen=True)
@@ -63,10 +66,12 @@ class GitHubClient:
         app_id: str,
         private_key: str,
         base_url: str = "https://api.github.com",
+        slug: str = "",
     ) -> None:
         self._app_id = app_id
         self._private_key = private_key
         self._base_url = base_url
+        self._slug = slug
         self._app = GitHub(
             AppAuthStrategy(app_id, private_key),
             base_url=base_url,
@@ -165,8 +170,11 @@ class GitHubClient:
 
     async def get_mention_handle(self) -> str:
         """What a comment writes after ``@`` to address this App — its slug, which
-        GitHub resolves to the App's bot user. The App is the one that knows it;
-        nobody should have to configure it."""
+        GitHub resolves to the App's bot user. The operator client carries the
+        slug stored at connect time and never refetches it; a client constructed
+        without one (the review identity) asks GitHub once and caches it."""
+        if self._slug:
+            return self._slug
         cached = _MENTION_HANDLE_CACHE.get(self._app_id)
         if cached:
             return cached
@@ -174,6 +182,17 @@ class GitHubClient:
         handle = getattr(response.parsed_data, "slug", None) or ""
         _MENTION_HANDLE_CACHE[self._app_id] = handle
         return handle
+
+    async def get_authenticated_app_slug(self) -> str:
+        """The slug GitHub reports for these credentials — a live App-JWT call,
+        so it proves the App ID matches the PEM. The connect flow's validation;
+        mention resolution reads the stored slug instead."""
+        async with GitHub(
+            AppAuthStrategy(self._app_id, self._private_key),
+            base_url=self._base_url,
+        ) as gh:
+            response = await gh.rest.apps.async_get_authenticated()
+            return str(getattr(response.parsed_data, "slug", None) or "")
 
     async def _installation_id(self, repo: str) -> int:
         if repo in self._installation_cache:
@@ -499,14 +518,16 @@ def _fold_comments_into_body(body: str, comments: list[ReviewComment]) -> str:
     return "\n".join(lines)
 
 
-def get_github_client(settings: Settings) -> GitHubClient:
-    if settings.github.operator_app_id and settings.github_operator_private_key_path:
-        return GitHubClient(
-            app_id=settings.github.operator_app_id,
-            private_key=settings.github_operator_private_key_path.read_text(),
-            base_url=settings.github_api_url,
-        )
-    raise GitHubAppNotConfiguredError(
-        "Operator GitHub App credentials are required: set github.operator_app_id and "
-        "GITHUB_OPERATOR_PRIVATE_KEY_PATH."
+def get_github_client() -> GitHubClient:
+    """The operator client, resolved from the GitHub service-identity row —
+    the only credential source; there is no settings or file fallback. Raises
+    ``ServiceNotConnectedError`` when GitHub isn't connected. ``github_api_url``
+    stays a Settings input because it is transport, not identity. PEM plaintext
+    exists only here, feeding the client's auth strategy."""
+    row = ServiceIdentity.get(GITHUB)
+    return GitHubClient(
+        app_id=row.identity["app_id"],
+        private_key=row.secrets["private_key"],
+        base_url=load_settings().github_api_url,
+        slug=row.identity["slug"],
     )

--- a/backend/druks/core/webhooks/github.py
+++ b/backend/druks/core/webhooks/github.py
@@ -1,8 +1,12 @@
 from datetime import UTC, datetime
 from typing import Any, ClassVar
 
+from fastapi import HTTPException, status
 from fastapi.responses import JSONResponse, Response
 
+from druks.core.apis.github import GITHUB
+from druks.service_identities.exceptions import ServiceNotConnectedError
+from druks.service_identities.models import ServiceIdentity
 from druks.signals import publish
 from druks.webhooks import Webhook, verify_hmac_sha256
 
@@ -25,10 +29,20 @@ class GitHubEvents(Webhook):
     DELIVERY_HEADER: ClassVar[str] = "x-github-delivery"
 
     def request_is_authentic(self) -> bool:
+        # The delivery secret lives on the GitHub service-identity row — the
+        # same paste that connected the App. No identity, no secret to verify
+        # against: reject before any event dispatch.
+        try:
+            identity = ServiceIdentity.get(GITHUB)
+        except ServiceNotConnectedError as error:
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                "GitHub is not connected — connect it in Settings → Harnesses.",
+            ) from error
         verify_hmac_sha256(
             self.raw_body,
             self.request.headers.get(self.SIGNATURE_HEADER),
-            self.settings.secrets.webhook_secret,
+            identity.secrets["webhook_secret"],
         )
         return True
 

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -12,18 +12,19 @@ from urllib.parse import urlparse
 
 import httpx
 from drukbox_sdk import SandboxAPI
-from githubkit import AppAuthStrategy, GitHub
 from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
 from .agents import Agent
-from .core.apis.github import get_github_client
+from .core.apis.github import GITHUB, get_github_client
 from .database import create_engine_from_url, db_session
 from .extensions.loader import iter_extensions
 from .extensions.registry import _ROLES, agents, autodiscover, webhooks, workflows
 from .harnesses.models import HarnessConnection
 from .harnesses.registry import get_harnesses
 from .sandbox.client import sandbox_client
+from .service_identities.exceptions import ServiceNotConnectedError
+from .service_identities.models import ServiceIdentity
 from .settings import Settings, load_settings
 from .user_settings.models import UserSettings
 from .webhooks.base import Webhook
@@ -37,28 +38,54 @@ class CheckResult:
     detail: str
 
 
-def check_webhook_secret(settings: Settings) -> CheckResult:
-    secret = settings.secrets.webhook_secret
-    if not secret or secret == "change-me":
+def check_github_identity(settings: Settings) -> CheckResult:
+    """The GitHub service identity is database-backed like a harness
+    connection: this reports the row's presence, not a file or setting."""
+    engine = create_engine_from_url(settings.database_url)
+    try:
+        with Session(engine) as session:
+            db_session.registry.set(session)
+            row = ServiceIdentity.get(GITHUB)
+    except ServiceNotConnectedError:
         return CheckResult(
-            name="webhook_secret",
+            name="github_identity",
             ok=False,
-            detail="secrets.webhook_secret is empty or the placeholder.",
+            detail="not connected — connect GitHub in Settings → Harnesses.",
         )
-    return CheckResult(name="webhook_secret", ok=True, detail="set")
+    except Exception as error:  # noqa: BLE001 — a DB-read failure is a fail, not a crash
+        return CheckResult(
+            name="github_identity", ok=False, detail=f"cannot read the identity: {error}"
+        )
+    finally:
+        db_session.remove()
+        engine.dispose()
+    return CheckResult(
+        name="github_identity",
+        ok=True,
+        detail=f"connected; app_id={row.identity['app_id']} slug={row.identity['slug']}",
+    )
 
 
 def check_installations(settings: Settings) -> CheckResult:
     """Where druks may act = the operator App's installation accounts;
-    this check is the audit surface for that set."""
+    this check is the audit surface for that set. The zero-argument client
+    factory reads the service-identity row, so a one-off Session is bound
+    into the ambient ``db_session`` registry for the duration."""
+    engine = create_engine_from_url(settings.database_url)
     try:
-        accounts = asyncio.run(get_github_client(settings).list_installation_accounts())
+        with Session(engine) as session:
+            db_session.registry.set(session)
+            client = get_github_client()
+        accounts = asyncio.run(client.list_installation_accounts())
     except Exception as exc:  # noqa: BLE001 — doctor reports, never raises
         return CheckResult(
             name="installations",
             ok=False,
             detail=f"could not list operator App installations: {exc}",
         )
+    finally:
+        db_session.remove()
+        engine.dispose()
     if not accounts:
         return CheckResult(
             name="installations",
@@ -70,60 +97,6 @@ def check_installations(settings: Settings) -> CheckResult:
         ok=True,
         detail=f"operator App installed on: {', '.join(accounts)}",
     )
-
-
-def check_github_operator_app(settings: Settings) -> CheckResult:
-    return _check_github_app(
-        name="github_operator_app",
-        app_id=settings.github.operator_app_id,
-        pem_path=settings.github_operator_private_key_path,
-        id_key="github.operator_app_id",
-        env_pem="GITHUB_OPERATOR_PRIVATE_KEY_PATH",
-    )
-
-
-def check_github_reviewer_app(settings: Settings) -> CheckResult:
-    return _check_github_app(
-        name="github_reviewer_app",
-        app_id=settings.github.reviewer_app_id,
-        pem_path=settings.github_reviewer_private_key_path,
-        id_key="github.reviewer_app_id",
-        env_pem="GITHUB_REVIEWER_PRIVATE_KEY_PATH",
-    )
-
-
-def _check_github_app(
-    *,
-    name: str,
-    app_id: str | None,
-    pem_path: Path | None,
-    id_key: str,
-    env_pem: str,
-) -> CheckResult:
-    if not app_id:
-        return CheckResult(name=name, ok=False, detail=f"{id_key} is unset.")
-    if not pem_path:
-        return CheckResult(name=name, ok=False, detail=f"{env_pem} is unset.")
-    if not pem_path.exists():
-        return CheckResult(name=name, ok=False, detail=f"{pem_path} does not exist.")
-    body = pem_path.read_text(errors="replace")
-    if "BEGIN RSA PRIVATE KEY" not in body and "BEGIN PRIVATE KEY" not in body:
-        return CheckResult(name=name, ok=False, detail=f"{pem_path} is not a PEM private key.")
-    # Live-mint a JWT and ask the GitHub API who we are. Proves the App ID
-    # matches the PEM and the App still exists.
-    try:
-        slug = asyncio.run(_github_app_slug(app_id=app_id, private_key=body))
-    except Exception as error:  # noqa: BLE001 — auth failures surface as fail
-        return CheckResult(name=name, ok=False, detail=f"GitHub auth failed: {error}")
-    return CheckResult(name=name, ok=True, detail=f"app_id={app_id} slug={slug}")
-
-
-async def _github_app_slug(*, app_id: str, private_key: str) -> str:
-    # ``async with`` lazily creates the underlying httpx client on entry
-    # and closes it on exit; a bare ``GitHub(...)`` has no client to close.
-    async with GitHub(AppAuthStrategy(app_id, private_key)) as gh:
-        response = await gh.rest.apps.async_get_authenticated()
-        return response.parsed_data.slug
 
 
 def _harness_credential_check(
@@ -441,11 +414,9 @@ def _run_extension_check(extension_name: str, check) -> CheckResult:
 
 
 CHECKS = (
-    check_webhook_secret,
     check_webhook_ingress,
+    check_github_identity,
     check_installations,
-    check_github_operator_app,
-    check_github_reviewer_app,
     check_harness_credentials,
     check_data_dir,
     check_database,

--- a/backend/druks/extensions/fetcher.py
+++ b/backend/druks/extensions/fetcher.py
@@ -17,7 +17,7 @@ async def fetch_file(*, repo: str, path: str) -> str | None:
         if time.time() - cache.stat().st_mtime < _TTL_SECONDS:
             return cache.read_text() or None
 
-    github = get_github_client(load_settings())
+    github = get_github_client()
 
     try:
         body = await github.get_file_content(repo, path)

--- a/backend/druks/extensions/settings.py
+++ b/backend/druks/extensions/settings.py
@@ -61,6 +61,17 @@ def field_section(field: FieldInfo) -> str:
     return ""
 
 
+def field_multiline(field: FieldInfo) -> bool:
+    # A field whose pasted value carries meaningful newlines (a PEM private
+    # key); the UI renders a textarea instead of a one-line input. Declared as
+    # ``json_schema_extra={"multiline": True}``; presentation only — storage,
+    # redaction, and write-only semantics are unchanged.
+    metadata = field.json_schema_extra
+    if isinstance(metadata, dict):
+        return bool(metadata.get("multiline", False))
+    return False
+
+
 def field_visibility(field: FieldInfo) -> tuple[str, Any]:
     # The sibling field this one is shown for and the value that field must hold. The
     # name is empty when the field is always shown.

--- a/backend/druks/service_identities/exceptions.py
+++ b/backend/druks/service_identities/exceptions.py
@@ -1,0 +1,7 @@
+class ServiceNotConnectedError(Exception):
+    """No identity is connected for this service — the appliance has nothing to
+    act as there. The message names the service so any refusal is actionable."""
+
+    def __init__(self, service: str) -> None:
+        self.service = service
+        super().__init__(f"{service} is not connected — connect it in Settings → Harnesses.")

--- a/backend/druks/service_identities/models.py
+++ b/backend/druks/service_identities/models.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from druks.database import db_session
+from druks.models import Base
+from druks.secrets.fields import EncryptedJsonField
+from druks.service_identities.exceptions import ServiceNotConnectedError
+
+
+class ServiceIdentity(Base):
+    """The appliance's own identity at an external service — druks acting as
+    itself, not a per-user harness login. Each service carries its own shape:
+    non-secret facts in ``identity``, credentials in ``secrets``."""
+
+    __tablename__ = "service_identities"
+
+    service: Mapped[str] = mapped_column(primary_key=True)
+    identity: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict)
+    secrets = EncryptedJsonField()
+    connected_at: Mapped[datetime]
+
+    @classmethod
+    def get(cls, service: str) -> "ServiceIdentity":
+        identity = db_session().get(cls, service)
+        if identity is None:
+            raise ServiceNotConnectedError(service)
+        return identity
+
+    @classmethod
+    def connect(
+        cls, service: str, *, identity: dict[str, Any], secrets: dict[str, str]
+    ) -> "ServiceIdentity":
+        # The caller verifies the credentials against the service first; this
+        # trusts what it is given and overwrites whatever was connected.
+        row = db_session().get(cls, service)
+        if row is None:
+            row = cls(service=service)
+            db_session().add(row)
+        row.identity = identity
+        row.secrets = secrets
+        row.connected_at = Base.utc_now()
+        db_session().flush()
+        return row

--- a/backend/druks/service_identities/routes.py
+++ b/backend/druks/service_identities/routes.py
@@ -1,0 +1,55 @@
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from druks.core.apis.github import GITHUB, GitHubClient
+from druks.service_identities.exceptions import ServiceNotConnectedError
+from druks.service_identities.models import ServiceIdentity
+from druks.service_identities.schemas import GitHubConnectRequest, GitHubIdentityResponse
+from druks.settings import load_settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/service-identities", tags=["service-identities"])
+
+
+@router.get("/github", response_model=GitHubIdentityResponse, response_model_by_alias=True)
+async def get_github_identity() -> GitHubIdentityResponse:
+    try:
+        return GitHubIdentityResponse.from_row(ServiceIdentity.get(GITHUB))
+    except ServiceNotConnectedError:
+        return GitHubIdentityResponse.from_row(None)
+
+
+@router.post("/github", response_model=GitHubIdentityResponse, response_model_by_alias=True)
+async def connect_github(payload: GitHubConnectRequest) -> GitHubIdentityResponse:
+    app_id = payload.app_id.strip()
+    if not app_id or not payload.private_key.strip() or not payload.webhook_secret:
+        raise HTTPException(
+            status_code=422,
+            detail="App ID, PEM private key, and webhook secret are all required.",
+        )
+    try:
+        # Live-authenticate the pasted credentials as the App and take the
+        # slug GitHub reports — proves the App ID matches the PEM before
+        # anything may displace a working identity.
+        client = GitHubClient(
+            app_id=app_id,
+            private_key=payload.private_key,
+            base_url=load_settings().github_api_url,
+        )
+        slug = await client.get_authenticated_app_slug()
+    except Exception as error:  # noqa: BLE001 — any auth/parse failure is a rejected paste
+        # A fixed message: the failure detail could quote request internals,
+        # and nothing pasted may echo back.
+        logger.warning("GitHub service-identity connect rejected: %s", type(error).__name__)
+        raise HTTPException(
+            status_code=422,
+            detail="GitHub did not accept these credentials — check the App ID and PEM key.",
+        ) from error
+    row = ServiceIdentity.connect(
+        GITHUB,
+        identity={"app_id": app_id, "slug": slug},
+        secrets={"private_key": payload.private_key, "webhook_secret": payload.webhook_secret},
+    )
+    return GitHubIdentityResponse.from_row(row)

--- a/backend/druks/service_identities/schemas.py
+++ b/backend/druks/service_identities/schemas.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from druks.schemas import BaseResponse
+
+if TYPE_CHECKING:
+    from druks.service_identities.models import ServiceIdentity
+
+
+class GitHubConnectRequest(BaseModel):
+    app_id: str = Field(validation_alias="appId")
+    private_key: str = Field(validation_alias="privateKey")
+    webhook_secret: str = Field(validation_alias="webhookSecret")
+
+
+class GitHubIdentityResponse(BaseResponse):
+    # Connection state only — identity facts, never either stored secret.
+    connected: bool
+    app_id: str | None
+    slug: str | None
+    connected_at: datetime | None
+
+    @classmethod
+    def from_row(cls, row: "ServiceIdentity | None") -> "GitHubIdentityResponse":
+        facts = row.identity if row else {}
+        return cls(
+            connected=bool(row),
+            app_id=facts.get("app_id"),
+            slug=facts.get("slug"),
+            connected_at=row.connected_at if row else None,
+        )

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -25,12 +25,6 @@ PACKAGED_MCP_CATALOG = Path(__file__).with_name("mcp") / "catalog.json"
 PACKAGED_MCP_TRUSTED = Path(__file__).with_name("mcp") / "trusted.json"
 
 
-def _empty_str_to_none(value: Any) -> Any:
-    if value == "":
-        return None
-    return value
-
-
 def _expand_path(value: Any) -> Any:
     if isinstance(value, str):
         return Path(value).expanduser()
@@ -64,7 +58,6 @@ def _secrets_key(value: Any) -> Any:
     return ",".join(segments)
 
 
-EmptyToNone = Annotated[str | None, BeforeValidator(_empty_str_to_none)]
 SecretsKey = Annotated[str, BeforeValidator(_secrets_key)]
 ExpandedPath = Annotated[Path, BeforeValidator(_expand_path)]
 OptionalExpandedPath = Annotated[Path | None, BeforeValidator(_expand_optional_path)]
@@ -131,14 +124,6 @@ class Identity(BaseModel):
         return self
 
 
-class GitHub(BaseModel):
-    # Where druks may act is the operator Extension's installation set — GitHub's
-    # own state: webhooks only arrive from installations, tokens only mint
-    # for them. See GitHubClient.list_installation_accounts.
-    operator_app_id: EmptyToNone = None
-    reviewer_app_id: EmptyToNone = None
-
-
 class Urls(BaseModel):
     # The base URL the operator's browser reaches druks at (the dashboard host,
     # not the webhook ingress). The OAuth connect flow builds its callback
@@ -151,9 +136,9 @@ class Urls(BaseModel):
 
 
 class Secrets(BaseModel):
-    webhook_secret: str = ""
-    # Encrypts stored secrets (MCP tokens, OAuth grants) at rest. Required —
-    # a missing or malformed key refuses boot; `druks setup` generates one.
+    # Encrypts stored secrets (MCP tokens, OAuth grants, the GitHub service
+    # identity) at rest. Required — a missing or malformed key refuses boot;
+    # `druks setup` generates one.
     secrets_key: SecretsKey
 
 
@@ -189,7 +174,6 @@ class Settings(BaseSettings):
     )
 
     identity: Identity = Identity()
-    github: GitHub = GitHub()
     urls: Urls = Urls()
     secrets: Secrets
     sandbox: Sandbox = Sandbox()
@@ -204,15 +188,9 @@ class Settings(BaseSettings):
         alias="DRUKS_DATABASE_URL",
     )
 
+    # Transport only — GitHub credentials live on the service-identity row,
+    # not in Settings; this points every client at a compatible API endpoint.
     github_api_url: str = Field(default="https://api.github.com", alias="GITHUB_API_URL")
-    github_operator_private_key_path: OptionalExpandedPath = Field(  # type: ignore[assignment]
-        default=None,
-        alias="GITHUB_OPERATOR_PRIVATE_KEY_PATH",
-    )
-    github_reviewer_private_key_path: OptionalExpandedPath = Field(  # type: ignore[assignment]
-        default=None,
-        alias="GITHUB_REVIEWER_PRIVATE_KEY_PATH",
-    )
 
     # The Slack app's signing secret, gating inbound interactivity callbacks —
     # distinct from the per-destination outbound webhook URLs.
@@ -318,11 +296,6 @@ def setup_logging(settings: Settings) -> None:
     # drops) stay audible.
     asyncssh.set_log_level(logging.WARNING)
     asyncssh.set_sftp_log_level(logging.WARNING)
-
-    if not settings.secrets.webhook_secret:
-        logging.getLogger(__name__).warning(
-            "secrets.webhook_secret is not set — all webhooks will be rejected.",
-        )
 
 
 def ensure_data_dirs(settings: Settings) -> None:

--- a/backend/druks/testing.py
+++ b/backend/druks/testing.py
@@ -20,6 +20,7 @@ import druks.harnesses.models  # noqa: F401
 import druks.mcp.models  # noqa: F401
 import druks.notifications.models  # noqa: F401
 import druks.redis
+import druks.service_identities.models  # noqa: F401
 import druks.skills.models  # noqa: F401
 import druks.user_settings.models  # noqa: F401
 from druks.bootstrap import seed
@@ -158,12 +159,9 @@ def make_settings(tmp_path: Path, **overrides: object) -> Settings:
         "data_dir": tmp_path,
         "database_url": TEST_DATABASE_URL,
         "secrets": {
-            "webhook_secret": "test-secret",
             "secrets_key": "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=",
         },
         "github_api_url": "https://api.github.com",
-        "github_operator_private_key_path": None,
-        "github_reviewer_private_key_path": None,
         "redis_url": TEST_REDIS_URL,
         "log_level": "WARNING",
     }

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -4,7 +4,13 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.fields import FieldInfo
 
-from druks.extensions.settings import field_choices, field_kind, field_section, field_visibility
+from druks.extensions.settings import (
+    field_choices,
+    field_kind,
+    field_multiline,
+    field_section,
+    field_visibility,
+)
 from druks.schemas import BaseResponse
 
 if TYPE_CHECKING:
@@ -115,6 +121,9 @@ class SettingsFieldResponse(BaseResponse):
     # default). None for every other kind — the UI shows a "set / not set" hint only
     # for secrets.
     secret_set: bool | None
+    # The value carries meaningful newlines (a pasted PEM) — the UI renders a
+    # textarea. Presentation only; declared via json_schema_extra.
+    multiline: bool = False
     overridden: bool
 
     @classmethod
@@ -136,6 +145,7 @@ class SettingsFieldResponse(BaseResponse):
             visible_when_field=controller,
             visible_when_value=target,
             secret_set=bool(value) if secret else None,
+            multiline=field_multiline(field),
             overridden=overridden,
         )
 

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -6,6 +6,7 @@ import druks.durable.models  # noqa: F401
 import druks.harnesses.models  # noqa: F401
 import druks.mcp.models  # noqa: F401
 import druks.notifications.models  # noqa: F401
+import druks.service_identities.models  # noqa: F401
 import druks.skills.models  # noqa: F401
 import druks.user_settings.models  # noqa: F401
 from alembic import context

--- a/backend/migrations/versions/c9e5b1d47a26_add_service_identities.py
+++ b/backend/migrations/versions/c9e5b1d47a26_add_service_identities.py
@@ -1,0 +1,34 @@
+"""add service identities
+
+Revision ID: c9e5b1d47a26
+Revises: a4c8e2f7b913
+Create Date: 2026-08-09 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "c9e5b1d47a26"
+down_revision: str | Sequence[str] | None = "a4c8e2f7b913"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "service_identities",
+        sa.Column("service", sa.String(), nullable=False),
+        sa.Column("identity", postgresql.JSONB(), nullable=False),
+        sa.Column("secrets", sa.LargeBinary(), nullable=False),
+        sa.Column("connected_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("service"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("service_identities")

--- a/backend/tests/druks-field_notes/druks_field_notes/extension.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/extension.py
@@ -52,6 +52,18 @@ class FieldNotes(Extension):
         # SecretStr, so its value is redacted everywhere it surfaces; empty means
         # unset, and a malformed key is rejected server-side (with its raw value
         # kept out of the error).
+        # A multiline secret: a pasted PEM-shaped credential whose newlines
+        # matter. ``multiline`` is presentation only — the settings UI renders
+        # a textarea; storage and redaction are the ordinary secret plane.
+        sync_signing_key: Secret = Field(
+            title="Sync signing key",
+            description="PEM key used to sign notes synced to the external service.",
+            json_schema_extra={
+                "section": "Sharing",
+                "visible_when": {"visibility": "public"},
+                "multiline": True,
+            },
+        )
         sync_token: Secret = Field(
             title="Sync token",
             description="API key for syncing notes to an external service.",

--- a/backend/tests/druks-field_notes/tests/test_extension.py
+++ b/backend/tests/druks-field_notes/tests/test_extension.py
@@ -31,3 +31,18 @@ def test_settings_require_a_sync_token_for_public_visibility():
         "sync_token": "Required when visibility is public."
     }
     assert FieldNotes.Settings(visibility="public", sync_token="sk-sync-token").clean() == {}
+
+
+def test_the_signing_key_declares_the_multiline_secret_presentation():
+    # An author marks a pasted PEM-shaped secret multiline; the platform keeps
+    # newlines intact end to end, so the stored value is exactly the paste.
+    from druks.extensions.settings import field_kind, field_multiline
+
+    field = FieldNotes.Settings.model_fields["sync_signing_key"]
+    assert field_kind(field) == "secret"
+    assert field_multiline(field)
+    assert not field_multiline(FieldNotes.Settings.model_fields["sync_token"])
+
+    pem = "-----BEGIN KEY-----\nline-one\nline-two\n-----END KEY-----"
+    settings = FieldNotes.Settings(sync_signing_key=pem)
+    assert settings.sync_signing_key.get_secret_value() == pem

--- a/backend/tests/ship/test_build_dispatch.py
+++ b/backend/tests/ship/test_build_dispatch.py
@@ -1,15 +1,42 @@
 from datetime import UTC, datetime
 
 from druks.contrib.ship.workflows import Build
+from druks.service_identities.models import ServiceIdentity
+from druks.signals import publish
 from druks.testing import seed_run
 
 from ship.factories import make_test_work_item
+
+
+def _connect_github() -> None:
+    ServiceIdentity.connect(
+        "github",
+        identity={"app_id": "1", "slug": "druks-operator"},
+        secrets={"private_key": "operator-pem", "webhook_secret": "hook-secret"},
+    )
+
+
+def _ticket(item, **overrides) -> dict:
+    ticket = {
+        "source": item.source,
+        "identifier": item.ticket_key,
+        "status": "Ready",
+        "title": item.title,
+        "url": f"https://tracker.test/{item.ticket_key}",
+        "project_name": "r",
+        "labels": [],
+        "assignee_email": None,
+        "assignee_name": None,
+    }
+    ticket.update(overrides)
+    return ticket
 
 
 async def test_dispatch_leaves_the_item_alone(druks_db, monkeypatch) -> None:
     """Dispatch starts the build and touches nothing else — clearing the previous
     attempt is the scheduled reaction's (test_lane_reactions), and a duplicate
     dispatch never makes that announcement."""
+    _connect_github()
     seed_run(druks_db, kind=Build.kind, run_id="run-old")
     seed_run(druks_db, kind=Build.kind, run_id="run-new")
     item = make_test_work_item(repo="o/r", title="t", ticket_key="ACME-2")
@@ -20,23 +47,109 @@ async def test_dispatch_leaves_the_item_alone(druks_db, monkeypatch) -> None:
         return "run-new"
 
     monkeypatch.setattr(Build, "start", classmethod(fake_start))
-    await Build.dispatch(
-        ticket={
-            "source": item.source,
-            "identifier": item.ticket_key,
-            "status": "Ready",
-            "title": item.title,
-            "url": "https://tracker.test/ACME-2",
-            "project_name": "r",
-            "labels": [],
-            "assignee_email": None,
-            "assignee_name": None,
-        }
-    )
+    await Build.dispatch(ticket=_ticket(item))
 
     assert item.pr_number == 7
     assert item.branch == "agent/old"
     assert item.resolution == "closed"
+
+
+async def test_dispatch_stands_down_without_github_instead_of_raising(
+    druks_db, monkeypatch, caplog
+) -> None:
+    """The tracker delivery already succeeded — a raise here would 5xx the
+    webhook into provider redelivery. No identity: log the not-connected
+    direction and start nothing."""
+    item = make_test_work_item(repo="o/r", title="t", ticket_key="ACME-8")
+    started = []
+
+    async def fake_start(cls, **kwargs):
+        started.append(kwargs)
+        return "run-x"
+
+    monkeypatch.setattr(Build, "start", classmethod(fake_start))
+
+    with caplog.at_level("INFO"):
+        result = await Build.dispatch(ticket=_ticket(item))
+
+    assert result is None
+    assert not started
+    assert any("not connected" in record.getMessage() for record in caplog.records)
+
+
+async def test_the_tracker_funnel_swallows_the_missing_identity(druks_db, monkeypatch) -> None:
+    """End to end through publish: an unconnected appliance must not turn a
+    ticket transition into an escaping exception (which the webhook layer
+    would 5xx into indefinite redelivery)."""
+    from druks.contrib.ship import subscribers  # noqa: F401 — the import registers it
+    from druks.contrib.ship.extension import Ship
+
+    settings = Ship.settings()
+    item = make_test_work_item(repo="o/r", title="t", ticket_key="ACME-9", source=settings.tracker)
+    started = []
+
+    async def fake_start(cls, **kwargs):
+        started.append(kwargs)
+        return "run-x"
+
+    monkeypatch.setattr(Build, "start", classmethod(fake_start))
+
+    await publish(
+        "ticket.transitioned",
+        payload=_ticket(item, source=settings.tracker, status=settings.trigger_status),
+    )
+
+    assert not started
+
+
+async def test_dispatch_merged_noop_still_precedes_the_identity_guard(
+    druks_db, monkeypatch, caplog
+) -> None:
+    """A merged item's redelivery keeps its own no-op — the identity guard only
+    decides deliveries that would otherwise start."""
+    item = make_test_work_item(repo="o/r", title="t", ticket_key="ACME-10")
+    item.update(pr_number=7, branch="agent/old")
+    item.resolve(merged=True, at=datetime.now(UTC))
+
+    async def fake_start(cls, **kwargs):
+        raise AssertionError("a merged item never starts")
+
+    monkeypatch.setattr(Build, "start", classmethod(fake_start))
+
+    with caplog.at_level("INFO"):
+        assert await Build.dispatch(ticket=_ticket(item)) is None
+
+    assert any("already merged" in record.getMessage() for record in caplog.records)
+
+
+async def test_dispatch_unroutable_noop_still_precedes_the_identity_guard(
+    druks_db, monkeypatch, caplog
+) -> None:
+    started = []
+
+    async def fake_start(cls, **kwargs):
+        started.append(kwargs)
+
+    monkeypatch.setattr(Build, "start", classmethod(fake_start))
+
+    with caplog.at_level("INFO"):
+        result = await Build.dispatch(
+            ticket={
+                "source": "linear",
+                "identifier": "ACME-11",
+                "status": "Ready",
+                "title": "t",
+                "url": "https://tracker.test/ACME-11",
+                "project_name": "no-such-project",
+                "labels": [],
+                "assignee_email": None,
+                "assignee_name": None,
+            }
+        )
+
+    assert result is None
+    assert not started
+    assert any("no routable repo" in record.getMessage() for record in caplog.records)
 
 
 def test_update_clears_nullable_with_none_and_skips_omitted(druks_db) -> None:

--- a/backend/tests/ship/test_build_workspace.py
+++ b/backend/tests/ship/test_build_workspace.py
@@ -78,7 +78,7 @@ def _workspace_kwargs_stubs(monkeypatch: pytest.MonkeyPatch, *, review_actor):
     monkeypatch.setattr(host_mod.Sandbox, "exec", fake_exec)
     monkeypatch.setattr(
         "druks.contrib.ship.workflows.get_github_client",
-        lambda _s: SimpleNamespace(token_for_repo=_token),
+        lambda: SimpleNamespace(token_for_repo=_token),
     )
     monkeypatch.setattr("druks.contrib.ship.workflows.get_review_actor", review_actor)
     monkeypatch.setattr("druks.sandbox.repo.ensure", fake_ensure)

--- a/backend/tests/ship/test_extension_config.py
+++ b/backend/tests/ship/test_extension_config.py
@@ -57,7 +57,7 @@ class TestFetchFile:
     def _wire(self, monkeypatch, tmp_path, github):
         settings = make_settings(tmp_path)
         monkeypatch.setattr("druks.extensions.fetcher.load_settings", lambda: settings)
-        monkeypatch.setattr("druks.extensions.fetcher.get_github_client", lambda _settings: github)
+        monkeypatch.setattr("druks.extensions.fetcher.get_github_client", lambda: github)
 
     async def test_404_is_cached_as_empty(self, monkeypatch, tmp_path):
         from druks.extensions.fetcher import fetch_file

--- a/backend/tests/ship/test_profiling.py
+++ b/backend/tests/ship/test_profiling.py
@@ -4,6 +4,8 @@ from druks.contrib.ship.models import Project, ProjectRepo
 from druks.contrib.ship.policy import RepoPolicy, VerificationProfile
 from druks.contrib.ship.workflows import Profile
 from druks.durable.engine import configure_engine
+from druks.service_identities.exceptions import ServiceNotConnectedError
+from druks.service_identities.models import ServiceIdentity
 from druks.skills.datastructures import InstalledSkill
 from druks.skills.models import SkillCollection
 
@@ -64,6 +66,11 @@ async def _no_policy(repo):
 
 @pytest.mark.parametrize("refresh_only", [False, True])
 async def test_dispatch_shapes_the_profile_start(druks_db, monkeypatch, refresh_only):
+    ServiceIdentity.connect(
+        "github",
+        identity={"app_id": "1", "slug": "druks-operator"},
+        secrets={"private_key": "operator-pem", "webhook_secret": "hook-secret"},
+    )
     repo = _seed_repo()
     calls: list[dict] = []
 
@@ -77,6 +84,18 @@ async def test_dispatch_shapes_the_profile_start(druks_db, monkeypatch, refresh_
 
     assert run_id == "profile-run"
     assert calls == [{"subject": repo, "repo_id": repo.id, "refresh_only": refresh_only}]
+
+
+async def test_dispatch_refuses_before_start_without_github(druks_db, monkeypatch):
+    repo = _seed_repo()
+
+    async def _start(cls, **kwargs):
+        raise AssertionError("start must not be reached without a GitHub identity")
+
+    monkeypatch.setattr(Profile, "start", classmethod(_start))
+
+    with pytest.raises(ServiceNotConnectedError, match="github is not connected"):
+        await Profile.dispatch(repo)
 
 
 class TestProfileRun:

--- a/backend/tests/ship/test_project_repo_routes.py
+++ b/backend/tests/ship/test_project_repo_routes.py
@@ -47,6 +47,19 @@ def test_adding_a_repo_dispatches_a_profile_run(client: TestClient, monkeypatch)
     assert repo["profile"] == {}
 
 
+def test_adding_a_repo_survives_when_github_is_not_connected(client: TestClient):
+    # Registering a repo is metadata; a missing GitHub identity defers profiling
+    # but must not discard the repo — a rollback would 500 and lose it.
+    project = client.post("/api/ship/projects", json={"name": "Acme"}).json()
+    response = client.post(
+        f"/api/ship/projects/{project['id']}/repos",
+        json={"fullName": "acme/widget"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["fullName"] == "acme/widget"
+
+
 def test_profile_endpoint_dispatches(client: TestClient, monkeypatch):
     # Concurrency is the Profile workflow's subject-unique lock, not the route's
     # job — the route always dispatches and start() dedups against a live run.

--- a/backend/tests/ship/test_webhooks_jira.py
+++ b/backend/tests/ship/test_webhooks_jira.py
@@ -7,6 +7,7 @@ from druks.contrib.ship import webhooks as webhook_module
 from druks.contrib.ship.extension import Ship
 from druks.contrib.ship.webhooks import JiraEvents
 from druks.contrib.ship.workflows import Build
+from druks.service_identities.models import ServiceIdentity
 from druks.testing import make_settings, seed_run
 from druks.webhooks.router import router as webhooks_router
 from fastapi import HTTPException
@@ -183,6 +184,11 @@ async def test_trigger_status_does_not_redispatch_a_merged_item(druks_db, monkey
 
 
 async def test_trigger_status_redispatches_a_closed_item(druks_db, monkeypatch):
+    ServiceIdentity.connect(
+        "github",
+        identity={"app_id": "1", "slug": "druks-operator"},
+        secrets={"private_key": "operator-pem", "webhook_secret": "hook-secret"},
+    )
     item = make_test_work_item(
         repo="octo/alfred",
         source="jira",

--- a/backend/tests/ship/test_webhooks_pull_request.py
+++ b/backend/tests/ship/test_webhooks_pull_request.py
@@ -292,7 +292,7 @@ async def test_external_close_honors_delete_branch_policy(druks_db, tmp_path, mo
         deleted.append((repo, branch))
 
     monkeypatch.setattr(
-        build_models, "get_github_client", lambda settings: SimpleNamespace(delete_branch=_record)
+        build_models, "get_github_client", lambda: SimpleNamespace(delete_branch=_record)
     )
 
     repo, pr_number, branch = "ClawHaven/acme-app", 93, "agent/eng-22"
@@ -315,7 +315,7 @@ async def test_external_close_deletes_branch_by_default(druks_db, tmp_path, monk
         deleted.append((repo, branch))
 
     monkeypatch.setattr(
-        build_models, "get_github_client", lambda settings: SimpleNamespace(delete_branch=_record)
+        build_models, "get_github_client", lambda: SimpleNamespace(delete_branch=_record)
     )
 
     repo, pr_number, branch = "ClawHaven/acme-app", 94, "agent/eng-23"
@@ -347,7 +347,7 @@ async def test_external_close_survives_policy_resolution_failure(druks_db, tmp_p
         deleted.append((repo, branch))
 
     monkeypatch.setattr(
-        build_models, "get_github_client", lambda settings: SimpleNamespace(delete_branch=_delete)
+        build_models, "get_github_client", lambda: SimpleNamespace(delete_branch=_delete)
     )
 
     pushed = []

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -14,6 +14,7 @@ from druks.durable.dbos_state import workflow_status
 from druks.durable.models import AgentCall, Run
 from druks.durable.reads import read_transcript_chunk
 from druks.mcp.gateway import services
+from druks.service_identities.models import ServiceIdentity
 from druks.testing import configure_app_for_test, make_settings, seed_call, seed_run
 from druks_field_notes.models import Note
 from druks_field_notes.workflows import Summarize
@@ -48,6 +49,15 @@ def client(tmp_path: Path, druks_db, monkeypatch):
 def account(druks_db):
     # The account configure_app_for_test signs requests in as.
     return Account.get_or_create("op@example.com")
+
+
+def _connect_github() -> None:
+    # Start routes guard on the GitHub service identity before spending a run.
+    ServiceIdentity.connect(
+        "github",
+        identity={"app_id": "1", "slug": "druks-operator"},
+        secrets={"private_key": "operator-pem", "webhook_secret": "hook-secret"},
+    )
 
 
 @pytest.fixture
@@ -117,6 +127,7 @@ def test_openapi_pins_platform_and_extension_agent_routes(client: TestClient):
 def test_review_request_returns_the_run_id_start_hands_back(
     client: TestClient, account: Account, monkeypatch
 ):
+    _connect_github()
     project = Project.create(name="Acme")
     ProjectRepo.create(project_id=project.id, full_name="acme/app")
     live_run_id = "review-run-id"
@@ -250,6 +261,23 @@ def test_ship_start_does_not_acknowledge_a_tracker_failure(tmp_path, druks_db, m
 
     assert response.status_code == 500
     assert response.json() == {"error": "INTERNAL_ERROR", "detail": "Internal server error"}
+
+
+def test_review_request_refuses_when_github_is_not_connected(
+    client: TestClient, monkeypatch
+):
+    project = Project.create(name="Acme")
+    ProjectRepo.create(project_id=project.id, full_name="acme/app")
+
+    async def start(cls, **kwargs):
+        raise AssertionError("start must not be reached without a GitHub identity")
+
+    monkeypatch.setattr(PullRequestReview, "start", classmethod(start))
+
+    response = client.post("/api/review/reviews", json={"repo": "acme/app", "prNumber": 7})
+
+    assert response.status_code == 409
+    assert "not connected" in response.json()["detail"]
 
 
 def test_agent_routes_sit_behind_the_gate(tmp_path, druks_db):

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -241,6 +241,7 @@ def test_extensions_surface_build_agents_and_workflow_defaults(tmp_path: Path):
         "visibleWhenField": "",
         "visibleWhenValue": None,
         "secretSet": None,
+        "multiline": False,
         "overridden": False,
     }
 

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import httpx
 import pytest
 from druks import doctor
+from druks.database import db_session
+from druks.service_identities.models import ServiceIdentity
 from druks.testing import make_settings
 
 _SECRETS_KEY = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
@@ -13,155 +15,105 @@ def _named(results: list[doctor.CheckResult], name: str) -> doctor.CheckResult:
     return next(result for result in results if result.name == name)
 
 
-def test_webhook_secret_fails_on_placeholder(tmp_path: Path) -> None:
-    settings = make_settings(
-        tmp_path,
-        secrets={"webhook_secret": "change-me", "secrets_key": _SECRETS_KEY},
+@pytest.fixture
+def doctor_db(druks_db, monkeypatch: pytest.MonkeyPatch):
+    """Point doctor's one-off engines at the test transaction. Doctor's checks
+    remove their session from the ambient registry, so rebind the fixture's
+    afterwards for the teardown that still needs it."""
+    monkeypatch.setattr(doctor, "create_engine_from_url", lambda _url: druks_db.get_bind())
+    yield druks_db
+    db_session.registry.set(druks_db)
+
+
+def _connect_github(slug: str = "druks-operator") -> ServiceIdentity:
+    return ServiceIdentity.connect(
+        "github",
+        identity={"app_id": "12345", "slug": slug},
+        secrets={
+            "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----\n",
+            "webhook_secret": "hook-secret",
+        },
     )
 
-    result = doctor.check_webhook_secret(settings)
+
+def test_github_identity_fails_when_absent(tmp_path: Path, doctor_db) -> None:
+    result = doctor.check_github_identity(make_settings(tmp_path))
 
     assert not result.ok
-    assert "secrets.webhook_secret" in result.detail
+    assert "not connected" in result.detail
 
 
-def test_webhook_secret_passes_when_set(tmp_path: Path) -> None:
-    settings = make_settings(
-        tmp_path,
-        secrets={"webhook_secret": "a-real-secret", "secrets_key": _SECRETS_KEY},
-    )
+def test_github_identity_reports_the_connected_row(tmp_path: Path, doctor_db) -> None:
+    _connect_github()
 
-    result = doctor.check_webhook_secret(settings)
+    result = doctor.check_github_identity(make_settings(tmp_path))
 
     assert result.ok
+    assert "app_id=12345" in result.detail
+    assert "slug=druks-operator" in result.detail
 
 
-def test_installations_fails_without_app_creds(tmp_path: Path) -> None:
-    # No operator app configured → the client can't even be built; doctor
+def test_installations_fails_without_a_connected_identity(tmp_path: Path, doctor_db) -> None:
+    # No github row → the zero-argument client can't even be built; doctor
     # reports the failure instead of raising.
-    settings = make_settings(tmp_path)
-
-    result = doctor.check_installations(settings)
+    result = doctor.check_installations(make_settings(tmp_path))
 
     assert not result.ok
     assert "installations" in result.name
+    assert "not connected" in result.detail
 
 
-def test_installations_lists_accounts(tmp_path: Path, monkeypatch) -> None:
-    settings = make_settings(tmp_path)
-
+def test_installations_lists_accounts(tmp_path: Path, doctor_db, monkeypatch) -> None:
     class _FakeClient:
         async def list_installation_accounts(self):
             return ("clawhaven",)
 
-    monkeypatch.setattr("druks.doctor.get_github_client", lambda _s: _FakeClient())
+    monkeypatch.setattr("druks.doctor.get_github_client", lambda: _FakeClient())
 
-    result = doctor.check_installations(settings)
+    result = doctor.check_installations(make_settings(tmp_path))
 
     assert result.ok
     assert "clawhaven" in result.detail
 
 
-def test_installations_fails_when_app_has_none(tmp_path: Path, monkeypatch) -> None:
-    settings = make_settings(tmp_path)
-
+def test_installations_fails_when_app_has_none(tmp_path: Path, doctor_db, monkeypatch) -> None:
     class _FakeClient:
         async def list_installation_accounts(self):
             return ()
 
-    monkeypatch.setattr("druks.doctor.get_github_client", lambda _s: _FakeClient())
+    monkeypatch.setattr("druks.doctor.get_github_client", lambda: _FakeClient())
 
-    result = doctor.check_installations(settings)
+    result = doctor.check_installations(make_settings(tmp_path))
 
     assert not result.ok
     assert "no installations" in result.detail
 
 
-def test_github_app_fails_when_pem_missing(tmp_path: Path) -> None:
-    settings = make_settings(
-        tmp_path,
-        github={"operator_app_id": "12345"},
-        github_operator_private_key_path=None,
-    )
-
-    result = doctor.check_github_operator_app(settings)
-
-    assert not result.ok
-    assert "GITHUB_OPERATOR_PRIVATE_KEY_PATH" in result.detail
-
-
-def test_github_app_fails_when_pem_does_not_exist(tmp_path: Path) -> None:
-    settings = make_settings(
-        tmp_path,
-        github={"operator_app_id": "12345"},
-        github_operator_private_key_path=tmp_path / "missing.pem",
-    )
-
-    result = doctor.check_github_operator_app(settings)
-
-    assert not result.ok
-    assert "does not exist" in result.detail
-
-
-def test_github_app_fails_when_pem_is_not_a_key(tmp_path: Path) -> None:
-    pem_path = tmp_path / "fake.pem"
-    pem_path.write_text("not actually a PEM key\n")
-    settings = make_settings(
-        tmp_path,
-        github={"operator_app_id": "12345"},
-        github_operator_private_key_path=pem_path,
-    )
-
-    result = doctor.check_github_operator_app(settings)
-
-    assert not result.ok
-    assert "PEM" in result.detail
-
-
-def test_github_app_passes_when_live_mint_succeeds(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+def test_installations_builds_the_client_from_the_row(
+    tmp_path: Path, doctor_db, monkeypatch
 ) -> None:
-    pem_path = tmp_path / "real.pem"
-    pem_path.write_text("-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----\n")
+    # The real zero-argument factory resolves the row inside doctor's own
+    # bound session; the fake transport keeps GitHub out of it.
+    _connect_github()
 
-    async def fake_slug(*, app_id: str, private_key: str) -> str:
-        return "druks-operator"
+    class _FakeClient:
+        async def list_installation_accounts(self):
+            return ("clawhaven",)
 
-    monkeypatch.setattr(doctor, "_github_app_slug", fake_slug)
-    settings = make_settings(
-        tmp_path,
-        github={"operator_app_id": "12345"},
-        github_operator_private_key_path=pem_path,
-    )
+    real_factory = doctor.get_github_client
+    built: list[str] = []
 
-    result = doctor.check_github_operator_app(settings)
+    def _tracking_factory():
+        client = real_factory()
+        built.append(client._app_id)
+        return _FakeClient()
+
+    monkeypatch.setattr(doctor, "get_github_client", _tracking_factory)
+
+    result = doctor.check_installations(make_settings(tmp_path))
 
     assert result.ok
-    assert "druks-operator" in result.detail
-
-
-def test_github_app_fails_when_live_mint_raises(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    pem_path = tmp_path / "real.pem"
-    pem_path.write_text("-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----\n")
-
-    async def fake_slug(*, app_id: str, private_key: str) -> str:
-        raise RuntimeError("401 Unauthorized")
-
-    monkeypatch.setattr(doctor, "_github_app_slug", fake_slug)
-    settings = make_settings(
-        tmp_path,
-        github={"operator_app_id": "12345"},
-        github_operator_private_key_path=pem_path,
-    )
-
-    result = doctor.check_github_operator_app(settings)
-
-    assert not result.ok
-    assert "401" in result.detail
+    assert built == ["12345"]
 
 
 def test_data_dir_fails_when_missing(tmp_path: Path) -> None:
@@ -221,12 +173,11 @@ def test_run_checks_covers_all_check_names(tmp_path: Path) -> None:
 
     # Installed extensions contribute their own checks alongside the platform's.
     assert {result.name for result in results} >= {
-        "webhook_secret",
         "webhook_ingress",
+        "github_identity",
         "installations",
-        "github_operator_app",
-        "github_reviewer_app",
         "ship:settings",
+        "review:settings",
         "claude_credentials",
         "codex_credentials",
         "data_dir",

--- a/backend/tests/test_extension_doctor_checks.py
+++ b/backend/tests/test_extension_doctor_checks.py
@@ -79,6 +79,28 @@ def test_stored_incoherent_settings_fail_with_declared_field_titles(
     assert result.detail == ("Linear webhook secret: Required once the Linear API key is set.")
 
 
+def test_half_configured_review_identity_fails_through_review_settings(
+    installed, tmp_path: Path, druks_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Review identity health is Review's own: the incoherent pair fails under
+    # ``review:settings`` while the set/unset check stays healthy — no core
+    # doctor check hardcodes review knowledge, and no GitHub call is made.
+    SettingsOverride.set_extension_setting("review", "app_id", "42", is_secret=True)
+    monkeypatch.setattr(doctor, "create_engine_from_url", lambda _: druks_db.get_bind())
+
+    try:
+        results = doctor.check_extensions(make_settings(tmp_path))
+    finally:
+        db_session.registry.set(druks_db)
+
+    settings_result = _named(results, "review:settings")
+    assert not settings_result.ok
+    assert settings_result.detail == (
+        "Review App private key: Required once the review App ID is set."
+    )
+    assert _named(results, "review:identity").ok
+
+
 def test_coherent_stored_settings_pass(
     installed, tmp_path: Path, druks_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_proof_extension_install.py
+++ b/backend/tests/test_proof_extension_install.py
@@ -14,7 +14,12 @@ _CHECK = textwrap.dedent(
     extension = load_extension("field_notes")
     assert [subject.__name__ for subject in extension.subject_classes()] == ["Note"]
     assert extension.settings_model is not None
-    assert list(extension.settings_model.model_fields) == ["board_size", "visibility", "sync_token"]
+    assert list(extension.settings_model.model_fields) == [
+        "board_size",
+        "visibility",
+        "sync_signing_key",
+        "sync_token",
+    ]
     assert [workflow.__name__ for workflow in extension.workflows()] == ["Summarize"]
     assert {router.prefix for router in extension.routers()} >= {"/notes", "/note"}
     assert extension.migrations_dir() is not None

--- a/backend/tests/test_review.py
+++ b/backend/tests/test_review.py
@@ -4,11 +4,16 @@ from types import SimpleNamespace
 import pytest
 from druks.contrib.review import subscribers  # noqa: F401 — the import registers it
 from druks.contrib.review.datastructures import PullRequest
+from druks.contrib.review.extension import Review, check_review_identity
 from druks.contrib.review.github import get_review_actor
 from druks.contrib.review.workflows import PullRequestReview
+from druks.extensions.settings import field_kind, field_multiline
 from druks.prompts import render_prompt
+from druks.service_identities.exceptions import ServiceNotConnectedError
+from druks.service_identities.models import ServiceIdentity
 from druks.signals import publish
 from druks.testing import configure_app_for_test, make_settings, seed_run
+from druks.user_settings.models import SettingsOverride
 from druks.workflows import _bind_instance
 from fastapi.testclient import TestClient
 
@@ -125,30 +130,113 @@ async def test_comment_mode_reviews_publish_as_comments():
     assert "`COMMENT` event" in output
 
 
-def test_a_configured_review_identity_approves(tmp_path: Path, monkeypatch):
-    pem = tmp_path / "review.pem"
-    pem.write_text("test-key")
-    settings = make_settings(
-        tmp_path,
-        github={"operator_app_id": "1", "reviewer_app_id": "2"},
-        github_reviewer_private_key_path=pem,
+def _connect_operator() -> None:
+    ServiceIdentity.connect(
+        "github",
+        identity={"app_id": "1", "slug": "druks-operator"},
+        secrets={"private_key": "operator-pem", "webhook_secret": "hook-secret"},
     )
-    monkeypatch.setattr("druks.contrib.review.github.load_settings", lambda: settings)
-
-    assert get_review_actor().mode == "approve"
 
 
-def test_an_unset_review_identity_means_comment_mode(tmp_path: Path, monkeypatch):
-    pem = tmp_path / "operator.pem"
-    pem.write_text("test-key")
-    settings = make_settings(
-        tmp_path,
-        github={"operator_app_id": "1"},
-        github_operator_private_key_path=pem,
+def _set_review_setting(field: str, value: str) -> None:
+    SettingsOverride.set_extension_setting("review", field, value, is_secret=True)
+
+
+def test_a_configured_review_identity_approves(druks_db):
+    _set_review_setting("app_id", "2")
+    _set_review_setting("private_key", "review-pem\nline-two")
+
+    actor = get_review_actor()
+
+    assert actor.mode == "approve"
+    assert actor.client._app_id == "2"
+
+
+def test_an_unset_review_identity_borrows_the_operator_in_comment_mode(druks_db):
+    _connect_operator()
+
+    actor = get_review_actor()
+
+    assert actor.mode == "comment"
+    assert actor.client._app_id == "1"
+
+
+def test_a_half_configured_review_identity_still_borrows_the_operator(druks_db):
+    # Only a complete pair selects the distinct client; app_id alone is the
+    # incoherent state clean() flags, not a mode switch.
+    _connect_operator()
+    _set_review_setting("app_id", "2")
+
+    actor = get_review_actor()
+
+    assert actor.mode == "comment"
+    assert actor.client._app_id == "1"
+
+
+def test_review_settings_reject_a_half_configured_pair():
+    assert Review.Settings(app_id="2").clean() == {
+        "private_key": "Required once the review App ID is set."
+    }
+    assert Review.Settings(private_key="review-pem").clean() == {
+        "app_id": "Required once the review App private key is set."
+    }
+    assert Review.Settings().clean() == {}
+    assert Review.Settings(app_id="2", private_key="review-pem").clean() == {}
+
+
+def test_the_review_pem_declares_the_multiline_secret_presentation():
+    field = Review.Settings.model_fields["private_key"]
+
+    assert field_kind(field) == "secret"
+    assert field_multiline(field)
+    assert not field_multiline(Review.Settings.model_fields["app_id"])
+
+
+def test_review_identity_check_is_healthy_set_or_unset(druks_db):
+    assert check_review_identity().ok
+    assert "unset" in check_review_identity().detail
+
+    _set_review_setting("app_id", "2")
+    _set_review_setting("private_key", "review-pem")
+
+    result = check_review_identity()
+    assert result.ok
+    assert "distinct App" in result.detail
+
+
+async def test_review_dispatch_refuses_before_start_without_github(druks_db, monkeypatch):
+    started = []
+
+    async def _start(cls, **kwargs):
+        started.append(kwargs)
+        return "run-review"
+
+    monkeypatch.setattr(PullRequestReview, "start", classmethod(_start))
+
+    with pytest.raises(ServiceNotConnectedError, match="github is not connected"):
+        await PullRequestReview.dispatch(
+            repo="acme/app", pr_number=7, requested_by="dev@example.com"
+        )
+
+    assert not started
+
+
+async def test_review_dispatch_starts_once_github_is_connected(druks_db, monkeypatch):
+    _connect_operator()
+    started = []
+
+    async def _start(cls, **kwargs):
+        started.append(kwargs)
+        return "run-review"
+
+    monkeypatch.setattr(PullRequestReview, "start", classmethod(_start))
+
+    run_id = await PullRequestReview.dispatch(
+        repo="acme/app", pr_number=7, requested_by="dev@example.com"
     )
-    monkeypatch.setattr("druks.contrib.review.github.load_settings", lambda: settings)
 
-    assert get_review_actor().mode == "comment"
+    assert run_id == "run-review"
+    assert len(started) == 1
 
 
 async def test_a_passer_by_cannot_spend_a_review(monkeypatch):

--- a/backend/tests/test_service_identities.py
+++ b/backend/tests/test_service_identities.py
@@ -1,0 +1,227 @@
+import hashlib
+import hmac
+from types import SimpleNamespace
+
+import pytest
+from druks.core.apis.github import GitHubClient, get_github_client
+from druks.core.webhooks.github import GitHubEvents
+from druks.service_identities.exceptions import ServiceNotConnectedError
+from druks.service_identities.models import ServiceIdentity
+from druks.testing import make_settings
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+_PEM = "-----BEGIN RSA PRIVATE KEY-----\nline-one\nline-two\n-----END RSA PRIVATE KEY-----\n"
+_SECRET = "hook-secret-value"
+
+
+def _connect(
+    *, app_id="12345", slug="druks-operator", private_key=_PEM, webhook_secret=_SECRET
+) -> ServiceIdentity:
+    return ServiceIdentity.connect(
+        "github",
+        identity={"app_id": app_id, "slug": slug},
+        secrets={"private_key": private_key, "webhook_secret": webhook_secret},
+    )
+
+
+# --- The row (AC1) ----------------------------------------------------------
+
+
+def test_secrets_round_trip_and_rest_is_ciphertext(druks_db):
+    _connect()
+    druks_db.expire_all()
+
+    row = ServiceIdentity.get("github")
+    assert row.identity["app_id"] == "12345"
+    assert row.identity["slug"] == "druks-operator"
+    assert row.connected_at is not None
+    assert row.secrets["private_key"] == _PEM
+    assert row.secrets["webhook_secret"] == _SECRET
+
+    stored = druks_db.execute(text("SELECT secrets FROM service_identities")).scalar_one()
+    assert _PEM.encode() not in bytes(stored)
+    assert _SECRET.encode() not in bytes(stored)
+
+
+def test_connect_replaces_the_single_github_row(druks_db):
+    _connect()
+    _connect(app_id="777", slug="new-slug", private_key="new-pem", webhook_secret="new-secret")
+    druks_db.expire_all()
+
+    count = druks_db.execute(text("SELECT count(*) FROM service_identities")).scalar_one()
+    assert count == 1
+    row = ServiceIdentity.get("github")
+    assert row.identity["app_id"] == "777"
+    assert row.identity["slug"] == "new-slug"
+    assert row.secrets["private_key"] == "new-pem"
+    assert row.secrets["webhook_secret"] == "new-secret"
+
+
+def test_get_raises_when_the_service_is_not_connected(druks_db):
+    with pytest.raises(ServiceNotConnectedError, match="github is not connected"):
+        ServiceIdentity.get("github")
+
+
+# --- The zero-argument client factory (AC3) ---------------------------------
+
+
+def test_client_factory_resolves_only_the_row(druks_db):
+    _connect()
+
+    client = get_github_client()
+
+    assert client._app_id == "12345"
+    assert client._private_key == _PEM
+    assert client._slug == "druks-operator"
+
+
+async def test_mention_handle_is_the_stored_slug(druks_db):
+    # No transport stub: a refetch would ask GitHub and fail loudly here.
+    _connect()
+
+    assert await get_github_client().get_mention_handle() == "druks-operator"
+
+
+def test_client_factory_raises_the_typed_error_when_absent(druks_db):
+    with pytest.raises(ServiceNotConnectedError):
+        get_github_client()
+
+
+# --- Webhook verification (AC4) ---------------------------------------------
+
+
+def _events(body: bytes, signature: str | None, tmp_path) -> GitHubEvents:
+    headers = {}
+    if signature is not None:
+        headers["x-hub-signature-256"] = signature
+    events = GitHubEvents(
+        request=SimpleNamespace(headers=headers),  # type: ignore[arg-type]
+        kwargs={},
+        settings=make_settings(tmp_path),
+    )
+    events.raw_body = body
+    return events
+
+
+def test_webhook_accepts_the_row_secrets_signature(druks_db, tmp_path):
+    _connect()
+    body = b'{"hello":"world"}'
+    signature = "sha256=" + hmac.new(_SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+    assert _events(body, signature, tmp_path).request_is_authentic()
+
+
+def test_webhook_rejects_a_mismatched_signature(druks_db, tmp_path):
+    _connect()
+
+    with pytest.raises(HTTPException) as raised:
+        _events(b"{}", "sha256=bogus", tmp_path).request_is_authentic()
+
+    assert raised.value.status_code == 401
+
+
+def test_webhook_rejects_a_missing_identity_before_dispatch(druks_db, tmp_path):
+    with pytest.raises(HTTPException) as raised:
+        _events(b"{}", "sha256=anything", tmp_path).request_is_authentic()
+
+    assert raised.value.status_code == 401
+    assert "not connected" in raised.value.detail
+
+
+# --- The identity-gated API (AC2) -------------------------------------------
+
+
+def _mock_authenticated_app(monkeypatch, slug: str = "druks-operator") -> None:
+    async def _slug(self) -> str:
+        return slug
+
+    monkeypatch.setattr(GitHubClient, "get_authenticated_app_slug", _slug)
+
+
+def test_get_reports_disconnected_state(druks_client: TestClient):
+    body = druks_client.get("/api/service-identities/github").json()
+
+    assert body == {"connected": False, "appId": None, "slug": None, "connectedAt": None}
+
+
+def test_post_authenticates_then_creates_the_row(druks_client: TestClient, druks_db, monkeypatch):
+    _mock_authenticated_app(monkeypatch)
+
+    response = druks_client.post(
+        "/api/service-identities/github",
+        json={"appId": "12345", "privateKey": _PEM, "webhookSecret": _SECRET},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["connected"] is True
+    assert body["appId"] == "12345"
+    assert body["slug"] == "druks-operator"
+    # No response carries either pasted secret.
+    assert _PEM not in response.text
+    assert _SECRET not in response.text
+
+    connected = druks_client.get("/api/service-identities/github").json()
+    assert connected["connected"] is True
+    assert connected["slug"] == "druks-operator"
+
+
+def test_post_replaces_an_existing_row(druks_client: TestClient, druks_db, monkeypatch):
+    _connect()
+    _mock_authenticated_app(monkeypatch, slug="replacement-app")
+
+    response = druks_client.post(
+        "/api/service-identities/github",
+        json={"appId": "777", "privateKey": "new-pem", "webhookSecret": "new-secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["appId"] == "777"
+    assert response.json()["slug"] == "replacement-app"
+
+
+def test_invalid_credentials_preserve_the_previous_row(
+    druks_client: TestClient, druks_db, monkeypatch
+):
+    _connect()
+
+    async def _rejected(self) -> str:
+        raise RuntimeError("boom-marker bad credentials")
+
+    monkeypatch.setattr(GitHubClient, "get_authenticated_app_slug", _rejected)
+
+    response = druks_client.post(
+        "/api/service-identities/github",
+        json={"appId": "999", "privateKey": "bad-pem", "webhookSecret": "bad-secret"},
+    )
+
+    assert response.status_code == 422
+    assert "credentials" in response.json()["detail"]
+    # The failure detail never echoes the submitted values or the raw error.
+    assert "boom-marker" not in response.text
+    assert "bad-pem" not in response.text
+
+    druks_db.expire_all()
+    row = ServiceIdentity.get("github")
+    assert row.identity["app_id"] == "12345"
+    assert row.secrets["private_key"] == _PEM
+
+
+def test_blank_fields_are_rejected_without_touching_github(
+    druks_client: TestClient, druks_db, monkeypatch
+):
+    async def _never(self) -> str:
+        raise AssertionError("blank fields must not reach GitHub")
+
+    monkeypatch.setattr(GitHubClient, "get_authenticated_app_slug", _never)
+
+    response = druks_client.post(
+        "/api/service-identities/github",
+        json={"appId": " ", "privateKey": "", "webhookSecret": ""},
+    )
+
+    assert response.status_code == 422
+    with pytest.raises(ServiceNotConnectedError):
+        ServiceIdentity.get("github")

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -63,16 +63,11 @@ def test_toml_populates_authored_submodels(tmp_path, monkeypatch):
 mode = "header"
 header = "X-Edge-Email"
 
-[github]
-operator_app_id = "123"
-reviewer_app_id = "456"
-
 [urls]
 endpoint = "https://druks.example.com"
 webhook_host = "hooks.example.com"
 
 [secrets]
-webhook_secret = "webhook-secret"
 secrets_key = "{_SECRETS_KEY}"
 
 [sandbox]
@@ -89,11 +84,8 @@ timeout = 180
 
     assert settings.identity.mode == "header"
     assert settings.identity.header == "X-Edge-Email"
-    assert settings.github.operator_app_id == "123"
-    assert settings.github.reviewer_app_id == "456"
     assert settings.urls.endpoint == "https://druks.example.com"
     assert settings.urls.webhook_host == "hooks.example.com"
-    assert settings.secrets.webhook_secret == "webhook-secret"
     assert settings.secrets.secrets_key == _SECRETS_KEY
     assert settings.sandbox.service_token == "sandbox-token"
     assert settings.sandbox.service_url == "https://sandbox.example.com"

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -456,7 +456,6 @@ def test_setup_toml_is_the_settings_source(tmp_path, monkeypatch):
 
     assert settings.identity.model_dump() == config["identity"]
     assert settings.urls.model_dump() == config["urls"]
-    assert settings.secrets.webhook_secret == config["secrets"]["webhook_secret"]
     assert settings.secrets.secrets_key == config["secrets"]["secrets_key"]
     assert settings.sandbox.service_token == config["sandbox"]["service_token"]
     assert settings.sandbox.service_url == config["sandbox"]["service_url"]

--- a/backend/tests/test_user_settings.py
+++ b/backend/tests/test_user_settings.py
@@ -62,6 +62,7 @@ class _Declared(BaseModel):
     # Optional so an unset secret resolves to None — a plain SecretStr with a length
     # floor and an empty default couldn't satisfy its own constraint.
     secret: SecretStr | None = Field(default=None, min_length=8)
+    pasted_key: SecretStr | None = Field(default=None, json_schema_extra={"multiline": True})
 
     @field_validator("secret")
     @classmethod
@@ -117,6 +118,19 @@ def test_secret_field_redacts_value_and_default_and_reports_set():
     assert setted["value"] is None
     assert setted["secretSet"] is True
     assert "sk-raw" not in str(setted)
+
+
+def test_multiline_projects_only_where_declared():
+    # A pasted-PEM secret opts into the textarea; everything else stays a
+    # one-line control. Redaction is unchanged by the presentation flag.
+    projected = _field("pasted_key", value="-----BEGIN KEY-----\nbody\n-----END KEY-----")
+    assert projected["type"] == "secret"
+    assert projected["multiline"] is True
+    assert projected["value"] is None
+    assert projected["secretSet"] is True
+
+    assert _field("secret", value="")["multiline"] is False
+    assert _field("label", value="hi")["multiline"] is False
 
 
 def test_optional_secret_is_still_treated_as_a_secret():

--- a/backend/tests/test_webhooks_framework.py
+++ b/backend/tests/test_webhooks_framework.py
@@ -32,7 +32,6 @@ def settings(tmp_path) -> Settings:
     return Settings(
         data_dir=tmp_path,
         secrets={
-            "webhook_secret": "test-secret",
             "secrets_key": "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=",
         },
     )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,8 +6,8 @@ without replacing the process.
 
 | Plane | Examples | Stored in |
 | --- | --- | --- |
-| Deployment | identity, ingress, GitHub App keys, Drukbox, encryption key | `~/druks/druks.toml` |
-| Dashboard | timezone, harness and tracker credentials, workflow and agent overrides, notifications, MCP servers, skills | Postgres |
+| Deployment | identity, ingress, Drukbox, encryption key | `~/druks/druks.toml` |
+| Dashboard | timezone, the GitHub connection, harness and tracker credentials, workflow and agent overrides, notifications, MCP servers, skills | Postgres |
 
 The installer renders the complete deployment `.env` from `druks.toml`; `.env`
 is a build artifact consumed by Compose, Druks, and Drukbox, not an authored
@@ -32,7 +32,6 @@ host-run development template for that environment plane.
 | Table | Purpose |
 | --- | --- |
 | `[identity]` | Browser identity mode and header or JWT verification inputs |
-| `[github]` | Operator and reviewer App ids and host PEM paths |
 | `[urls]` | Dashboard callback base URL and public webhook hostname |
 | `[secrets]` | Generated deployment secrets |
 | `[paths]` | Host data and harness configuration paths |
@@ -78,7 +77,6 @@ caches, and the sandbox provisioning gate.
 | --- | --- |
 | `urls.endpoint` | Browser-visible dashboard base URL used to build MCP OAuth callbacks |
 | `urls.webhook_host` | Public webhook hostname used by `druks doctor` for its ingress probe |
-| `secrets.webhook_secret` | Shared HMAC secret used by the GitHub webhook integration |
 | `identity.mode` | `none` (default; no authentication, single operator), `header` (edge-asserted identity), or `jwt` (edge-signed assertion, verified) |
 | `identity.header` | The trusted identity header; rendered for the shipped Caddy edge too. No default — header and jwt modes refuse to start without it |
 | `identity.jwks_url` | `jwt` mode: where the edge publishes its signing keys |
@@ -159,39 +157,21 @@ to identify it) and mint a replacement — rotation is mint first, revoke
 second. Agents consume the API through the MCP endpoint; see
 [Connect your agent](connect-your-agent.md).
 
-## GitHub Apps
+## GitHub
 
-The bundled `ship` extension requires two GitHub Apps. These are application
-requirements, not requirements of the Druks extension mechanism itself.
+Druks acts at GitHub as one **operator App** — its service identity. The App
+receives webhooks and performs application-owned writes such as branches,
+pull requests, comments, labels, and merges. Its credentials live encrypted
+in Postgres, pasted in from **Settings → Harnesses → Connect GitHub**: the
+App ID, the PEM private key exactly as GitHub issued it, and the webhook
+secret. Connecting validates the pasted credentials against GitHub and stores
+the App's slug; from then on every operator client resolves from that row and
+webhook deliveries verify against its stored secret. There is no TOML,
+environment, or PEM-file source — until GitHub is connected, agent runs
+refuse with a pointed message and `druks doctor` reports the identity as not
+connected.
 
-- **Operator app:** receives webhooks and performs application-owned writes
-  such as branches, pull requests, comments, labels, and merges.
-- **Reviewer app:** submits reviews through a distinct GitHub identity.
-
-Personal access tokens are not a supported substitute. Install both Apps on
-the same repositories; that installation set is where `ship` may act.
-
-The fast path is:
-
-```bash
-cd ~/druks
-bash <(curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh) --apps
-```
-
-This uses the GitHub manifest files under
-[`scripts/manifests/`](../scripts/manifests) and writes the returned App ids,
-PEMs, and webhook secret into the install through `druks setup`.
-
-### Operator app
-
-```toml
-[github]
-operator_app_id = "123456"
-operator_pem = "secrets/operator.pem"
-
-[secrets]
-webhook_secret = "<same secret configured on the app webhook>"
-```
+Registering the App by hand:
 
 Webhook URL:
 `https://<webhook-host>/_external/github/events/`
@@ -207,21 +187,28 @@ Subscribe to issue comment, pull request, pull request review, and push events.
 | Checks | Read |
 | Commit statuses | Read |
 
-### Reviewer app
+Install the App on the repositories Druks should work in; that installation
+set is where `ship` may act. Personal access tokens are not a supported
+substitute.
 
-```toml
-[github]
-reviewer_app_id = "123457"
-reviewer_pem = "secrets/reviewer.pem"
-```
+**Upgrading an existing installation** is a one-time paste on each live box
+after rollout: open Settings → Harnesses and connect GitHub with the existing
+operator App's ID, private key, and webhook secret. Do not create a
+replacement App — the current App's webhook and installations keep working
+under the pasted credentials.
 
-It needs read access to metadata and contents and read/write access to pull
-requests. It does not need a webhook.
+### Review identity (optional)
 
-`GITHUB_API_URL` defaults to `https://api.github.com` and can point both clients
-at another compatible GitHub API endpoint.
-Compose pins `GITHUB_OPERATOR_PRIVATE_KEY_PATH` and
-`GITHUB_REVIEWER_PRIVATE_KEY_PATH` to the mounted in-container PEM paths.
+The bundled `review` extension can post its verdict reviews as a second
+GitHub App, so GitHub accepts approvals on Druks-authored pull requests.
+Configure it in **Settings → Review**: the review App ID and its PEM private
+key, both stored encrypted and empty-as-unset. Leave the pair empty and
+reviews publish as operator comments; setting both flips reviews to distinct
+approving reviews. The review App needs read access to metadata and contents,
+read/write access to pull requests, and no webhook.
+
+`GITHUB_API_URL` defaults to `https://api.github.com` and can point every
+client at another compatible GitHub API endpoint.
 
 ## Ticketing integrations
 
@@ -328,7 +315,8 @@ per-agent capability manifest records the delivered set.
 
 ## Credential custody and secrets at rest
 
-`secrets.secrets_key` encrypts MCP tokens and OAuth grants with AES-256-GCM.
+`secrets.secrets_key` encrypts MCP tokens, OAuth grants, and the GitHub
+service identity's private key and webhook secret with AES-256-GCM.
 Each database column supplies authenticated associated data, and each value
 gets a derived encryption key. The setting is one or more comma-separated,
 base64-encoded 32-byte master keys:
@@ -353,4 +341,5 @@ The encryption envelope does **not** currently cover tracker extension settings,
 harness subscription payloads, or notification webhook URLs. They are stored as
 ordinary Postgres fields, although APIs withhold or mask their values. Treat
 access to Postgres and its backups as access to those credentials. GitHub App
-private keys remain files mounted into the process rather than database values.
+private keys — the operator identity's and the review extension's — are
+database values under the envelope, no longer files mounted into the process.

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -647,7 +647,11 @@ Supported display shapes are scalar values, `Literal` choices, and
 Secret values and submitted validation errors are redacted. Declare a secret
 field as `Secret`: an unset one is an empty, falsy `SecretStr`, so
 `if self.service_token:` reads set-ness and `.get_secret_value()` never needs
-a guard. `section` is a plain heading rendered in first-declaration order, with
+a guard. A secret whose pasted value carries meaningful newlines — a PEM
+private key — may declare `json_schema_extra={"multiline": True}`: the
+settings form renders a textarea and the paste keeps its newlines; storage,
+redaction, and write-only semantics are unchanged. `section` is a plain
+heading rendered in first-declaration order, with
 unsectioned fields first. `visible_when` takes one same-model `{field: value}`
 equality condition. Its controller must be non-secret and unconditional, and a
 `Literal` controller requires one of its declared members.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,9 +3,11 @@ import type {
   AgentCallFiles,
   ArtifactContent,
   ConnectChallenge,
+  ConnectGitHubRequest,
   DashboardHealth,
   FeedResponse,
   ExtensionsSettingsResponse,
+  GitHubServiceIdentity,
   Harness,
   Identity,
   Pat,
@@ -214,6 +216,11 @@ export const api = {
     }),
   disconnectHarness: (name: string) =>
     deleteJSON<Harness>(`/api/harnesses/${encodeURIComponent(name)}/connection`),
+  // The appliance's own GitHub App identity — connect validates the pasted
+  // credentials against GitHub before anything replaces a working identity.
+  githubIdentity: () => getJSON<GitHubServiceIdentity>('/api/service-identities/github'),
+  connectGithubIdentity: (body: ConnectGitHubRequest) =>
+    postJSON<GitHubServiceIdentity>('/api/service-identities/github', body),
   getExtensionSettings: () => getJSON<ExtensionsSettingsResponse>('/api/settings/extensions'),
   updateExtensionSettings: (body: UpdateExtensionsSettingsRequest) =>
     patchJSON<ExtensionsSettingsResponse>('/api/settings/extensions', body),

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -258,6 +258,22 @@ export interface UpdateHarnessRequest {
   timeout?: number
 }
 
+/** The appliance's own GitHub App connection state — identity facts only;
+ * the stored PEM and webhook secret never leave the backend. */
+export interface GitHubServiceIdentity {
+  connected: boolean
+  appId: string | null
+  slug: string | null
+  connectedAt: string | null
+}
+
+export interface ConnectGitHubRequest {
+  appId: string
+  /** Pasted PEM private key — newlines are meaningful and preserved. */
+  privateKey: string
+  webhookSecret: string
+}
+
 // --- Settings --------------------------------------------------------------
 
 export interface UserSettings {
@@ -310,6 +326,8 @@ export interface WorkflowSettingField {
   visibleWhenValue: unknown
   /** For a secret field, whether a value is currently stored; null otherwise. */
   secretSet: boolean | null
+  /** The value carries meaningful newlines (a pasted PEM) — render a textarea. */
+  multiline: boolean
   overridden: boolean
 }
 

--- a/frontend/src/components/GitHubConnectCard.test.tsx
+++ b/frontend/src/components/GitHubConnectCard.test.tsx
@@ -1,0 +1,138 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { GitHubServiceIdentity } from '../api/types'
+import { GitHubConnectCard } from './SettingsModal'
+
+const PEM = '-----BEGIN RSA PRIVATE KEY-----\nline-one\nline-two\n-----END RSA PRIVATE KEY-----'
+const SECRET = 'hook-secret-value'
+
+const disconnected: GitHubServiceIdentity = {
+  connected: false,
+  appId: null,
+  slug: null,
+  connectedAt: null,
+}
+
+const connected: GitHubServiceIdentity = {
+  connected: true,
+  appId: '12345',
+  slug: 'druks-operator',
+  connectedAt: '2026-08-09T00:00:00Z',
+}
+
+function stubFetch(states: GitHubServiceIdentity[]) {
+  // GET serves the states in order (post-connect refetch sees the next one);
+  // POST answers with the connected shape.
+  const gets = [...states]
+  const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+    async (url, init) => {
+      if (url === '/api/service-identities/github' && init?.method === 'POST') {
+        return new Response(JSON.stringify(connected), { status: 200 })
+      }
+      if (url === '/api/service-identities/github') {
+        const state = gets.length > 1 ? gets.shift() : gets[0]
+        return new Response(JSON.stringify(state), { status: 200 })
+      }
+      return new Response('{}', { status: 404 })
+    },
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+function renderCard() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <GitHubConnectCard />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+describe('GitHubConnectCard', () => {
+  it('renders the disconnected paste-in form', async () => {
+    stubFetch([disconnected])
+    renderCard()
+
+    expect(await screen.findByText('not connected')).toBeTruthy()
+    expect(await screen.findByLabelText('App ID')).toBeTruthy()
+    expect(screen.getByLabelText('Private key (PEM)')).toBeTruthy()
+    expect(screen.getByLabelText('Webhook secret')).toBeTruthy()
+  })
+
+  it('submits all three values, keeps PEM newlines, and refreshes to the connected facts', async () => {
+    const fetchMock = stubFetch([disconnected, connected])
+    renderCard()
+
+    fireEvent.change(await screen.findByLabelText('App ID'), { target: { value: '12345' } })
+    fireEvent.change(screen.getByLabelText('Private key (PEM)'), { target: { value: PEM } })
+    fireEvent.change(screen.getByLabelText('Webhook secret'), { target: { value: SECRET } })
+    fireEvent.click(screen.getByText('Connect GitHub'))
+    await flush()
+    await flush()
+
+    const post = fetchMock.mock.calls.find(
+      ([url, init]) => url === '/api/service-identities/github' && init?.method === 'POST',
+    )
+    expect(JSON.parse(String(post?.[1]?.body))).toEqual({
+      appId: '12345',
+      privateKey: PEM,
+      webhookSecret: SECRET,
+    })
+
+    // The refreshed connected response renders identity facts only — the
+    // submitted secrets are nowhere in the connected UI.
+    expect(await screen.findByText(/connected · druks-operator/)).toBeTruthy()
+    expect(document.body.textContent).not.toContain('line-one')
+    expect(document.body.textContent).not.toContain(SECRET)
+    expect(screen.queryByLabelText('Private key (PEM)')).toBeNull()
+  })
+
+  it('keeps a rejected paste out of the row and shows the error', async () => {
+    const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async (url, init) => {
+        if (url === '/api/service-identities/github' && init?.method === 'POST') {
+          return new Response(
+            JSON.stringify({ detail: 'GitHub did not accept these credentials — check the App ID and PEM private key.' }),
+            { status: 422, statusText: 'Unprocessable Entity' },
+          )
+        }
+        return new Response(JSON.stringify(disconnected), { status: 200 })
+      },
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    renderCard()
+
+    fireEvent.change(await screen.findByLabelText('App ID'), { target: { value: 'bad' } })
+    fireEvent.change(screen.getByLabelText('Private key (PEM)'), { target: { value: 'bad-pem' } })
+    fireEvent.change(screen.getByLabelText('Webhook secret'), { target: { value: 'bad-secret' } })
+    fireEvent.click(screen.getByText('Connect GitHub'))
+
+    expect(await screen.findByText(/did not accept these credentials/)).toBeTruthy()
+    expect(screen.getByText('not connected')).toBeTruthy()
+  })
+
+  it('shows connected facts with a Replace affordance and no secret fields', async () => {
+    stubFetch([connected])
+    renderCard()
+
+    expect(await screen.findByText(/connected · druks-operator/)).toBeTruthy()
+    expect(screen.queryByLabelText('Private key (PEM)')).toBeNull()
+
+    fireEvent.click(screen.getByText('Replace'))
+    expect(screen.getByLabelText('Private key (PEM)')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -73,6 +73,46 @@ const extensionSettings = {
         },
       ],
     },
+    {
+      name: 'review',
+      description: 'Review settings',
+      icon: 'git-pull-request',
+      builtin: false,
+      agents: [],
+      workflows: [],
+      settings: [
+        {
+          name: 'app_id',
+          label: 'Review App ID',
+          help: '',
+          type: 'secret',
+          value: null,
+          default: null,
+          choices: null,
+          section: '',
+          visibleWhenField: '',
+          visibleWhenValue: null,
+          secretSet: false,
+          multiline: false,
+          overridden: false,
+        },
+        {
+          name: 'private_key',
+          label: 'Review App private key',
+          help: '',
+          type: 'secret',
+          value: null,
+          default: null,
+          choices: null,
+          section: '',
+          visibleWhenField: '',
+          visibleWhenValue: null,
+          secretSet: true,
+          multiline: true,
+          overridden: true,
+        },
+      ],
+    },
   ],
 }
 
@@ -176,6 +216,38 @@ describe('SettingsModal extension fields', () => {
       )
     const body = JSON.parse(String(patchCall?.[1]?.body))
     expect(body.extensionSettings.ship).toEqual({ tracker: 'jira' })
+  })
+
+  it('renders a multiline secret as a textarea and PATCHes the paste with newlines intact', async () => {
+    stubFetch(false)
+    const onClose = renderModal()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'review' }))
+    const pemField = screen.getByText('Review App private key').closest('.set-field')
+    const textarea = pemField?.querySelector('textarea')
+    expect(textarea).toBeTruthy()
+    // A stored secret never redisplays — the control shows only the set hint.
+    expect((textarea as HTMLTextAreaElement).value).toBe('')
+    expect((textarea as HTMLTextAreaElement).placeholder).toBe('•••••••• (set)')
+    // The single-line secret sibling keeps its password input.
+    const appIdField = screen.getByText('Review App ID').closest('.set-field')
+    expect(appIdField?.querySelector('input')).toBeTruthy()
+    expect(appIdField?.querySelector('textarea')).toBeNull()
+
+    const pem =
+      '-----BEGIN RSA PRIVATE KEY-----\nline-one\nline-two\n-----END RSA PRIVATE KEY-----'
+    fireEvent.change(textarea as HTMLTextAreaElement, { target: { value: pem } })
+    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled())
+    const patchCall = vi
+      .mocked(fetch)
+      .mock.calls.find(
+        ([input, init]) =>
+          String(input) === '/api/settings/extensions' && init?.method === 'PATCH',
+      )
+    const body = JSON.parse(String(patchCall?.[1]?.body))
+    expect(body.extensionSettings.review).toEqual({ private_key: pem })
   })
 
   it('renders a 422 message for a field hidden by the tracker selection', async () => {

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -824,7 +824,131 @@ function HarnessesPane({
               </div>
             )
           })}
+          <GitHubConnectCard />
         </div>
+      </div>
+    </div>
+  )
+}
+
+// The appliance's own GitHub App — one hand-placed card beside the
+// registry-driven harness cards. Connection persists immediately, outside the
+// modal's Save, so it owns its query, submit, busy, and error state. The
+// pasted PEM and webhook secret are write-only: a success drops them from
+// state, and the connected rendering shows identity facts only.
+export function GitHubConnectCard() {
+  const queryClient = useQueryClient()
+  const identityQuery = useQuery({
+    queryKey: ['githubIdentity'],
+    queryFn: () => api.githubIdentity(),
+    staleTime: 60_000,
+  })
+  const [replacing, setReplacing] = useState(false)
+  const [appId, setAppId] = useState('')
+  const [privateKey, setPrivateKey] = useState('')
+  const [webhookSecret, setWebhookSecret] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const identity = identityQuery.data
+  const formOpen = (identity && !identity.connected) || replacing
+  const complete = appId.trim() !== '' && privateKey.trim() !== '' && webhookSecret !== ''
+
+  const submit = () => {
+    setBusy(true)
+    setError(null)
+    void api
+      .connectGithubIdentity({ appId: appId.trim(), privateKey, webhookSecret })
+      .then(async () => {
+        setAppId('')
+        setPrivateKey('')
+        setWebhookSecret('')
+        setReplacing(false)
+        await queryClient.invalidateQueries({ queryKey: ['githubIdentity'] })
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setBusy(false))
+  }
+
+  return (
+    <div className="set-card harness-row" style={{ '--fam': 'var(--accent-violet)' } as CSSProperties}>
+      <div className="hr-head">
+        <span className="set-card-name">
+          <span className="dot" />
+          github
+        </span>
+        <span className="set-card-tag">service identity</span>
+      </div>
+      <div className="set-pane-sub">
+        The GitHub App druks acts as — it receives webhooks and writes branches, pull requests, and comments. Paste the App&apos;s credentials from the GitHub developer settings page.
+      </div>
+      <div className="hr-connect">
+        <div className="hr-conn-status">
+          {identity?.connected ? (
+            <span className="hr-chip hr-chip-on">
+              connected · {identity.slug} (app {identity.appId})
+            </span>
+          ) : (
+            <span className="hr-chip hr-chip-off">not connected</span>
+          )}
+          {identity?.connected && identity.connectedAt && (
+            <span className="hr-conn-exp">connected {new Date(identity.connectedAt).toLocaleString()}</span>
+          )}
+          <span className="hr-conn-actions">
+            {identity?.connected && !replacing && (
+              <button className="hr-conn-btn" onClick={() => setReplacing(true)} disabled={busy}>
+                Replace
+              </button>
+            )}
+          </span>
+        </div>
+        {formOpen && (
+          <div className="gh-connect-form">
+            <div className="set-field">
+              <span className="set-field-label">app id</span>
+              <input
+                className="set-select"
+                aria-label="App ID"
+                value={appId}
+                onChange={(e) => setAppId(e.target.value)}
+                disabled={busy}
+              />
+            </div>
+            <div className="set-field">
+              <span className="set-field-label">private key (PEM)</span>
+              <textarea
+                className="set-select set-textarea"
+                aria-label="Private key (PEM)"
+                value={privateKey}
+                placeholder="-----BEGIN RSA PRIVATE KEY-----"
+                onChange={(e) => setPrivateKey(e.target.value)}
+                disabled={busy}
+              />
+            </div>
+            <div className="set-field">
+              <span className="set-field-label">webhook secret</span>
+              <input
+                className="set-select"
+                type="password"
+                aria-label="Webhook secret"
+                value={webhookSecret}
+                onChange={(e) => setWebhookSecret(e.target.value)}
+                disabled={busy}
+              />
+            </div>
+            <span className="hr-conn-actions">
+              {replacing && (
+                <button className="hr-conn-btn hr-conn-ghost" onClick={() => setReplacing(false)} disabled={busy}>
+                  Cancel
+                </button>
+              )}
+              <button className="hr-conn-btn" onClick={submit} disabled={busy || !complete}>
+                {identity?.connected ? 'Replace connection' : 'Connect GitHub'}
+              </button>
+            </span>
+          </div>
+        )}
+        {error && <div className="hr-conn-error">{error}</div>}
       </div>
     </div>
   )
@@ -1956,6 +2080,17 @@ function ExtensionPane({
                               <CronField
                                 value={String(cur ?? '')}
                                 onChange={(v) => setOption(o, v)}
+                                disabled={busy}
+                              />
+                            ) : o.f.type === 'secret' && o.f.multiline ? (
+                              // A pasted multiline secret (a PEM): same write-only
+                              // semantics as the secret input, but a textarea so the
+                              // paste keeps its newlines.
+                              <textarea
+                                className="set-select set-textarea"
+                                value={override !== undefined ? String(override ?? '') : ''}
+                                placeholder={o.f.secretSet ? '•••••••• (set)' : 'not set'}
+                                onChange={(e) => setOption(o, e.target.value || undefined)}
                                 disabled={busy}
                               />
                             ) : o.f.type === 'secret' ? (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -980,6 +980,8 @@ a.row-repo:hover { color: var(--bucket-run); text-decoration: underline; }
 .set-select:focus { outline: none; border-color: var(--accent); }
 /* Text inputs share .set-select's frame but must not wear its dropdown chevron. */
 input.set-select { background-image: none; padding-right: 12px; }
+/* Multiline secrets (a pasted PEM): the same frame, grown into a textarea. */
+textarea.set-textarea { background-image: none; height: auto; min-height: 96px; padding: 8px 12px; line-height: 1.45; resize: vertical; white-space: pre; }
 
 .set-cards { display: flex; flex-direction: column; gap: 12px; }
 .set-card { border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); padding: 16px; display: flex; flex-direction: column; gap: 13px; }
@@ -1018,6 +1020,9 @@ input.set-select { background-image: none; padding-right: 12px; }
 .hr-conn-input { flex: 1; min-width: 200px; padding: 6px 10px; border-radius: 4px; background: var(--surface-2); border: 1px solid var(--border); color: var(--text); font-family: var(--font-mono); font-size: 12px; }
 .hr-conn-input:focus { outline: none; border-color: color-mix(in oklch, var(--fam, var(--accent)) 55%, transparent); }
 .hr-conn-error { font-size: 11.5px; color: var(--outcome-failed); font-family: var(--font-mono); }
+/* Connect GitHub — the service-identity paste-in form on its hand-placed card. */
+.gh-connect-form { display: flex; flex-direction: column; gap: 12px; padding: 11px 12px; border-radius: 5px; background: var(--surface); border: 1px solid var(--border); }
+.gh-connect-form .hr-conn-actions { margin-left: 0; justify-content: flex-end; }
 
 .set-switch { position: relative; width: 34px; height: 18px; border-radius: 10px; flex-shrink: 0; background: var(--surface-3); border: 1px solid var(--border-loud); transition: all 140ms; cursor: pointer; }
 .set-switch::after { content: ''; position: absolute; top: 1.5px; left: 1.5px; width: 12px; height: 12px; border-radius: 50%; background: var(--text-dim); transition: all 140ms; }


### PR DESCRIPTION
The `github` service identity stores app id and slug in plaintext and the PEM and webhook secret encrypted. `get_github_client()` is zero-argument and resolves only that row, webhook verification reads its secret, and the legacy `github.*` / `secrets.webhook_secret` settings are gone.

The review extension declares its optional identity as empty-as-unset, multiline-capable `Secret` settings feeding `get_review_actor()`. Operator entry points refuse before starting when the identity is absent (the tracker funnel logs and stands down instead of 5xxing), doctor reports the database-backed identity, and Settings → Harnesses gains the hand-placed Connect GitHub card.