### PR TITLE
Field introspection lives on the settings domain; the MCP callback renders from a template

### DIFF
--- a/backend/druks/core/routes.py
+++ b/backend/druks/core/routes.py
@@ -1,24 +1,17 @@
 import json
-from pathlib import Path
 from urllib.parse import quote
 
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse
-from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 from druks.core.apis.github import GITHUB
 from druks.core.services import GitHubApp
+from druks.core.templates import render_page
 from druks.services.models import ServiceIdentity
 
 # Mounted by the loader under /api/core, like any extension's routes.
 router = APIRouter(prefix="/github", tags=["services"])
-
-_templates = Environment(
-    loader=FileSystemLoader(Path(__file__).parent / "templates"),
-    autoescape=True,
-    undefined=StrictUndefined,
-)
 
 
 @router.get("/manifest", response_class=HTMLResponse)
@@ -45,8 +38,7 @@ async def create_github_app(request: Request) -> HTMLResponse:
         "redirect_url": f"{endpoint}/api/core/github/manifest/callback",
         "hook_attributes": {"url": f"{webhook_base}/_external/github/events/", "active": True},
     }
-    page = _templates.get_template("github_manifest.html")
-    return HTMLResponse(page.render(manifest_json=json.dumps(manifest)))
+    return render_page("github_manifest.html", manifest_json=json.dumps(manifest))
 
 
 @router.get("/manifest/callback", response_class=HTMLResponse)
@@ -77,5 +69,6 @@ async def github_manifest_callback(request: Request, code: str = "") -> HTMLResp
     # druks opened this tab via window.open; the broadcast tells the connect
     # card to refetch, then the tab moves on to the one step GitHub still
     # needs — installing the App on the repositories druks should work in.
-    page = _templates.get_template("github_manifest_callback.html")
-    return HTMLResponse(page.render(slug=slug, install_url=install_url, service=GITHUB))
+    return render_page(
+        "github_manifest_callback.html", slug=slug, install_url=install_url, service=GITHUB
+    )

--- a/backend/druks/core/templates.py
+++ b/backend/druks/core/templates.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from typing import Any
+
+from fastapi.responses import HTMLResponse
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+_templates = Environment(
+    loader=FileSystemLoader(Path(__file__).parent / "templates"),
+    autoescape=True,
+    undefined=StrictUndefined,
+)
+
+
+def render_page(template: str, **context: Any) -> HTMLResponse:
+    """One of the operator-facing pages in ``core/templates`` — server-rendered
+    browser stops (connect callbacks, the GitHub App manifest form) that share
+    the dashboard's chrome."""
+    return HTMLResponse(_templates.get_template(template).render(context))

--- a/backend/druks/core/templates/github_manifest.html
+++ b/backend/druks/core/templates/github_manifest.html
@@ -1,5 +1,5 @@
-<html>
-<body>
+{% extends "page.html" %}
+{% block content %}
 <form method="post" action="https://github.com/settings/apps/new">
   <input type="hidden" name="manifest" value="{{ manifest_json }}">
   <p>Continue to GitHub to create the App druks acts as. GitHub creates it on
@@ -14,5 +14,4 @@
     this.elements.org.disabled = true;
   };
 </script>
-</body>
-</html>
+{% endblock %}

--- a/backend/druks/core/templates/github_manifest_callback.html
+++ b/backend/druks/core/templates/github_manifest_callback.html
@@ -1,10 +1,9 @@
-<html>
-<body>
+{% extends "page.html" %}
+{% block content %}
 <p>Created GitHub App <b>{{ slug }}</b>.
   Next, <a href="{{ install_url }}">install it on your repositories</a>.</p>
 <script>
   new BroadcastChannel('druks-service-connect').postMessage({{ service | tojson }});
   window.location.replace({{ install_url | tojson }});
 </script>
-</body>
-</html>
+{% endblock %}

--- a/backend/druks/core/templates/mcp_oauth_callback.html
+++ b/backend/druks/core/templates/mcp_oauth_callback.html
@@ -1,0 +1,9 @@
+{% extends "page.html" %}
+{% block content %}
+<p>Connected MCP server <b>{{ name }}</b>.
+  You can close this tab and return to druks.</p>
+<script>
+  new BroadcastChannel('druks-mcp-connect').postMessage({{ name | tojson }});
+  window.close();
+</script>
+{% endblock %}

--- a/backend/druks/core/templates/page.html
+++ b/backend/druks/core/templates/page.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>druks</title>
+  {# The dashboard's tokens, inlined: these pages are served by the API with no
+     SPA assets in reach, and a hashed stylesheet URL would rot. #}
+  <style>
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center;
+           background: #0a0c12; color: #f0f2f7;
+           font: 15px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    main { background: #0e1119; border: 1px solid #1c2030; border-radius: 8px;
+           padding: 28px 32px; max-width: 30rem; }
+    .wordmark { color: #7e889d; font-size: 12px; letter-spacing: .14em;
+                text-transform: uppercase; margin-bottom: 14px; }
+    p { margin: 0 0 12px; color: #b4bccd; }
+    a { color: #a78bfa; }
+    b { color: #f0f2f7; }
+    label { display: block; color: #99a3b9; font-size: 13px; }
+    input { width: 100%; box-sizing: border-box; margin-top: 4px; padding: 8px 10px;
+            background: #131825; color: #f0f2f7; border: 1px solid #1c2030;
+            border-radius: 5px; font: inherit; }
+    button { padding: 9px 16px; background: #a78bfa; color: #0a0c12; border: 0;
+             border-radius: 5px; font: inherit; font-weight: 600; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <main>
+    <div class="wordmark">druks</div>
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/backend/druks/mcp/routes.py
+++ b/backend/druks/mcp/routes.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.responses import HTMLResponse
 
 from druks.accounts.context import current_account_id
+from druks.core.templates import render_page
 from druks.extensions.registry import mcp_servers
 from druks.mcp import oauth, registry
 from druks.mcp.enums import IdentityMode, TokenSource
@@ -225,12 +226,7 @@ async def oauth_callback(state: str = "", code: str = "", error: str = "") -> HT
     # druks opened this tab via window.open, so the page may close itself; the
     # broadcast tells the settings modal to refetch before the tab goes. The
     # text stays for browsers that refuse the close.
-    return HTMLResponse(
-        f"<html><body><p>Connected MCP server <b>{name}</b>. "
-        "You can close this tab and return to druks.</p>"
-        f"<script>new BroadcastChannel('druks-mcp-connect').postMessage({name!r});"
-        "window.close()</script></body></html>"
-    )
+    return render_page("mcp_oauth_callback.html", name=name)
 
 
 @router.delete("/{name}/grant", status_code=204)


### PR DESCRIPTION
The two cleanups the service-seam arc flagged and parked, now that their conventions exist:

- **`field_spec` is the one door to `FieldInfo`.** The settings domain (`extensions/settings.py`) now composes a field's declaration-derived facts in one place; `SettingsFieldResponse.from_field` becomes a thin projection applying only wire policy (secret redaction, set-hint, overridden), and `Service.connect_fields` picks its subset from the same spec instead of re-deriving labels and kinds. No schema reads pydantic fields anymore.

- **The MCP OAuth callback renders from a Jinja template** (`mcp/templates/oauth_callback.html`), the convention the GitHub manifest pages established — autoescape + StrictUndefined instead of hand-assembled f-string HTML. Same page, same broadcast, same self-close.

No wire shapes change; the settings and services responses are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
