### PR TITLE
ENG-838 — The connect card creates the GitHub App through the manifest flow

### DIFF
--- a/backend/druks/service_identities/routes.py
+++ b/backend/druks/service_identities/routes.py
@@ -1,6 +1,11 @@
+import html
+import json
 import logging
+from urllib.parse import quote
 
-from fastapi import APIRouter, HTTPException
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse
 
 from druks.core.apis.github import GITHUB, GitHubClient
 from druks.service_identities.exceptions import ServiceNotConnectedError
@@ -11,6 +16,23 @@ from druks.settings import load_settings
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/service-identities", tags=["service-identities"])
+
+# What the created App is: the single operator identity documented in
+# docs/configuration.md — keep the two in step.
+_GITHUB_APP_MANIFEST = {
+    "name": "druks",
+    "description": "Druks operator — receives webhooks, writes branches, PRs, and comments.",
+    "public": False,
+    "default_events": ["issue_comment", "pull_request", "pull_request_review", "push"],
+    "default_permissions": {
+        "metadata": "read",
+        "contents": "write",
+        "pull_requests": "write",
+        "issues": "write",
+        "checks": "read",
+        "statuses": "read",
+    },
+}
 
 
 @router.get("/github", response_model=GitHubIdentityResponse, response_model_by_alias=True)
@@ -53,3 +75,76 @@ async def connect_github(payload: GitHubConnectRequest) -> GitHubIdentityRespons
         secrets={"private_key": payload.private_key, "webhook_secret": payload.webhook_secret},
     )
     return GitHubIdentityResponse.from_row(row)
+
+
+@router.get("/github/manifest", response_class=HTMLResponse)
+async def create_github_app(request: Request, org: str = "") -> HTMLResponse:
+    # The operator's browser lands here from the connect card. GitHub only
+    # accepts a manifest via form POST, so this page carries it across and
+    # submits itself; GitHub walks the operator through creating the App,
+    # then redirects to the callback below with a one-time code.
+    settings = request.app.state.settings
+    endpoint = settings.urls.endpoint.rstrip("/")
+    if not endpoint:
+        raise HTTPException(
+            status_code=409,
+            detail="Set urls.endpoint to the base URL the operator's browser reaches druks "
+            "at, to create the GitHub App.",
+        )
+    webhook_base = (
+        f"https://{settings.urls.webhook_host}" if settings.urls.webhook_host else endpoint
+    )
+    manifest = {
+        **_GITHUB_APP_MANIFEST,
+        "url": endpoint,
+        "redirect_url": f"{endpoint}/api/service-identities/github/manifest/callback",
+        "hook_attributes": {"url": f"{webhook_base}/_external/github/events/", "active": True},
+    }
+    create_url = "https://github.com/settings/apps/new"
+    if org:
+        create_url = f"https://github.com/organizations/{quote(org, safe='')}/settings/apps/new"
+    return HTMLResponse(
+        "<html><body>"
+        f'<form method="post" action="{html.escape(create_url)}">'
+        f'<input type="hidden" name="manifest" value="{html.escape(json.dumps(manifest))}">'
+        "<p>Continuing to GitHub to create the App — "
+        '<button type="submit">continue manually</button> if nothing happens.</p>'
+        "</form><script>document.forms[0].submit()</script></body></html>"
+    )
+
+
+@router.get("/github/manifest/callback", response_class=HTMLResponse)
+async def github_manifest_callback(request: Request, code: str = "") -> HTMLResponse:
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing code in the GitHub redirect.")
+    api_url = request.app.state.settings.github_api_url
+    async with httpx.AsyncClient() as client:
+        converted = await client.post(
+            f"{api_url}/app-manifests/{quote(code, safe='')}/conversions",
+            headers={"Accept": "application/vnd.github+json"},
+        )
+    if converted.is_error:
+        # Codes are single-use and expire within the hour; the only fix is a
+        # fresh pass through the create page.
+        raise HTTPException(
+            status_code=400,
+            detail="GitHub rejected the creation code — restart from Create GitHub App.",
+        )
+    app = converted.json()
+    slug = app["slug"]
+    ServiceIdentity.connect(
+        GITHUB,
+        identity={"app_id": str(app["id"]), "slug": slug},
+        secrets={"private_key": app["pem"], "webhook_secret": app["webhook_secret"]},
+    )
+    install_url = f"https://github.com/apps/{quote(slug, safe='')}/installations/new"
+    # druks opened this tab via window.open; the broadcast tells the connect
+    # card to refetch, then the tab moves on to the one step GitHub still
+    # needs — installing the App on the repositories druks should work in.
+    return HTMLResponse(
+        "<html><body>"
+        f"<p>Created GitHub App <b>{html.escape(slug)}</b>. "
+        f'Next, <a href="{html.escape(install_url)}">install it on your repositories</a>.</p>'
+        f"<script>new BroadcastChannel('druks-github-connect').postMessage({json.dumps(slug)});"
+        f"window.location.replace({json.dumps(install_url)})</script></body></html>"
+    )

