### PR TITLE
Sandbox commits carry the operator's identity; the dispatcher rides as co-author

### DIFF
--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -38,7 +38,9 @@ class Account(Base, Uuid7Pk):
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
 
     @classmethod
-    def get(cls, account_id: str) -> "Account | None":
+    def get(cls, account_id: str, *, exclude_system: bool = False) -> "Account | None":
+        if exclude_system and account_id == SYSTEM_ACCOUNT_ID:
+            return
         return db_session().get(cls, account_id)
 
     @classmethod

--- a/backend/druks/contrib/ship/workspace.py
+++ b/backend/druks/contrib/ship/workspace.py
@@ -1,7 +1,11 @@
+import shlex
 from dataclasses import dataclass
 from typing import Any
 
+from druks.accounts.models import Account
+from druks.core.apis.github import get_github_client
 from druks.sandbox.datastructures import Workspace
+from druks.sandbox.exceptions import ExecFailed
 from druks.sandbox.layout import get_repo_root
 
 
@@ -20,3 +24,39 @@ class RepoWorkspace(Workspace):
     def get_agent_run_kwargs(self, **kwargs: Any) -> dict[str, Any]:
         kwargs["github_token"] = self.github_token
         return kwargs
+
+    async def run_agent(self, *, account_id: str | None, **kwargs: Any):
+        await self.set_git_identity(account_id)
+        return await super().run_agent(account_id=account_id, **kwargs)
+
+    async def set_git_identity(self, account_id: str | None) -> None:
+        """Commits in the repo are authored as the operator's bot user, with a
+        prepare-commit-msg hook crediting the account that dispatched the run.
+        Rewritten before every agent call so a reused warm host follows the
+        current run's dispatcher — a system dispatch carries no hook and
+        credits nobody."""
+        author_name, author_email = await get_github_client().get_bot_git_author()
+        steps = [
+            f"cd {shlex.quote(self.repo_path)}",
+            f"git config user.name {shlex.quote(author_name)}",
+            f"git config user.email {shlex.quote(author_email)}",
+            "rm -f .git/hooks/prepare-commit-msg",
+        ]
+        if account_id and (account := Account.get(account_id, exclude_system=True)):
+            trailer = f"Co-Authored-By: {account.username} <{account.username}>"
+            hook = (
+                "#!/bin/sh\n"
+                f"git interpret-trailers --in-place --if-exists doNothing"
+                f' --trailer {shlex.quote(trailer)} "$1"\n'
+            )
+            steps += [
+                f"printf %s {shlex.quote(hook)} > .git/hooks/prepare-commit-msg",
+                "chmod 755 .git/hooks/prepare-commit-msg",
+            ]
+        result = await self.sandbox.exec(["sh", "-c", " && ".join(steps)], timeout=10.0)
+        if not result.ok:
+            raise ExecFailed(
+                f"failed to set the workspace git identity: "
+                f"exit={result.exit_code} stderr={result.stderr.strip()}",
+                exit_code=result.exit_code,
+            )

--- a/backend/druks/core/apis/github.py
+++ b/backend/druks/core/apis/github.py
@@ -32,8 +32,9 @@ class ReviewComment:
 _INSTALLATION_ACCOUNTS_TTL_SECONDS = 600.0
 _INSTALLATION_ACCOUNTS_CACHE: dict[str, tuple[float, tuple[str, ...]]] = {}
 
-# An App's slug is fixed for the life of the App, so this needs no expiry.
+# An App's slug and bot user id are fixed for its life, so these need no expiry.
 _MENTION_HANDLE_CACHE: dict[str, str] = {}
+_BOT_USER_ID_CACHE: dict[str, int] = {}
 
 
 F = TypeVar("F", bound=Callable[..., Awaitable[Any]])
@@ -182,6 +183,20 @@ class GitHubClient:
         handle = getattr(response.parsed_data, "slug", None) or ""
         _MENTION_HANDLE_CACHE[self._app_id] = handle
         return handle
