### PR TITLE
The Services pane is a card overview with per-service detail views

### DIFF
--- a/frontend/src/components/ServicesPane.test.tsx
+++ b/frontend/src/components/ServicesPane.test.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Service } from '../api/types'
-import { ServiceCards } from './SettingsModal'
+import { ServicesPane } from './SettingsModal'
 
 const PEM = '-----BEGIN RSA PRIVATE KEY-----\nline-one\nline-two\n-----END RSA PRIVATE KEY-----'
 const SECRET = 'hook-secret-value'
@@ -66,13 +66,20 @@ function stubFetch(states: Service[][]) {
   return fetchMock
 }
 
-function renderCards() {
+function renderPane() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={queryClient}>
-      <ServiceCards />
+      <ServicesPane />
     </QueryClientProvider>,
   )
+}
+
+// Overview card → detail view, then the explicit action that reveals the
+// credential fields.
+async function openGithubForm() {
+  fireEvent.click(await screen.findByText('GitHub'))
+  fireEvent.click(await screen.findByText('Connect an existing GitHub App'))
 }
 
 afterEach(() => {
@@ -86,32 +93,55 @@ async function flush() {
   })
 }
 
-describe('ServiceCards', () => {
-  it('renders the disconnected paste-in form from the field spec', async () => {
-    stubFetch([[disconnected]])
-    renderCards()
+describe('ServicesPane', () => {
+  it('shows compact cards with no credential fields on the overview', async () => {
+    stubFetch([[disconnected, pasteOnly]])
+    renderPane()
 
-    expect(await screen.findByText('not connected')).toBeTruthy()
-    expect(await screen.findByLabelText('App ID')).toBeTruthy()
+    expect(await screen.findByText('GitHub')).toBeTruthy()
+    expect(screen.getByText('Google OAuth client')).toBeTruthy()
+    expect(screen.getAllByText('Not connected')).toHaveLength(2)
+    expect(screen.queryByLabelText('App ID')).toBeNull()
+    expect(screen.queryByLabelText('Client ID')).toBeNull()
+    expect(document.body.textContent).not.toContain('service identity')
+  })
+
+  it('opens a focused detail view and reveals fields only after the connect action', async () => {
+    stubFetch([[disconnected, pasteOnly]])
+    renderPane()
+
+    fireEvent.click(await screen.findByText('Google OAuth client'))
+    expect(screen.getByText('← Services')).toBeTruthy()
+    expect(screen.queryByLabelText('Client ID')).toBeNull()
+
+    fireEvent.click(screen.getByText('Connect Google OAuth client'))
+    expect(screen.getByLabelText('Client ID')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('← Services'))
+    expect(screen.getByText('GitHub')).toBeTruthy()
+    expect(screen.queryByLabelText('Client ID')).toBeNull()
+  })
+
+  it('keeps Create GitHub App primary and paste behind the existing-app disclosure', async () => {
+    stubFetch([[disconnected]])
+    renderPane()
+
+    fireEvent.click(await screen.findByText('GitHub'))
+    expect(screen.getByText('Create GitHub App')).toBeTruthy()
+    expect(screen.queryByLabelText('App ID')).toBeNull()
+
+    fireEvent.click(screen.getByText('Connect an existing GitHub App'))
+    expect(screen.getByLabelText('App ID')).toBeTruthy()
     expect(screen.getByLabelText('Private key (PEM)')).toBeTruthy()
     expect(screen.getByLabelText('Webhook secret')).toBeTruthy()
   })
 
-  it('renders one card per service, with the create affordance only on github', async () => {
-    stubFetch([[disconnected, pasteOnly]])
-    renderCards()
-
-    expect(await screen.findByText('gmail')).toBeTruthy()
-    expect(screen.getByLabelText('Client ID')).toBeTruthy()
-    expect(screen.getByText('Create GitHub App')).toBeTruthy()
-    expect(screen.getByText('Connect Google OAuth client')).toBeTruthy()
-  })
-
   it('submits the spec-named values, keeps PEM newlines, and refreshes to the connected facts', async () => {
     const fetchMock = stubFetch([[disconnected], [connected]])
-    renderCards()
+    renderPane()
 
-    fireEvent.change(await screen.findByLabelText('App ID'), { target: { value: '12345' } })
+    await openGithubForm()
+    fireEvent.change(screen.getByLabelText('App ID'), { target: { value: '12345' } })
     fireEvent.change(screen.getByLabelText('Private key (PEM)'), { target: { value: PEM } })
     fireEvent.change(screen.getByLabelText('Webhook secret'), { target: { value: SECRET } })
     fireEvent.click(screen.getByText('Connect GitHub'))
@@ -129,7 +159,9 @@ describe('ServiceCards', () => {
 
     // The refreshed connected response renders identity facts only — the
     // submitted secrets are nowhere in the connected UI.
-    expect(await screen.findByText(/connected · app_id 12345 · slug druks-operator/)).toBeTruthy()
+    expect(await screen.findByText('Connected')).toBeTruthy()
+    expect(screen.getByText('druks-operator')).toBeTruthy()
+    expect(screen.getByText('12345')).toBeTruthy()
     expect(document.body.textContent).not.toContain('line-one')
     expect(document.body.textContent).not.toContain(SECRET)
     expect(screen.queryByLabelText('Private key (PEM)')).toBeNull()
@@ -148,25 +180,28 @@ describe('ServiceCards', () => {
       },
     )
     vi.stubGlobal('fetch', fetchMock)
-    renderCards()
+    renderPane()
 
-    fireEvent.change(await screen.findByLabelText('App ID'), { target: { value: 'bad' } })
+    await openGithubForm()
+    fireEvent.change(screen.getByLabelText('App ID'), { target: { value: 'bad' } })
     fireEvent.change(screen.getByLabelText('Private key (PEM)'), { target: { value: 'bad-pem' } })
     fireEvent.change(screen.getByLabelText('Webhook secret'), { target: { value: 'bad-secret' } })
     fireEvent.click(screen.getByText('Connect GitHub'))
 
     expect(await screen.findByText(/did not accept these credentials/)).toBeTruthy()
-    expect(screen.getByText('not connected')).toBeTruthy()
+    expect(screen.getByText('Not connected')).toBeTruthy()
   })
 
   it('shows connected facts with a Replace affordance and no secret fields', async () => {
     stubFetch([[connected]])
-    renderCards()
+    renderPane()
 
-    expect(await screen.findByText(/connected · app_id 12345/)).toBeTruthy()
+    fireEvent.click(await screen.findByText('GitHub'))
+    expect(screen.getByText('Connected')).toBeTruthy()
+    expect(screen.getByText('12345')).toBeTruthy()
     expect(screen.queryByLabelText('Private key (PEM)')).toBeNull()
 
-    fireEvent.click(screen.getByText('Replace'))
+    fireEvent.click(screen.getByText('Replace connection'))
     expect(screen.getByLabelText('Private key (PEM)')).toBeTruthy()
   })
 
@@ -174,23 +209,25 @@ describe('ServiceCards', () => {
     stubFetch([[disconnected], [connected]])
     const open = vi.fn()
     vi.stubGlobal('open', open)
-    renderCards()
+    renderPane()
 
-    fireEvent.click(await screen.findByText('Create GitHub App'))
+    fireEvent.click(await screen.findByText('GitHub'))
+    fireEvent.click(screen.getByText('Create GitHub App'))
     expect(open).toHaveBeenCalledWith('/api/core/github/manifest')
 
     act(() => {
       new BroadcastChannel('druks-service-connect').postMessage('github')
     })
 
-    expect(await screen.findByText(/connected · app_id 12345/)).toBeTruthy()
+    expect(await screen.findByText('druks-operator')).toBeTruthy()
   })
 
   it('links installation management to the connected slug', async () => {
     stubFetch([[connected]])
-    renderCards()
+    renderPane()
 
-    const link = await screen.findByText('Manage installations')
+    fireEvent.click(await screen.findByText('GitHub'))
+    const link = screen.getByText('Manage installations')
 
     expect(link.getAttribute('href')).toBe(
       'https://github.com/apps/druks-operator/installations/new',

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -839,68 +839,105 @@ function HarnessesPane({
   )
 }
 
-// Services — the appliance's own identities at external providers, one card
-// per declared service.
-function ServicesPane() {
-  return (
-    <div className="set-pane">
-      <div className="set-pane-head">
-        <div className="set-pane-sub">
-          The identities druks itself holds at external services — connected once per installation, verified before anything replaces a working one.
-        </div>
-      </div>
-      <div className="set-group">
-        <div className="set-group-label">services</div>
-        <div className="set-cards">
-          <ServiceCards />
-        </div>
-      </div>
-    </div>
-  )
-}
-
-// The appliance's own identities at external services, one card per declared
-// service, fields rendered from each entry's spec. Connection persists
-// immediately, outside the modal's Save, so each card owns its query, submit,
-// busy, and error state. Pasted secrets are write-only: a success drops them
-// from state, and the connected rendering shows identity facts only.
-export function ServiceCards() {
+// Services — the appliance's own identities at external providers. The
+// overview is a grid of compact cards; clicking one swaps in a focused detail
+// view in the same pane. Connection persists immediately, outside the modal's
+// Save, so the detail view owns its own submit, busy, and error state.
+export function ServicesPane() {
+  const queryClient = useQueryClient()
   const query = useQuery({
     queryKey: ['services'],
     queryFn: () => api.services(),
     staleTime: 60_000,
   })
-  return (
-    <>
-      {(query.data ?? []).map((service) => (
-        <ServiceCard key={service.name} service={service} />
-      ))}
-    </>
-  )
-}
-
-export function ServiceCard({ service }: { service: Service }) {
-  const queryClient = useQueryClient()
-  const [replacing, setReplacing] = useState(false)
-  const [values, setValues] = useState<Record<string, string>>({})
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [selectedName, setSelectedName] = useState<string | null>(null)
 
   // A guided create flow (the GitHub App manifest tab) lands on a callback
   // page, which broadcasts the service name once the credentials are stored.
   useEffect(() => {
     const channel = new BroadcastChannel('druks-service-connect')
-    channel.onmessage = (event) => {
-      if (event.data === service.name) {
-        setReplacing(false)
-        void queryClient.invalidateQueries({ queryKey: ['services'] })
-      }
-    }
+    channel.onmessage = () => void queryClient.invalidateQueries({ queryKey: ['services'] })
     return () => channel.close()
-  }, [queryClient, service.name])
+  }, [queryClient])
 
-  const formOpen = !service.connected || replacing
+  const services = query.data ?? []
+  const selected = services.find((service) => service.name === selectedName)
+
+  return (
+    <div className="set-pane mcp-pane svc-pane">
+      {selected ? (
+        <ServiceDetail service={selected} onBack={() => setSelectedName(null)} />
+      ) : (
+        <>
+          <header className="mcp-pane-head">
+            <h2 className="mcp-pane-title">Services</h2>
+            <p className="mcp-pane-sub">
+              Connect the accounts druks uses to work with external services.
+            </p>
+          </header>
+          <div className="svc-grid">
+            {services.map((service) => {
+              const identity = service.connected
+                ? (service.facts.slug ?? Object.values(service.facts)[0])
+                : undefined
+              return (
+                <button
+                  key={service.name}
+                  type="button"
+                  className="svc-card"
+                  onClick={() => setSelectedName(service.name)}
+                >
+                  <span className="svc-card-top">
+                    <span className="svc-card-name">{service.title}</span>
+                    <ServiceStatus connected={service.connected} />
+                  </span>
+                  <span className="svc-card-desc">{service.description}</span>
+                  <span className="svc-card-foot">
+                    {identity ? (
+                      <span className="svc-card-id">{identity}</span>
+                    ) : (
+                      <span className="svc-card-cue">Configure</span>
+                    )}
+                    <span className="svc-card-chevron" aria-hidden="true">
+                      ›
+                    </span>
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function ServiceStatus({ connected }: { connected: boolean }) {
+  return (
+    <span className={'svc-status' + (connected ? ' is-on' : '')}>
+      <span className="svc-status-dot" />
+      {connected ? 'Connected' : 'Not connected'}
+    </span>
+  )
+}
+
+// Credential fields stay hidden until the user explicitly chooses to connect
+// or replace. Pasted secrets are write-only: a success drops them from state,
+// and the connected rendering shows identity facts only.
+function ServiceDetail({ service, onBack }: { service: Service; onBack: () => void }) {
+  const queryClient = useQueryClient()
+  const [formOpen, setFormOpen] = useState(false)
+  const [values, setValues] = useState<Record<string, string>>({})
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
   const complete = service.fields.every((field) => (values[field.name] ?? '').trim() !== '')
+
+  const closeForm = () => {
+    setFormOpen(false)
+    setValues({})
+    setError(null)
+  }
 
   const submit = () => {
     setBusy(true)
@@ -909,112 +946,134 @@ export function ServiceCard({ service }: { service: Service }) {
       .connectService(service.name, values)
       .then(async () => {
         setValues({})
-        setReplacing(false)
+        setFormOpen(false)
         await queryClient.invalidateQueries({ queryKey: ['services'] })
       })
       .catch((e) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setBusy(false))
   }
 
-  const facts = Object.entries(service.facts)
+  const createGithubApp = (
+    <button
+      className="set-btn primary"
+      onClick={() => window.open('/api/core/github/manifest')}
+      disabled={busy}
+    >
+      Create GitHub App
+    </button>
+  )
 
   return (
-    <div className="set-card harness-row" style={{ '--fam': 'var(--accent-violet)' } as CSSProperties}>
-      <div className="hr-head">
-        <span className="set-card-name">
-          <span className="dot" />
-          {service.name}
-        </span>
-        <span className="set-card-tag">service identity</span>
+    <>
+      <div>
+        <button type="button" className="svc-back" onClick={onBack}>
+          ← Services
+        </button>
       </div>
-      <div className="set-pane-sub">{service.description}</div>
-      <div className="hr-connect">
-        <div className="hr-conn-status">
-          {service.connected ? (
-            <span className="hr-chip hr-chip-on">
-              connected{facts.map(([key, value]) => ` · ${key} ${value}`).join('')}
-            </span>
-          ) : (
-            <span className="hr-chip hr-chip-off">not connected</span>
-          )}
-          {service.connected && service.connectedAt && (
-            <span className="hr-conn-exp">connected {new Date(service.connectedAt).toLocaleString()}</span>
-          )}
-          <span className="hr-conn-actions">
-            {service.name === 'github' && service.connected && (
-              <a
-                className="hr-conn-btn"
-                href={`https://github.com/apps/${encodeURIComponent(service.facts.slug ?? '')}/installations/new`}
-                target="_blank"
-                rel="noreferrer"
-              >
-                Manage installations
-              </a>
-            )}
-            {service.connected && !replacing && (
-              <button className="hr-conn-btn" onClick={() => setReplacing(true)} disabled={busy}>
-                Replace
-              </button>
-            )}
-          </span>
+      <header className="mcp-pane-head">
+        <div className="svc-detail-head">
+          <h2 className="mcp-pane-title">{service.title}</h2>
+          <ServiceStatus connected={service.connected} />
         </div>
-        {formOpen && (
-          <div className="si-connect-form">
-            {service.name === 'github' && (
-              <>
-                <span className="hr-conn-actions">
-                  <button
-                    className="hr-conn-btn"
-                    onClick={() => window.open('/api/core/github/manifest')}
-                    disabled={busy}
-                  >
-                    Create GitHub App
-                  </button>
-                </span>
-                <div className="set-pane-sub">…or paste an existing App&apos;s credentials:</div>
-              </>
-            )}
-            {service.fields.map((field) =>
-              field.multiline ? (
-                <div className="set-field" key={field.name}>
-                  <span className="set-field-label">{field.label}</span>
-                  <textarea
-                    className="set-select set-textarea"
-                    aria-label={field.label}
-                    value={values[field.name] ?? ''}
-                    onChange={(e) => setValues({ ...values, [field.name]: e.target.value })}
-                    disabled={busy}
-                  />
-                </div>
-              ) : (
-                <div className="set-field" key={field.name}>
-                  <span className="set-field-label">{field.label}</span>
-                  <input
-                    className="set-select"
-                    type={field.type === 'secret' ? 'password' : 'text'}
-                    aria-label={field.label}
-                    value={values[field.name] ?? ''}
-                    onChange={(e) => setValues({ ...values, [field.name]: e.target.value })}
-                    disabled={busy}
-                  />
-                </div>
-              ),
-            )}
-            <span className="hr-conn-actions">
-              {replacing && (
-                <button className="hr-conn-btn hr-conn-ghost" onClick={() => setReplacing(false)} disabled={busy}>
-                  Cancel
-                </button>
-              )}
-              <button className="hr-conn-btn" onClick={submit} disabled={busy || !complete}>
-                {service.connected ? 'Replace connection' : `Connect ${service.title}`}
-              </button>
-            </span>
+        <p className="mcp-pane-sub">{service.description}</p>
+      </header>
+      {error && (
+        <div className="mcp-error" role="alert">
+          {error}
+        </div>
+      )}
+      {service.connected && (
+        <section className="mcp-section">
+          <div className="svc-facts">
+            {Object.entries(service.facts).map(([key, value]) => (
+              <div className="svc-fact" key={key}>
+                <span className="svc-fact-key">{key}</span>
+                <span className="svc-fact-val">{value}</span>
+              </div>
+            ))}
           </div>
-        )}
-        {error && <div className="hr-conn-error">{error}</div>}
-      </div>
-    </div>
+          {service.connectedAt && (
+            <p className="svc-meta">Connected {new Date(service.connectedAt).toLocaleString()}</p>
+          )}
+          {!formOpen && (
+            <div className="svc-actions">
+              {service.name === 'github' && (
+                <a
+                  className="set-btn ghost"
+                  href={`https://github.com/apps/${encodeURIComponent(service.facts.slug ?? '')}/installations/new`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Manage installations
+                </a>
+              )}
+              <button className="set-btn ghost" onClick={() => setFormOpen(true)} disabled={busy}>
+                Replace connection
+              </button>
+            </div>
+          )}
+        </section>
+      )}
+      {!service.connected && !formOpen && (
+        <section className="mcp-section">
+          {service.name === 'github' ? (
+            <>
+              <div>{createGithubApp}</div>
+              <button type="button" className="svc-alt" onClick={() => setFormOpen(true)}>
+                Connect an existing GitHub App
+              </button>
+            </>
+          ) : (
+            <div>
+              <button className="set-btn primary" onClick={() => setFormOpen(true)}>
+                Connect {service.title}
+              </button>
+            </div>
+          )}
+        </section>
+      )}
+      {formOpen && (
+        <section className="mcp-section">
+          {service.name === 'github' && service.connected && (
+            <>
+              <div>{createGithubApp}</div>
+              <p className="mcp-help">…or paste an existing App&apos;s credentials:</p>
+            </>
+          )}
+          {service.fields.map((field) => (
+            <div className="mcp-field" key={field.name}>
+              <span className="mcp-label">{field.label}</span>
+              {field.multiline ? (
+                <textarea
+                  className="skill-add-input svc-textarea"
+                  aria-label={field.label}
+                  value={values[field.name] ?? ''}
+                  onChange={(e) => setValues({ ...values, [field.name]: e.target.value })}
+                  disabled={busy}
+                />
+              ) : (
+                <input
+                  className="skill-add-input"
+                  type={field.type === 'secret' ? 'password' : 'text'}
+                  aria-label={field.label}
+                  value={values[field.name] ?? ''}
+                  onChange={(e) => setValues({ ...values, [field.name]: e.target.value })}
+                  disabled={busy}
+                />
+              )}
+            </div>
+          ))}
+          <div className="svc-actions">
+            <button className="set-btn ghost" onClick={closeForm} disabled={busy}>
+              Cancel
+            </button>
+            <button className="set-btn primary" onClick={submit} disabled={busy || !complete}>
+              {service.connected ? 'Replace connection' : `Connect ${service.title}`}
+            </button>
+          </div>
+        </section>
+      )}
+    </>
   )
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1021,8 +1021,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .hr-conn-input:focus { outline: none; border-color: color-mix(in oklch, var(--fam, var(--accent)) 55%, transparent); }
 .hr-conn-error { font-size: 11.5px; color: var(--outcome-failed); font-family: var(--font-mono); }
 /* Connect GitHub — the service-identity paste-in form on its hand-placed card. */
-.si-connect-form { display: flex; flex-direction: column; gap: 12px; padding: 11px 12px; border-radius: 5px; background: var(--surface); border: 1px solid var(--border); }
-.si-connect-form .hr-conn-actions { margin-left: 0; justify-content: flex-end; }
 
 .set-switch { position: relative; width: 34px; height: 18px; border-radius: 10px; flex-shrink: 0; background: var(--surface-3); border: 1px solid var(--border-loud); transition: all 140ms; cursor: pointer; }
 .set-switch::after { content: ''; position: absolute; top: 1.5px; left: 1.5px; width: 12px; height: 12px; border-radius: 50%; background: var(--text-dim); transition: all 140ms; }
@@ -1200,8 +1198,43 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .mcp-enable-label { font-size: 12.5px; color: var(--text-mid); }
 .mcp-actions { display: flex; align-items: center; justify-content: flex-end; flex-wrap: wrap; gap: 8px; }
 
+/* Services — an overview grid of provider cards, each opening a focused
+   detail view in the same pane. Shares the MCP pane's measure and type
+   scale; monospace is reserved for identity values. */
+.svc-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+.svc-card { display: flex; flex-direction: column; gap: 8px; min-width: 0; padding: 13px 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); cursor: pointer; text-align: left; font: inherit; color: inherit; transition: border-color 120ms, background 120ms; }
+.svc-card:hover { border-color: var(--border-loud); background: var(--surface-3); }
+.svc-card:active { background: var(--surface); }
+.svc-card-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.svc-card-name { font-size: 13.5px; font-weight: 600; color: var(--text); }
+.svc-card-desc { font-size: 12px; line-height: 1.45; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.svc-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: auto; }
+.svc-card-id { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.svc-card-cue { font-size: 12px; color: var(--text-dim); }
+.svc-card-chevron { font-family: var(--font-mono); font-size: 14px; color: var(--text-faint); flex-shrink: 0; }
+
+.svc-status { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; font-weight: 500; color: var(--text-dim); white-space: nowrap; }
+.svc-status-dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
+.svc-status.is-on { color: var(--outcome-merged); }
+.svc-status.is-on .svc-status-dot { box-shadow: 0 0 8px color-mix(in oklch, var(--outcome-merged) 60%, transparent); }
+
+.svc-back { padding: 0; border: none; background: none; font: inherit; font-size: 12.5px; color: var(--text-mid); cursor: pointer; }
+.svc-back:hover { color: var(--text); }
+.svc-detail-head { display: flex; align-items: center; gap: 12px; }
+.svc-facts { display: flex; flex-direction: column; gap: 6px; padding: 12px 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); }
+.svc-fact { display: flex; gap: 12px; min-width: 0; font-family: var(--font-mono); font-size: 12px; }
+.svc-fact-key { color: var(--text-dim); flex-shrink: 0; }
+.svc-fact-val { color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.svc-meta { margin: 0; font-size: 12px; color: var(--text-faint); }
+.svc-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.svc-alt { align-self: flex-start; padding: 0; border: none; background: none; font: inherit; font-size: 12.5px; color: var(--text-mid); cursor: pointer; text-decoration: underline; text-underline-offset: 3px; }
+.svc-alt:hover { color: var(--text); }
+.svc-textarea { height: auto; min-height: 96px; padding: 8px 12px; line-height: 1.45; resize: vertical; white-space: pre; font-size: 12px; }
+.svc-pane a.set-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
 @media (max-width: 720px) {
   .set-extension-toggles { grid-template-columns: 1fr; }
+  .svc-grid { grid-template-columns: 1fr; }
   .set-thead { display: none; }
   .set-trow { grid-template-columns: 1fr 1fr; gap: 8px; padding: 12px 14px; }
   .skill-row { grid-template-columns: 1fr; }


### PR DESCRIPTION
The Services settings pane now uses a list/detail flow instead of full-width credential forms.

**Overview.** One compact card per provider: name, one-line description, connection status, and the connected identity (the GitHub App slug). Cards sit in a two-column grid, one column on narrow layouts. The whole card is a button. No credential fields appear on the overview, and the repeated "SERVICE IDENTITY" label is gone.

**Detail.** Clicking a card swaps in a focused view in the same content pane — no nested modal. It shows a back action, the provider name and status, identity facts in monospace, the connection date, and the provider's actions. Credential fields only render after an explicit choice:

- GitHub disconnected: **Create GitHub App** is the primary action; **Connect an existing GitHub App** is a secondary disclosure that reveals the paste form.
- GitHub connected: **Manage installations** and a lower-emphasis **Replace connection**; the replace form keeps the create-App path.
- Jira disconnected: a **Connect Jira** action reveals the Base URL / email / token / webhook secret fields.
- Jira connected: saved facts plus **Replace connection**.

Green marks connected status only; disconnected is neutral. The decorative violet top borders are gone. The pane reuses the MCP pane's measure, type scale, and status treatment.

**Behavior is unchanged**: immediate connection persistence outside the modal's Save, write-only secrets, replacement verification, busy/error states, and the BroadcastChannel refresh after GitHub App creation — the listener moved up to the pane so a callback landing while the overview shows still refreshes. The dead `.si-connect-form` CSS (its only consumer was the old inline form) is removed, and the test file is renamed `ServicesPane.test.tsx` to match the component it renders.