### PR TITLE
ENG-841 — druks.ai/install.sh redirect + docs cutover

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ call, not yours.
 ## 2. Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh | DRUKS_PROVIDER=docker bash
+curl -fsSL https://druks.ai/install.sh | DRUKS_PROVIDER=docker bash
 ```
 
 Verification: the command exits 0 and ends with `docker compose up -d`

--- a/README.md
+++ b/README.md
@@ -28,37 +28,23 @@ explains the exact boundary.
 The installer supports three deployment shapes backed by
 [Drukbox](https://github.com/czpython/drukbox):
 
-- `exe` (default): exe.dev sandbox VMs over a tailnet
-- any provider name other than `exe` or `docker`: the generic remote shape
-- `docker`: local sandbox containers, with Drukbox running on the host
+- `docker` (default): local sandbox containers on the host Docker daemon — the
+  zero-config laptop shape
+- `exe`: exe.dev sandbox VMs over a tailnet
+- any other provider name: the generic remote shape
 
-For a remote install:
+The default is the local shape, so the bare command boots a stack with no
+authored values:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh | bash
+curl -fsSL https://druks.ai/install.sh | bash
 ```
 
 That command follows the edge channel while Druks has no stable release. Once
 versioned releases exist, install the script and image from the same tag as
 described in [the release process](https://github.com/czpython/druks/blob/main/docs/releasing.md#install-an-immutable-version).
-
-The installer is non-interactive. The first run creates `~/druks/druks.toml`
-with generated secrets and, when the shape still needs values only you know
-(remote provider credentials, identity edge), prints that checklist and exits;
-set them in `druks.toml` and re-run the same command. A boot-ready run renders
-`.env`, pulls images, runs migrations, and starts the stack. Re-running is also
-the upgrade path.
-See the [deployment runbook](https://github.com/czpython/druks/blob/main/deploy/README.md) for prerequisites, access
-control, verification, and rollback.
-
-For a laptop-only stack:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh | DRUKS_PROVIDER=docker bash
-```
-
-The local shape needs no authored values — the first run boots the stack.
-Then follow [full local setup](https://github.com/czpython/druks/blob/main/docs/full-local.md) to finish in
+Re-running is also the upgrade path. Then follow
+[full local setup](https://github.com/czpython/druks/blob/main/docs/full-local.md) to finish in
 the dashboard: connect the agent harnesses and the GitHub App the bundled
 `ship` extension acts through; a standalone extension may have different
 integration requirements.
@@ -70,6 +56,20 @@ or any agent with shell access on the target machine:
 > <https://raw.githubusercontent.com/czpython/druks/main/INSTALL.md>
 > exactly: run every step's verification, and if one fails, stop and show me
 > the failing step and its output instead of improvising.
+
+For a remote install, name the provider — `exe` for exe.dev VMs, any other
+Drukbox provider name for the generic remote shape:
+
+```bash
+curl -fsSL https://druks.ai/install.sh | DRUKS_PROVIDER=exe bash
+```
+
+The installer is non-interactive: the first run writes `~/druks/druks.toml`
+with generated secrets, and when a remote shape still needs values only you
+know (provider credentials, identity edge) it prints that checklist and exits;
+set them in `druks.toml` and re-run the same command. See the
+[deployment runbook](https://github.com/czpython/druks/blob/main/deploy/README.md)
+for prerequisites, access control, verification, and rollback.
 
 ```text
 trigger ──> extension workflow ──> durable step ──> agent ──> sandbox

--- a/backend/druks/cli.py
+++ b/backend/druks/cli.py
@@ -42,7 +42,7 @@ def main() -> None:
     setup_parser.add_argument("env_path", help="Path to the rendered .env.")
     setup_parser.add_argument(
         "--provider",
-        default="exe",
+        default="docker",
         help="Fresh-install sandbox provider; ignored when druks.toml exists.",
     )
     setup_parser.add_argument(

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -21,12 +21,12 @@ there is no second datastore to run or back up separately.
 
 The Druks services use the **host network** so they can reach Postgres, Redis,
 Drukbox, and provider-specific sandbox addresses from the host network
-namespace. The default exe.dev shape reaches VMs over the host's tailnet;
+namespace. The exe.dev shape reaches VMs over the host's tailnet;
 other providers may return directly reachable SSH addresses.
 
 ## First-time setup on a fresh box
 
-Prerequisites: Docker with the Compose plugin. The default exe.dev shape also
+Prerequisites: Docker with the Compose plugin. The exe.dev shape also
 needs `tailscaled` joined to the intended tailnet (`tailscale status` shows
 peers). Other remote providers have their own network and credential
 requirements; the local Docker shape is covered in
@@ -41,23 +41,26 @@ Everything else — `compose.yaml`, the Caddyfile, `druks.toml`, the rendered
 ### 1. Run the installer
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh | bash
+curl -fsSL https://druks.ai/install.sh | DRUKS_PROVIDER=exe bash
 ```
 
-First pass writes `~/druks/druks.toml` with random secrets pre-filled, renders
-`~/druks/.env`, and exits when required values are missing. It tells you exactly what to do next: edit `druks.toml` — for a
-generic remote shape, fill `[sandbox.<provider>]` from Drukbox's
+`docker` is the default provider (the local shape); a remote deploy names its
+provider — `exe` for exe.dev, any other Drukbox provider name for the generic
+remote shape. First pass writes `~/druks/druks.toml` with random secrets
+pre-filled, renders `~/druks/.env`, and exits when required values are missing.
+It tells you exactly what to do next: edit `druks.toml` — for a generic remote
+shape, fill `[sandbox.<provider>]` from Drukbox's
 [configuration reference](https://github.com/czpython/drukbox).
 
 The GitHub App druks acts as is connected from the dashboard after boot
 (**Settings → Harnesses → Connect GitHub**), per the permission table in
 [`docs/configuration.md`](../docs/configuration.md#github).
 
-The sandbox backend defaults to exe.dev + Tailscale. Pass `DRUKS_PROVIDER`
-on the first run to choose another. `docker` selects the local shape; any other
-Drukbox provider name selects the generic remote shape and is passed through
-without a Druks provider registry. Re-runs read `[sandbox].provider` from
-`druks.toml`, so the environment flag is only a fresh-install seed.
+The sandbox backend defaults to the local `docker` shape. Pass `DRUKS_PROVIDER`
+on the first run to choose another: `exe` for exe.dev + Tailscale, any other
+Drukbox provider name for the generic remote shape (passed through without a
+Druks provider registry). Re-runs read `[sandbox].provider` from `druks.toml`,
+so the environment flag is only a fresh-install seed.
 
 Override the install dir with `DRUKS_INSTALL_DIR=/srv/druks` if you
 want it elsewhere.
@@ -65,11 +68,11 @@ want it elsewhere.
 ### 2. Re-run the installer
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh)
+curl -fsSL https://druks.ai/install.sh | bash
 ```
 
-Second pass renders `.env` from `druks.toml`, validates the required values and
-PEMs, then: `docker compose pull` → migrate the databases out of band
+Second pass renders `.env` from `druks.toml`, validates the required values,
+then: `docker compose pull` → migrate the databases out of band
 (`docker compose run --rm web druks init-db`, plus drukbox's schema on a
 remote install) → `docker compose up -d`. Nothing migrates on boot.
 

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -26,8 +26,11 @@ and `linux/arm64`.
 ## 1. Install the local Druks profile
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh | DRUKS_PROVIDER=docker bash
+curl -fsSL https://druks.ai/install.sh | bash
 ```
+
+`docker` is the default provider, so the bare command selects the local shape;
+`DRUKS_PROVIDER=docker` is equivalent and explicit.
 
 The local shape needs no authored values, so the first run goes all the way:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -51,8 +51,8 @@ files it downloads. When `DRUKS_TAG` is omitted, a `v*` ref selects the matching
 image tag and a full commit SHA selects `sha-<full-git-sha>`.
 
 ```bash
-DRUKS_REF=v0.1.0 \
-  bash <(curl -fsSL https://raw.githubusercontent.com/czpython/druks/v0.1.0/scripts/install.sh)
+curl -fsSL https://raw.githubusercontent.com/czpython/druks/v0.1.0/scripts/install.sh \
+  | DRUKS_REF=v0.1.0 bash
 ```
 
 For rollback, prefer the immutable full-SHA tag recorded during release. Check

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,16 +12,16 @@
 #
 # Usage:
 #
-#   curl -fsSL https://raw.githubusercontent.com/czpython/druks/main/scripts/install.sh | bash
+#   curl -fsSL https://druks.ai/install.sh | bash
 #
 # Env knobs:
 #   DRUKS_INSTALL_DIR     default ~/druks
 #   DRUKS_REF             default main — tag or full SHA to fetch deploy files from
 #   DRUKS_TAG             image tag to pull/run; defaults to the v* DRUKS_REF,
 #                         sha-<DRUKS_REF> for a full SHA, or latest for main
-#   DRUKS_PROVIDER        default exe — sandbox provider on the first run, which
-#                         picks the install shape: `docker` local, `exe` exe.dev
-#                         + tailnet, any other name generic remote. Drukbox
+#   DRUKS_PROVIDER        default docker — sandbox provider on the first run,
+#                         which picks the install shape: `docker` local, `exe`
+#                         exe.dev + tailnet, any other name generic remote. Drukbox
 #                         validates it. Ignored after druks.toml exists.
 
 set -euo pipefail
@@ -50,7 +50,7 @@ main() {
   REPO="czpython/druks"
   REF="${DRUKS_REF:-main}"
   # Validated by ``druks setup`` (the single authority on provider names).
-  PROVIDER="${DRUKS_PROVIDER:-exe}"
+  PROVIDER="${DRUKS_PROVIDER:-docker}"
 
   if [ -n "${DRUKS_TAG:-}" ]; then
     IMAGE_TAG="$DRUKS_TAG"


### PR DESCRIPTION
Final install-UX polish, stacked on the merged arc (#218–#221).

## 1. druks.ai/install.sh is the canonical URL

Every evergreen install command moves to `curl -fsSL https://druks.ai/install.sh | bash`.

- `druks.ai/install.sh` is a **307 redirect** to `raw.githubusercontent.com/czpython/druks/main/scripts/install.sh` (verified live). Memorable URL, zero hosting, script versioned in the repo, and the redirect hits in the access logs are the install counter. The script itself sends no telemetry.
- Version-pinned installs (`docs/releasing.md`) intentionally keep fetching from the release tag on GitHub.

## 2. The local (docker) shape is the default

`DRUKS_PROVIDER` defaults to `docker` instead of `exe`, so the bare `curl … | bash` boots the zero-config local shape in one command — the one-command boot the arc promised, previously stranded behind `DRUKS_PROVIDER=docker`.

- A remote deploy names its provider: `DRUKS_PROVIDER=exe` (exe.dev) or any other Drukbox provider name.
- **Safe because the default only seeds a fresh install.** Re-runs read `[sandbox].provider` from `druks.toml`, so no existing deployment shifts. And a local install's drukbox can't fall back to exe: `druks setup` writes `DEFAULT_HOST_PROVIDER=docker` to `.env` *and* `compose.local.yaml` pins it on the service (verified by rendering setup + `docker compose config`).
- README now leads with the local command; the deploy runbook names the provider explicitly. Also fixes a stale README line ("Drukbox running on the host" — #220 folded it into compose).

Verified: redirect returns `307 → …/main/scripts/install.sh` and serves the installer; `bash -n`; ruff; every install URL audited (evergreen → druks.ai, pinned/release stays raw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