+
+    async def get_bot_git_author(self) -> tuple[str, str]:
+        """Name and email for commits made as the App's bot user — the
+        ``<id>+<slug>[bot]@users.noreply.github.com`` convention, the same
+        identity a squash-merge advertises. The id comes from the public users
+        endpoint, no auth needed."""
+        bot_name = f"{await self.get_mention_handle()}[bot]"
+        user_id = _BOT_USER_ID_CACHE.get(self._app_id)
+        if not user_id:
+            async with GitHub(base_url=self._base_url) as github:
+                response = await github.rest.users.async_get_by_username(bot_name)
+            user_id = response.parsed_data.id
+            _BOT_USER_ID_CACHE[self._app_id] = user_id
+        return bot_name, f"{user_id}+{bot_name}@users.noreply.github.com"
 
     async def get_authenticated_app_slug(self) -> str:
         """The slug GitHub reports for these credentials — a live App-JWT call,

--- a/backend/tests/ship/test_build_workspace.py
+++ b/backend/tests/ship/test_build_workspace.py
@@ -1,12 +1,17 @@
+import shlex
+import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from druks.contrib.ship import workspace as workspace_mod
 from druks.contrib.ship.constants import GITHUB_MCP_NAME, GITHUB_MCP_URL
 from druks.contrib.ship.workflows import Build, BuildWorkspace
+from druks.contrib.ship.workspace import RepoWorkspace
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.sandbox import host as host_mod
-from druks.sandbox.layout import get_related_root
+from druks.sandbox.layout import get_related_root, get_repo_root
 from druks.workflows import FatalError
 
 
@@ -138,3 +143,72 @@ async def test_get_workspace_kwargs_fails_loudly_when_the_token_wont_mint(
 
     with pytest.raises(FatalError, match="github MCP server"):
         await workflow.get_workspace_kwargs(sandbox)
+
+
+class _IdentitySandbox:
+    ssh_username = "exedev"
+
+    def __init__(self, repo_path: Path) -> None:
+        self.repo_path = repo_path
+
+    async def exec(self, command: list[str], *, timeout: float = 30.0) -> Any:
+        del timeout
+        local = command[2].replace(
+            get_repo_root(self.ssh_username), shlex.quote(str(self.repo_path))
+        )
+        result = subprocess.run(["sh", "-c", local], check=False, capture_output=True, text=True)
+        return SimpleNamespace(ok=result.returncode == 0, exit_code=result.returncode, stderr="")
+
+
+def _dispatched_by(monkeypatch: pytest.MonkeyPatch, username: str | None) -> None:
+    async def _bot_git_author() -> tuple[str, str]:
+        return "app[bot]", "1+app[bot]@users.noreply.github.com"
+
+    monkeypatch.setattr(
+        workspace_mod,
+        "get_github_client",
+        lambda: SimpleNamespace(get_bot_git_author=_bot_git_author),
+    )
+    account = SimpleNamespace(username=username) if username else None
+    monkeypatch.setattr(
+        workspace_mod,
+        "Account",
+        SimpleNamespace(get=lambda _id, *, exclude_system: account),
+    )
+
+
+async def test_set_git_identity_stamps_the_workspace_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_path = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", str(repo_path)], check=True)
+    workspace = RepoWorkspace(sandbox=_IdentitySandbox(repo_path), repo="o/main", github_token="t")  # type: ignore[arg-type]
+    hook = repo_path / ".git" / "hooks" / "prepare-commit-msg"
+    message = repo_path / "COMMIT_EDITMSG"
+
+    _dispatched_by(monkeypatch, "dev@example.com")
+    await workspace.set_git_identity("account-1")
+    message.write_text("Change\n")
+    subprocess.run([str(hook), str(message), "squash"], check=True)
+    subprocess.run([str(hook), str(message)], check=True)
+    email = subprocess.run(
+        ["git", "-C", str(repo_path), "config", "user.email"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert email.stdout.strip() == "1+app[bot]@users.noreply.github.com"
+    assert message.read_text().count("Co-Authored-By: dev@example.com <dev@example.com>") == 1
+
+    # A reused warm host follows the next run's dispatcher.
+    _dispatched_by(monkeypatch, "second@example.com")
+    await workspace.set_git_identity("account-2")
+    message.write_text("Change\n")
+    subprocess.run([str(hook), str(message)], check=True)
+    assert "dev@example.com" not in message.read_text()
+    assert "Co-Authored-By: second@example.com" in message.read_text()
+
+    # A system dispatch keeps the author but credits nobody.
+    _dispatched_by(monkeypatch, None)
+    await workspace.set_git_identity(None)
+    assert not hook.exists()

--- a/backend/tests/test_github.py
+++ b/backend/tests/test_github.py
@@ -558,3 +558,47 @@ async def test_get_file_content_returns_none_when_app_not_installed() -> None:
 
     client = _UninstalledClient()
     assert await client.get_file_content("clawhaven/.druks", "prompts/x.md") is None
+
+
+async def test_get_bot_git_author_composes_the_public_bot_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The author is the App's bot user with GitHub's <id>+<login> noreply
+    # address; the id comes from one unauthenticated lookup, cached for the
+    # life of the process.
+    requested: list[str] = []
+
+    class _Users:
+        async def async_get_by_username(self, username: str) -> SimpleNamespace:
+            requested.append(username)
+            return SimpleNamespace(parsed_data=SimpleNamespace(id=123456789))
+
+    class _PublicGitHub:
+        def __init__(self, *, base_url: str) -> None:
+            assert base_url == "https://github.example/api/v3"
+            self.rest = SimpleNamespace(users=_Users())
+
+        async def __aenter__(self) -> "_PublicGitHub":
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            pass
+
+    monkeypatch.setattr(github_api, "GitHub", _PublicGitHub)
+    monkeypatch.setattr(github_api, "_BOT_USER_ID_CACHE", {})
+
+    class _SluggedClient(GitHubClient):
+        def __init__(self) -> None:  # skip real auth
+            self._app_id = "12345"
+            self._slug = "example-app"
+            self._base_url = "https://github.example/api/v3"
+
+    client = _SluggedClient()
+    author = await client.get_bot_git_author()
+
+    assert author == (
+        "example-app[bot]",
+        "123456789+example-app[bot]@users.noreply.github.com",
+    )
+    assert await client.get_bot_git_author() == author
+    assert requested == ["example-app[bot]"]


### PR DESCRIPTION
Commits made inside a sandbox were authored as the VM image's default git identity, and nothing recorded who dispatched the run.

`RepoWorkspace` now stamps the repo before every agent call: `user.name`/`user.email` from the connected App's bot identity (`GitHubClient.get_bot_git_author`, id from the public users endpoint), plus a `prepare-commit-msg` hook — one `git interpret-trailers` line — adding `Co-Authored-By` for the dispatching account. Rewritten per call, so a reused warm host follows the current run's dispatcher; a system dispatch carries no hook and credits nobody.

Fixes ENG-834.
