### PR TITLE
Service identities get their own Settings section

### DIFF
--- a/backend/druks/contrib/ship/exceptions.py
+++ b/backend/druks/contrib/ship/exceptions.py
@@ -18,5 +18,5 @@ class TrackerNotConfigured(AgentApiError):
     def __init__(self) -> None:
         super().__init__(
             "No ticket tracker is configured — select Linear or Jira in the ship "
-            "settings and connect its identity in Settings → Harnesses."
+            "settings and connect its identity in Settings → Services."
         )

--- a/backend/druks/contrib/ship/extension.py
+++ b/backend/druks/contrib/ship/extension.py
@@ -44,7 +44,7 @@ def check_tracker_identity() -> CheckResult:
         ok=False,
         pending=True,
         detail=f"tracker is {settings.tracker} but it is not connected — "
-        "connect it in Settings → Harnesses.",
+        "connect it in Settings → Services.",
     )
 
 

--- a/backend/druks/contrib/ship/webhooks.py
+++ b/backend/druks/contrib/ship/webhooks.py
@@ -24,7 +24,7 @@ class LinearEvents(Webhook):
         except ServiceNotConnectedError as error:
             raise HTTPException(
                 status.HTTP_401_UNAUTHORIZED,
-                "Linear is not connected — connect it in Settings → Harnesses.",
+                "Linear is not connected — connect it in Settings → Services.",
             ) from error
         verify_hmac_sha256(
             self.raw_body,
@@ -100,7 +100,7 @@ class JiraEvents(Webhook):
         except ServiceNotConnectedError as error:
             raise HTTPException(
                 status.HTTP_401_UNAUTHORIZED,
-                "Jira is not connected — connect it in Settings → Harnesses.",
+                "Jira is not connected — connect it in Settings → Services.",
             ) from error
         provided = self.request.headers.get("x-druks-webhook-token") or ""
         if not hmac.compare_digest(provided, webhook_secret):

--- a/backend/druks/core/webhooks/github.py
+++ b/backend/druks/core/webhooks/github.py
@@ -37,7 +37,7 @@ class GitHubEvents(Webhook):
         except ServiceNotConnectedError as error:
             raise HTTPException(
                 status.HTTP_401_UNAUTHORIZED,
-                "GitHub is not connected — connect it in Settings → Harnesses.",
+                "GitHub is not connected — connect it in Settings → Services.",
             ) from error
         verify_hmac_sha256(
             self.raw_body,

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -65,7 +65,7 @@ def check_service_identities(settings: Settings) -> list[CheckResult]:
                             ok=not service.required,
                             pending=service.required,
                             detail=f"not connected — connect {service.title} in "
-                            "Settings → Harnesses.",
+                            "Settings → Services.",
                         )
                     )
                     continue
@@ -99,7 +99,7 @@ def check_installations(settings: Settings) -> CheckResult:
             name="installations",
             ok=False,
             pending=True,
-            detail="github is not connected — connect it in Settings → Harnesses.",
+            detail="github is not connected — connect it in Settings → Services.",
         )
     except Exception as exc:  # noqa: BLE001 — doctor reports, never raises
         return CheckResult(

--- a/backend/druks/services/exceptions.py
+++ b/backend/druks/services/exceptions.py
@@ -4,7 +4,7 @@ class ServiceNotConnectedError(Exception):
 
     def __init__(self, service: str) -> None:
         self.service = service
-        super().__init__(f"{service} is not connected — connect it in Settings → Harnesses.")
+        super().__init__(f"{service} is not connected — connect it in Settings → Services.")
 
 
 class ServiceConnectError(Exception):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,7 +165,7 @@ in Postgres; there is no TOML, environment, or PEM-file source — until GitHub
 is connected, agent runs refuse with a pointed message and `druks doctor`
 reports the identity as not connected.
 
-Connect it from **Settings → Harnesses**. **Create GitHub App** registers the
+Connect it from **Settings → Services**. **Create GitHub App** registers the
 App through GitHub's manifest flow: name a GitHub org (or leave it empty for
 a personal account), confirm on GitHub, and druks stores the created App's
 credentials and sends you on to install it on your repositories. Creating the
@@ -200,7 +200,7 @@ set is where `ship` may act. Personal access tokens are not a supported
 substitute.
 
 **Upgrading an existing installation** is a one-time paste on each live box
-after rollout: open Settings → Harnesses and connect GitHub with the existing
+after rollout: open Settings → Services and connect GitHub with the existing
 operator App's ID, private key, and webhook secret. Do not create a
 replacement App — the current App's webhook and installations keep working
 under the pasted credentials.
