### PR TITLE
Browser-flavored sandbox image with in-image session tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,3 +49,8 @@ updates:
     directory: /deploy/sandbox
     schedule:
       interval: weekly
+
+  - package-ecosystem: docker
+    directory: /deploy/browser
+    schedule:
+      interval: weekly

--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -1,7 +1,7 @@
 name: Publish Sandbox Image
 
-# The sandbox image is independent of the application code — it only
-# rebuilds when its own build context (or this workflow) changes.
+# The sandbox and browser images are independent of the application code —
+# they only rebuild when their own build contexts (or this workflow) change.
 on:
   workflow_dispatch:
   push:
@@ -9,6 +9,7 @@ on:
     tags: ["v*"]
     paths:
       - "deploy/sandbox/**"
+      - "deploy/browser/**"
       - ".github/workflows/publish-sandbox-image.yml"
 
 concurrency:
@@ -53,3 +54,39 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           cache-from: type=gha,scope=sandbox
           cache-to: type=gha,scope=sandbox,mode=max
+
+  browser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # arm64 too: the browser image's home is the druks box, which is a
+      # developer laptop in the local shape.
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/druks-browser
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=long
+            type=ref,event=tag
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: deploy/browser
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=browser
+          cache-to: type=gha,scope=browser,mode=max

--- a/deploy/browser/Dockerfile
+++ b/deploy/browser/Dockerfile
@@ -1,0 +1,63 @@
+# Browser image: the home of druks browser sessions. Druks boots these
+# containers on its own box (drukbox docker provider) to materialize a
+# vault session and drive it — over CDP or pinchtab, both loopback-only,
+# reached through SSH like every sandbox. No harness ever runs here.
+#
+# Built from the drukbox sandbox base (Ubuntu + sshd); the entrypoint
+# seeds a non-root user and starts the display stack.
+#
+# Published by .github/workflows/publish-sandbox-image.yml as
+# ghcr.io/czpython/druks-browser.
+FROM ghcr.io/czpython/drukbox/sandbox:latest@sha256:a5312ab8289cab543f30ec7ba1f1ada8e027c78c9fe06ed5d52c0459e5a2ffef
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PINCHTAB_VERSION=0.15.1
+ARG PLAYWRIGHT_VERSION=1.62.0
+ARG TARGETARCH
+
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# Package revisions differ across the base image's architectures and external
+# vendor repositories; pin the image and the tools while allowing apt fixes.
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+    && install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        fonts-liberation fonts-noto-cjk fonts-noto-color-emoji nodejs x11vnc xvfb \
+    && rm -rf /var/lib/apt/lists/* \
+    && install -d -m 0755 /opt/druks-browser \
+    && cd /opt/druks-browser \
+    && npm install --no-package-lock --omit=dev "playwright@${PLAYWRIGHT_VERSION}" \
+    && npx playwright install --with-deps chromium \
+    && rm -rf /var/lib/apt/lists/* \
+    && chromium_path="$(find /ms-playwright -type f -path '*/chrome-linux*/chrome' -print -quit)" \
+    && test -n "$chromium_path" \
+    && ln -s "$chromium_path" /usr/local/bin/chromium \
+    && pinchtab_asset="pinchtab-linux-${TARGETARCH}" \
+    && curl -fsSLo /tmp/pinchtab \
+        "https://github.com/pinchtab/pinchtab/releases/download/v${PINCHTAB_VERSION}/${pinchtab_asset}" \
+    && curl -fsSLo /tmp/pinchtab-checksums.txt \
+        "https://github.com/pinchtab/pinchtab/releases/download/v${PINCHTAB_VERSION}/checksums.txt" \
+    && grep "  ${pinchtab_asset}$" /tmp/pinchtab-checksums.txt \
+        | sed 's#  .*#  /tmp/pinchtab#' \
+        | sha256sum --check --strict - \
+    && install -m 0755 /tmp/pinchtab /usr/local/bin/pinchtab \
+    && rm -f /tmp/pinchtab /tmp/pinchtab-checksums.txt
+
+RUN useradd --create-home --shell /bin/bash druks
+
+COPY session-launch session-export /usr/local/bin/
+COPY entrypoint /usr/local/bin/druks-browser-entrypoint
+RUN chmod 0755 /usr/local/bin/session-launch /usr/local/bin/session-export \
+        /usr/local/bin/druks-browser-entrypoint \
+    && install -d -m 0700 -o druks -g druks /work/session
+
+ENTRYPOINT ["/usr/local/bin/druks-browser-entrypoint"]

