### PR TITLE
ENG-842 — INSTALL.md agent runbook + README paste-in prompt

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,61 @@
+# Install runbook
+
+A deterministic install of the local (laptop) shape, written for a coding
+agent operating a shell on the target machine. Humans are welcome too — the
+narrative version is [docs/full-local.md](docs/full-local.md), and remote
+shapes are covered by [deploy/README.md](deploy/README.md).
+
+Rules: run the steps in order; after each step run its verification exactly;
+if a verification fails, stop and report the failing step with its command
+output — do not improvise a fix or continue.
+
+## 1. Preconditions
+
+```bash
+docker info --format '{{.ServerVersion}}'
+docker compose version
+```
+
+Verification: both commands succeed. If either fails, stop — Docker with the
+Compose plugin is the one prerequisite, and installing it is the operator's
+call, not yours.
+
+## 2. Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh | DRUKS_PROVIDER=docker bash
+```
+
+Verification: the command exits 0 and ends with `docker compose up -d`
+output followed by a message that the stack is up. `~/druks` now contains
+`druks.toml`, `.env`, and `compose.yaml`.
+
+## 3. Services are up
+
+```bash
+cd ~/druks
+docker compose ps
+curl -fsS http://127.0.0.1:8001/health
+```
+
+Verification: `web`, `postgres`, `redis`, and `drukbox` are running
+(none restarting), and the health endpoint returns `{"status":"ok"}`.
+
+## 4. Preflight
+
+```bash
+cd ~/druks
+docker compose exec web druks doctor
+```
+
+Verification: every check passes except the Claude, Codex, and GitHub
+connection checks — those correctly fail until the operator connects them in
+the browser, which no shell step can do.
+
+## 5. Hand back to the operator
+
+Report that druks is installed and tell the operator to finish in the
+dashboard at <http://127.0.0.1:8001>: **Settings → Harnesses** connects
+Claude and Codex (agent runs refuse to start on an unconnected harness) and
+the GitHub App druks acts as. Then `docker compose exec web druks doctor
+--sandbox` proves the full sandbox path with a real container.

--- a/README.md
+++ b/README.md
@@ -58,10 +58,18 @@ curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install
 ```
 
 The local shape needs no authored values — the first run boots the stack.
-Then follow [full local setup](https://github.com/czpython/druks/blob/main/docs/full-local.md) to start Drukbox and finish in
+Then follow [full local setup](https://github.com/czpython/druks/blob/main/docs/full-local.md) to finish in
 the dashboard: connect the agent harnesses and the GitHub App the bundled
 `ship` extension acts through; a standalone extension may have different
 integration requirements.
+
+Or hand the install to a coding agent — paste this into Claude Code, Codex,
+or any agent with shell access on the target machine:
+
+> Install druks on this machine by following
+> <https://raw.githubusercontent.com/czpython/druks/main/INSTALL.md>
+> exactly: run every step's verification, and if one fails, stop and show me
+> the failing step and its output instead of improvising.
 
 ```text
 trigger ──> extension workflow ──> durable step ──> agent ──> sandbox


### PR DESCRIPTION
Stacked on #220 (and #219, #218).

## What changed

- `INSTALL.md` at the repo root: the local-shape install as a deterministic runbook addressed to a coding agent with shell access — exact commands in order, a machine-checkable verification after every step (`docker compose ps`, `curl :8001/health`, `druks doctor` with the expected browser-only failures called out), and a standing stop-and-report rule instead of improvised fixes. It ends by handing back to the operator for the browser-only steps (harness + GitHub connect).
- The README install section gains the paste-in prompt that points an agent at the runbook.

Narrative documentation stays canonical in `docs/full-local.md` / `deploy/README.md`; the runbook links rather than repeats.

The end-to-end acceptance (paste the prompt on a fresh box, get a working install) needs a fresh machine — worth one manual pass before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)