### PR TITLE
Tracker credentials are ship-declared service identities

### DIFF
--- a/backend/druks/contrib/ship/exceptions.py
+++ b/backend/druks/contrib/ship/exceptions.py
@@ -17,6 +17,6 @@ class TrackerNotConfigured(AgentApiError):
 
     def __init__(self) -> None:
         super().__init__(
-            "No ticket tracker is configured — select Linear or Jira and set its "
-            "credentials in the ship settings."
+            "No ticket tracker is configured — select Linear or Jira in the ship "
+            "settings and connect its identity in Settings → Harnesses."
         )

--- a/backend/druks/contrib/ship/extension.py
+++ b/backend/druks/contrib/ship/extension.py
@@ -3,6 +3,7 @@ from typing import Literal
 from pydantic import Field
 
 from druks.agents import Agent
+from druks.contrib.ship import services
 from druks.contrib.ship.contracts import (
     CodeReviewOutput,
     ContractRevisionOutput,
@@ -17,7 +18,9 @@ from druks.contrib.ship.ticketing.base import Tracker
 from druks.contrib.ship.ticketing.jira import Jira
 from druks.contrib.ship.ticketing.linear import Linear
 from druks.db import StoredSubject
-from druks.extensions import Extension, ExtensionSettings, Secret
+from druks.doctor import CheckResult
+from druks.extensions import Extension, ExtensionSettings
+from druks.services import ServiceNotConnectedError
 from druks.workflows import SubjectActivity
 
 # Only what the timeline can't already show. A running agent has an agent call
@@ -25,6 +28,24 @@ from druks.workflows import SubjectActivity
 _PHASE_META: dict[str, SubjectActivity] = {
     "provisioning_vm": SubjectActivity(label="Building sandbox VM…", kind="infra"),
 }
+
+
+def check_tracker_identity() -> CheckResult:
+    """Whether the selected tracker's identity is connected. Trackerless is a
+    choice, not a fault; a selected-but-unconnected tracker is pending setup."""
+    settings = Ship.settings()
+    if settings.tracker == "none":
+        return CheckResult(name="tracker", ok=True, detail="trackerless by choice")
+    service = {"linear": services.Linear, "jira": services.Jira}[settings.tracker]
+    if service.is_connected():
+        return CheckResult(name="tracker", ok=True, detail=f"{settings.tracker} connected")
+    return CheckResult(
+        name="tracker",
+        ok=False,
+        pending=True,
+        detail=f"tracker is {settings.tracker} but it is not connected — "
+        "connect it in Settings → Harnesses.",
+    )
 
 
 class Ship(Extension):
@@ -45,16 +66,6 @@ class Ship(Extension):
             title="Tracker",
             description="Which ticket tracker this installation uses.",
         )
-        linear_api_key: Secret = Field(
-            title="Linear API key",
-            description="API key used to read and update Linear tickets.",
-            json_schema_extra={"section": "Linear", "visible_when": {"tracker": "linear"}},
-        )
-        linear_webhook_secret: Secret = Field(
-            title="Linear webhook secret",
-            description="Secret used to authenticate Linear webhook deliveries.",
-            json_schema_extra={"section": "Linear", "visible_when": {"tracker": "linear"}},
-        )
         # The tracker status names that drive build's funnel. They're operator
         # knobs — the names an operator's Linear/Jira workflow actually uses — so
         # they live here, not on core Settings.
@@ -71,28 +82,6 @@ class Ship(Extension):
                 "Status druks returns a ticket to when it stops working on it; empty leaves it put."
             ),
             json_schema_extra={"section": "Linear", "visible_when": {"tracker": "linear"}},