--- a/deploy/browser/entrypoint
+++ b/deploy/browser/entrypoint
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# First-boot entrypoint. Seeds the non-root ``druks`` user like the sandbox
+# entrypoint, then the display stack: Xvfb for the browser to render into,
+# loopback-only VNC for the login window's bridge. SSH stays the only ingress.
+set -euo pipefail
+
+: "${DRUKBOX_AUTHORIZED_KEY:?DRUKBOX_AUTHORIZED_KEY is required}"
+
+install -d -m 700 -o druks -g druks /home/druks/.ssh
+printf '%s\n' "$DRUKBOX_AUTHORIZED_KEY" > /home/druks/.ssh/authorized_keys
+chmod 600 /home/druks/.ssh/authorized_keys
+chown druks:druks /home/druks/.ssh/authorized_keys
+
+# Persist caller-supplied env for SSH sessions: pam_env reads /etc/environment.
+for name in ${DRUKBOX_ENV_KEYS:-}; do
+  printf '%s=%s\n' "$name" "${!name-}" >> /etc/environment
+done
+
+install -d -m 0700 -o druks -g druks /run/druks
+install -m 0600 -o druks -g druks /dev/null /run/druks/x11vnc.password
+head -c 6 /dev/urandom | base64 > /run/druks/x11vnc.password
+
+Xvfb :99 -screen 0 1920x1080x24 -nolisten tcp -ac &
+# -loop retries until Xvfb's display exists; a broken display surfaces as a
+# loud connect error at the bridge, not a hung boot.
+x11vnc -display :99 -loop -forever -listen 127.0.0.1 -rfbport 5900 \
+  -passwdfile /run/druks/x11vnc.password -noxdamage -shared &
+
+ssh-keygen -A
+
+exec /usr/sbin/sshd -D -e

--- a/deploy/browser/session-export
+++ b/deploy/browser/session-export
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+session_root=/work/session
+pid_path="$session_root/.runtime/launcher.pid"
+closed_path="$session_root/.runtime/closed"
+output_path="$session_root/out"
+
+# Never tar a live Chrome: ask the launcher to close and wait for its
+# closed sentinel.
+kill -TERM "$(<"$pid_path")"
+for _ in {1..600}; do
+  if [[ -f "$closed_path" ]]; then
+    break
+  fi
+  sleep 0.1
+done
+if [[ ! -f "$closed_path" ]]; then
+  printf 'session-launch did not close the browser cleanly\n' >&2
+  exit 1
+fi
+
+rm -rf "$output_path"
+install -d -m 0700 "$output_path"
+
+tar \
+  --exclude='*/Cache' \
+  --exclude='*/Code Cache' \
+  --exclude='*/GPUCache' \
+  --exclude='*/Service Worker/CacheStorage' \
+  -czf "$output_path/state.tar.gz" \
+  -C "$session_root/profile" \
+  .
+tar -tzf "$output_path/state.tar.gz" > /dev/null
+
+version="$(node -p 'JSON.parse(require("fs").readFileSync("/work/session/state.meta.json", "utf8")).version')"
+printf '{"format":"profile_dir","version":%s}\n' "$version" > "$output_path/state.meta.json"
+chmod 0600 "$output_path/state.tar.gz" "$output_path/state.meta.json"

