### PR TITLE
ENG-840 — Local drukbox runs in compose

### DIFF
--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -17,7 +17,8 @@ _COMPOSE_ENV_KEYS = (
     "DRUKS_GID",
     "DRUKS_TAG",
     "DRUKS_WEB_BIND_HOST",
-    "COMPOSE_PROFILES",
+    "DRUKS_DOCKER_GID",
+    "COMPOSE_FILE",
 )
 _ENV_KEY_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
@@ -522,7 +523,7 @@ def _shape_message(provider: str) -> str:
     if not provider:
         return "sandbox provider is not configured"
     if provider == "docker":
-        return "provider 'docker' → local shape; host-run drukbox validates its configuration"
+        return "provider 'docker' → local shape; drukbox validates its configuration"
     if provider == "exe":
         return "provider 'exe' → exe shape; check `druks doctor` after boot"
     return (

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -309,14 +309,17 @@ def test_deleted_env_is_regenerated_byte_identically(tmp_path):
 def test_compose_plane_env_additions_survive_rerender(tmp_path):
     env_path = tmp_path / ".env"
     _run(env_path, provider="docker")
-    env_path.write_text(env_path.read_text() + "DRUKS_UID=1000\nCOMPOSE_PROFILES=\n")
+    env_path.write_text(
+        env_path.read_text()
+        + "DRUKS_UID=1000\nDRUKS_DOCKER_GID=988\nCOMPOSE_FILE=compose.yaml:compose.local.yaml\n"
+    )
 
     _run(env_path)
 
     values = read_env(env_path)
     assert values["DRUKS_UID"] == "1000"
-    assert "COMPOSE_PROFILES" in values
-    assert values["COMPOSE_PROFILES"] == ""
+    assert values["DRUKS_DOCKER_GID"] == "988"
+    assert values["COMPOSE_FILE"] == "compose.yaml:compose.local.yaml"
     assert "# OPERATOR ADDITIONS" in env_path.read_text()
 
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,18 +1,23 @@
 # Druks Deployment
 
-The whole stack runs in Docker Compose: Druks (`web`, which embeds the DBOS
-durable engine and serves the dashboard SPA), Postgres, and Redis. A
-**remote** install (any `DRUKS_PROVIDER` except `docker`) also brings up stock
-Caddy (identity edge + proxy, Caddyfile bind-mounted) and the Drukbox sandbox
-control plane (`sandbox-service`, `sandbox-janitor`). Those three live in the
-Compose `remote` profile, which `install.sh` selects by writing
-`COMPOSE_PROFILES` to `.env`, so plain `docker compose` commands in the install
-dir pick it up.
+The base `compose.yaml` is Druks (`web`, which embeds the DBOS durable engine
+and serves the dashboard SPA), Postgres, and Redis. A shape overlay adds the
+Drukbox sandbox control plane on top: `install.sh` writes `COMPOSE_FILE` to
+`.env` (e.g. `compose.yaml:compose.remote.yaml`), so plain `docker compose`
+commands in the install dir load the right pair.
 
-A **local** install (`DRUKS_PROVIDER=docker`) runs neither: the dashboard is
-reached directly on `127.0.0.1:8001` and sandboxes are local Docker
-containers with drukbox on the host — see
-[Full local](../docs/full-local.md).
+A **remote** install (any `DRUKS_PROVIDER` except `docker`) uses
+`compose.remote.yaml`: the Drukbox control plane (`drukbox`, `drukbox-janitor`)
+against a cloud provider, plus stock Caddy (identity edge + proxy, Caddyfile
+bind-mounted).
+
+A **local** install (`DRUKS_PROVIDER=docker`) uses `compose.local.yaml`: one
+`drukbox` with the host's Docker socket mounted, so sandboxes are sibling
+containers on the host daemon, and no Caddy — the dashboard is reached directly
+on `127.0.0.1:8001`. See [Full local](../docs/full-local.md).
+
+Drukbox keeps its own schema in a `drukbox` database in the same Postgres, so
+there is no second datastore to run or back up separately.
 
 The Druks services use the **host network** so they can reach Postgres, Redis,
 Drukbox, and provider-specific sandbox addresses from the host network
@@ -192,7 +197,7 @@ code.
 
 ```bash
 docker compose logs -f web
-docker compose logs -f sandbox-service sandbox-janitor   # remote install only
+docker compose logs -f drukbox               # the sandbox control plane
 docker compose down
 ```
 

--- a/deploy/compose.local.yaml
+++ b/deploy/compose.local.yaml
@@ -1,0 +1,41 @@
+# Local overlay: drukbox drives sandboxes as sibling containers on the host
+# Docker daemon through the mounted socket. install.sh writes
+# COMPOSE_FILE=compose.yaml:compose.local.yaml into .env, so plain
+# `docker compose` loads this with the base. The dashboard is reached directly
+# on 127.0.0.1:8001 — no Caddy.
+
+services:
+  drukbox:
+    image: ${DRUKS_SANDBOX_SERVICE_IMAGE:-ghcr.io/czpython/drukbox:latest}
+    network_mode: host
+    restart: unless-stopped
+    # Runs as the image's non-root appuser (uid 1001). The Docker socket is
+    # group-owned; install.sh records its gid (DRUKS_DOCKER_GID) so appuser may
+    # use it — on macOS the mounted socket is group root, so setup writes 0.
+    group_add:
+      - "${DRUKS_DOCKER_GID:-0}"
+    env_file:
+      - ./.env
+    environment:
+      DATABASE_URL: postgresql+psycopg://${DRUKS_POSTGRES_USER:-druks}:${DRUKS_POSTGRES_PASSWORD}@127.0.0.1:5432/drukbox
+      DEFAULT_HOST_PROVIDER: docker
+      TAILSCALE_ENABLED: "false"
+      DOCKER_SSH_USERNAME: druks
+      SERVICE_TOKENS: dev-token
+      # Loopback + port 8000 to match the service_url local setup writes; the
+      # image healthcheck follows below.
+      UVICORN_HOST: 127.0.0.1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: [".venv/bin/uvicorn", "api.app:app", "--port", "8000"]
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=2)",
+        ]
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/deploy/compose.remote.yaml
+++ b/deploy/compose.remote.yaml
@@ -1,0 +1,60 @@
+# Remote overlay: drukbox drives a cloud sandbox provider (exe/aws/…), plus
+# Caddy as the identity edge + webhook TLS. install.sh writes
+# COMPOSE_FILE=compose.yaml:compose.remote.yaml into .env. Provider credentials
+# ride in .env (the [sandbox.<provider>] passthrough from setup); the exe shape
+# additionally reaches its VMs over the host tailscaled.
+
+x-drukbox: &drukbox
+  image: ${DRUKS_SANDBOX_SERVICE_IMAGE:-ghcr.io/czpython/drukbox:latest}
+  network_mode: host
+  env_file:
+    - ./.env
+  environment:
+    DATABASE_URL: postgresql+psycopg://${DRUKS_POSTGRES_USER:-druks}:${DRUKS_POSTGRES_PASSWORD}@127.0.0.1:5432/drukbox
+  depends_on:
+    postgres:
+      condition: service_healthy
+
+services:
+  drukbox:
+    <<: *drukbox
+    restart: unless-stopped
+
+  # Periodic janitor — drukbox ships no scheduler, so loop with sleep; a
+  # real timer belongs in the drukbox service/image, not in compose.
+  drukbox-janitor:
+    <<: *drukbox
+    restart: unless-stopped
+    entrypoint:
+      - sh
+      - -c
+      - "while true; do .venv/bin/python -m hosts.janitor || true; sleep 60; done"
+    # The image HEALTHCHECK probes the HTTP API — on host networking the
+    # janitor would health-check the *service's* port, doubling /healthz
+    # traffic and reporting a status that isn't its own.
+    healthcheck:
+      disable: true
+
+  caddy:
+    # Stock Caddy — the identity edge + webhook TLS. Caddyfile is fetched next
+    # to this compose file by install.sh.
+    image: caddy:2.10-alpine
+    network_mode: host
+    restart: unless-stopped
+    environment:
+      DRUKS_UPSTREAM: ${DRUKS_UPSTREAM:-127.0.0.1:8001}
+      # Setup renders identity.header for Caddy; druks reads it from druks.toml.
+      # Caddy requires the edge's assertion, and druks maps it to an account.
+      # No default anywhere — the backend refuses header mode without it.
+      DRUKS_AUTH_HEADER: ${DRUKS_AUTH_HEADER:-}
+      # ``:-`` so an empty .env value still collapses to the inert loopback
+      # default — Caddy treats set-but-empty as a real (broken) site address.
+      DRUKS_WEBHOOK_HOST: ${DRUKS_WEBHOOK_HOST:-http://127.0.0.1:8081}
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,5 +1,9 @@
-# Full Druks stack. Host networking is required: services reach Redis on
-# 127.0.0.1 and use the host's tailscaled to SSH into sandbox VMs.
+# Druks base stack: web, Postgres, Redis. The sandbox control plane (drukbox)
+# and, for remote installs, Caddy come from an overlay — compose.local.yaml or
+# compose.remote.yaml — selected by COMPOSE_FILE in .env, which install.sh
+# writes. Host networking throughout: services reach Postgres and Redis on
+# 127.0.0.1, and drukbox reaches each sandbox's sshd at the address its provider
+# returns — a host-loopback port locally, a provider-reachable address remotely.
 
 x-druks: &druks
   image: ghcr.io/czpython/druks:${DRUKS_TAG:-latest}
@@ -35,9 +39,6 @@ x-druks: &druks
     - ${DRUKS_CLAUDE_HOME:-${HOME}/.claude}:/harnesses/claude:ro
     - ${DRUKS_CODEX_HOME:-${HOME}/.codex}:/harnesses/codex:ro
     - ${DRUKS_CLAUDE_JSON:-${HOME}/.claude.json}:/harnesses/.claude.json:ro
-    # Operator-installed skills live under the /app/data mount (DRUKS_SKILLS_DIR
-    # → /app/data/skills), writable and owned by the deploy user — no separate
-    # mount needed.
     # Shared so a reattaching worker reads the key the acquirer wrote.
     - druks_sandbox_keys:/app/sandbox-keys
   depends_on:
@@ -45,29 +46,6 @@ x-druks: &druks
       condition: service_healthy
     postgres:
       condition: service_healthy
-
-# Shared config for the drukbox sandbox control-plane containers
-# (service / janitor), gated behind the ``remote`` profile — a local
-# install runs drukbox on the host instead. They use SQLite: one file on a
-# shared volume so both containers see the same DB (separate containers, so a
-# per-container relative path would be two different files). Host
-# networking for the service's HTTP API + the host tailscaled.
-x-drukbox: &druksox
-  image: ${DRUKS_SANDBOX_SERVICE_IMAGE:-ghcr.io/czpython/drukbox:latest}
-  network_mode: host
-  # Runs as the image's non-root appuser (uid 1001). The shared SQLite
-  # volume must therefore be owned by 1001 — a fresh named volume mounts
-  # root-owned, so install.sh chowns it (one-time host-side step; /data is
-  # OUR mount path, not drukbox's concern, so the image stays untouched).
-  env_file:
-    - ./.env
-  environment:
-    # Absolute path (four slashes) on the shared volume mounted at /data.
-    # Overrides any DATABASE_URL in .env so the stack can't drift back to
-    # the removed Postgres.
-    DATABASE_URL: sqlite+aiosqlite:////data/drukbox.db
-  volumes:
-    - drukbox_data:/data
 
 services:
   web:
@@ -89,50 +67,6 @@ services:
         "--port",
         "8001",
       ]
