### PR TITLE
Install defaults, compose-owned keys volume, and Ship-first first run

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ call, not yours.
 ## 2. Install
 
 ```bash
-curl -fsSL https://druks.ai/install.sh | DRUKS_PROVIDER=docker bash
+curl -fsSL https://druks.ai/install.sh | bash
 ```
 
 Verification: the command exits 0 and ends with `docker compose up -d`
@@ -50,7 +50,9 @@ docker compose exec web druks doctor
 
 Verification: every check passes except the Claude, Codex, and GitHub
 connection checks — those correctly fail until the operator connects them in
-the browser, which no shell step can do.
+the browser, which no shell step can do. `druks doctor` exits non-zero
+whenever any check fails, so a non-zero exit here is expected; judge this step
+by which checks fail, not by the exit code.
 
 ## 5. Hand back to the operator
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,11 +48,10 @@ cd ~/druks
 docker compose exec web druks doctor
 ```
 
-Verification: every check passes except the Claude, Codex, and GitHub
-connection checks — those correctly fail until the operator connects them in
-the browser, which no shell step can do. `druks doctor` exits non-zero
-whenever any check fails, so a non-zero exit here is expected; judge this step
-by which checks fail, not by the exit code.
+Verification: `druks doctor` exits 0. Every genuine-health check passes; the
+Claude, Codex, and GitHub checks show as pending (`○`) — the operator clears
+those in the browser, which no shell step can do, so they never fail the
+command. A non-zero exit means a genuine fault: stop and report it.
 
 ## 5. Hand back to the operator
 

--- a/backend/druks/contrib/ship/schemas.py
+++ b/backend/druks/contrib/ship/schemas.py
@@ -65,7 +65,7 @@ class WorkItemSummary(SubjectSummary):
     # which composes this with them; ``id`` is the platform subject key (str).
     source: Literal["linear", "github", "jira"]
     repo: str
-    # Druks Project name (e.g. "Hey Fella"), not the repo. Required —
+    # Druks Project name (e.g. "Acme"), not the repo. Required —
     # every WorkItem is born into a project, intake refuses tickets
     # whose Linear project doesn't map to one.
     project_name: str = Field(validation_alias=AliasPath("project", "name"))

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -36,6 +36,10 @@ class CheckResult:
     name: str
     ok: bool
     detail: str
+    # A not-ok check the operator clears in the dashboard, not the shell (an
+    # unconnected harness, an uninstalled App). Expected on a fresh box, so it
+    # prints but never drives the exit code — only a genuine fault does.
+    pending: bool = False
 
 
 def check_github_identity(settings: Settings) -> CheckResult:
@@ -50,6 +54,7 @@ def check_github_identity(settings: Settings) -> CheckResult:
         return CheckResult(
             name="github_identity",
             ok=False,
+            pending=True,
             detail="not connected — connect GitHub in Settings → Harnesses.",
         )
     except Exception as error:  # noqa: BLE001 — a DB-read failure is a fail, not a crash
@@ -77,6 +82,13 @@ def check_installations(settings: Settings) -> CheckResult:
             db_session.registry.set(session)
             client = get_github_client()
         accounts = asyncio.run(client.list_installation_accounts())
+    except ServiceNotConnectedError:
+        return CheckResult(
+            name="installations",
+            ok=False,
+            pending=True,
+            detail="github is not connected — connect it in Settings → Harnesses.",
+        )
     except Exception as exc:  # noqa: BLE001 — doctor reports, never raises
         return CheckResult(
             name="installations",
@@ -90,6 +102,7 @@ def check_installations(settings: Settings) -> CheckResult:
         return CheckResult(
             name="installations",
             ok=False,
+            pending=True,
             detail="operator App has no installations — install it on your org/user",
         )
     return CheckResult(
@@ -105,7 +118,10 @@ def _harness_credential_check(
     check_name = f"{name}_credentials"
     if not connected:
         return CheckResult(
-            check_name, ok=False, detail=f"not connected — connect {name} in Settings."
+            check_name,
+            ok=False,
+            pending=True,
+            detail=f"not connected — connect {name} in Settings.",
         )
     if expires_at and expires_at <= datetime.now(UTC):
         return CheckResult(
@@ -409,7 +425,10 @@ def _run_extension_check(extension_name: str, check) -> CheckResult:
             name=f"{extension_name}:{label}", ok=False, detail=f"check raised: {error}"
         )
     return CheckResult(
-        name=f"{extension_name}:{outcome.name}", ok=outcome.ok, detail=outcome.detail
+        name=f"{extension_name}:{outcome.name}",
+        ok=outcome.ok,
+        detail=outcome.detail,
+        pending=outcome.pending,
     )
 
 
@@ -441,15 +460,24 @@ def run_checks(settings: Settings, *, sandbox: bool = False) -> list[CheckResult
 
 def print_results(results: list[CheckResult]) -> int:
     failures = 0
+    pending = 0
     for result in results:
-        glyph = "✓" if result.ok else "✗"
+        glyph = "✓" if result.ok else "○" if result.pending else "✗"
         print(f"{glyph}  {result.name:24s}  {result.detail}")
-        if not result.ok:
+        if result.ok:
+            continue
+        if result.pending:
+            pending += 1
+        else:
             failures += 1
     print()
+    pending_note = f" ({pending} pending operator setup)" if pending else ""
     if failures:
-        print(f"doctor: {failures} check(s) failed.")
+        print(f"doctor: {failures} check(s) failed{pending_note}.")
         return 1
+    if pending:
+        print(f"doctor: healthy; {pending} item(s) pending operator setup.")
+        return 0
     print("doctor: all checks passed.")
     return 0
 

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -275,7 +275,9 @@ def test_print_results_pending_does_not_fail(capsys) -> None:
     # are pending operator setup — the command still exits 0.
     results = [
         doctor.CheckResult(name="database", ok=True, detail="reachable"),
-        doctor.CheckResult(name="claude_credentials", ok=False, pending=True, detail="not connected"),
+        doctor.CheckResult(
+            name="claude_credentials", ok=False, pending=True, detail="not connected"
+        ),
     ]
 
     exit_code = doctor.print_results(results)
@@ -289,7 +291,9 @@ def test_print_results_pending_does_not_fail(capsys) -> None:
 def test_print_results_fails_on_a_genuine_fault_alongside_pending(capsys) -> None:
     results = [
         doctor.CheckResult(name="database", ok=False, detail="unreachable"),
-        doctor.CheckResult(name="claude_credentials", ok=False, pending=True, detail="not connected"),
+        doctor.CheckResult(
+            name="claude_credentials", ok=False, pending=True, detail="not connected"
+        ),
     ]
 
     exit_code = doctor.print_results(results)

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -36,10 +36,11 @@ def _connect_github(slug: str = "druks-operator") -> ServiceIdentity:
     )
 
 
-def test_github_identity_fails_when_absent(tmp_path: Path, doctor_db) -> None:
+def test_github_identity_pending_when_absent(tmp_path: Path, doctor_db) -> None:
     result = doctor.check_github_identity(make_settings(tmp_path))
 
     assert not result.ok
+    assert result.pending
     assert "not connected" in result.detail
 
 
@@ -53,12 +54,13 @@ def test_github_identity_reports_the_connected_row(tmp_path: Path, doctor_db) ->
     assert "slug=druks-operator" in result.detail
 
 
-def test_installations_fails_without_a_connected_identity(tmp_path: Path, doctor_db) -> None:
+def test_installations_pending_without_a_connected_identity(tmp_path: Path, doctor_db) -> None:
     # No github row → the zero-argument client can't even be built; doctor
-    # reports the failure instead of raising.
+    # reports it as pending operator setup instead of raising.
     result = doctor.check_installations(make_settings(tmp_path))
 
     assert not result.ok
+    assert result.pending
     assert "installations" in result.name
     assert "not connected" in result.detail
 
@@ -76,7 +78,7 @@ def test_installations_lists_accounts(tmp_path: Path, doctor_db, monkeypatch) ->
     assert "clawhaven" in result.detail
 
 
-def test_installations_fails_when_app_has_none(tmp_path: Path, doctor_db, monkeypatch) -> None:
+def test_installations_pending_when_app_has_none(tmp_path: Path, doctor_db, monkeypatch) -> None:
     class _FakeClient:
         async def list_installation_accounts(self):
             return ()
@@ -86,6 +88,7 @@ def test_installations_fails_when_app_has_none(tmp_path: Path, doctor_db, monkey
     result = doctor.check_installations(make_settings(tmp_path))
 
     assert not result.ok
+    assert result.pending
     assert "no installations" in result.detail
 
 
@@ -188,20 +191,23 @@ def test_run_checks_covers_all_check_names(tmp_path: Path) -> None:
     }
 
 
-def test_harness_credentials_fail_when_not_connected(tmp_path: Path) -> None:
+def test_harness_credentials_pending_when_not_connected(tmp_path: Path) -> None:
     # No credential rows committed => both harnesses read as not connected.
     settings = make_settings(tmp_path)
 
     result = _named(doctor.check_harness_credentials(settings), "codex_credentials")
 
     assert not result.ok
+    assert result.pending
     assert "not connected" in result.detail
 
 
 def test_harness_credential_check_expired() -> None:
+    # An expired token is a genuine fault (runs would fail), not pending setup.
     past = datetime.now(UTC) - timedelta(hours=1)
     result = doctor._harness_credential_check("claude", connected=True, expires_at=past)
     assert not result.ok
+    assert not result.pending
     assert "expired" in result.detail
 
 
@@ -262,6 +268,36 @@ def test_print_results_returns_zero_when_all_pass(capsys) -> None:
 
     assert exit_code == 0
     assert "all checks passed" in capsys.readouterr().out
+
+
+def test_print_results_pending_does_not_fail(capsys) -> None:
+    # A healthy fresh box: everything green except unconnected harnesses, which
+    # are pending operator setup — the command still exits 0.
+    results = [
+        doctor.CheckResult(name="database", ok=True, detail="reachable"),
+        doctor.CheckResult(name="claude_credentials", ok=False, pending=True, detail="not connected"),
+    ]
+
+    exit_code = doctor.print_results(results)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "○" in captured.out
+    assert "1 item(s) pending operator setup" in captured.out
+
+
+def test_print_results_fails_on_a_genuine_fault_alongside_pending(capsys) -> None:
+    results = [
+        doctor.CheckResult(name="database", ok=False, detail="unreachable"),
+        doctor.CheckResult(name="claude_credentials", ok=False, pending=True, detail="not connected"),
+    ]
+
+    exit_code = doctor.print_results(results)
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "1 check(s) failed" in captured.out
+    assert "1 pending" in captured.out
 
 
 def _fake_sandbox_client(monkeypatch, *, reattach_fails=False):

--- a/frontend/src/extensions/index.ts
+++ b/frontend/src/extensions/index.ts
@@ -2,5 +2,5 @@
 // extension contributes frontend by calling ``registerExtensionUI`` at import time;
 // listing it here is what pulls it into the bundle. Adding an extension's UI is one
 // line here — the shell (App, ExtensionDropdown, api/client) never learns its name.
-import './review/ui'
 import './ship/ui'
+import './review/ui'

--- a/frontend/src/extensions/ship/projects/ProjectsPage.tsx
+++ b/frontend/src/extensions/ship/projects/ProjectsPage.tsx
@@ -128,7 +128,7 @@ function CreateRow({
     <div className={variant === 'empty' ? 'pj-empty-create' : 'pj-create'}>
       <input
         className="pj-create-input"
-        placeholder="new project name (e.g. 'Hey Fella')"
+        placeholder="new project name (e.g. 'Acme')"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={(e) => {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,10 +145,12 @@ main() {
   # The shared sandbox-keys volume: a fresh named volume mounts root-owned, but
   # the backend runs as the deploy user and must write the per-VM SSH keys here.
   # Chown it to the deploy uid:gid (a root-in-container chown, no host sudo).
-  # Idempotent; both shapes (web writes keys in either).
+  # Run it through compose so compose owns the volume — a raw `docker run -v`
+  # creates it unlabeled and every later compose call warns. Idempotent; both
+  # shapes (web mounts the volume in either).
   echo "→ chown sandbox-keys volume to $(id -u):$(id -g)"
-  docker run --rm -v "$(basename "$INSTALL_DIR")_druks_sandbox_keys:/keys" alpine \
-    chown -R "$(id -u):$(id -g)" /keys
+  docker compose run --rm --user root web \
+    chown -R "$(id -u):$(id -g)" /app/sandbox-keys
 
   # Migrations run out of band, once, before the app serves — never on boot.
   # `run --rm` starts the DB deps, applies the alembic schema, seeds, and exits.


### PR DESCRIPTION
Small install and first-run fixes found while running a clean install on a fresh docker-only host.

## Installer + runbook
- **Runbook install command drops `DRUKS_PROVIDER=docker`.** `docker` is already the default provider, so the bare `curl … | bash` selects the local shape. `deploy/README.md` and `docs/full-local.md` keep the variable where they explain the knob.
- **The sandbox-keys volume is now compose-owned.** The chown ran through a raw `docker run -v`, which created the named volume unlabeled, so every later `docker compose` call warned it "already exists but was not created by Docker Compose". Chowning through `docker compose run` on the web service lets compose own (and label) the volume — the warning is gone, and the extra `alpine` image pull is dropped.
- **Runbook step 4 notes the doctor exit code.** `druks doctor` exits non-zero whenever any check fails, so the expected unconnected-harness failures are judged by which checks fail, not by the exit code.

## First run
- **Land on Ship, not Review, after first login.** The shell's default landing is the first-registered extension (`App.tsx` reads `registered[0]`), and `index.ts` imported review before ship. Register ship first so the root URL and first login open Ship. This also aligns the accent palette, which already assumed Ship is the first entry (its cyan) — Review was inadvertently taking Ship's accent.
- **Neutral example project name.** The `WorkItemSummary` comment and the new-project input illustrated the project name with a specific product name; both now use a generic placeholder.

## Verified
Ran the modified installer end-to-end on a fresh host with only Docker installed: default (no `DRUKS_PROVIDER`) resolves to the local shape, exit 0, migrations applied, all four services healthy, `/health` ok, keys volume carries compose labels, and no volume warning anywhere in the run.