--- a/deploy/browser/session-launch
+++ b/deploy/browser/session-launch
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+process.env.DISPLAY ||= ":99";
+process.env.PLAYWRIGHT_BROWSERS_PATH ||= "/ms-playwright";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const { chromium } = require("/opt/druks-browser/node_modules/playwright");
+
+const SESSION_ROOT = "/work/session";
+const META_PATH = path.join(SESSION_ROOT, "state.meta.json");
+const PROFILE_ARCHIVE_PATH = path.join(SESSION_ROOT, "state.tar.gz");
+const STORAGE_STATE_PATH = path.join(SESSION_ROOT, "state.json");
+const PROFILE_PATH = path.join(SESSION_ROOT, "profile");
+const RUNTIME_PATH = path.join(SESSION_ROOT, ".runtime");
+const PID_PATH = path.join(RUNTIME_PATH, "launcher.pid");
+const READY_PATH = path.join(RUNTIME_PATH, "ready.json");
+const CLOSED_PATH = path.join(RUNTIME_PATH, "closed");
+
+const [mode] = process.argv.slice(2);
+if (!mode || process.argv.length !== 3 || !["--headed", "--headless"].includes(mode)) {
+  console.error("usage: session-launch --headed|--headless");
+  process.exit(2);
+}
+const headless = mode === "--headless";
+
+let requestShutdown;
+const shutdownRequested = new Promise((resolve) => {
+  requestShutdown = resolve;
+});
+
+process.on("SIGINT", requestShutdown);
+process.on("SIGHUP", requestShutdown);
+process.on("SIGTERM", requestShutdown);
+
+function readSessionMeta() {
+  const meta = JSON.parse(fs.readFileSync(META_PATH, "utf8"));
+  if (!["profile_dir", "storage_state"].includes(meta.format)) {
+    throw new Error(`unsupported session format: ${meta.format}`);
+  }
+  if (!("version" in meta)) {
+    throw new Error("session metadata is missing version");
+  }
+  return meta;
+}
+
+function unpackProfileArchive() {
+  const unpacked = spawnSync(
+    "tar",
+    [
+      "-xzf",
+      PROFILE_ARCHIVE_PATH,
+      "--no-same-owner",
+      "--no-same-permissions",
+      "-C",
+      PROFILE_PATH,
+    ],
+    { encoding: "utf8" },
+  );
+  if (unpacked.status !== 0) {
+    throw new Error(`failed to unpack profile archive: ${unpacked.stderr.trim()}`);
+  }
+}
+
+async function main() {
+  const meta = readSessionMeta();
+
+  fs.rmSync(PROFILE_PATH, { force: true, recursive: true });
+  fs.rmSync(RUNTIME_PATH, { force: true, recursive: true });
+  fs.mkdirSync(PROFILE_PATH, { mode: 0o700, recursive: true });
+  fs.mkdirSync(RUNTIME_PATH, { mode: 0o700, recursive: true });
+  fs.writeFileSync(PID_PATH, `${process.pid}\n`, { mode: 0o600 });
+
+  if (meta.format === "profile_dir") {
+    unpackProfileArchive();
+  }
+
+  let context;
+  let isReady = false;
+  try {
+    context = await chromium.launchPersistentContext(PROFILE_PATH, {
+      args: [
+        "--remote-debugging-address=127.0.0.1",
+        "--remote-debugging-port=9222",
+        "--window-size=1920,1080",
+      ],
+      handleSIGHUP: false,
+      handleSIGINT: false,
+      handleSIGTERM: false,
+      headless,
+      viewport: null,
+    });
+    context.on("close", requestShutdown);
+
+    if (meta.format === "storage_state") {
+      await context.setStorageState(STORAGE_STATE_PATH);
+    }
+
+    fs.writeFileSync(
+      READY_PATH,
+      `${JSON.stringify({ cdp: "http://127.0.0.1:9222", headless })}\n`,
+      { mode: 0o600 },
+    );
+    isReady = true;
+
+    await shutdownRequested;
+  } finally {
+    if (context) {
+      await context.close();
+    }
+    if (isReady) {
+      fs.writeFileSync(CLOSED_PATH, "\n", { mode: 0o600 });
+    }
+    fs.rmSync(PID_PATH, { force: true });
+  }
+}
+
+main().catch((error) => {
+  fs.rmSync(PID_PATH, { force: true });
+  console.error(error.stack || error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## What

First phase of browser sessions as a druks primitive: the sandbox image gains a `browser` flavor and the session tooling that keeps druks core blind to browser-state formats.

- **Dockerfile**: named `slim`/`browser` stages. The browser stage adds chromium (via pinned playwright, browsers under `/ms-playwright`), a pinned checksum-verified pinchtab binary, fonts, Xvfb, and x11vnc. Everything slim has stays present — harnesses run in browser sandboxes too. Untargeted local builds keep producing slim via a final `default` alias stage.
- **entrypoint**: the browser flavor starts Xvfb (:99) and x11vnc bound to 127.0.0.1:5900 with a 0600 password file generated at boot, and fails the boot loudly if either doesn't come up. Slim starts neither. VNC is loopback-only; SSH stays the only ingress.
- **session-launch / session-export**: image-owned scripts that interpret session formats so druks core never does. Launch materializes a profile tarball or applies a `storage_state` JSON to a persistent context (raw Chromium can't consume storage_state) and exposes loopback CDP for playwright and pinchtab alike; export closes the browser first (never tars a live Chrome), archives the profile without caches, validates the archive, and writes tar + meta to `/work/session/out/`. Both scripts are self-contained under SSH invocation, which carries none of the image ENV.
- **sandbox client**: `browser=True` on `ephemeral`/`acquire`/`provision` resolves the configured image to its `browser` tag (an explicit `image_override` still wins). Browser hosts always name their image explicitly, so they bypass the default-image warm pool.
- **publish workflow**: builds and pushes both flavors — existing tags for slim, `browser`/`browser-sha-*`/`browser-<tag>` for the browser target.

## Testing

- Unit tests cover browser-tag resolution (default, untagged, tagged, registry-with-port, digest-pinned) and `browser=True` flowing into `create_host(image=...)`; they run in CI (local runs are blocked by the shared-DB fixture).
- ruff, ruff format, pyright, `bash -n`, `node --check` all clean.
- Image boot, VNC handshake, both session round trips, and the harness-in-browser-sandbox check are CI/manual docker verification once the image publishes.