-
-  sandbox-service:
-    <<: *druksox
-    profiles: ["remote"]
-    restart: unless-stopped
-
-  # Periodic janitor — drukbox ships no scheduler, so loop with sleep; a
-  # real timer belongs in the drukbox service/image, not in compose.
-  sandbox-janitor:
-    <<: *druksox
-    profiles: ["remote"]
-    restart: unless-stopped
-    entrypoint:
-      - sh
-      - -c
-      - "while true; do .venv/bin/python -m hosts.janitor || true; sleep 60; done"
-    # The image HEALTHCHECK probes the HTTP API — on host networking the
-    # janitor would health-check the *service's* port, doubling /healthz
-    # traffic and reporting a status that isn't its own.
-    healthcheck:
-      disable: true
-
-  caddy:
-    # Stock Caddy — the identity edge + webhook TLS. A local install skips it
-    # (dashboard reached directly on 127.0.0.1:8001, identity.mode=none), so
-    # it lives in the ``remote`` profile. Caddyfile is fetched next to this
-    # compose file by install.sh.
-    image: caddy:2.10-alpine
-    profiles: ["remote"]
-    network_mode: host
-    restart: unless-stopped
-    environment:
-      DRUKS_UPSTREAM: ${DRUKS_UPSTREAM:-127.0.0.1:8001}
-      # Setup renders identity.header for Caddy; druks reads it from druks.toml.
-      # Caddy requires the edge's assertion, and druks maps it to an account.
-      # No default anywhere — the backend refuses header mode without it.
-      DRUKS_AUTH_HEADER: ${DRUKS_AUTH_HEADER:-}
-      # ``:-`` so an empty .env value still collapses to the inert loopback
-      # default — Caddy treats set-but-empty as a real (broken) site address.
-      DRUKS_WEBHOOK_HOST: ${DRUKS_WEBHOOK_HOST:-http://127.0.0.1:8081}
-    volumes:
-      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
-      - caddy_data:/data
-      - caddy_config:/config
 
   postgres:
     image: postgres:16-alpine
@@ -173,10 +107,6 @@ services:
       retries: 5
 
 volumes:
-  caddy_data:
-  caddy_config:
   redis_data:
   postgres_data:
-  # Drukbox's SQLite DB, shared across migrate/service/janitor.
-  drukbox_data:
   druks_sandbox_keys:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,8 +48,8 @@ of overriding its canonical value. On a remote shape,
 providers. `docker` and `exe` select shape-specific first-write templates.
 Every other provider name selects the generic remote shape and is validated by
 Drukbox.
-The local `docker` shape does not render `[sandbox.<provider>]` because host-run
-Drukbox reads its own checkout's environment.
+The local `docker` shape does not render `[sandbox.<provider>]`: its Drukbox
+service takes a fixed environment from `deploy/compose.local.yaml`.
 
 Secrets are generated only when the TOML is first created. Preserve
 `[secrets]` when moving or recovering an installation. Use repeatable

--- a/docs/development.md
+++ b/docs/development.md
@@ -151,7 +151,9 @@ currently ship a Markdown linter or link-check command.
 ## Working with sandboxes
 
 Backend tests mock most provider boundaries. For a real local sandbox, run
-Drukbox on the host as described in [Full local setup](full-local.md) and set:
+Drukbox on the host from its own checkout
+(`DOCKER_SSH_USERNAME=druks make dev` in
+[czpython/drukbox](https://github.com/czpython/drukbox)) and set:
 
 ```toml
 [sandbox]

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -1,6 +1,6 @@
 # Full local setup
 
-The local profile keeps every component on one machine:
+The local shape keeps every component on one machine:
 
 ```text
 browser -> Druks :8001 -> Drukbox :8000 -> Docker sandbox containers
@@ -8,17 +8,16 @@ browser -> Druks :8001 -> Drukbox :8000 -> Docker sandbox containers
                           -> SSH from Druks to each container
 ```
 
-Druks, Postgres, and Redis run in Compose. Drukbox runs on the host because its
-`docker` provider needs access to the host Docker daemon. Agent work still runs
-in isolated containers rather than in the Druks process.
+Everything runs in Compose: Druks, Postgres, Redis, and Drukbox — the
+Drukbox service holds the host's Docker socket, so its `docker` provider
+starts sandboxes as sibling containers on the host daemon. Agent work still
+runs in those isolated containers rather than in the Druks process.
 
 ## Prerequisites
 
 - Docker with the Compose plugin
-- Git
 - enough local Docker capacity for Postgres, Redis, Druks, Drukbox, and
   short-lived sandbox containers
-- two GitHub Apps if you intend to use the bundled `ship` extension
 
 No Tailscale account or remote VM provider is needed.
 The Druks application and sandbox images are published for both `linux/amd64`
@@ -35,38 +34,25 @@ The local shape needs no authored values, so the first run goes all the way:
 - writes `~/druks/druks.toml` with `[sandbox].provider = "docker"`
 - renders `~/druks/.env` with `DEFAULT_HOST_PROVIDER=docker`
 - generates the database password and the stored-secret key
-- points Druks at Drukbox on `127.0.0.1:8000`
-- pulls images, applies Druks migrations, and starts Druks, Postgres, and
-  Redis — it does not start Drukbox in the local profile
+- pulls images, applies migrations, and starts Druks, Postgres, Redis, and
+  Drukbox on `127.0.0.1:8000` (`COMPOSE_FILE=compose.yaml:compose.local.yaml`)
+
+Drukbox drives sandboxes through the mounted `/var/run/docker.sock`; the
+installer records the socket's group id in `.env` so the service's non-root
+user may use it. Drukbox keeps its schema in a `drukbox` database in the same
+Postgres — no separate datastore. On macOS, if sandbox SSH turns out
+unreachable, enable host networking in Docker Desktop's settings.
 
 For the bundled `ship` extension, connect the GitHub App druks acts as from
-the dashboard after boot (**Settings → Harnesses → Connect GitHub**) — see
+the dashboard after boot (**Settings → Harnesses**) — create it there or
+paste an existing App's credentials, see
 [the GitHub connection](configuration.md#github).
 
-## 2. Run Drukbox on the host
+Existing installs that still run Drukbox on the host via `make dev`: finish
+or cancel local runs, stop the host process, and re-run the installer — the
+Compose service starts with a fresh sandbox registry.
 
-In a separate checkout:
-
-```bash
-git clone https://github.com/czpython/drukbox
-cd drukbox
-DOCKER_SSH_USERNAME=druks make dev
-```
-
-`make dev` starts Drukbox on `127.0.0.1:8000` with the Docker provider,
-Tailscale disabled, and the `dev-token` expected by the local Druks setup.
-`DOCKER_SSH_USERNAME=druks` matches the non-root user in the shipped sandbox
-image.
-
-If port 8000 is already occupied, run Drukbox on another port, set its URL in
-`~/druks/druks.toml`, then re-run the installer:
-
-```toml
-[sandbox]
-service_url = "http://127.0.0.1:8100"
-```
-
-## 3. Verify the first working system
+## 2. Verify the first working system
 
 ```bash
 cd ~/druks
@@ -77,7 +63,7 @@ curl -fsS http://127.0.0.1:8001/health
 Success means the Compose services are up and the health endpoint returns
 `{"status":"ok"}`. The dashboard is at <http://127.0.0.1:8001>.
 
-## 4. Connect agent harnesses
+## 3. Connect agent harnesses
 
 Open **Settings → Harnesses** in the dashboard and connect Claude and Codex.
 Druks stores those subscription credentials in Postgres and writes a fresh
@@ -112,7 +98,7 @@ docker compose exec web druks doctor --sandbox
 
 This creates and deletes a real sandbox container.
 
-## 5. Exercise an application
+## 4. Exercise an application
 
 Druks does not invent a generic domain job: an installed extension supplies the
 workflow and its trigger. In the bundled distribution, `ship` is the reference

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -52,12 +52,12 @@ state.
 
 ### A migration is missing
 
-The web service never migrates on boot. Apply both Druks and, on a remote
-profile, Drukbox migrations before starting the new images:
+The web service never migrates on boot. Apply both the Druks and the Drukbox
+migrations before starting the new images:
 
 ```bash
 docker compose run --rm web druks init-db
-docker compose run --rm sandbox-service .venv/bin/alembic upgrade head
+docker compose run --rm drukbox .venv/bin/alembic upgrade head
 docker compose up -d
 ```
 
@@ -101,7 +101,7 @@ grep -E '^(DRUKS_AUTH_HEADER|DRUKS_UPSTREAM)=' ~/druks/.env
 docker compose logs --tail=200 caddy web
 ```
 
-The local `docker` profile intentionally skips Caddy; use
+The local `docker` shape intentionally skips Caddy; use
 <http://127.0.0.1:8001>. It runs with `[identity].mode = "none"` — no authentication —
 and must remain loopback-only.
 
@@ -154,13 +154,12 @@ Run:
 
 ```bash
 docker compose exec web druks doctor
-docker compose logs --tail=200 sandbox-service sandbox-janitor
+docker compose logs --tail=200 drukbox
 ```
 
-For the local provider, Drukbox runs on the host, not in this Compose project.
-Confirm it listens at `[sandbox].service_url` in `druks.toml`. For remote
-providers, a healthy Drukbox API does not prove SSH reachability; follow with
-`druks doctor --sandbox`.
+Confirm the service listens at `[sandbox].service_url` in `druks.toml`. For
+remote providers, a healthy Drukbox API does not prove SSH reachability;
+follow with `druks doctor --sandbox`.
 
 ### A sandbox process appears stuck
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,12 +69,16 @@ main() {
   mkdir -p "$INSTALL_DIR"
   cd "$INSTALL_DIR"
 
-  # compose.yaml — single source of truth lives in the repo, always refresh.
-  echo "→ fetching deploy/compose.yaml from $REPO@$REF"
+  # compose files — the base plus both shape overlays live in the repo, always
+  # refresh. COMPOSE_FILE in .env (written below) selects which overlay loads;
+  # the unused one sits inert.
+  echo "→ fetching compose files from $REPO@$REF"
   fetch_from_repo deploy/compose.yaml compose.yaml
+  fetch_from_repo deploy/compose.local.yaml compose.local.yaml
+  fetch_from_repo deploy/compose.remote.yaml compose.remote.yaml
 
-  # The Caddyfile is bind-mounted by compose (stock caddy image, no baked
-  # config), so it refreshes together with compose.yaml on every re-run.
+  # The Caddyfile is bind-mounted by the remote overlay (stock caddy image, no
+  # baked config), so it refreshes on every re-run.
   echo "→ fetching deploy/caddy/Caddyfile from $REPO@$REF"
   mkdir -p caddy
   fetch_from_repo deploy/caddy/Caddyfile caddy/Caddyfile
@@ -118,13 +122,21 @@ main() {
     set_env_var DRUKS_WEB_BIND_HOST "127.0.0.1"
   fi
 
-  # Compose profile → .env, so plain `docker compose` in this dir picks it up.
-  # `remote` brings up the drukbox control-plane + Caddy; local runs neither
-  # (drukbox lives on the host, dashboard is reached directly on :8001).
+  # COMPOSE_FILE → .env, so plain `docker compose` in this dir loads the right
+  # overlay. `local` drives sandboxes on the host Docker daemon (dashboard on
+  # :8001, no Caddy); `remote` runs the cloud provider + Caddy. For local, the
+  # socket's gid rides along so drukbox's non-root appuser may use it — on
+  # macOS the host path is a user-owned symlink, but the socket Docker Desktop
+  # mounts into containers is group root, so the host gid would grant nothing.
   if [ "$PROVIDER" = "docker" ]; then
-    set_env_var COMPOSE_PROFILES ""
+    set_env_var COMPOSE_FILE "compose.yaml:compose.local.yaml"
+    if [ "$(uname -s)" = "Darwin" ]; then
+      set_env_var DRUKS_DOCKER_GID "0"
+    else
+      set_env_var DRUKS_DOCKER_GID "$(stat -c '%g' /var/run/docker.sock)"
+    fi
   else
-    set_env_var COMPOSE_PROFILES "remote"
+    set_env_var COMPOSE_FILE "compose.yaml:compose.remote.yaml"
   fi
 
   echo "→ docker compose pull"
@@ -138,24 +150,24 @@ main() {
   docker run --rm -v "$(basename "$INSTALL_DIR")_druks_sandbox_keys:/keys" alpine \
     chown -R "$(id -u):$(id -g)" /keys
 
-  # drukbox runs as its non-root appuser (uid 1001); a fresh named volume mounts
-  # root-owned, so appuser can't create the SQLite DB. Chown it once, host-side.
-  # Remote only — a local install has no drukbox container (it's on the host).
-  if [ "$PROVIDER" != "docker" ]; then
-    echo "→ chown drukbox SQLite volume to appuser (1001:999)"
-    docker run --rm -v "$(basename "$INSTALL_DIR")_drukbox_data:/data" alpine \
-      chown -R 1001:999 /data
-  fi
-
   # Migrations run out of band, once, before the app serves — never on boot.
   # `run --rm` starts the DB deps, applies the alembic schema, seeds, and exits.
   # Idempotent, so it doubles as the upgrade step.
   echo "→ druks init-db (idempotent)"
   docker compose run --rm web druks init-db
-  if [ "$PROVIDER" != "docker" ]; then
-    echo "→ drukbox alembic upgrade (idempotent)"
-    docker compose run --rm sandbox-service .venv/bin/alembic upgrade head
-  fi
+
+  # drukbox keeps its schema in its own database in the shared Postgres; alembic
+  # creates the schema but never the database, so create it here — idempotent,
+  # covering both a fresh install and an upgrade from the old SQLite volume.
+  PG_USER=$(sed -n 's/^DRUKS_POSTGRES_USER=//p' .env)
+  PG_USER=${PG_USER:-druks}
+  echo "→ ensure drukbox database exists"
+  docker compose exec -T postgres \
+    psql -U "$PG_USER" -d postgres -tc "SELECT 1 FROM pg_database WHERE datname='drukbox'" \
+    | grep -q 1 || docker compose exec -T postgres createdb -U "$PG_USER" drukbox
+
+  echo "→ drukbox alembic upgrade (idempotent)"
+  docker compose run --rm drukbox .venv/bin/alembic upgrade head
 
   echo "→ docker compose up -d"
   docker compose up -d
@@ -179,9 +191,8 @@ MSG
 
 Dashboard: http://127.0.0.1:8001
 
-Sandboxes run as local Docker containers — start drukbox on the host:
-  git clone https://github.com/czpython/drukbox
-  cd drukbox && DOCKER_SSH_USERNAME=druks make dev
+Sandboxes run as local Docker containers, driven by the drukbox
+service in this compose stack.
 ------------------------------------------------------------
 MSG
   elif [ "$PROVIDER" = "exe" ]; then


### PR DESCRIPTION
Stacked on main (218, 219 merged).

## What changed (reworked per review)

Reshaped from the first cut (one compose file with `profiles:` + a SQLite drukbox) into the structure the peers and Docker's own idiom point at.

**Separate compose files, not profiles.** `deploy/compose.yaml` is now just the base — web, Postgres, Redis. `compose.local.yaml` and `compose.remote.yaml` are shape overlays that add the drukbox control plane (and, for remote, Caddy). `install.sh` writes `COMPOSE_FILE=compose.yaml:compose.<shape>.yaml` to `.env`, so plain `docker compose` loads the right pair with no flags — the same ergonomic `COMPOSE_PROFILES` gave, without the profile noise. `druks setup` preserves `COMPOSE_FILE` across re-renders.

**Drukbox on the shared Postgres, not its own SQLite.** Both shapes point drukbox at a `drukbox` database in the Postgres druks already runs (`postgresql+psycopg://…/drukbox`). This deletes the `drukbox_data` named volume, the root-owned-volume chown dance, and the shared-SQLite-file gymnastics between service and janitor. `install.sh` creates the database idempotently before drukbox's alembic — covering a fresh install and an upgrade off the old SQLite volume alike.

**Local drukbox** (`compose.local.yaml`): one service on the host Docker socket (sandboxes are sibling containers on the host daemon), port 8000 to match the `service_url` local setup writes, `group_add` the socket's gid (`DRUKS_DOCKER_GID` — `stat` on Linux, `0` on macOS where Docker Desktop mounts the socket group-root), no Caddy.

**Remote drukbox** (`compose.remote.yaml`): the cloud-provider service + janitor + Caddy, unchanged behavior, now on Postgres. Services renamed `drukbox` / `drukbox-janitor` so one name works in both shapes and `install.sh` needs no branch to migrate or log them.

Existing host-run local installs stop the host process and re-run the installer; existing remote installs re-render to `COMPOSE_FILE` and move off the SQLite volume on the next upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