@@ -222,7 +222,7 @@ client at another compatible GitHub API endpoint.
 
 Tracker credentials are service identities: connect Linear (API key + webhook
 secret) or Jira Cloud (base URL, email, API token, webhook secret) from
-**Settings → Harnesses**, on the same cards as the GitHub App. Connecting
+**Settings → Services**, on the same cards as the GitHub App. Connecting
 verifies the credentials against the tracker before anything is stored. Which
 tracker drives `ship` work — and the statuses that trigger or move it — stays a
 ship extension setting in **Settings → Ship**.

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -47,7 +47,7 @@ Postgres — no separate datastore. On macOS, if sandbox SSH turns out
 unreachable, enable host networking in Docker Desktop's settings.
 
 For the bundled `ship` extension, connect the GitHub App druks acts as from
-the dashboard after boot (**Settings → Harnesses**) — create it there or
+the dashboard after boot (**Settings → Services**) — create it there or
 paste an existing App's credentials, see
 [the GitHub connection](configuration.md#github).
 
@@ -139,7 +139,7 @@ value.
 
 GitHub, Linear, and Jira cannot reach a loopback listener. Dashboard-initiated
 actions work locally, but provider-driven flows need an HTTPS tunnel forwarding
-to `127.0.0.1:8001`. Connect tracker credentials under **Settings → Harnesses** and
+to `127.0.0.1:8001`. Connect tracker credentials under **Settings → Services** and
 keep the exact public paths:
 
 ```text

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -344,6 +344,7 @@ export function SettingsModal({ open, onClose }: Props) {
           <nav className="set-rail">
             <RailItem icon="general" label="General" active={section === 'general'} onClick={() => setSection('general')} />
             <RailItem icon="harnesses" label="Harnesses" active={section === 'harnesses'} onClick={() => setSection('harnesses')} />
+            <RailItem icon="services" label="Services" active={section === 'services'} onClick={() => setSection('services')} />
             <RailItem icon="skills" label="Skills" active={section === 'skills'} onClick={() => setSection('skills')} />
             <RailItem icon="mcp" label="MCP" active={section === 'mcp'} onClick={() => setSection('mcp')} />
             <RailItem icon="agent-access" label="Tokens" active={section === 'agent-access'} onClick={() => setSection('agent-access')} />
@@ -388,6 +389,7 @@ export function SettingsModal({ open, onClose }: Props) {
                   <div className="set-pane-sub">loading…</div>
                 </div>
               ))}
+            {section === 'services' && <ServicesPane />}
             {section === 'skills' && <SkillsPane />}
             {section === 'mcp' && <McpServersPane />}
             {section === 'agent-access' && <AgentAccessPane />}
@@ -466,6 +468,12 @@ function RailGlyph({ name }: { name: string }) {
       <>
         <rect x="2" y="3" width="12" height="10" rx="1.5" />
         <path d="M4.5 6.5 6.7 8 4.5 9.5M8 10h3.2" />
+      </>
+    ),
+    services: (
+      <>
+        <circle cx="5.5" cy="10.5" r="2.5" />
+        <path d="M7.5 8.5 13 3M10.5 5.5l2 2" />
       </>
     ),
     skills: (
@@ -825,6 +833,25 @@ function HarnessesPane({
               </div>
             )
           })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Services — the appliance's own identities at external providers, one card
+// per declared service.
+function ServicesPane() {
+  return (
+    <div className="set-pane">
+      <div className="set-pane-head">
+        <div className="set-pane-sub">
+          The identities druks itself holds at external services — connected once per installation, verified before anything replaces a working one.
+        </div>
+      </div>
+      <div className="set-group">
+        <div className="set-group-label">services</div>
+        <div className="set-cards">
           <ServiceIdentityCards />
         </div>
       </div>


### PR DESCRIPTION
The generic service-identity cards have rendered at the tail of the Harnesses pane since #224 — inherited from where the hardcoded GitHub card lived. With #228 adding Linear and Jira they outgrow that home, and the categories differ: harness logins are per-operator subscription identities, service identities are the appliance's own.

- A **Services** rail section in Settings hosts the cards; the Harnesses pane is harnesses again.
- Every message and doc line that pointed identity connect at Settings → Harnesses now says **Settings → Services**: `ServiceNotConnectedError`, the doctor details, both tracker webhooks and the GitHub webhook, the ship tracker check, and the GitHub/tracker doc sections. Harness-login strings are untouched.

Stacked on #228.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