--- a/backend/tests/test_service_identities.py
+++ b/backend/tests/test_service_identities.py
@@ -1,7 +1,10 @@
 import hashlib
 import hmac
+import html
+import json
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from druks.core.apis.github import GitHubClient, get_github_client
 from druks.core.webhooks.github import GitHubEvents
@@ -223,5 +226,120 @@ def test_blank_fields_are_rejected_without_touching_github(
     )
 
     assert response.status_code == 422
+    with pytest.raises(ServiceNotConnectedError):
+        ServiceIdentity.get("github")
+
+
+# --- The manifest flow (dashboard-created App) -------------------------------
+
+
+def _manifest_from(page: str) -> dict:
+    value = page.partition('name="manifest" value="')[2].partition('">')[0]
+    return json.loads(html.unescape(value))
+
+
+def test_manifest_page_submits_the_documented_app_to_github(druks_client: TestClient, tmp_path):
+    druks_client.app.state.settings = make_settings(
+        tmp_path, urls={"endpoint": "https://druks.example/"}
+    )
+
+    response = druks_client.get("/api/service-identities/github/manifest")
+
+    assert response.status_code == 200
+    assert 'action="https://github.com/settings/apps/new"' in response.text
+    manifest = _manifest_from(response.text)
+    assert manifest["name"] == "druks"
+    assert manifest["url"] == "https://druks.example"
+    assert (
+        manifest["redirect_url"]
+        == "https://druks.example/api/service-identities/github/manifest/callback"
+    )
+    assert manifest["hook_attributes"] == {
+        "url": "https://druks.example/_external/github/events/",
+        "active": True,
+    }
+    assert manifest["public"] is False
+    assert manifest["default_permissions"]["contents"] == "write"
+    assert "pull_request_review" in manifest["default_events"]
+
+
+def test_manifest_page_prefers_the_webhook_host_for_deliveries(druks_client: TestClient, tmp_path):
+    druks_client.app.state.settings = make_settings(
+        tmp_path,
+        urls={"endpoint": "https://druks.example", "webhook_host": "hooks.druks.example"},
+    )
+
+    manifest = _manifest_from(druks_client.get("/api/service-identities/github/manifest").text)
+
+    assert (
+        manifest["hook_attributes"]["url"] == "https://hooks.druks.example/_external/github/events/"
+    )
+
+
+def test_manifest_page_targets_the_org_form(druks_client: TestClient, tmp_path):
+    druks_client.app.state.settings = make_settings(
+        tmp_path, urls={"endpoint": "https://druks.example"}
+    )
+
+    response = druks_client.get("/api/service-identities/github/manifest", params={"org": "acme"})
+
+    assert 'action="https://github.com/organizations/acme/settings/apps/new"' in response.text
+
+
+def test_manifest_page_refuses_without_an_endpoint(druks_client: TestClient):
+    response = druks_client.get("/api/service-identities/github/manifest")
+
+    assert response.status_code == 409
+    assert "urls.endpoint" in response.json()["detail"]
+
+
+def test_manifest_callback_exchanges_the_code_and_connects(
+    druks_client: TestClient, druks_db, monkeypatch
+):
+    exchanged = []
+
+    async def fake_post(self, url, **kwargs):
+        exchanged.append(url)
+        return httpx.Response(
+            200,
+            json={
+                "id": 4242,
+                "slug": "druks",
+                "pem": _PEM,
+                "webhook_secret": _SECRET,
+                "html_url": "https://github.com/apps/druks",
+            },
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    response = druks_client.get(
+        "/api/service-identities/github/manifest/callback", params={"code": "fresh-code"}
+    )
+
+    assert response.status_code == 200
+    assert exchanged == ["https://api.github.com/app-manifests/fresh-code/conversions"]
+    assert "https://github.com/apps/druks/installations/new" in response.text
+    # The page never carries the stored secrets.
+    assert "line-one" not in response.text
+    assert _SECRET not in response.text
+    druks_db.expire_all()
+    row = ServiceIdentity.get("github")
+    assert row.identity == {"app_id": "4242", "slug": "druks"}
+    assert row.secrets == {"private_key": _PEM, "webhook_secret": _SECRET}
+
+
+def test_manifest_callback_rejects_a_dead_code(druks_client: TestClient, druks_db, monkeypatch):
+    async def fake_post(self, url, **kwargs):
+        return httpx.Response(404, json={"message": "Not Found"})
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    response = druks_client.get(
+        "/api/service-identities/github/manifest/callback", params={"code": "stale"}
+    )
+
+    assert response.status_code == 400
+    assert "restart" in response.json()["detail"]
     with pytest.raises(ServiceNotConnectedError):
         ServiceIdentity.get("github")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -161,16 +161,25 @@ second. Agents consume the API through the MCP endpoint; see
 Druks acts at GitHub as one **operator App** — its service identity. The App
 receives webhooks and performs application-owned writes such as branches,
 pull requests, comments, labels, and merges. Its credentials live encrypted
-in Postgres, pasted in from **Settings → Harnesses → Connect GitHub**: the
-App ID, the PEM private key exactly as GitHub issued it, and the webhook
-secret. Connecting validates the pasted credentials against GitHub and stores
-the App's slug; from then on every operator client resolves from that row and
-webhook deliveries verify against its stored secret. There is no TOML,
-environment, or PEM-file source — until GitHub is connected, agent runs
-refuse with a pointed message and `druks doctor` reports the identity as not
-connected.
+in Postgres; there is no TOML, environment, or PEM-file source — until GitHub
+is connected, agent runs refuse with a pointed message and `druks doctor`
+reports the identity as not connected.
 
-Registering the App by hand:
+Connect it from **Settings → Harnesses**. **Create GitHub App** registers the
+App through GitHub's manifest flow: name a GitHub org (or leave it empty for
+a personal account), confirm on GitHub, and druks stores the created App's
+credentials and sends you on to install it on your repositories. Creating the
+App needs `urls.endpoint` set to the base URL the operator's browser reaches
+druks at, and the webhook lands on `urls.webhook_host` when configured, the
+endpoint host otherwise.
+
+Alternatively paste an existing App's credentials into the same card: the App
+ID, the PEM private key exactly as GitHub issued it, and the webhook secret.
+Connecting validates the pasted credentials against GitHub and stores the
+App's slug; from then on every operator client resolves from that row and
+webhook deliveries verify against its stored secret.
+
+Registering the App by hand instead:
 
 Webhook URL:
 `https://<webhook-host>/_external/github/events/`

