### PR TITLE
The Harnesses pane wears the settings type scale, defaults and connection as separate bands

### DIFF
--- a/frontend/src/components/HarnessConnect.test.tsx
+++ b/frontend/src/components/HarnessConnect.test.tsx
@@ -63,9 +63,10 @@ describe('HarnessConnect', () => {
       }),
     )
 
-    expect(screen.getByText('connected · claude-seat@corp.com')).toBeTruthy()
-    expect(screen.getByText('connected · codex-seat@corp.com')).toBeTruthy()
-    expect(screen.queryByText('connected · ops@corp.com')).toBeNull()
+    expect(screen.getAllByText('Connected')).toHaveLength(2)
+    expect(screen.getByText('claude-seat@corp.com')).toBeTruthy()
+    expect(screen.getByText('codex-seat@corp.com')).toBeTruthy()
+    expect(screen.queryByText('ops@corp.com')).toBeNull()
   })
 
   it('drives the connection flow end to end and refreshes only the harness query', async () => {

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -518,15 +518,18 @@ function Switch({
   onClick,
   disabled,
   label,
+  id,
 }: {
   on: boolean
   onClick: () => void
   disabled?: boolean
   label?: string
+  id?: string
 }) {
   return (
     <button
       type="button"
+      id={id}
       className={'set-switch' + (on ? ' on' : '')}
       onClick={onClick}
       disabled={disabled}
@@ -754,6 +757,7 @@ function HarnessesPane({
   harnessColor: Record<string, string>
   busy: boolean
 }) {
+  const fieldId = useId()
   // Agents whose effective harness is this one — the same resolution the agent
   // rows' harness chip shows, so the card count and the chips agree even when an
   // agent's model is overridden across harnesses.
@@ -764,76 +768,88 @@ function HarnessesPane({
     )
 
   return (
-    <div className="set-pane">
-      <div className="set-pane-head">
-        <div className="set-pane-sub">
-          Each harness pairs a coding agent with a default model, effort and timeout — every agent <i>follows its harness</i> unless overridden on its row.
-        </div>
-      </div>
-      <div className="set-group">
-        <div className="set-group-label">harnesses</div>
-        <div className="set-cards">
-          {harnesses.map((harness) => {
-            // Effective values: saved harness overlaid with this session's pending edits.
-            const h = { ...harness, ...edits[harness.name] }
-            const timeouts = TIMEOUTS.includes(h.timeout)
-              ? TIMEOUTS
-              : [...TIMEOUTS, h.timeout].sort((a, b) => a - b)
-            return (
-              <div key={harness.name} className="set-card harness-row" style={{ '--fam': harnessColor[harness.name] } as CSSProperties}>
-                <div className="hr-head">
-                  <span className="set-card-name">
-                    <span className="dot" />
-                    {harness.name}
-                  </span>
-                  <span className="set-card-tag">{harness.provider}</span>
-                  <span className="hr-count">
-                    <b>{agentCount(harness.name)}</b> agents
-                  </span>
-                </div>
-                <div className="hr-controls">
-                  <div className="set-field">
-                    <span className="set-field-label">default model</span>
-                    <select className="set-select" value={h.model} onChange={(e) => onField(harness.name, { model: e.target.value })} disabled={busy}>
-                      {harness.allowedModels.map((m) => (
-                        <option key={m.id} value={m.id}>
-                          {m.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="set-field">
-                    <span className="set-field-label">effort</span>
-                    <select className="set-select" value={h.effort} onChange={(e) => onField(harness.name, { effort: e.target.value })} disabled={busy}>
-                      {allowedEfforts.map((e) => (
-                        <option key={e} value={e}>
-                          {e}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="set-field">
-                    <span className="set-field-label">timeout</span>
-                    <select className="set-select" value={String(h.timeout)} onChange={(e) => onField(harness.name, { timeout: Number(e.target.value) })} disabled={busy}>
-                      {timeouts.map((t) => (
-                        <option key={t} value={t}>
-                          {t}s
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="set-field hr-fast">
-                    <span className="set-field-label">fast extension</span>
-                    <span className="hf-switch">
-                      <Switch on={h.fastMode} onClick={() => onField(harness.name, { fastMode: !h.fastMode })} disabled={busy} />
-                    </span>
-                  </div>
-                </div>
-                <HarnessConnect harness={harness} />
+    <div className="set-pane mcp-pane hrs-pane">
+      <header className="mcp-pane-head">
+        <h2 className="mcp-pane-title">Harnesses</h2>
+        <p className="mcp-pane-sub">
+          The default model, effort, and timeout for each coding agent. Agents follow their
+          harness unless overridden on their own row.
+        </p>
+      </header>
+      <div className="hrs-list">
+        {harnesses.map((harness) => {
+          // Effective values: saved harness overlaid with this session's pending edits.
+          const h = { ...harness, ...edits[harness.name] }
+          const timeouts = TIMEOUTS.includes(h.timeout)
+            ? TIMEOUTS
+            : [...TIMEOUTS, h.timeout].sort((a, b) => a - b)
+          const id = (field: string) => `${fieldId}-${harness.name}-${field}`
+          return (
+            <div key={harness.name} className="hr-card" style={{ '--fam': harnessColor[harness.name] } as CSSProperties}>
+              <div className="hr-ident">
+                <span className="hr-ident-dot" />
+                <span className="hr-name">{harness.name}</span>
+                <span className="hr-provider">{harness.provider}</span>
+                <span className="hr-count">
+                  <b>{agentCount(harness.name)}</b> agents
+                </span>
               </div>
-            )
-          })}
-        </div>
+              <div className="hr-controls">
+                <div className="mcp-field">
+                  <label className="mcp-label" htmlFor={id('model')}>
+                    Default model
+                  </label>
+                  <select id={id('model')} className="set-select" value={h.model} onChange={(e) => onField(harness.name, { model: e.target.value })} disabled={busy}>
+                    {harness.allowedModels.map((m) => (
+                      <option key={m.id} value={m.id}>
+                        {m.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="mcp-field">
+                  <label className="mcp-label" htmlFor={id('effort')}>
+                    Effort
+                  </label>
+                  <select id={id('effort')} className="set-select" value={h.effort} onChange={(e) => onField(harness.name, { effort: e.target.value })} disabled={busy}>
+                    {allowedEfforts.map((e) => (
+                      <option key={e} value={e}>
+                        {e}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="mcp-field">
+                  <label className="mcp-label" htmlFor={id('timeout')}>
+                    Timeout
+                  </label>
+                  <select id={id('timeout')} className="set-select" value={String(h.timeout)} onChange={(e) => onField(harness.name, { timeout: Number(e.target.value) })} disabled={busy}>
+                    {timeouts.map((t) => (
+                      <option key={t} value={t}>
+                        {t}s
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="mcp-field">
+                  <label className="mcp-label" htmlFor={id('fast')}>
+                    Fast extension
+                  </label>
+                  <span className="hr-fast">
+                    <Switch
+                      id={id('fast')}
+                      on={h.fastMode}
+                      onClick={() => onField(harness.name, { fastMode: !h.fastMode })}
+                      disabled={busy}
+                      label={`Fast extension (${harness.name})`}
+                    />
+                  </span>
+                </div>
+              </div>
+              <HarnessConnect harness={harness} />
+            </div>
+          )
+        })}
       </div>
     </div>
   )
@@ -1104,31 +1120,36 @@ export function HarnessConnect({ harness }: { harness: Harness }) {
   return (
     <div className="hr-connect">
       <div className="hr-conn-status">
-        {harness.connected ? (
-          <span className="hr-chip hr-chip-on">
-            connected · {harness.providerEmail}
-          </span>
-        ) : (
-          <span className="hr-chip hr-chip-off">not connected</span>
+        <ServiceStatus connected={harness.connected} />
+        {harness.connected && harness.providerEmail && (
+          <span className="hr-conn-id">{harness.providerEmail}</span>
         )}
         {harness.connected && harness.expiresAt && (
           <span className="hr-conn-exp">token expires {new Date(harness.expiresAt).toLocaleString()}</span>
         )}
         <span className="hr-conn-actions">
           {harness.connected && (
-            <button className="hr-conn-btn hr-conn-ghost" onClick={disconnect} disabled={busy || flow.busy}>
+            <button className="set-btn danger quiet" onClick={disconnect} disabled={busy || flow.busy}>
               Disconnect
             </button>
           )}
           {!flow.challenge && (
-            <button className="hr-conn-btn" onClick={() => void flow.start()} disabled={busy || flow.busy}>
+            <button
+              className={'set-btn ' + (harness.connected ? 'ghost' : 'primary')}
+              onClick={() => void flow.start()}
+              disabled={busy || flow.busy}
+            >
               {harness.connected ? 'Reconnect' : 'Connect'}
             </button>
           )}
         </span>
       </div>
       <ConnectSteps flow={flow} />
-      {(error ?? flow.error) && <div className="hr-conn-error">{error ?? flow.error}</div>}
+      {(error ?? flow.error) && (
+        <div className="hr-conn-error" role="alert">
+          {error ?? flow.error}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -983,21 +983,23 @@ input.set-select { background-image: none; padding-right: 12px; }
 /* Multiline secrets (a pasted PEM): the same frame, grown into a textarea. */
 textarea.set-textarea { background-image: none; height: auto; min-height: 96px; padding: 8px 12px; line-height: 1.45; resize: vertical; white-space: pre; }
 
-.set-cards { display: flex; flex-direction: column; gap: 12px; }
-.set-card { border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); padding: 16px; display: flex; flex-direction: column; gap: 13px; }
-.set-card.harness-row { border-top: 2px solid var(--fam, var(--border-loud)); }
-.set-card-name { display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 13px; letter-spacing: 0.02em; }
-.set-card-name .dot { width: 8px; height: 8px; border-radius: 2px; }
-.harness-row .dot { background: var(--fam); }
-.set-card-tag { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-faint); }
-.harness-row { padding: 14px 16px 16px; gap: 14px; }
-.harness-row .hr-head { display: flex; align-items: center; gap: 10px; }
-.harness-row .hr-count { margin-left: auto; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); white-space: nowrap; }
-.harness-row .hr-count b { color: var(--text-mid); font-weight: 500; }
-.hr-controls { display: grid; grid-template-columns: minmax(160px, 1fr) 110px 110px 80px; gap: 14px; align-items: end; }
+/* Harnesses — the MCP pane's measure and scale; each card separates identity,
+   defaults, and connection into three bands. Provider color survives only as
+   the identity dot and the guided connect-flow accent. */
+.hrs-list { display: flex; flex-direction: column; gap: 12px; }
+.hr-card { display: flex; flex-direction: column; gap: 13px; padding: 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); }
+.hr-ident { display: flex; align-items: center; gap: 9px; }
+.hr-ident-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fam, var(--border-loud)); flex-shrink: 0; }
+.hr-name { font-family: var(--font-mono); font-size: 13px; color: var(--text); }
+.hr-provider { font-size: 12px; color: var(--text-faint); }
+.hr-count { margin-left: auto; font-size: 12px; color: var(--text-dim); white-space: nowrap; }
+.hr-count b { color: var(--text-mid); font-weight: 500; }
+.hr-controls { display: grid; grid-template-columns: minmax(180px, 1fr) 110px 110px auto; gap: 12px 14px; align-items: end; }
+.hr-fast { height: 34px; display: flex; align-items: center; padding: 0 1px; }
+.hr-conn-id { font-family: var(--font-mono); font-size: 12px; color: var(--text-mid); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.hrs-pane .set-select:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-color: var(--border); }
 @media (max-width: 720px) { .hr-controls { grid-template-columns: 1fr 1fr; } }
-.hr-fast .set-field-label { white-space: nowrap; }
-.hr-fast .hf-switch { height: 34px; display: flex; align-items: center; }
+@media (max-width: 460px) { .hr-controls { grid-template-columns: 1fr; } }
 
 /* Subscription connection — status chip + connect/paste/disconnect flow. */
 .hr-connect { border-top: 1px solid var(--border); padding-top: 12px; display: flex; flex-direction: column; gap: 10px; }
@@ -1020,7 +1022,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .hr-conn-input { flex: 1; min-width: 200px; padding: 6px 10px; border-radius: 4px; background: var(--surface-2); border: 1px solid var(--border); color: var(--text); font-family: var(--font-mono); font-size: 12px; }
 .hr-conn-input:focus { outline: none; border-color: color-mix(in oklch, var(--fam, var(--accent)) 55%, transparent); }
 .hr-conn-error { font-size: 11.5px; color: var(--outcome-failed); font-family: var(--font-mono); }
-/* Connect GitHub — the service-identity paste-in form on its hand-placed card. */
 
 .set-switch { position: relative; width: 34px; height: 18px; border-radius: 10px; flex-shrink: 0; background: var(--surface-3); border: 1px solid var(--border-loud); transition: all 140ms; cursor: pointer; }
 .set-switch::after { content: ''; position: absolute; top: 1.5px; left: 1.5px; width: 12px; height: 12px; border-radius: 50%; background: var(--text-dim); transition: all 140ms; }


### PR DESCRIPTION
Visual and UX cleanup of the Harnesses settings pane, following the Services redesign in #232. All behavior is unchanged.

**Hierarchy.** The pane now has a "Harnesses" title with one line of supporting copy, on the same measure and type scale as the MCP pane. The uppercase "HARNESSES" group label is gone.

**Cards.** Each card reads as three bands instead of one undifferentiated form:

- *Identity* — provider-color dot, monospace harness name, provider, and the assigned-agent count.
- *Defaults* — labelled Default model / Effort / Timeout selects and the Fast extension switch, aligned on one grid row. Model stays the wide column. Labels are normal-case UI font; values stay monospace.
- *Connection* — status first, then account and token expiry as secondary metadata, actions on the right.

**Connection hierarchy.** Connected is green (the same status treatment as Services and MCP); disconnected is neutral. Reconnect is a neutral ghost button, Disconnect a quiet destructive one, and a disconnected harness leads with a primary Connect. The guided challenge steps and their provider accent are untouched.

**Removed decoration.** The thick provider-color top border is gone; the provider color survives only as the identity dot and the connect-flow accent.

**Accessibility.** Selects get real `<label>`s, the switch has an accessible name plus a label hit target, connection errors announce via `role=alert`, and selects join the pane's focus-visible outline. The defaults grid steps to two columns and then one on narrow panes, and the connection row wraps without orphaning its buttons.

The old harness card CSS (`.set-card`, `.harness-row`, `.hf-switch` — the harness card was their last consumer) is removed.