### PR TITLE
The wire serves services, keyed by name

### DIFF
--- a/backend/druks/core/routes.py
+++ b/backend/druks/core/routes.py
@@ -12,7 +12,7 @@ from druks.core.services import GitHubApp
 from druks.services.models import ServiceIdentity
 
 # Mounted by the loader under /api/core, like any extension's routes.
-router = APIRouter(prefix="/github", tags=["service-identities"])
+router = APIRouter(prefix="/github", tags=["services"])
 
 _templates = Environment(
     loader=FileSystemLoader(Path(__file__).parent / "templates"),

--- a/backend/druks/services/routes.py
+++ b/backend/druks/services/routes.py
@@ -4,20 +4,20 @@ from druks.accounts.dependencies import current_session_account
 from druks.extensions.registry import services
 from druks.services.exceptions import ServiceConnectError, ServiceNotConnectedError
 from druks.services.models import ServiceIdentity
-from druks.services.schemas import ServiceIdentityResponse
+from druks.services.schemas import ServiceResponse
 
-router = APIRouter(prefix="/api/service-identities", tags=["service-identities"])
+router = APIRouter(prefix="/api/services", tags=["services"])
 
 
-@router.get("", response_model=list[ServiceIdentityResponse], response_model_by_alias=True)
-async def list_service_identities() -> list[ServiceIdentityResponse]:
+@router.get("", response_model=list[ServiceResponse], response_model_by_alias=True)
+async def list_services() -> list[ServiceResponse]:
     entries = []
     for service in services.all():
         try:
             row = ServiceIdentity.get(service.name)
         except ServiceNotConnectedError:
             row = None
-        entries.append(ServiceIdentityResponse.from_row(service, row))
+        entries.append(ServiceResponse.from_row(service, row))
     return entries
 
 
@@ -25,11 +25,11 @@ async def list_service_identities() -> list[ServiceIdentityResponse]:
 # credentials are never writable with an agent PAT.
 @router.post(
     "/{name}",
-    response_model=ServiceIdentityResponse,
+    response_model=ServiceResponse,
     response_model_by_alias=True,
     dependencies=[Depends(current_session_account)],
 )
-async def connect_service_identity(name: str, payload: dict[str, str]) -> ServiceIdentityResponse:
+async def connect_service(name: str, payload: dict[str, str]) -> ServiceResponse:
     service = services.get(name)
     if not service:
         raise HTTPException(status_code=404, detail=f"No service {name!r}.")
@@ -37,4 +37,4 @@ async def connect_service_identity(name: str, payload: dict[str, str]) -> Servic
         row = await service.connect(payload)
     except ServiceConnectError as error:
         raise HTTPException(status_code=422, detail=str(error)) from error
-    return ServiceIdentityResponse.from_row(service, row)
+    return ServiceResponse.from_row(service, row)

--- a/backend/druks/services/schemas.py
+++ b/backend/druks/services/schemas.py
@@ -18,9 +18,9 @@ class ServiceFieldSpec(BaseResponse):
     multiline: bool
 
 
-class ServiceIdentityResponse(BaseResponse):
+class ServiceResponse(BaseResponse):
     # Connection state and identity facts only — never a stored secret.
-    service: str
+    name: str
     title: str
     description: str
     required: bool
@@ -30,11 +30,9 @@ class ServiceIdentityResponse(BaseResponse):
     fields: list[ServiceFieldSpec]
 
     @classmethod
-    def from_row(
-        cls, service: "type[Service]", row: "ServiceIdentity | None"
-    ) -> "ServiceIdentityResponse":
+    def from_row(cls, service: "type[Service]", row: "ServiceIdentity | None") -> "ServiceResponse":
         return cls(
-            service=service.name,
+            name=service.name,
             title=service.title,
             description=service.description,
             required=service.required,

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -24,14 +24,14 @@ SESSION_ONLY_API_ROUTES = {
     ("DELETE", "/api/auth/personal-tokens/{pat_id}"),
     ("DELETE", "/api/harnesses/{name}/connection"),
     ("PATCH", "/api/settings/extensions"),
-    ("POST", "/api/service-identities/{name}"),
+    ("POST", "/api/services/{name}"),
 }
 
 # Session-gated routes that also sit behind their router's identity gate —
 # the route-level session dependency is the stricter of the two.
 DUAL_GATED_API_PATHS = {
     "/api/settings/extensions",
-    "/api/service-identities/{name}",
+    "/api/services/{name}",
 }
 
 # The connection flow must answer during none/zero setup, before any account

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -206,9 +206,9 @@ def test_a_pat_reads_but_cannot_write_service_identities(tmp_path, druks_db):
         _, token = _mint("op@example.com")
         headers = _bearer(token)
 
-        read = client.get("/api/service-identities", headers=headers)
+        read = client.get("/api/services", headers=headers)
         write = client.post(
-            "/api/service-identities/github",
+            "/api/services/github",
             json={"app_id": "1", "private_key": "p", "webhook_secret": "s"},
             headers=headers,
         )

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -30,8 +30,8 @@ def _connect(
 
 
 def _github_entry(client: TestClient) -> dict:
-    entries = client.get("/api/service-identities").json()
-    return next(entry for entry in entries if entry["service"] == "github")
+    entries = client.get("/api/services").json()
+    return next(entry for entry in entries if entry["name"] == "github")
 
 
 # --- The row ----------------------------------------------------------------
@@ -173,7 +173,7 @@ def test_post_authenticates_then_creates_the_row(druks_client: TestClient, druks
     _mock_authenticated_app(monkeypatch)
 
     response = druks_client.post(
-        "/api/service-identities/github",
+        "/api/services/github",
         json={"app_id": "12345", "private_key": _PEM, "webhook_secret": _SECRET},
     )
 
@@ -195,7 +195,7 @@ def test_post_replaces_an_existing_row(druks_client: TestClient, druks_db, monke
     _mock_authenticated_app(monkeypatch, slug="replacement-app")
 
     response = druks_client.post(
-        "/api/service-identities/github",
+        "/api/services/github",
         json={"app_id": "777", "private_key": "new-pem", "webhook_secret": "new-secret"},
     )
 
@@ -204,7 +204,7 @@ def test_post_replaces_an_existing_row(druks_client: TestClient, druks_db, monke
 
 
 def test_post_rejects_an_unknown_service(druks_client: TestClient):
-    response = druks_client.post("/api/service-identities/nope", json={"anything": "x"})
+    response = druks_client.post("/api/services/nope", json={"anything": "x"})
 
     assert response.status_code == 404
 
@@ -220,7 +220,7 @@ def test_invalid_credentials_preserve_the_previous_row(
     monkeypatch.setattr(GitHubClient, "get_authenticated_app_slug", _rejected)
 
     response = druks_client.post(
-        "/api/service-identities/github",
+        "/api/services/github",
         json={"app_id": "999", "private_key": "bad-pem", "webhook_secret": "bad-secret"},
     )
 
@@ -245,7 +245,7 @@ def test_blank_fields_are_rejected_without_touching_github(
     monkeypatch.setattr(GitHubClient, "get_authenticated_app_slug", _never)
 
     response = druks_client.post(
-        "/api/service-identities/github",
+        "/api/services/github",
         json={"app_id": " ", "private_key": "", "webhook_secret": ""},
     )
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -19,7 +19,7 @@ import type {
   UsageTodayResponse,
   McpRegistryCandidate,
   McpServer,
-  ServiceIdentity,
+  Service,
   Skill,
   SkillCollection,
   UserSettings,
@@ -218,9 +218,9 @@ export const api = {
   // The appliance's own identities at external services — connect verifies the
   // pasted credentials against the provider before anything replaces a working
   // identity. Field names come from each entry's spec.
-  serviceIdentities: () => getJSON<ServiceIdentity[]>('/api/service-identities'),
-  connectServiceIdentity: (service: string, fields: Record<string, string>) =>
-    postJSON<ServiceIdentity>(`/api/service-identities/${encodeURIComponent(service)}`, fields),
+  services: () => getJSON<Service[]>('/api/services'),
+  connectService: (name: string, fields: Record<string, string>) =>
+    postJSON<Service>(`/api/services/${encodeURIComponent(name)}`, fields),
   getExtensionSettings: () => getJSON<ExtensionsSettingsResponse>('/api/settings/extensions'),
   updateExtensionSettings: (body: UpdateExtensionsSettingsRequest) =>
     patchJSON<ExtensionsSettingsResponse>('/api/settings/extensions', body),

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -258,7 +258,7 @@ export interface UpdateHarnessRequest {
   timeout?: number
 }
 
-export interface ServiceIdentityField {
+export interface ServiceField {
   name: string
   label: string
   help: string
@@ -268,15 +268,15 @@ export interface ServiceIdentityField {
 
 /** One declared service: the appliance's own registered app at an external
  * provider. Facts are identity only — stored secrets never leave the backend. */
-export interface ServiceIdentity {
-  service: string
+export interface Service {
+  name: string
   title: string
   description: string
   required: boolean
   connected: boolean
   facts: Record<string, string>
   connectedAt: string | null
-  fields: ServiceIdentityField[]
+  fields: ServiceField[]
 }
 
 // --- Settings --------------------------------------------------------------

--- a/frontend/src/components/ServiceCard.test.tsx
+++ b/frontend/src/components/ServiceCard.test.tsx
@@ -2,8 +2,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { ServiceIdentity } from '../api/types'
-import { ServiceIdentityCards } from './SettingsModal'
+import type { Service } from '../api/types'
+import { ServiceCards } from './SettingsModal'
 
 const PEM = '-----BEGIN RSA PRIVATE KEY-----\nline-one\nline-two\n-----END RSA PRIVATE KEY-----'
 const SECRET = 'hook-secret-value'
@@ -14,8 +14,8 @@ const githubFields = [
   { name: 'webhook_secret', label: 'Webhook secret', help: '', type: 'secret', multiline: false },
 ]
 
-const disconnected: ServiceIdentity = {
-  service: 'github',
+const disconnected: Service = {
+  name: 'github',
   title: 'GitHub',
   description: 'The GitHub App druks acts as.',
   required: true,
@@ -25,15 +25,15 @@ const disconnected: ServiceIdentity = {
   fields: githubFields,
 }
 
-const connected: ServiceIdentity = {
+const connected: Service = {
   ...disconnected,
   connected: true,
   facts: { app_id: '12345', slug: 'druks-operator' },
   connectedAt: '2026-08-09T00:00:00Z',
 }
 
-const pasteOnly: ServiceIdentity = {
-  service: 'gmail',
+const pasteOnly: Service = {
+  name: 'gmail',
   title: 'Google OAuth client',
   description: 'The OAuth client every mailbox authenticates against.',
   required: true,
@@ -46,16 +46,16 @@ const pasteOnly: ServiceIdentity = {
   ],
 }
 
-function stubFetch(states: ServiceIdentity[][]) {
+function stubFetch(states: Service[][]) {
   // GET serves the list states in order (post-connect refetch sees the next
   // one); POST answers with the connected github entry.
   const gets = [...states]
   const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
     async (url, init) => {
-      if (url === '/api/service-identities/github' && init?.method === 'POST') {
+      if (url === '/api/services/github' && init?.method === 'POST') {
         return new Response(JSON.stringify(connected), { status: 200 })
       }
-      if (url === '/api/service-identities') {
+      if (url === '/api/services') {
         const state = gets.length > 1 ? gets.shift() : gets[0]
         return new Response(JSON.stringify(state), { status: 200 })
       }
@@ -70,7 +70,7 @@ function renderCards() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={queryClient}>
-      <ServiceIdentityCards />
+      <ServiceCards />
     </QueryClientProvider>,
   )
 }
@@ -86,7 +86,7 @@ async function flush() {
   })
 }
 
-describe('ServiceIdentityCards', () => {
+describe('ServiceCards', () => {
   it('renders the disconnected paste-in form from the field spec', async () => {
     stubFetch([[disconnected]])
     renderCards()
@@ -119,7 +119,7 @@ describe('ServiceIdentityCards', () => {
     await flush()
 
     const post = fetchMock.mock.calls.find(
-      ([url, init]) => url === '/api/service-identities/github' && init?.method === 'POST',
+      ([url, init]) => url === '/api/services/github' && init?.method === 'POST',
     )
     expect(JSON.parse(String(post?.[1]?.body))).toEqual({
       app_id: '12345',
@@ -138,7 +138,7 @@ describe('ServiceIdentityCards', () => {
   it('keeps a rejected paste out of the row and shows the error', async () => {
     const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
       async (url, init) => {
-        if (url === '/api/service-identities/github' && init?.method === 'POST') {
+        if (url === '/api/services/github' && init?.method === 'POST') {
           return new Response(
             JSON.stringify({ detail: 'GitHub did not accept these credentials — check the App ID and PEM private key.' }),
             { status: 422, statusText: 'Unprocessable Entity' },

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -11,7 +11,7 @@ import {
   type McpRegistryCandidate,
   type McpServer,
   type Pat,
-  type ServiceIdentity,
+  type Service,
   type SkillCollection,
   type UpdateHarnessRequest,
   type UpdateExtensionsSettingsRequest,
@@ -852,7 +852,7 @@ function ServicesPane() {
       <div className="set-group">
         <div className="set-group-label">services</div>
         <div className="set-cards">
-          <ServiceIdentityCards />
+          <ServiceCards />
         </div>
       </div>
     </div>
@@ -864,22 +864,22 @@ function ServicesPane() {
 // immediately, outside the modal's Save, so each card owns its query, submit,
 // busy, and error state. Pasted secrets are write-only: a success drops them
 // from state, and the connected rendering shows identity facts only.
-export function ServiceIdentityCards() {
+export function ServiceCards() {
   const query = useQuery({
-    queryKey: ['serviceIdentities'],
-    queryFn: () => api.serviceIdentities(),
+    queryKey: ['services'],
+    queryFn: () => api.services(),
     staleTime: 60_000,
   })
   return (
     <>
-      {(query.data ?? []).map((identity) => (
-        <ServiceIdentityCard key={identity.service} identity={identity} />
+      {(query.data ?? []).map((service) => (
+        <ServiceCard key={service.name} service={service} />
       ))}
     </>
   )
 }
 
-export function ServiceIdentityCard({ identity }: { identity: ServiceIdentity }) {
+export function ServiceCard({ service }: { service: Service }) {
   const queryClient = useQueryClient()
   const [replacing, setReplacing] = useState(false)
   const [values, setValues] = useState<Record<string, string>>({})
@@ -891,67 +891,67 @@ export function ServiceIdentityCard({ identity }: { identity: ServiceIdentity })
   useEffect(() => {
     const channel = new BroadcastChannel('druks-service-connect')
     channel.onmessage = (event) => {
-      if (event.data === identity.service) {
+      if (event.data === service.name) {
         setReplacing(false)
-        void queryClient.invalidateQueries({ queryKey: ['serviceIdentities'] })
+        void queryClient.invalidateQueries({ queryKey: ['services'] })
       }
     }
     return () => channel.close()
-  }, [queryClient, identity.service])
+  }, [queryClient, service.name])
 
-  const formOpen = !identity.connected || replacing
-  const complete = identity.fields.every((field) => (values[field.name] ?? '').trim() !== '')
+  const formOpen = !service.connected || replacing
+  const complete = service.fields.every((field) => (values[field.name] ?? '').trim() !== '')
 
   const submit = () => {
     setBusy(true)
     setError(null)
     void api
-      .connectServiceIdentity(identity.service, values)
+      .connectService(service.name, values)
       .then(async () => {
         setValues({})
         setReplacing(false)
-        await queryClient.invalidateQueries({ queryKey: ['serviceIdentities'] })
+        await queryClient.invalidateQueries({ queryKey: ['services'] })
       })
       .catch((e) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setBusy(false))
   }
 
-  const facts = Object.entries(identity.facts)
+  const facts = Object.entries(service.facts)
 
   return (
     <div className="set-card harness-row" style={{ '--fam': 'var(--accent-violet)' } as CSSProperties}>
       <div className="hr-head">
         <span className="set-card-name">
           <span className="dot" />
-          {identity.service}
+          {service.name}
         </span>
         <span className="set-card-tag">service identity</span>
       </div>
-      <div className="set-pane-sub">{identity.description}</div>
+      <div className="set-pane-sub">{service.description}</div>
       <div className="hr-connect">
         <div className="hr-conn-status">
-          {identity.connected ? (
+          {service.connected ? (
             <span className="hr-chip hr-chip-on">
               connected{facts.map(([key, value]) => ` · ${key} ${value}`).join('')}
             </span>
           ) : (
             <span className="hr-chip hr-chip-off">not connected</span>
           )}
-          {identity.connected && identity.connectedAt && (
-            <span className="hr-conn-exp">connected {new Date(identity.connectedAt).toLocaleString()}</span>
+          {service.connected && service.connectedAt && (
+            <span className="hr-conn-exp">connected {new Date(service.connectedAt).toLocaleString()}</span>
           )}
           <span className="hr-conn-actions">
-            {identity.service === 'github' && identity.connected && (
+            {service.name === 'github' && service.connected && (
               <a
                 className="hr-conn-btn"
-                href={`https://github.com/apps/${encodeURIComponent(identity.facts.slug ?? '')}/installations/new`}
+                href={`https://github.com/apps/${encodeURIComponent(service.facts.slug ?? '')}/installations/new`}
                 target="_blank"
                 rel="noreferrer"
               >
                 Manage installations
               </a>
             )}
-            {identity.connected && !replacing && (
+            {service.connected && !replacing && (
               <button className="hr-conn-btn" onClick={() => setReplacing(true)} disabled={busy}>
                 Replace
               </button>
@@ -960,7 +960,7 @@ export function ServiceIdentityCard({ identity }: { identity: ServiceIdentity })
         </div>
         {formOpen && (
           <div className="si-connect-form">
-            {identity.service === 'github' && (
+            {service.name === 'github' && (
               <>
                 <span className="hr-conn-actions">
                   <button
@@ -974,7 +974,7 @@ export function ServiceIdentityCard({ identity }: { identity: ServiceIdentity })
                 <div className="set-pane-sub">…or paste an existing App&apos;s credentials:</div>
               </>
             )}
-            {identity.fields.map((field) =>
+            {service.fields.map((field) =>
               field.multiline ? (
                 <div className="set-field" key={field.name}>
                   <span className="set-field-label">{field.label}</span>
@@ -1007,7 +1007,7 @@ export function ServiceIdentityCard({ identity }: { identity: ServiceIdentity })
                 </button>
               )}
               <button className="hr-conn-btn" onClick={submit} disabled={busy || !complete}>
-                {identity.connected ? 'Replace connection' : `Connect ${identity.title}`}
+                {service.connected ? 'Replace connection' : `Connect ${service.title}`}
               </button>
             </span>
           </div>


### PR DESCRIPTION
Follow-up to #224, aligning the wire with the vocabulary rule: you declare a Service; connecting stores the appliance's service identity at it. The wire lists services (each with its identity state), so the names now say that:

- `GET /api/service-identities` → `GET /api/services`; connect stays `POST /api/services/{name}`.
- `ServiceIdentityResponse` → `ServiceResponse`, and its `service` field → `name` — it is the declaration's `name`, and the connect path already used the word.
- Frontend follows: `Service` / `ServiceField` types, `api.services()` / `api.connectService()`, `ServiceCards` / `ServiceCard`.

The `ServiceIdentity` row model, the `service_identities` table, and the doctor's identity checks keep their names — those are the identity side of the rule. No migration; the frontend is the wire's only consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