--- a/frontend/src/components/GitHubConnectCard.test.tsx
+++ b/frontend/src/components/GitHubConnectCard.test.tsx
@@ -135,4 +135,43 @@ describe('GitHubConnectCard', () => {
     fireEvent.click(screen.getByText('Replace'))
     expect(screen.getByLabelText('Private key (PEM)')).toBeTruthy()
   })
+
+  it('opens the manifest page for the typed org and refreshes on the callback broadcast', async () => {
+    stubFetch([disconnected, connected])
+    const open = vi.fn()
+    vi.stubGlobal('open', open)
+    renderCard()
+
+    fireEvent.change(await screen.findByLabelText('GitHub org'), { target: { value: 'acme' } })
+    fireEvent.click(screen.getByText('Create GitHub App'))
+    expect(open).toHaveBeenCalledWith('/api/service-identities/github/manifest?org=acme')
+
+    act(() => {
+      new BroadcastChannel('druks-github-connect').postMessage('druks-operator')
+    })
+
+    expect(await screen.findByText(/connected · druks-operator/)).toBeTruthy()
+  })
+
+  it('opens the personal-account manifest page when no org is typed', async () => {
+    stubFetch([disconnected])
+    const open = vi.fn()
+    vi.stubGlobal('open', open)
+    renderCard()
+
+    fireEvent.click(await screen.findByText('Create GitHub App'))
+
+    expect(open).toHaveBeenCalledWith('/api/service-identities/github/manifest')
+  })
+
+  it('links installation management to the connected slug', async () => {
+    stubFetch([connected])
+    renderCard()
+
+    const link = await screen.findByText('Manage installations')
+
+    expect(link.getAttribute('href')).toBe(
+      'https://github.com/apps/druks-operator/installations/new',
+    )
+  })
 })

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -844,11 +844,28 @@ export function GitHubConnectCard() {
     staleTime: 60_000,
   })
   const [replacing, setReplacing] = useState(false)
