### PR TITLE
One card surface, one status indicator, one chevron across the settings panes

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -785,7 +785,7 @@ function HarnessesPane({
             : [...TIMEOUTS, h.timeout].sort((a, b) => a - b)
           const id = (field: string) => `${fieldId}-${harness.name}-${field}`
           return (
-            <div key={harness.name} className="hr-card" style={{ '--fam': harnessColor[harness.name] } as CSSProperties}>
+            <div key={harness.name} className="set-card hr-card" style={{ '--fam': harnessColor[harness.name] } as CSSProperties}>
               <div className="hr-ident">
                 <span className="hr-ident-dot" />
                 <span className="hr-name">{harness.name}</span>
@@ -900,7 +900,7 @@ export function ServicesPane() {
                 <button
                   key={service.name}
                   type="button"
-                  className="svc-card"
+                  className="set-card svc-card"
                   onClick={() => setSelectedName(service.name)}
                 >
                   <span className="svc-card-top">
@@ -914,9 +914,7 @@ export function ServicesPane() {
                     ) : (
                       <span className="svc-card-cue">Configure</span>
                     )}
-                    <span className="svc-card-chevron" aria-hidden="true">
-                      ›
-                    </span>
+                    <span className="chev" aria-hidden="true" />
                   </span>
                 </button>
               )
@@ -930,8 +928,8 @@ export function ServicesPane() {
 
 function ServiceStatus({ connected }: { connected: boolean }) {
   return (
-    <span className={'svc-status' + (connected ? ' is-on' : '')}>
-      <span className="svc-status-dot" />
+    <span className={'mcp-conn' + (connected ? ' is-live' : '')}>
+      <span className="mcp-conn-dot" />
       {connected ? 'Connected' : 'Not connected'}
     </span>
   )
@@ -1000,7 +998,7 @@ function ServiceDetail({ service, onBack }: { service: Service; onBack: () => vo
       )}
       {service.connected && (
         <section className="mcp-section">
-          <div className="svc-facts">
+          <div className="set-card svc-facts">
             {Object.entries(service.facts).map(([key, value]) => (
               <div className="svc-fact" key={key}>
                 <span className="svc-fact-key">{key}</span>
@@ -1330,7 +1328,7 @@ function CollectionCard({
   }
 
   return (
-    <div className="skill-col">
+    <div className="set-card skill-col">
       <div className="skill-col-head">
         <button
           type="button"
@@ -1338,7 +1336,7 @@ function CollectionCard({
           aria-expanded={open}
           onClick={() => setOpen((v) => !v)}
         >
-          <span className="sc-chevron" aria-hidden="true" />
+          <span className="chev" aria-hidden="true" />
           <span className="sc-id">
             <span className="sc-repo">{collection.name}</span>
             <span className="sc-meta">
@@ -1611,7 +1609,7 @@ function McpServersPane() {
               <div key={candidate.registryName}>
                 <button
                   className={
-                    'mcp-reg-row' +
+                    'set-card mcp-reg-row' +
                     (selected?.registryName === candidate.registryName ? ' is-selected' : '')
                   }
                   aria-expanded={selected?.registryName === candidate.registryName}
@@ -1681,7 +1679,7 @@ function McpServersPane() {
         )}
       </section>
 
-      <details className="mcp-custom">
+      <details className="set-card mcp-custom">
         <summary className="mcp-custom-summary">Add a custom server</summary>
         <div className="mcp-custom-body">
           <p className="mcp-help">
@@ -1814,7 +1812,7 @@ function McpServerRow({
   // A header-auth'd (or auth-free) server holds no credential to connect.
   const isLive = server.hasToken || !server.tokenSource
   return (
-    <div className={'mcp-row' + (server.isEnabled ? '' : ' is-off')}>
+    <div className={'set-card mcp-row' + (server.isEnabled ? '' : ' is-off')}>
       <div className="mcp-id">
         <span className="mcp-name" title={server.name}>
           {server.name}
@@ -2050,7 +2048,7 @@ function PatRow({
 }) {
   const active = pat.status === 'active'
   return (
-    <div className={'mcp-row' + (active ? '' : ' is-off')}>
+    <div className={'set-card mcp-row' + (active ? '' : ' is-off')}>
       <div className="mcp-id">
         <span className="mcp-name">{pat.name}</span>
         <span className="mcp-url">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -983,11 +983,16 @@ input.set-select { background-image: none; padding-right: 12px; }
 /* Multiline secrets (a pasted PEM): the same frame, grown into a textarea. */
 textarea.set-textarea { background-image: none; height: auto; min-height: 96px; padding: 8px 12px; line-height: 1.45; resize: vertical; white-space: pre; }
 
+/* Shared settings primitives — every pane's card rides .set-card and adds its
+   own layout; .chev is the one disclosure/drill-in glyph. */
+.set-card { border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); }
+.chev::before, .mcp-custom-summary::before { content: '›'; display: inline-block; font-family: var(--font-mono); font-size: 13px; color: var(--text-faint); transition: transform 120ms; }
+
 /* Harnesses — the MCP pane's measure and scale; each card separates identity,
    defaults, and connection into three bands. Provider color survives only as
    the identity dot and the guided connect-flow accent. */
 .hrs-list { display: flex; flex-direction: column; gap: 12px; }
-.hr-card { display: flex; flex-direction: column; gap: 13px; padding: 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); }
+.hr-card { display: flex; flex-direction: column; gap: 13px; padding: 14px; }
 .hr-ident { display: flex; align-items: center; gap: 9px; }
 .hr-ident-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fam, var(--border-loud)); flex-shrink: 0; }
 .hr-name { font-family: var(--font-mono); font-size: 13px; color: var(--text); }
@@ -1099,15 +1104,14 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .skill-add-input::placeholder { color: var(--text-faint); }
 .skill-add .set-btn { height: 36px; flex-shrink: 0; }
 .skill-cols { display: flex; flex-direction: column; gap: 8px; }
-.skill-col { border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); overflow: hidden; }
+.skill-col { overflow: hidden; }
 .skill-col-head { display: flex; align-items: center; gap: 10px; padding-right: 14px; border-bottom: 1px solid var(--border-soft); }
 .skill-col-head:last-child { border-bottom: none; }
 /* The summary is one expand/collapse button; Sync and Remove sit beside it. */
 .sc-toggle { flex: 1; min-width: 0; display: flex; align-items: center; gap: 10px; padding: 11px 14px; background: none; border: none; font: inherit; color: inherit; text-align: left; cursor: pointer; }
 .sc-toggle:hover { background: var(--surface-3); }
-.sc-chevron::before { content: '›'; display: inline-block; font-family: var(--font-mono); font-size: 13px; color: var(--text-dim); transition: transform 120ms; }
-.sc-toggle:hover .sc-chevron::before { color: var(--text); }
-.sc-toggle[aria-expanded='true'] .sc-chevron::before { transform: rotate(90deg); }
+.sc-toggle:hover .chev::before { color: var(--text); }
+.sc-toggle[aria-expanded='true'] .chev::before { transform: rotate(90deg); }
 .sc-id { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
 .sc-repo { font-family: var(--font-mono); font-size: 13px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .sc-meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -1131,7 +1135,7 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
    .mcp-tok) for its token list, so everything the MCP pane redefines is
    scoped under .mcp-pane. */
 .mcp-servers { display: flex; flex-direction: column; gap: 8px; }
-.mcp-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto auto; gap: 14px; align-items: center; padding: 10px 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); }
+.mcp-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto auto; gap: 14px; align-items: center; padding: 10px 14px; }
 .mcp-row.is-off { opacity: 0.6; }
 .mcp-id { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .mcp-name { font-family: var(--font-mono); font-size: 12.5px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -1168,7 +1172,7 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .mcp-reg-search { display: flex; gap: 10px; }
 .mcp-pane :is(.mcp-reg-search, .skill-add) .skill-add-input { flex: 1; min-width: 0; }
 .mcp-reg-results { display: flex; flex-direction: column; gap: 8px; }
-.mcp-reg-row { display: flex; flex-direction: column; gap: 3px; width: 100%; padding: 10px 13px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); cursor: pointer; text-align: left; font: inherit; }
+.mcp-reg-row { display: flex; flex-direction: column; gap: 3px; width: 100%; padding: 10px 13px; cursor: pointer; text-align: left; font: inherit; }
 .mcp-reg-row:hover { border-color: var(--border-loud); background: var(--surface-3); }
 .mcp-reg-row.is-selected { border-color: color-mix(in oklch, var(--accent) 50%, transparent); border-radius: 7px 7px 0 0; background: var(--surface-3); }
 .mcp-reg-top { display: flex; align-items: center; gap: 8px; min-width: 0; }
@@ -1178,10 +1182,8 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .mcp-reg-form { display: flex; flex-direction: column; gap: 13px; padding: 14px; border: 1px solid color-mix(in oklch, var(--accent) 50%, transparent); border-top: none; border-radius: 0 0 7px 7px; background: var(--surface); }
 
 /* Secondary by weight, not by hiding: one quiet control until it is wanted. */
-.mcp-custom { border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); }
 .mcp-custom-summary { display: flex; align-items: center; gap: 8px; padding: 11px 14px; border-radius: 7px; font-size: 13px; color: var(--text-mid); cursor: pointer; list-style: none; }
 .mcp-custom-summary::-webkit-details-marker { display: none; }
-.mcp-custom-summary::before { content: '›'; font-family: var(--font-mono); color: var(--text-faint); transition: transform 120ms; }
 .mcp-custom-summary:hover { color: var(--text); }
 .mcp-custom[open] .mcp-custom-summary { border-bottom: 1px solid var(--border); border-radius: 7px 7px 0 0; color: var(--text); }
 .mcp-custom[open] .mcp-custom-summary::before { transform: rotate(90deg); }
@@ -1195,7 +1197,12 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .mcp-pane .mcp-row:hover { border-color: var(--border-loud); }
 .mcp-pane .mcp-row.is-off { opacity: 1; background: var(--surface); }
 .mcp-pane .mcp-row.is-off :is(.mcp-id, .mcp-conn) { opacity: 0.5; }
-.mcp-conn { display: inline-flex; align-items: center; gap: 7px; justify-self: end; padding-top: 2px; font-size: 12px; font-weight: 500; color: var(--decision-request-revision); white-space: nowrap; }
+/* The one connection-status indicator: neutral when off, green when live.
+   Inside an MCP server row the off state stays attention-colored — a listed
+   server that isn't connected wants action. */
+.mcp-conn { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; font-weight: 500; color: var(--text-dim); white-space: nowrap; }
+.mcp-row .mcp-conn { justify-self: end; padding-top: 2px; }
+.mcp-row .mcp-conn:not(.is-live) { color: var(--decision-request-revision); }
 .mcp-conn-dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
 .mcp-conn.is-live { color: var(--outcome-merged); }
 .mcp-conn.is-live .mcp-conn-dot { box-shadow: 0 0 8px color-mix(in oklch, var(--outcome-merged) 60%, transparent); }
@@ -1208,7 +1215,7 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
    detail view in the same pane. Shares the MCP pane's measure and type
    scale; monospace is reserved for identity values. */
 .svc-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
-.svc-card { display: flex; flex-direction: column; gap: 8px; min-width: 0; padding: 13px 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); cursor: pointer; text-align: left; font: inherit; color: inherit; transition: border-color 120ms, background 120ms; }
+.svc-card { display: flex; flex-direction: column; gap: 8px; min-width: 0; padding: 13px 14px; cursor: pointer; text-align: left; font: inherit; color: inherit; transition: border-color 120ms, background 120ms; }
 .svc-card:hover { border-color: var(--border-loud); background: var(--surface-3); }
 .svc-card:active { background: var(--surface); }
 .svc-card-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
@@ -1217,17 +1224,12 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .svc-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: auto; }
 .svc-card-id { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .svc-card-cue { font-size: 12px; color: var(--text-dim); }
-.svc-card-chevron { font-family: var(--font-mono); font-size: 14px; color: var(--text-faint); flex-shrink: 0; }
-
-.svc-status { display: inline-flex; align-items: center; gap: 7px; font-size: 12px; font-weight: 500; color: var(--text-dim); white-space: nowrap; }
-.svc-status-dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
-.svc-status.is-on { color: var(--outcome-merged); }
-.svc-status.is-on .svc-status-dot { box-shadow: 0 0 8px color-mix(in oklch, var(--outcome-merged) 60%, transparent); }
+.svc-card .chev { flex-shrink: 0; }
 
 .svc-back { padding: 0; border: none; background: none; font: inherit; font-size: 12.5px; color: var(--text-mid); cursor: pointer; }
 .svc-back:hover { color: var(--text); }
 .svc-detail-head { display: flex; align-items: center; gap: 12px; }
-.svc-facts { display: flex; flex-direction: column; gap: 6px; padding: 12px 14px; border: 1px solid var(--border); border-radius: 7px; background: var(--surface-2); }
+.svc-facts { display: flex; flex-direction: column; gap: 6px; padding: 12px 14px; }
 .svc-fact { display: flex; gap: 12px; min-width: 0; font-family: var(--font-mono); font-size: 12px; }
 .svc-fact-key { color: var(--text-dim); flex-shrink: 0; }
 .svc-fact-val { color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }


### PR DESCRIPTION
Follow-up to #232 / #237 / #238, stacked on #238: folds the three duplicated visual primitives the pane redesigns left behind into shared ones. Rendering is unchanged — this is a net-zero-line CSS/markup consolidation (+32 / −32).

- **`.set-card`** returns as the one card recipe (border, radius, surface). Every pane's card now rides it and keeps only its own layout: the services cards and facts block, the harness cards, the skill collections, the MCP server rows, registry results, and custom-server disclosure, and the Tokens PAT rows.
- **`.mcp-conn`** is the one connection-status indicator — neutral when off, green when live — used by Services, Harnesses (via the shared `ServiceStatus` component), and MCP. The MCP server row keeps its deliberate attention-colored off state via a rule scoped to `.mcp-row`: a listed server without its token wants action, while a not-yet-connected service or harness is just a fact.
- **`.chev`** is the one disclosure/drill-in glyph. The services card arrow, the skills collection toggle, and the MCP custom-server summary share a single definition; consumers keep only their own rotation and hover wiring. The duplicate `.svc-status` family, `.svc-card-chevron`, and `.sc-chevron` are gone.

Verified in the browser that all four panes — Services, Harnesses, Skills, MCP (including the amber no-token state and the Tokens-style rows) — render identically to before.