### PR TITLE
The Skills pane wears the settings type scale; the collection summary becomes a real disclosure button

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1224,37 +1224,67 @@ export function SkillsPane() {
     }
   }
 
+  const fieldId = useId()
+
   return (
-    <div className="set-pane">
-      <div className="set-pane-head">
-        <div className="set-pane-sub">
-          Add a <b>collection</b> — a GitHub repo druks scans to extract <b>skills</b> your agents can use, projected onto every sandbox VM. Removing a collection removes its skills.
+    <div className="set-pane mcp-pane skills-pane">
+      <header className="mcp-pane-head">
+        <h2 className="mcp-pane-title">Skills</h2>
+        <p className="mcp-pane-sub">
+          Import skill collections from GitHub. Enabled skills are available to agents in every
+          sandbox.
+        </p>
+      </header>
+
+      {error && (
+        <div className="mcp-error" role="alert">
+          {error}
         </div>
-      </div>
-      <div className="set-group">
-        <div className="set-group-label">add collection</div>
-        <div className="skill-add">
-          <input
-            className="skill-add-input"
-            placeholder="Paste a repository URL…  e.g. github.com/org/repo"
-            value={repo}
-            onChange={(e) => setRepo(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') void install()
-            }}
-            disabled={busy}
-          />
-          <button className="set-btn primary" disabled={busy || !repo.trim()} onClick={() => void install()}>
-            {busy ? 'importing…' : 'import'}
-          </button>
-        </div>
-        {error && <div className="set-skill-error">{error}</div>}
-      </div>
-      {cols.length > 0 && (
-        <div className="set-group">
-          <div className="set-group-label">
-            collections<span className="gl-count">{cols.length}</span>
+      )}
+
+      <section className="mcp-section">
+        <h3 className="mcp-h">Add a collection</h3>
+        <p className="mcp-help">
+          A GitHub repository druks scans for skills. Removing a collection removes its skills.
+        </p>
+        <div className="mcp-field">
+          <label className="mcp-label" htmlFor={`${fieldId}-repo`}>
+            Repository URL
+          </label>
+          <div className="skill-add">
+            <input
+              id={`${fieldId}-repo`}
+              className="skill-add-input"
+              type="url"
+              placeholder="github.com/org/repo"
+              value={repo}
+              onChange={(e) => setRepo(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void install()
+              }}
+              autoComplete="off"
+              data-1p-ignore=""
+              data-lpignore="true"
+              disabled={busy}
+            />
+            <button
+              className="set-btn primary"
+              disabled={busy || !repo.trim()}
+              aria-busy={busy}
+              onClick={() => void install()}
+            >
+              {busy ? 'Importing…' : 'Import collection'}
+            </button>
           </div>
+        </div>
+      </section>
+
+      <section className="mcp-section">
+        <h3 className="mcp-h">
+          Collections <span className="gl-count">{cols.length}</span>
+        </h3>
+        {cols.length === 0 && <p className="mcp-help">No collections yet — import one above.</p>}
+        {cols.length > 0 && (
           <div className="skill-cols">
             {cols.map((c: SkillCollection) => (
               <CollectionCard
@@ -1267,14 +1297,15 @@ export function SkillsPane() {
               />
             ))}
           </div>
-        </div>
-      )}
+        )}
+      </section>
     </div>
   )
 }
 