+  const [org, setOrg] = useState('')
   const [appId, setAppId] = useState('')
   const [privateKey, setPrivateKey] = useState('')
   const [webhookSecret, setWebhookSecret] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // The manifest tab lands on the callback page, which broadcasts once the
+  // created App's credentials are stored.
+  useEffect(() => {
+    const channel = new BroadcastChannel('druks-github-connect')
+    channel.onmessage = () => {
+      setReplacing(false)
+      void queryClient.invalidateQueries({ queryKey: ['githubIdentity'] })
+    }
+    return () => channel.close()
+  }, [queryClient])
+
+  const createApp = () => {
+    const query = org.trim() ? `?org=${encodeURIComponent(org.trim())}` : ''
+    window.open(`/api/service-identities/github/manifest${query}`)
+  }
 
   const identity = identityQuery.data
   const formOpen = (identity && !identity.connected) || replacing
@@ -880,7 +897,7 @@ export function GitHubConnectCard() {
         <span className="set-card-tag">service identity</span>
       </div>
       <div className="set-pane-sub">
-        The GitHub App druks acts as — it receives webhooks and writes branches, pull requests, and comments. Paste the App&apos;s credentials from the GitHub developer settings page.
+        The GitHub App druks acts as — it receives webhooks and writes branches, pull requests, and comments. Create it from here, or paste an existing App&apos;s credentials from the GitHub developer settings page.
       </div>
       <div className="hr-connect">
         <div className="hr-conn-status">
@@ -895,6 +912,16 @@ export function GitHubConnectCard() {
             <span className="hr-conn-exp">connected {new Date(identity.connectedAt).toLocaleString()}</span>
           )}
           <span className="hr-conn-actions">
+            {identity?.connected && (
+              <a
+                className="hr-conn-btn"
+                href={`https://github.com/apps/${encodeURIComponent(identity.slug ?? '')}/installations/new`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Manage installations
+              </a>
+            )}
             {identity?.connected && !replacing && (
               <button className="hr-conn-btn" onClick={() => setReplacing(true)} disabled={busy}>
                 Replace
@@ -904,6 +931,22 @@ export function GitHubConnectCard() {
         </div>
         {formOpen && (
           <div className="gh-connect-form">
+            <div className="set-field">
+              <span className="set-field-label">github org (empty for a personal account)</span>
+              <input
+                className="set-select"
+                aria-label="GitHub org"
+                value={org}
+                onChange={(e) => setOrg(e.target.value)}
+                disabled={busy}
+              />
+            </div>
+            <span className="hr-conn-actions">
+              <button className="hr-conn-btn" onClick={createApp} disabled={busy}>
+                Create GitHub App
+              </button>
+            </span>
+            <div className="set-pane-sub">…or paste an existing App&apos;s credentials:</div>
             <div className="set-field">
               <span className="set-field-label">app id</span>
               <input


### PR DESCRIPTION
Stacked on #218.

## What changed

The GitHub connect card (Settings → Harnesses) gains **Create GitHub App**: type an org (or leave empty for a personal account) and druks drives GitHub's App-manifest flow end to end.

- `GET /api/service-identities/github/manifest` serves a self-submitting form that posts the operator-App manifest (the permissions/events documented in `docs/configuration.md#github`) to GitHub's create-app page — personal or org variant.
- GitHub redirects its one-time code to `GET …/manifest/callback`, which exchanges it at `/app-manifests/{code}/conversions`, stores the created App's id, slug, PEM, and webhook secret through the same `ServiceIdentity.connect` path the paste-in uses, notifies the card over a `BroadcastChannel`, and forwards the tab to GitHub's install page — installing the App on repositories is the one step GitHub still owns.
- The manifest requires `urls.endpoint` (409 with a pointed message otherwise, mirroring the MCP OAuth connect) and targets webhook delivery at `urls.webhook_host` when set, the endpoint host otherwise.
- A connected card links to **Manage installations** (`github.com/apps/<slug>/installations/new`), derived from the stored slug.
- A dead or reused code fails with a restartable 400; nothing partial is stored.

The paste-in path is unchanged and remains the migration route for existing Apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)