-        )
-        jira_base_url: str = Field(
-            default="",
-            title="Jira base URL",
-            description="Base URL of the Jira Cloud site.",
-            json_schema_extra={"section": "Jira", "visible_when": {"tracker": "jira"}},
-        )
-        jira_email: str = Field(
-            default="",
-            title="Jira email",
-            description="Email address used to authenticate with Jira Cloud.",
-            json_schema_extra={"section": "Jira", "visible_when": {"tracker": "jira"}},
-        )
-        jira_api_token: Secret = Field(
-            title="Jira API token",
-            description="API token used to read and update Jira tickets.",
-            json_schema_extra={"section": "Jira", "visible_when": {"tracker": "jira"}},
-        )
-        jira_webhook_secret: Secret = Field(
-            title="Jira webhook secret",
-            description="Secret used to authenticate Jira webhook deliveries.",
-            json_schema_extra={"section": "Jira", "visible_when": {"tracker": "jira"}},
         )
         jira_trigger_status: str = Field(
             default="Ready for Agent",
@@ -118,43 +107,36 @@ class Ship(Extension):
                 return self.jira_trigger_status
             return ""
 
-        def clean(self) -> dict[str, str]:
-            problems: dict[str, str] = {}
-            if self.linear_api_key and not self.linear_webhook_secret:
-                problems["linear_webhook_secret"] = "Required once the Linear API key is set."
-            if self.jira_api_token and not self.jira_webhook_secret:
-                problems["jira_webhook_secret"] = "Required once the Jira API token is set."
-            return problems
+    checks = [check_tracker_identity]
 
     @classmethod
     def get_tracker(cls, source: str | None = None) -> Tracker | None:
-        """The configured tracker, once its credentials are set; None when the
-        installation runs trackerless or the credentials are missing. Pass a
-        ``source`` to get it only when that source is the configured one — a
+        """The selected tracker, once its service identity is connected; None when
+        the installation runs trackerless or the identity is missing. Pass a
+        ``source`` to get it only when that source is the selected one — a
         work item syncs only to the tracker that owns it."""
         settings = cls.settings()
         if source is not None and source != settings.tracker:
             return
-        if settings.tracker == "linear" and settings.linear_api_key:
-            return Linear(
-                api_key=settings.linear_api_key.get_secret_value(),
-                backlog_status=settings.linear_resting_status,
-                trigger_status=settings.trigger_status,
-            )
-        if (
-            settings.tracker == "jira"
-            and settings.jira_base_url
-            and settings.jira_email
-            and settings.jira_api_token
-        ):
-            return Jira(
-                base_url=settings.jira_base_url,
-                email=settings.jira_email,
-                api_token=settings.jira_api_token.get_secret_value(),
-                backlog_status=settings.jira_resting_status,
-                trigger_status=settings.trigger_status,
-            )
-        return
+        try:
+            if settings.tracker == "linear":
+                row = services.Linear.get()
+                return Linear(
+                    api_key=row.secrets["api_key"],
+                    backlog_status=settings.linear_resting_status,
+                    trigger_status=settings.trigger_status,
+                )
+            if settings.tracker == "jira":
+                row = services.Jira.get()
+                return Jira(
+                    base_url=row.identity["base_url"],
+                    email=row.identity["email"],
+                    api_token=row.secrets["api_token"],
+                    backlog_status=settings.jira_resting_status,
+                    trigger_status=settings.trigger_status,
+                )
+        except ServiceNotConnectedError:
+            return
 
     # The build pipeline's agents — the extension owns them; any of its workflows run
     # them. The attribute name is each agent's id (its durable settings/timeline key).

--- a/backend/druks/contrib/ship/services.py
+++ b/backend/druks/contrib/ship/services.py
@@ -1,0 +1,74 @@
+import logging
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field, SecretStr
+
+from druks.contrib.ship.ticketing.linear import LINEAR_GRAPHQL_URL
+from druks.services import Service, ServiceConnectError
+
+logger = logging.getLogger(__name__)
+
+_VERIFY_TIMEOUT = 10.0
+
+
+class Linear(Service):
+    name = "linear"
+    title = "Linear"
+    description = (
+        "The Linear identity druks reads and updates tickets as; its webhook "
+        "secret verifies inbound deliveries."
+    )
+    required = False
+
+    class Settings(BaseModel):
+        api_key: SecretStr = Field(title="API key")
+        webhook_secret: SecretStr = Field(title="Webhook secret")
+
+    @classmethod
+    async def verify(cls, settings: Settings) -> dict[str, Any]:
+        try:
+            async with httpx.AsyncClient(timeout=_VERIFY_TIMEOUT) as client:
+                response = await client.post(
+                    LINEAR_GRAPHQL_URL,
+                    json={"query": "{ viewer { name } organization { name } }"},
+                    headers={"Authorization": settings.api_key.get_secret_value()},
+                )
+            response.raise_for_status()
+            data = response.json()["data"]
+            facts = {"actor": data["viewer"]["name"], "workspace": data["organization"]["name"]}
+        except Exception as error:  # noqa: BLE001 — any auth/transport failure is a rejected paste
+            logger.warning("Linear service-identity connect rejected: %s", type(error).__name__)
+            raise ServiceConnectError("Linear did not accept this API key.") from error
+        return facts
+
+
+class Jira(Service):
+    name = "jira"
+    title = "Jira"
+    description = (
+        "The Jira Cloud identity druks reads and updates tickets as; its webhook "
+        "secret authenticates Automation deliveries."
+    )
+    required = False
+
+    class Settings(BaseModel):
+        base_url: str = Field(title="Base URL", description="Base URL of the Jira Cloud site.")
+        email: str = Field(title="Email")
+        api_token: SecretStr = Field(title="API token")
+        webhook_secret: SecretStr = Field(title="Webhook secret")
+
+    @classmethod
+    async def verify(cls, settings: Settings) -> dict[str, Any]:
+        auth = httpx.BasicAuth(settings.email, settings.api_token.get_secret_value())
+        try:
+            async with httpx.AsyncClient(timeout=_VERIFY_TIMEOUT, auth=auth) as client:
+                response = await client.get(f"{settings.base_url.rstrip('/')}/rest/api/3/myself")
+            response.raise_for_status()
+            facts = {"display_name": response.json()["displayName"]}
+        except Exception as error:  # noqa: BLE001 — any auth/transport failure is a rejected paste
+            logger.warning("Jira service-identity connect rejected: %s", type(error).__name__)
+            raise ServiceConnectError(
+                "Jira did not accept these credentials — check the base URL, email, and API token."
+            ) from error
+        return facts

--- a/backend/druks/contrib/ship/webhooks.py
+++ b/backend/druks/contrib/ship/webhooks.py
@@ -5,8 +5,9 @@ import logging
 from fastapi import HTTPException, status
 from fastapi.responses import JSONResponse, Response
 
-from druks.contrib.ship.extension import Ship
+from druks.contrib.ship import services
 from druks.contrib.ship.ticketing.linear import compute_delivery_key
+from druks.services import ServiceNotConnectedError
 from druks.signals import publish
 from druks.webhooks import Webhook, verify_hmac_sha256
 
@@ -18,11 +19,17 @@ class LinearEvents(Webhook):
     category = "events"
 
     def request_is_authentic(self) -> bool:
-        settings = Ship.settings()
+        try:
+            row = services.Linear.get()
+        except ServiceNotConnectedError as error:
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                "Linear is not connected — connect it in Settings → Harnesses.",
+            ) from error
         verify_hmac_sha256(
             self.raw_body,
             self.request.headers.get("linear-signature"),
-            settings.linear_webhook_secret.get_secret_value(),
+            row.secrets["webhook_secret"],
             prefix="",
         )
         return True
@@ -88,10 +95,13 @@ class JiraEvents(Webhook):
     category = "events"
 
     def request_is_authentic(self) -> bool:
-        settings = Ship.settings()
-        webhook_secret = settings.jira_webhook_secret.get_secret_value()
-        if not webhook_secret:
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Jira webhook secret not configured.")
+        try:
+            webhook_secret = services.Jira.get().secrets["webhook_secret"]
+        except ServiceNotConnectedError as error:
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                "Jira is not connected — connect it in Settings → Harnesses.",
+            ) from error
         provided = self.request.headers.get("x-druks-webhook-token") or ""
         if not hmac.compare_digest(provided, webhook_secret):
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid Jira webhook token.")
@@ -141,6 +151,7 @@ class JiraEvents(Webhook):
         )
         return JSONResponse({"accepted": True})
 
-    def _issue_url(self, key: str) -> str | None:
-        base_url = Ship.settings().jira_base_url
-        return f"{base_url.rstrip('/')}/browse/{key}" if base_url else None
+    def _issue_url(self, key: str) -> str:
+        # Dispatch runs after request_is_authentic, so the row is connected here.
+        base_url = services.Jira.get().identity["base_url"]
+        return f"{base_url.rstrip('/')}/browse/{key}"

--- a/backend/druks/services/routes.py
+++ b/backend/druks/services/routes.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from druks.accounts.dependencies import current_session_account
 from druks.extensions.registry import services
 from druks.services.exceptions import ServiceConnectError, ServiceNotConnectedError
 from druks.services.models import ServiceIdentity
@@ -20,7 +21,14 @@ async def list_service_identities() -> list[ServiceIdentityResponse]:
     return entries
 
 
-@router.post("/{name}", response_model=ServiceIdentityResponse, response_model_by_alias=True)
+# Session identity only, like the settings PATCH: the appliance's own
+# credentials are never writable with an agent PAT.
+@router.post(
+    "/{name}",
+    response_model=ServiceIdentityResponse,
+    response_model_by_alias=True,
+    dependencies=[Depends(current_session_account)],
+)
 async def connect_service_identity(name: str, payload: dict[str, str]) -> ServiceIdentityResponse:
     service = services.get(name)
     if not service:

--- a/backend/tests/ship/test_ticketing.py
+++ b/backend/tests/ship/test_ticketing.py
@@ -111,6 +111,7 @@ async def test_linear_verify_stores_the_actor_and_workspace(monkeypatch):
         return httpx.Response(
             200,
             json={"data": {"viewer": {"name": "druks"}, "organization": {"name": "Acme"}}},
+            request=httpx.Request("POST", url),
         )
 
     monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
@@ -122,7 +123,11 @@ async def test_linear_verify_stores_the_actor_and_workspace(monkeypatch):
 
 async def test_linear_verify_rejects_a_bad_key_without_echoing(monkeypatch):
     async def fake_post(self, url, **kwargs):
-        return httpx.Response(400, json={"errors": [{"message": "auth boom-marker"}]})
+        return httpx.Response(
+            400,
+            json={"errors": [{"message": "auth boom-marker"}]},
+            request=httpx.Request("POST", url),
+        )
 
     monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
 
@@ -138,7 +143,9 @@ async def test_jira_verify_stores_the_display_name(monkeypatch):
 
     async def fake_get(self, url, **kwargs):
         seen.append(url)
-        return httpx.Response(200, json={"displayName": "Druks Bot"})
+        return httpx.Response(
+            200, json={"displayName": "Druks Bot"}, request=httpx.Request("GET", url)
+        )
 
     monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
 
@@ -154,7 +161,7 @@ async def test_jira_verify_stores_the_display_name(monkeypatch):
 
 async def test_jira_verify_rejects_bad_credentials(monkeypatch):
     async def fake_get(self, url, **kwargs):
-        return httpx.Response(401, text="nope")
+        return httpx.Response(401, text="nope", request=httpx.Request("GET", url))
 
     monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
 

--- a/backend/tests/ship/test_ticketing.py
+++ b/backend/tests/ship/test_ticketing.py
@@ -2,7 +2,8 @@ import json
 
 import httpx
 import pytest
-from druks.contrib.ship.extension import Ship
+from druks.contrib.ship import services
+from druks.contrib.ship.extension import Ship, check_tracker_identity
 from druks.contrib.ship.ticketing.enums import TicketStatus
 from druks.contrib.ship.ticketing.exceptions import (
     JiraAPIError,
@@ -11,6 +12,8 @@ from druks.contrib.ship.ticketing.exceptions import (
 )
 from druks.contrib.ship.ticketing.jira import Jira, JiraClient
 from druks.contrib.ship.ticketing.linear import Linear, LinearClient
+from druks.services import ServiceConnectError
+from druks.services.models import ServiceIdentity
 
 from ship.factories import make_test_work_item
 
@@ -20,25 +23,29 @@ def _pin_ship_settings(monkeypatch, **values):
     monkeypatch.setattr(Ship, "settings", classmethod(lambda cls: settings))
 
 
-def test_settings_require_linear_webhook_secret_once_the_api_key_is_set():
-    settings = Ship.Settings(linear_api_key="x")
-
-    assert settings.clean() == {"linear_webhook_secret": "Required once the Linear API key is set."}
-
-
-def test_settings_require_jira_webhook_secret_once_the_api_token_is_set():
-    settings = Ship.Settings(jira_api_token="x")
-
-    assert settings.clean() == {"jira_webhook_secret": "Required once the Jira API token is set."}
+def _connect_linear():
+    return ServiceIdentity.connect(
+        "linear",
+        identity={"actor": "druks", "workspace": "Acme"},
+        secrets={"api_key": "lin_secret", "webhook_secret": "lin-hook"},
+    )
 
 
-# --- Ship.get_tracker: the configured tracker -------------------------------
+def _connect_jira():
+    return ServiceIdentity.connect(
+        "jira",
+        identity={"base_url": "https://jira.test", "email": "a@b.com", "display_name": "druks"},
+        secrets={"api_token": "jira_secret", "webhook_secret": "jira-hook"},
+    )
 
 
-def test_tracker_builds_linear_from_settings(monkeypatch):
+# --- Ship.get_tracker: the selected tracker ----------------------------------
+
+
+def test_tracker_builds_linear_from_the_service_row(druks_db, monkeypatch):
+    _connect_linear()
     _pin_ship_settings(
         monkeypatch,
-        linear_api_key="lin_secret",
         linear_resting_status="Backlog",
         linear_trigger_status="To Agent",
     )
@@ -46,17 +53,16 @@ def test_tracker_builds_linear_from_settings(monkeypatch):
     tracker = Ship.get_tracker("linear")
 
     assert isinstance(tracker, Linear)
+    assert tracker._client.api_key == "lin_secret"
     assert tracker._status_names[TicketStatus.BACKLOG] == "Backlog"
     assert tracker._status_names[TicketStatus.TRIGGER] == "To Agent"
 
 
-def test_tracker_builds_jira_from_settings(monkeypatch):
+def test_tracker_builds_jira_from_the_service_row(druks_db, monkeypatch):
+    _connect_jira()
     _pin_ship_settings(
         monkeypatch,
         tracker="jira",
-        jira_base_url="https://jira.test",
-        jira_email="a@b.com",
-        jira_api_token="jira_secret",
         jira_resting_status="Open",
         jira_trigger_status="To Agent",
     )
@@ -64,35 +70,132 @@ def test_tracker_builds_jira_from_settings(monkeypatch):
     tracker = Ship.get_tracker("jira")
 
     assert isinstance(tracker, Jira)
+    assert tracker._client.base_url == "https://jira.test"
     assert tracker._status_names[TicketStatus.BACKLOG] == "Open"
     assert tracker._status_names[TicketStatus.TRIGGER] == "To Agent"
 
 
-def test_tracker_is_none_for_github_and_missing_credentials(monkeypatch):
-    _pin_ship_settings(monkeypatch, linear_api_key="lin_secret")
+def test_tracker_is_none_for_github_and_a_disconnected_identity(druks_db, monkeypatch):
+    _connect_linear()
+    _pin_ship_settings(monkeypatch)
 
     assert not Ship.get_tracker("github")
     assert not Ship.get_tracker("jira")
 
-    _pin_ship_settings(
-        monkeypatch, tracker="jira", jira_base_url="https://jira.test", jira_email="a@b.com"
-    )
+    _pin_ship_settings(monkeypatch, tracker="jira")
     assert not Ship.get_tracker("jira")
     assert not Ship.get_tracker("linear")
 
 
-def test_tracker_ignores_a_nonchosen_source_with_credentials(monkeypatch):
-    _pin_ship_settings(monkeypatch, tracker="jira", linear_api_key="lin_secret")
+def test_tracker_ignores_a_nonchosen_source_with_a_connected_identity(druks_db, monkeypatch):
+    _connect_linear()
+    _pin_ship_settings(monkeypatch, tracker="jira")
 
     assert not Ship.get_tracker("linear")
 
 
-def test_empty_resting_status_leaves_backlog_unmapped(monkeypatch):
-    _pin_ship_settings(monkeypatch, linear_api_key="lin_secret", linear_resting_status="")
+def test_empty_resting_status_leaves_backlog_unmapped(druks_db, monkeypatch):
+    _connect_linear()
+    _pin_ship_settings(monkeypatch, linear_resting_status="")
 
     tracker = Ship.get_tracker("linear")
 
     assert TicketStatus.BACKLOG not in tracker._status_names
+
+
+# --- The tracker service identities ------------------------------------------
+
+
+async def test_linear_verify_stores_the_actor_and_workspace(monkeypatch):
+    async def fake_post(self, url, **kwargs):
+        return httpx.Response(
+            200,
+            json={"data": {"viewer": {"name": "druks"}, "organization": {"name": "Acme"}}},
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    facts = await services.Linear.verify(services.Linear.Settings(api_key="k", webhook_secret="s"))
+
+    assert facts == {"actor": "druks", "workspace": "Acme"}
+
+
+async def test_linear_verify_rejects_a_bad_key_without_echoing(monkeypatch):
+    async def fake_post(self, url, **kwargs):
+        return httpx.Response(400, json={"errors": [{"message": "auth boom-marker"}]})
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    with pytest.raises(ServiceConnectError) as raised:
+        await services.Linear.verify(services.Linear.Settings(api_key="bad", webhook_secret="s"))
+
+    assert "boom-marker" not in str(raised.value)
+    assert "bad" not in str(raised.value)
+
+
+async def test_jira_verify_stores_the_display_name(monkeypatch):
+    seen = []
+
+    async def fake_get(self, url, **kwargs):
+        seen.append(url)
+        return httpx.Response(200, json={"displayName": "Druks Bot"})
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    facts = await services.Jira.verify(
+        services.Jira.Settings(
+            base_url="https://jira.test/", email="a@b.com", api_token="t", webhook_secret="s"
+        )
+    )
+
+    assert facts == {"display_name": "Druks Bot"}
+    assert seen == ["https://jira.test/rest/api/3/myself"]
+
+
+async def test_jira_verify_rejects_bad_credentials(monkeypatch):
+    async def fake_get(self, url, **kwargs):
+        return httpx.Response(401, text="nope")
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    with pytest.raises(ServiceConnectError, match="did not accept"):
+        await services.Jira.verify(
+            services.Jira.Settings(
+                base_url="https://jira.test", email="a@b.com", api_token="bad", webhook_secret="s"
+            )
+        )
+
+
+# --- The tracker doctor check -------------------------------------------------
+
+
+def test_tracker_check_accepts_trackerless_by_choice(monkeypatch):
+    _pin_ship_settings(monkeypatch, tracker="none")
+
+    result = check_tracker_identity()
+
+    assert result.ok
+    assert "choice" in result.detail
+
+
+def test_tracker_check_reports_a_selected_connected_tracker(druks_db, monkeypatch):
+    _connect_linear()
+    _pin_ship_settings(monkeypatch)
+
+    result = check_tracker_identity()
+
+    assert result.ok
+    assert "linear" in result.detail
+
+
+def test_tracker_check_pends_a_selected_unconnected_tracker(druks_db, monkeypatch):
+    _pin_ship_settings(monkeypatch, tracker="jira")
+
+    result = check_tracker_identity()
+
+    assert not result.ok
+    assert result.pending
+    assert "jira" in result.detail
 
 
 # --- Linear provider --------------------------------------------------------

--- a/backend/tests/ship/test_webhooks_jira.py
+++ b/backend/tests/ship/test_webhooks_jira.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock
 import druks.contrib.ship.subscribers as subs
 import pytest
 from druks.contrib.ship import webhooks as webhook_module
-from druks.contrib.ship.extension import Ship
 from druks.contrib.ship.webhooks import JiraEvents
 from druks.contrib.ship.workflows import Build
 from druks.services.models import ServiceIdentity
@@ -59,7 +58,15 @@ def test_route_is_unchanged():
     assert f"{webhooks_router.prefix}/{JiraEvents.path}" == "/_external/jira/events/"
 
 
-def test_rejects_when_no_secret_configured(tmp_path, druks_db):
+def _connect_jira(*, base_url="https://jira.test/", webhook_secret="s3cret"):
+    return ServiceIdentity.connect(
+        "jira",
+        identity={"base_url": base_url, "email": "a@b.com", "display_name": "druks"},
+        secrets={"api_token": "tok", "webhook_secret": webhook_secret},
+    )
+
+
+def test_rejects_when_not_connected(tmp_path, druks_db):
     events = _provider(tmp_path, payload=_issue())
     with pytest.raises(HTTPException) as exc:
         events.request_is_authentic()
@@ -67,7 +74,7 @@ def test_rejects_when_no_secret_configured(tmp_path, druks_db):
 
 
 def test_authentic_when_token_header_matches(tmp_path, druks_db):
-    Ship.override_setting("jira_webhook_secret", "s3cret")
+    _connect_jira()
     events = _provider(
         tmp_path,
         payload=_issue(),
@@ -77,7 +84,7 @@ def test_authentic_when_token_header_matches(tmp_path, druks_db):
 
 
 def test_rejects_when_token_missing_or_wrong(tmp_path, druks_db):
-    Ship.override_setting("jira_webhook_secret", "s3cret")
+    _connect_jira()
     events = _provider(
         tmp_path,
         payload=_issue(),
@@ -100,7 +107,7 @@ async def test_emits_normalized_ticket_transition(tmp_path, druks_db, monkeypatc
     async def _emit(event_type, **kwargs):
         captured.update({"event": event_type, **kwargs})
 
-    Ship.override_setting("jira_base_url", "https://jira.test/")
+    _connect_jira()
     monkeypatch.setattr(webhook_module, "publish", _emit)
     await _provider(tmp_path, payload=_issue(key="IT-9", status="Ready")).on_issue_event()
 
@@ -113,13 +120,14 @@ async def test_emits_normalized_ticket_transition(tmp_path, druks_db, monkeypatc
     assert payload["url"] == "https://jira.test/browse/IT-9"
 
 
-async def test_done_category_marks_the_transition_terminal(tmp_path, monkeypatch):
+async def test_done_category_marks_the_transition_terminal(tmp_path, druks_db, monkeypatch):
     """The "done" statusCategory is Jira's terminal marker."""
     events = []
 
     async def _emit(event_type, **kwargs):
         events.append((event_type, kwargs["payload"]))
 
+    _connect_jira()
     monkeypatch.setattr(webhook_module, "publish", _emit)
     payload = _issue(key="IT-9", status="Done", status_category="done")
     await _provider(tmp_path, payload=payload).on_issue_event()
@@ -128,13 +136,14 @@ async def test_done_category_marks_the_transition_terminal(tmp_path, monkeypatch
     assert events[0][1]["terminal"] is True
 
 
-async def test_open_category_is_not_terminal(tmp_path, monkeypatch):
+async def test_open_category_is_not_terminal(tmp_path, druks_db, monkeypatch):
     """An in-flight status (any non-"done" category) transitions but isn't terminal."""
     events = []
 
     async def _emit(event_type, **kwargs):
         events.append((event_type, kwargs["payload"]))
 
+    _connect_jira()
     monkeypatch.setattr(webhook_module, "publish", _emit)
     provider = _provider(
         tmp_path, payload=_issue(status="In Progress", status_category="indeterminate")

--- a/backend/tests/ship/test_webhooks_linear.py
+++ b/backend/tests/ship/test_webhooks_linear.py
@@ -5,8 +5,8 @@ from typing import Any, cast
 
 import pytest
 from druks.contrib.ship import webhooks as webhook_module
-from druks.contrib.ship.extension import Ship
 from druks.contrib.ship.webhooks import LinearEvents
+from druks.services.models import ServiceIdentity
 from druks.testing import make_settings
 from druks.webhooks.router import router as webhooks_router
 from fastapi import HTTPException
@@ -52,11 +52,15 @@ def test_route_is_unchanged():
     assert f"{webhooks_router.prefix}/{LinearEvents.path}" == "/_external/linear/events/"
 
 
-def test_authentication_reads_the_ship_secret(tmp_path, druks_db):
+def test_authentication_reads_the_service_row(tmp_path, druks_db):
     secret = "linear-secret"
     raw_body = b"{}"
     signature = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
-    Ship.override_setting("linear_webhook_secret", secret)
+    ServiceIdentity.connect(
+        "linear",
+        identity={"actor": "druks", "workspace": "Acme"},
+        secrets={"api_key": "lin_secret", "webhook_secret": secret},
+    )
     events = _provider(
         tmp_path,
         payload={},
@@ -67,7 +71,7 @@ def test_authentication_reads_the_ship_secret(tmp_path, druks_db):
     assert events.request_is_authentic()
 
 
-def test_unconfigured_secret_keeps_signature_failure(tmp_path, druks_db):
+def test_rejects_when_not_connected(tmp_path, druks_db):
     events = _provider(
         tmp_path,
         payload={},
@@ -78,7 +82,8 @@ def test_unconfigured_secret_keeps_signature_failure(tmp_path, druks_db):
     with pytest.raises(HTTPException) as error:
         events.request_is_authentic()
 
-    assert error.value.status_code == 500
+    assert error.value.status_code == 401
+    assert "not connected" in error.value.detail
 
 
 async def test_terminal_state_types_mark_the_transition_terminal(tmp_path, monkeypatch):

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -257,17 +257,17 @@ def test_extensions_surface_build_agents_and_workflow_defaults(tmp_path: Path):
 
 
 def test_extension_secret_round_trip_encrypts_at_rest(tmp_path: Path):
-    secret = "linear-secret-value"
-    webhook_secret = "linear-webhook-secret"
-    key = "extension:ship:linear_api_key"
+    secret = "review-pem-value"
+    app_id = "42424242"
+    key = "extension:review:private_key"
     with _build_client(tmp_path) as client:
         written = client.patch(
             "/api/settings/extensions",
             json={
                 "extensionSettings": {
-                    "ship": {
-                        "linear_api_key": secret,
-                        "linear_webhook_secret": webhook_secret,
+                    "review": {
+                        "app_id": app_id,
+                        "private_key": secret,
                     }
                 }
             },
@@ -284,7 +284,7 @@ def test_extension_secret_round_trip_encrypts_at_rest(tmp_path: Path):
             .one()
         )
         read = client.get("/api/settings/extensions")
-        resolved = Ship.settings().linear_api_key
+        resolved = Review.settings().private_key
 
     assert written.status_code == 200
     assert read.status_code == 200
@@ -294,17 +294,19 @@ def test_extension_secret_round_trip_encrypts_at_rest(tmp_path: Path):
     assert secret.encode() not in stored.secret_value
     assert secret not in written.text
     assert secret not in read.text
-    assert webhook_secret not in written.text
-    assert webhook_secret not in read.text
+    assert app_id not in written.text
+    assert app_id not in read.text
     assert resolved and resolved.get_secret_value() == secret
-    ship = next(extension for extension in read.json()["extensions"] if extension["name"] == "ship")
-    fields = {field["name"]: field for field in ship["settings"]}
-    assert fields["linear_api_key"]["type"] == "secret"
-    assert fields["linear_api_key"]["value"] is None
-    assert fields["linear_api_key"]["default"] is None
-    assert fields["linear_api_key"]["secretSet"] is True
-    assert fields["linear_api_key"]["overridden"] is True
-    assert fields["linear_webhook_secret"]["secretSet"] is True
+    review = next(
+        extension for extension in read.json()["extensions"] if extension["name"] == "review"
+    )
+    fields = {field["name"]: field for field in review["settings"]}
+    assert fields["private_key"]["type"] == "secret"
+    assert fields["private_key"]["value"] is None
+    assert fields["private_key"]["default"] is None
+    assert fields["private_key"]["secretSet"] is True
+    assert fields["private_key"]["overridden"] is True
+    assert fields["app_id"]["secretSet"] is True
 
 
 def test_extension_secret_plaintext_row_is_unset_until_resaved(tmp_path: Path):

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from druks.contrib.review.extension import Review
 from druks.contrib.ship.extension import Ship
 from druks.database import db_session
 from druks.testing import configure_app_for_test, make_settings
@@ -183,6 +184,15 @@ def _ship_settings_fields(client: TestClient) -> dict:
     return {field["name"]: field for field in _ship_extension(client)["settings"]}
 
 
+def _review_extension(client: TestClient) -> dict:
+    body = client.get("/api/settings/extensions").json()
+    return next(m for m in body["extensions"] if m["name"] == "review")
+
+
+def _review_settings_fields(client: TestClient) -> dict:
+    return {field["name"]: field for field in _review_extension(client)["settings"]}
+
+
 def test_extensions_surface_build_agents(tmp_path: Path):
     """The build pipeline's agents all tune under the Ship extension."""
     with _build_client(tmp_path) as client:
@@ -299,20 +309,20 @@ def test_extension_secret_round_trip_encrypts_at_rest(tmp_path: Path):
 
 def test_extension_secret_plaintext_row_is_unset_until_resaved(tmp_path: Path):
     secret = "legacy-plaintext-secret"
-    key = "extension:ship:linear_api_key"
+    key = "extension:review:private_key"
     db_session().add(SettingsOverride(key=key, value=secret))
     db_session().flush()
 
     with _build_client(tmp_path) as client:
-        initial = _ship_extension(client)
-        resolved_initial = Ship.settings().linear_api_key
+        initial = _review_extension(client)
+        resolved_initial = Review.settings().private_key
         saved = client.patch(
             "/api/settings/extensions",
             json={
                 "extensionSettings": {
-                    "ship": {
-                        "linear_api_key": secret,
-                        "linear_webhook_secret": "webhook-secret",
+                    "review": {
+                        "app_id": "42",
+                        "private_key": secret,
                     }
                 }
             },
@@ -330,7 +340,7 @@ def test_extension_secret_plaintext_row_is_unset_until_resaved(tmp_path: Path):
         )
 
     initial_field = next(
-        setting for setting in initial["settings"] if setting["name"] == "linear_api_key"
+        setting for setting in initial["settings"] if setting["name"] == "private_key"
     )
     assert initial_field["secretSet"] is False
     assert not resolved_initial
@@ -342,13 +352,13 @@ def test_extension_secret_plaintext_row_is_unset_until_resaved(tmp_path: Path):
 
 
 def test_extension_non_secret_setting_stays_in_value(tmp_path: Path):
-    url = "https://example.atlassian.net"
-    key = "extension:ship:jira_base_url"
+    status = "Agent Queue"
+    key = "extension:ship:linear_trigger_status"
 
     with _build_client(tmp_path) as client:
         written = client.patch(
             "/api/settings/extensions",
-            json={"extensionSettings": {"ship": {"jira_base_url": url}}},
+            json={"extensionSettings": {"ship": {"linear_trigger_status": status}}},
         )
         stored = (
             db_session()
@@ -360,12 +370,14 @@ def test_extension_non_secret_setting_stays_in_value(tmp_path: Path):
         )
         ship = _ship_extension(client)
 
-    field = next(setting for setting in ship["settings"] if setting["name"] == "jira_base_url")
+    field = next(
+        setting for setting in ship["settings"] if setting["name"] == "linear_trigger_status"
+    )
     assert written.status_code == 200
-    assert stored.value == url
+    assert stored.value == status
     assert stored.secret_value == b""
-    assert Ship.settings().jira_base_url == url
-    assert field["value"] == url
+    assert Ship.settings().linear_trigger_status == status
+    assert field["value"] == status
     assert field["overridden"] is True
 
 
@@ -382,39 +394,39 @@ def test_incoherent_extension_save_is_rejected_and_rolled_back_before_schedules(
             json={
                 "agentModels": {"generate_plan": "claude-opus-4-7"},
                 "workflowSettings": {"core.refresh_tokens": {"schedule": "0 9 * * *"}},
-                "extensionSettings": {"ship": {"linear_api_key": "lin-secret"}},
+                "extensionSettings": {"review": {"app_id": "42"}},
             },
         )
 
         assert response.status_code == 422
         assert response.json()["detail"] == {
-            "ship": {"linear_webhook_secret": "Required once the Linear API key is set."}
+            "review": {"private_key": "Required once the review App ID is set."}
         }
         assert not reconciled
-        assert _ship_settings_fields(client)["linear_api_key"]["secretSet"] is False
+        assert _review_settings_fields(client)["app_id"]["secretSet"] is False
         agents = {agent["name"]: agent for agent in _ship_extension(client)["agents"]}
         assert agents["generate_plan"]["model"] == "gpt-5.5"
         assert _refresh_tokens_fields(client)["schedule"]["value"] == "*/15 * * * *"
 
 
-def test_clearing_the_api_key_deletes_its_override_and_stays_coherent(tmp_path: Path):
-    key = "extension:ship:linear_api_key"
+def test_clearing_the_identity_deletes_its_overrides_and_stays_coherent(tmp_path: Path):
+    key = "extension:review:app_id"
 
     with _build_client(tmp_path) as client:
         configured = client.patch(
             "/api/settings/extensions",
             json={
                 "extensionSettings": {
-                    "ship": {
-                        "linear_api_key": "lin-secret",
-                        "linear_webhook_secret": "webhook-secret",
+                    "review": {
+                        "app_id": "42",
+                        "private_key": "review-pem",
                     }
                 }
             },
         )
         cleared = client.patch(
             "/api/settings/extensions",
-            json={"extensionSettings": {"ship": {"linear_api_key": None}}},
+            json={"extensionSettings": {"review": {"app_id": None, "private_key": None}}},
         )
         stored = (
             db_session()
@@ -424,14 +436,14 @@ def test_clearing_the_api_key_deletes_its_override_and_stays_coherent(tmp_path: 
             )
             .one_or_none()
         )
-        fields = _ship_settings_fields(client)
+        fields = _review_settings_fields(client)
 
     assert configured.status_code == 200
     assert cleared.status_code == 200
     assert stored is None
-    assert not Ship.settings().linear_api_key
-    assert fields["linear_api_key"]["secretSet"] is False
-    assert fields["linear_webhook_secret"]["secretSet"] is True
+    assert not Review.settings().app_id
+    assert fields["app_id"]["secretSet"] is False
+    assert fields["private_key"]["secretSet"] is False
 
 
 def test_extensions_override_agent_model_persists(tmp_path: Path):

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -24,6 +24,14 @@ SESSION_ONLY_API_ROUTES = {
     ("DELETE", "/api/auth/personal-tokens/{pat_id}"),
     ("DELETE", "/api/harnesses/{name}/connection"),
     ("PATCH", "/api/settings/extensions"),
+    ("POST", "/api/service-identities/{name}"),
+}
+
+# Session-gated routes that also sit behind their router's identity gate —
+# the route-level session dependency is the stricter of the two.
+DUAL_GATED_API_PATHS = {
+    "/api/settings/extensions",
+    "/api/service-identities/{name}",
 }
 
 # The connection flow must answer during none/zero setup, before any account
@@ -116,7 +124,7 @@ def test_capability_management_is_session_only(api_routes):
     } == SESSION_ONLY_API_ROUTES
     for route in listed:
         assert _gated_by(route, current_session_account), route.path
-        if route.path != "/api/settings/extensions":
+        if route.path not in DUAL_GATED_API_PATHS:
             assert not _gated_by(route, current_account), route.path
     # And nothing else carries the session-only gate.
     for route in api_routes:

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -201,6 +201,22 @@ def test_a_pat_reads_but_cannot_write_extension_settings(tmp_path, druks_db):
     assert write.status_code == 401
 
 
+def test_a_pat_reads_but_cannot_write_service_identities(tmp_path, druks_db):
+    with _client(tmp_path) as client:
+        _, token = _mint("op@example.com")
+        headers = _bearer(token)
+
+        read = client.get("/api/service-identities", headers=headers)
+        write = client.post(
+            "/api/service-identities/github",
+            json={"app_id": "1", "private_key": "p", "webhook_secret": "s"},
+            headers=headers,
+        )
+
+    assert read.status_code == 200
+    assert write.status_code == 401
+
+
 def test_the_operator_manages_the_token_lifecycle(tmp_path, druks_db):
     with _client(tmp_path) as client:
         created = client.post(

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -193,7 +193,7 @@ def test_a_pat_reads_but_cannot_write_extension_settings(tmp_path, druks_db):
         read = client.get("/api/settings/extensions", headers=headers)
         write = client.patch(
             "/api/settings/extensions",
-            json={"extensionSettings": {"ship": {"linear_api_key": "lin_secret"}}},
+            json={"extensionSettings": {"ship": {"linear_trigger_status": "Agent Queue"}}},
             headers=headers,
         )
 

--- a/backend/tests/test_extension_doctor_checks.py
+++ b/backend/tests/test_extension_doctor_checks.py
@@ -64,19 +64,20 @@ def test_unreachable_settings_database_is_an_extension_check_failure(
     assert "check raised" in result.detail
 
 
-def test_stored_incoherent_settings_fail_with_declared_field_titles(
+def test_selected_unconnected_tracker_pends_through_ships_own_check(
     installed, tmp_path: Path, druks_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    SettingsOverride.set_extension_setting("ship", "linear_api_key", "lin-secret", is_secret=True)
+    # The default selector names linear; no identity is connected in this db.
     monkeypatch.setattr(doctor, "create_engine_from_url", lambda _: druks_db.get_bind())
 
     try:
-        result = _named(doctor.check_extensions(make_settings(tmp_path)), "ship:settings")
+        result = _named(doctor.check_extensions(make_settings(tmp_path)), "ship:tracker")
     finally:
         db_session.registry.set(druks_db)
 
     assert not result.ok
-    assert result.detail == ("Linear webhook secret: Required once the Linear API key is set.")
+    assert result.pending
+    assert "linear" in result.detail
 
 
 def test_half_configured_review_identity_fails_through_review_settings(
@@ -104,9 +105,8 @@ def test_half_configured_review_identity_fails_through_review_settings(
 def test_coherent_stored_settings_pass(
     installed, tmp_path: Path, druks_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    SettingsOverride.set_extension_setting("ship", "linear_api_key", "lin-secret", is_secret=True)
     SettingsOverride.set_extension_setting(
-        "ship", "linear_webhook_secret", "webhook-secret", is_secret=True
+        "ship", "linear_trigger_status", "Agent Queue", is_secret=False
     )
     monkeypatch.setattr(doctor, "create_engine_from_url", lambda _: druks_db.get_bind())
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,17 +220,20 @@ client at another compatible GitHub API endpoint.
 
 ## Ticketing integrations
 
-Configure one tracker in **Settings → Ship**. Linear needs an API key and webhook
-secret; Jira Cloud needs its base URL, email, API token, and webhook secret.
-Tracker credentials and the statuses that trigger or move `ship` work are stored
-as ship extension settings.
+Tracker credentials are service identities: connect Linear (API key + webhook
+secret) or Jira Cloud (base URL, email, API token, webhook secret) from
+**Settings → Harnesses**, on the same cards as the GitHub App. Connecting
+verifies the credentials against the tracker before anything is stored. Which
+tracker drives `ship` work — and the statuses that trigger or move it — stays a
+ship extension setting in **Settings → Ship**.
 
 Webhook URLs remain `/_external/linear/events/` and
 `/_external/jira/events/`. The Jira webhook is a Jira Automation "Send web
 request" action with **Issue data (Jira format)** as its body — the REST issue
 JSON under `issue` is the one accepted shape — and the shared token in the
-`x-druks-webhook-token` header. `druks doctor` treats an unconfigured tracker as
-optional and requires its webhook secret once its credentials are complete.
+`x-druks-webhook-token` header. `druks doctor` treats a disconnected tracker as
+optional, and reports pending setup when the selected tracker's identity is not
+connected.
 
 ## Harnesses
 
@@ -345,8 +348,8 @@ Keep the old key until no stored row depends on it. Losing every key used for a
 row makes that secret unrecoverable; reconnect OAuth grants and re-enter static
 tokens. Validation and API errors intentionally omit submitted secret values.
 
-The encryption envelope does **not** currently cover tracker extension settings,
-harness subscription payloads, or notification webhook URLs. They are stored as
+The encryption envelope does **not** currently cover harness subscription
+payloads or notification webhook URLs. They are stored as
 ordinary Postgres fields, although APIs withhold or mask their values. Treat
 access to Postgres and its backups as access to those credentials. GitHub App
 private keys — the operator identity's and the review extension's — are

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -139,7 +139,7 @@ value.
 
 GitHub, Linear, and Jira cannot reach a loopback listener. Dashboard-initiated
 actions work locally, but provider-driven flows need an HTTPS tunnel forwarding
-to `127.0.0.1:8001`. Configure tracker credentials under **Settings → Ship** and
+to `127.0.0.1:8001`. Connect tracker credentials under **Settings → Harnesses** and
 keep the exact public paths:
 
 ```text

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -30,45 +30,31 @@ const extensionSettings = {
           overridden: false,
         },
         {
-          name: 'linear_api_key',
-          label: 'Linear API key',
+          name: 'linear_trigger_status',
+          label: 'Linear trigger status',
           help: '',
-          type: 'secret',
-          value: null,
-          default: null,
+          type: 'str',
+          value: 'Ready for Agent',
+          default: 'Ready for Agent',
           choices: null,
           section: 'Linear',
           visibleWhenField: 'tracker',
           visibleWhenValue: 'linear',
-          secretSet: false,
+          secretSet: null,
           overridden: false,
         },
         {
-          name: 'linear_webhook_secret',
-          label: 'Linear webhook secret',
+          name: 'jira_trigger_status',
+          label: 'Jira trigger status',
           help: '',
-          type: 'secret',
-          value: null,
-          default: null,
-          choices: null,
-          section: 'Linear',
-          visibleWhenField: 'tracker',
-          visibleWhenValue: 'linear',
-          secretSet: false,
-          overridden: false,
-        },
-        {
-          name: 'jira_webhook_secret',
-          label: 'Jira webhook secret',
-          help: '',
-          type: 'secret',
-          value: null,
-          default: null,
+          type: 'str',
+          value: 'Ready for Agent',
+          default: 'Ready for Agent',
           choices: null,
           section: 'Jira',
           visibleWhenField: 'tracker',
           visibleWhenValue: 'jira',
-          secretSet: false,
+          secretSet: null,
           overridden: false,
         },
       ],
@@ -116,24 +102,25 @@ const extensionSettings = {
   ],
 }
 
-function stubFetch(shouldRejectPatch = true) {
+function stubFetch(
+  shouldRejectPatch = true,
+  detail: Record<string, Record<string, string>> = {
+    review: {
+      app_id: 'The review App ID is invalid.',
+      private_key: 'Required once the review App ID is set.',
+    },
+  },
+) {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const path = String(input)
       if (path === '/api/settings/extensions' && init?.method === 'PATCH') {
         if (!shouldRejectPatch) return new Response('{}', { status: 200 })
-        return new Response(
-          JSON.stringify({
-            detail: {
-              ship: {
-                linear_api_key: 'The Linear API key is invalid.',
-                linear_webhook_secret: 'Required once the Linear API key is set.',
-              },
-            },
-          }),
-          { status: 422, statusText: 'Unprocessable Entity' },
-        )
+        return new Response(JSON.stringify({ detail }), {
+          status: 422,
+          statusText: 'Unprocessable Entity',
+        })
       }
       if (path === '/api/settings/extensions') {
         return new Response(JSON.stringify(extensionSettings), { status: 200 })
@@ -171,17 +158,17 @@ describe('SettingsModal extension fields', () => {
     stubFetch()
     const onClose = renderModal()
 
-    fireEvent.click(await screen.findByRole('button', { name: 'ship' }))
-    const apiKeyField = screen.getByText('Linear API key').closest('.set-field')
-    const apiKeyInput = apiKeyField?.querySelector('input')
-    expect(apiKeyInput).toBeTruthy()
-    fireEvent.change(apiKeyInput as HTMLInputElement, { target: { value: 'lin-secret' } })
+    fireEvent.click(await screen.findByRole('button', { name: 'review' }))
+    const appIdField = screen.getByText('Review App ID').closest('.set-field')
+    const appIdInput = appIdField?.querySelector('input')
+    expect(appIdInput).toBeTruthy()
+    fireEvent.change(appIdInput as HTMLInputElement, { target: { value: '42' } })
     fireEvent.click(screen.getByRole('button', { name: 'save' }))
 
-    const linearError = await screen.findByText('Required once the Linear API key is set.')
-    const apiKeyError = await screen.findByText('The Linear API key is invalid.')
-    expect(linearError.closest('.set-field')?.textContent).toContain('Linear webhook secret')
-    expect(apiKeyError.closest('.set-field')?.textContent).toContain('Linear API key')
+    const pairError = await screen.findByText('Required once the review App ID is set.')
+    const appIdError = await screen.findByText('The review App ID is invalid.')
+    expect(pairError.closest('.set-field')?.textContent).toContain('Review App private key')
+    expect(appIdError.closest('.set-field')?.textContent).toContain('Review App ID')
     expect(onClose).not.toHaveBeenCalled()
   })
 
@@ -194,17 +181,17 @@ describe('SettingsModal extension fields', () => {
     expect(options?.textContent?.indexOf('Tracker')).toBeLessThan(
       options?.textContent?.indexOf('Linear') ?? -1,
     )
-    const apiKeyField = screen.getByText('Linear API key').closest('.set-field')
-    fireEvent.change(apiKeyField?.querySelector('input') as HTMLInputElement, {
-      target: { value: 'lin-secret' },
+    const statusField = screen.getByText('Linear trigger status').closest('.set-field')
+    fireEvent.change(statusField?.querySelector('input') as HTMLInputElement, {
+      target: { value: 'Agent Queue' },
     })
     const trackerField = screen.getByText('Tracker').closest('.set-field')
     fireEvent.change(trackerField?.querySelector('select') as HTMLSelectElement, {
       target: { value: 'jira' },
     })
 
-    expect(screen.queryByText('Linear API key')).toBeNull()
-    expect(screen.getByText('Jira webhook secret')).toBeTruthy()
+    expect(screen.queryByText('Linear trigger status')).toBeNull()
+    expect(screen.getByText('Jira trigger status')).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'save' }))
 
     await waitFor(() => expect(onClose).toHaveBeenCalled())
@@ -251,7 +238,7 @@ describe('SettingsModal extension fields', () => {
   })
 
   it('renders a 422 message for a field hidden by the tracker selection', async () => {
-    stubFetch()
+    stubFetch(true, { ship: { linear_trigger_status: 'Not a Linear status name.' } })
     renderModal()
 
     fireEvent.click(await screen.findByRole('button', { name: 'ship' }))
@@ -262,9 +249,7 @@ describe('SettingsModal extension fields', () => {
     fireEvent.click(screen.getByRole('button', { name: 'save' }))
 
     expect(
-      await screen.findByText(
-        'Linear webhook secret: Required once the Linear API key is set.',
-      ),
+      await screen.findByText('Linear trigger status: Not a Linear status name.'),
     ).toBeTruthy()
   })
 })


### PR DESCRIPTION
Linear and Jira credentials move off ship's extension settings onto the service-identity seam (#224): they are the appliance's standing identity at the tracker — one per deployment, all-or-nothing, paired with a webhook secret — the same shape as the GitHub App. This is the first extension-declared use of the seam.

## What moves

`contrib/ship/services.py` declares the two services:

- **Linear** — API key + webhook secret. `verify` proves the key with a `viewer`/`organization` query and stores the actor and workspace as identity facts.
- **Jira** — base URL, email, API token, webhook secret. `verify` calls `/rest/api/3/myself` and stores the reported display name; base URL and email are non-secret facts shown on the card.

Both are `required = False`: trackerless installs stay healthy. The generic connect cards, verify-before-store, and doctor coverage all come from the seam — no frontend or wire changes in this PR.

## What stays on ship settings

The `tracker` selector and the trigger/resting statuses — workflow policy, not identity. Connection and selection are independent: both trackers can be connected while the selector picks one. One new ship doctor check reports the cross-concern state: a selected-but-unconnected tracker is pending operator setup; trackerless by choice is healthy.

## Consumers

- `Ship.get_tracker()` builds clients from the service rows; a missing identity means trackerless, and the half-configured-Jira failure class is gone (connect is all-or-nothing).
- Both webhooks verify against the row's stored secret and answer 401 "not connected" when the identity is absent, matching the GitHub webhook's behavior. `_issue_url` reads the Jira base URL from the row.
- The `clean()` pairing rules are deleted — the connect form subsumes them.

Tracker credentials now live in the encrypted `service_identities` column; the docs' encryption-envelope caveat no longer lists them.

## Deploy

One-time re-paste per live box, same as the GitHub App pattern: connect Linear/Jira from **Settings → Harnesses** after rollout. The old settings-override rows are orphaned and harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