-// Collapsed by default: the head is the summary (name, count, source); the
-// per-skill rows only matter when curating, so they render on demand.
+// Collapsed by default: the summary button carries name, count, source, and
+// last sync; the per-skill rows only matter when curating, so they render on
+// demand. Sync and Remove sit beside the summary, never inside it.
 function CollectionCard({
   collection,
   busy,
@@ -1289,51 +1320,75 @@ function CollectionCard({
   onToggle: (collectionId: string, name: string, enabled: boolean) => Promise<void>
 }) {
   const [open, setOpen] = useState(false)
+  const switchId = useId()
+  const count = collection.skills.length
+
+  const remove = () => {
+    const skills = `${count} skill${count === 1 ? '' : 's'}`
+    if (!window.confirm(`Remove ${collection.name} and its ${skills}?`)) return
+    void onRemove(collection.id)
+  }
+
   return (
     <div className="skill-col">
-      <div className="skill-col-head skill-col-toggle" onClick={() => setOpen((v) => !v)}>
-        <span className="sc-glyph">{open ? '▾' : '▸'}</span>
-        <div className="sc-id">
-          <span className="sc-repo">{collection.name}</span>
-          <span className="sc-meta">
-            {collection.skills.length} skill{collection.skills.length === 1 ? '' : 's'} ·{' '}
-            {collection.source} · synced {relTimeFromIso(collection.updatedAt)}
+      <div className="skill-col-head">
+        <button
+          type="button"
+          className="sc-toggle"
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+        >
+          <span className="sc-chevron" aria-hidden="true" />
+          <span className="sc-id">
+            <span className="sc-repo">{collection.name}</span>
+            <span className="sc-meta">
+              {count} skill{count === 1 ? '' : 's'} · {collection.source} · synced{' '}
+              {relTimeFromIso(collection.updatedAt)}
+            </span>
           </span>
-        </div>
-        <button
-          className="sc-sync"
-          onClick={(e) => {
-            e.stopPropagation()
-            void onSync(collection.id)
-          }}
-          disabled={busy}
-          title="sync collection from source"
-        >
-          sync
         </button>
-        <button
-          className="sc-remove"
-          onClick={(e) => {
-            e.stopPropagation()
-            void onRemove(collection.id)
-          }}
-          disabled={busy}
-          title="remove collection and its skills"
-        >
-          ✕ remove
-        </button>
+        <span className="sc-actions">
+          <button
+            className="set-btn ghost"
+            onClick={() => void onSync(collection.id)}
+            disabled={busy}
+            title="Sync the collection from its repository"
+          >
+            Sync now
+          </button>
+          <button
+            className="set-btn danger quiet"
+            onClick={remove}
+            disabled={busy}
+            title="Remove the collection and its skills"
+          >
+            Remove
+          </button>
+        </span>
       </div>
       {open && (
         <div className="sc-skills">
+          {collection.skills.length === 0 && (
+            <p className="mcp-help sc-empty">No skills in this collection.</p>
+          )}
           {collection.skills.map((s) => (
             <div key={s.name} className={'skill-row' + (s.enabled ? '' : ' is-off')}>
-              <span className="sk-name">{s.name}</span>
-              <span className="sk-desc">{s.description}</span>
-              <Switch
-                on={s.enabled}
-                onClick={() => void onToggle(collection.id, s.name, !s.enabled)}
-                disabled={busy}
-              />
+              <span className="sk-name" title={s.name}>
+                {s.name}
+              </span>
+              <span className="sk-desc" title={s.description}>
+                {s.description}
+              </span>
+              <span className="sk-enable">
+                <Switch
+                  id={`${switchId}-${s.name}`}
+                  on={s.enabled}
+                  onClick={() => void onToggle(collection.id, s.name, !s.enabled)}
+                  disabled={busy}
+                  label={`Enable ${s.name} skill`}
+                />
+                <label htmlFor={`${switchId}-${s.name}`}>Enabled</label>
+              </span>
             </div>
           ))}
         </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1093,34 +1093,39 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .set-btn.danger.quiet { color: var(--text-dim); border-color: var(--border); background: none; }
 .set-btn.danger.quiet:hover { color: var(--bucket-dead); }
 
-.skill-add { display: flex; align-items: center; gap: 10px; max-width: 620px; }
+.skill-add { display: flex; align-items: center; gap: 10px; }
 .skill-add-input { flex: 1; height: 36px; border: 1px solid var(--border); border-radius: 5px; background: var(--bg); outline: none; color: var(--text); font-family: var(--font-mono); font-size: 13px; padding: 0 12px; }
 .skill-add-input:focus { border-color: var(--accent); }
 .skill-add-input::placeholder { color: var(--text-faint); }
-.skill-add .set-btn { height: 36px; }
-.skill-cols { display: flex; flex-direction: column; gap: 12px; }
+.skill-add .set-btn { height: 36px; flex-shrink: 0; }
+.skill-cols { display: flex; flex-direction: column; gap: 8px; }
 .skill-col { border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); overflow: hidden; }
-.skill-col-head { display: flex; align-items: center; gap: 11px; padding: 11px 14px; border-bottom: 1px solid var(--border-soft); }
+.skill-col-head { display: flex; align-items: center; gap: 10px; padding-right: 14px; border-bottom: 1px solid var(--border-soft); }
 .skill-col-head:last-child { border-bottom: none; }
-.skill-col-toggle { cursor: pointer; }
-.skill-col-toggle:hover .sc-glyph { color: var(--text); }
-.sc-glyph { color: var(--text-dim); font-size: 13px; font-family: var(--font-mono); }
+/* The summary is one expand/collapse button; Sync and Remove sit beside it. */
+.sc-toggle { flex: 1; min-width: 0; display: flex; align-items: center; gap: 10px; padding: 11px 14px; background: none; border: none; font: inherit; color: inherit; text-align: left; cursor: pointer; }
+.sc-toggle:hover { background: var(--surface-3); }
+.sc-chevron::before { content: '›'; display: inline-block; font-family: var(--font-mono); font-size: 13px; color: var(--text-dim); transition: transform 120ms; }
+.sc-toggle:hover .sc-chevron::before { color: var(--text); }
+.sc-toggle[aria-expanded='true'] .sc-chevron::before { transform: rotate(90deg); }
 .sc-id { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
 .sc-repo { font-family: var(--font-mono); font-size: 13px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.sc-meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); }
-.sc-sync, .sc-remove { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); border: 1px solid var(--border); border-radius: 4px; padding: 5px 10px; flex-shrink: 0; cursor: pointer; background: none; }
-.sc-sync:hover { color: var(--text); background: var(--surface); border-color: var(--border-loud); }
-.sc-remove:hover { color: var(--bucket-dead); border-color: color-mix(in oklch, var(--bucket-dead) 45%, transparent); background: color-mix(in oklch, var(--bucket-dead) 10%, var(--surface)); }
+.sc-meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.sc-actions { display: flex; gap: 8px; flex-shrink: 0; }
+.skills-pane .sc-actions .set-btn { height: 30px; padding: 0 11px; font-size: 12px; }
 .sc-skills { display: flex; flex-direction: column; }
-.skill-row { display: grid; grid-template-columns: minmax(130px, 0.8fr) minmax(0, 1.5fr) auto; gap: 14px; align-items: center; padding: 10px 14px 10px 30px; border-bottom: 1px solid var(--border-soft); position: relative; }
+.sc-empty { padding: 10px 14px 12px 33px; }
+.skill-row { display: grid; grid-template-columns: minmax(130px, 0.8fr) minmax(0, 1.5fr) auto; gap: 14px; align-items: center; padding: 10px 14px 10px 33px; border-bottom: 1px solid var(--border-soft); }
 .skill-row:last-child { border-bottom: none; }
-.skill-row::before { content: ''; position: absolute; left: 18px; top: 50%; width: 7px; height: 1px; background: var(--border-loud); }
-.skill-row::after { content: ''; position: absolute; left: 18px; top: 0; bottom: 0; width: 1px; background: var(--border); }
-.skill-row:last-child::after { bottom: 50%; }
 .sk-name { font-family: var(--font-mono); font-size: 12.5px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .sk-desc { font-size: 12px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.skill-row.is-off .sk-name { color: var(--text-dim); }
-.skill-row.is-off .sk-desc { color: var(--text-faint); }
+.skill-row.is-off :is(.sk-name, .sk-desc) { color: var(--text-dim); }
+.sk-enable { display: inline-flex; align-items: center; gap: 8px; }
+.sk-enable label { font-size: 12px; color: var(--text-mid); cursor: pointer; }
+
+/* Tokens — the revoke affordance on a PAT row. */
+.sc-remove { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); border: 1px solid var(--border); border-radius: 4px; padding: 5px 10px; flex-shrink: 0; cursor: pointer; background: none; }
+.sc-remove:hover { color: var(--bucket-dead); border-color: color-mix(in oklch, var(--bucket-dead) 45%, transparent); background: color-mix(in oklch, var(--bucket-dead) 10%, var(--surface)); }
 
 /* The agent-access pane reuses the row primitives (.mcp-row / .mcp-id /
    .mcp-tok) for its token list, so everything the MCP pane redefines is
@@ -1161,7 +1166,7 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .mcp-pane input:disabled { opacity: 0.6; cursor: default; }
 
 .mcp-reg-search { display: flex; gap: 10px; }
-.mcp-pane .mcp-reg-search .skill-add-input { flex: 1; min-width: 0; }
+.mcp-pane :is(.mcp-reg-search, .skill-add) .skill-add-input { flex: 1; min-width: 0; }
 .mcp-reg-results { display: flex; flex-direction: column; gap: 8px; }
 .mcp-reg-row { display: flex; flex-direction: column; gap: 3px; width: 100%; padding: 10px 13px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); cursor: pointer; text-align: left; font: inherit; }
 .mcp-reg-row:hover { border-color: var(--border-loud); background: var(--surface-3); }
@@ -1238,7 +1243,11 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
   .svc-grid { grid-template-columns: 1fr; }
   .set-thead { display: none; }
   .set-trow { grid-template-columns: 1fr 1fr; gap: 8px; padding: 12px 14px; }
-  .skill-row { grid-template-columns: 1fr; }
+  .skill-add { flex-direction: column; align-items: stretch; }
+  .skill-col-head { flex-wrap: wrap; }
+  .skill-col-head .sc-toggle { flex-basis: 100%; }
+  .skill-col-head .sc-actions { padding: 0 0 10px 33px; }
+  .skill-row { grid-template-columns: 1fr auto; }
   .skill-row .sk-desc { display: none; }
   .mcp-row { grid-template-columns: 1fr auto; row-gap: 8px; }
   .mcp-pane .mcp-row { grid-template-columns: minmax(0, 1fr); }


### PR DESCRIPTION
Hierarchy, interaction, and visual cleanup of the Skills settings pane, completing the pass over Services (#232) and Harnesses (#237). All behavior is unchanged.

**Hierarchy.** A "Skills" title with one line of supporting copy — *Import skill collections from GitHub. Enabled skills are available to agents in every sandbox.* — on the MCP pane's measure and type scale. The uppercase "ADD COLLECTION" / "COLLECTIONS" labels become readable section headings.

**Import.** "Add a collection" is its own section: a short explanation, a labelled Repository URL field (`type=url`, real `<label>`), and an "Import collection" action on one line, stacking cleanly on narrow panes. Errors announce at the top of the pane via `role=alert`.

**Collection rows.** Still a compact expandable list, collapsed by default. The summary — name, skill count, source, last synced — is now one semantic expand/collapse `<button>` with `aria-expanded`, a hover state, and a rotating CSS chevron in place of the raw `▸` glyph. "Sync now" and "Remove" sit beside the summary as separate controls instead of buttons nested inside a clickable div. Remove stays quiet until hover/focus and now confirms before deleting the collection and its skills. On narrow panes the actions wrap under the summary rather than crushing the name.

**Expanded skills.** The decorative tree-connector lines are gone; skills are clean rows — monospace name, UI-font description, and an explicit Enabled control. Each switch has an accessible name ("Enable code-review skill") and shares one hit target with its visible Enabled label. Disabled rows stay readable instead of fading out. Long names, descriptions, and repository URLs truncate safely with the full text available on hover. An expanded empty collection says "No skills in this collection", and a pane with no collections points at the import field.

The `.sc-remove` style survives for its one remaining consumer — the Tokens pane's revoke button — so that pane is untouched.