### PR TITLE
MCP OAuth: follow the resource origin's issuer claim once

### DIFF
--- a/backend/druks/mcp/oauth.py
+++ b/backend/druks/mcp/oauth.py
@@ -77,8 +77,26 @@ async def _discover(client: httpx.AsyncClient, name: str, server_url: str) -> di
                 )
             issuer = resource_metadata["authorization_servers"][0]
             break
-    if not issuer:
-        issuer = origin
+    if issuer:
+        candidate_issuers = [issuer]
+    else:
+        # No protected-resource metadata: the server is its own issuer, or its
+        # origin document names another — Atlassian serves its CDN alias this
+        # way — a claim with the same trust RFC 9728 gives authorization_servers.
+        document = await _get_json(client, f"{origin}/.well-known/oauth-authorization-server")
+        alias = document.get("issuer") if document else None
+        candidate_issuers = [origin, alias] if alias and alias != origin else [origin]
+    for issuer in candidate_issuers:
+        if metadata := await _self_claimed_metadata(client, issuer):
+            return metadata
+    raise OauthConnectError(
+        name,
+        f"no authorization-server metadata claiming issuer {issuer} found for {server_url}",
+    )
+
+
+async def _self_claimed_metadata(client: httpx.AsyncClient, issuer: str) -> dict | None:
+    """The issuer's metadata, only if it claims that issuer (RFC 8414 §3.3)."""
     issuer_origin = _origin(issuer)
     issuer_path = urlparse(issuer).path.rstrip("/")
     # An issuer with a path publishes under RFC 8414 insertion
@@ -102,10 +120,7 @@ async def _discover(client: httpx.AsyncClient, name: str, server_url: str) -> di
             and metadata.get("issuer", "").rstrip("/") == issuer.rstrip("/")
         ):
             return metadata
-    raise OauthConnectError(
-        name,
-        f"no authorization-server metadata claiming issuer {issuer} found for {server_url}",
-    )
+    return
 
 
 async def _register_client(

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -47,6 +47,7 @@ class FakeAuthServer:
     # token endpoint that records every request it answers.
     def __init__(self) -> None:
         self.discovery_supported = True
+        self.resource_metadata_supported = True
         self.registration_supported = True
         self.resource = _SERVER_URL
         self.issuer = _AUTH_BASE
@@ -64,7 +65,7 @@ class FakeAuthServer:
     def handler(self, request: httpx.Request) -> httpx.Response:
         path = request.url.path
         if path.startswith("/.well-known/oauth-protected-resource"):
-            if not self.discovery_supported:
+            if not (self.discovery_supported and self.resource_metadata_supported):
                 return httpx.Response(404)
             return httpx.Response(
                 200, json={"resource": self.resource, "authorization_servers": [_AUTH_BASE]}
@@ -240,6 +241,28 @@ async def test_begin_connect_skips_metadata_claiming_another_issuer(auth_server)
             account_id=SYSTEM_ACCOUNT_ID,
             identity_mode=IdentityMode.SHARED,
         )
+
+
+async def test_begin_connect_follows_the_origin_referral_to_an_alias_issuer(auth_server):
+    # Atlassian's shape: no protected-resource metadata, and the AS document the
+    # resource origin serves claims a CDN-alias issuer. The origin's claim is the
+    # same assertion RFC 9728 makes with authorization_servers, so it is followed
+    # once — and the referred document must claim itself, which here it does (the
+    # fake serves the same metadata on every host). The mix-up defense holds:
+    # with protected-resource metadata present, the foreign claim stays rejected
+    # (see the test above).
+    auth_server.resource_metadata_supported = False
+    auth_server.issuer = "https://alias.test"
+
+    url = await oauth.begin_connect(
+        _NAME,
+        _SERVER_URL,
+        _ENDPOINT,
+        account_id=SYSTEM_ACCOUNT_ID,
+        identity_mode=IdentityMode.SHARED,
+    )
+
+    assert url.startswith(f"{_AUTH_BASE}/authorize")
 
 
 async def test_begin_connect_requires_s256_when_methods_are_advertised(auth_server):


### PR DESCRIPTION
Closes #247.

Atlassian's server publishes no protected-resource metadata and serves, at the resource origin, AS metadata claiming its CDN alias (`cf.mcp.atlassian.com`) as issuer. The strict RFC 8414 §3.3 check skipped it and the connect failed with no candidates.

When no protected-resource document named the issuer — it was only derived from the resource origin — a foreign-issuer claim served by that origin is the same assertion RFC 9728 makes with `authorization_servers`: follow it once, and require the referred document to claim itself at its own well-known location.

The mix-up defense holds:
- a PRM-named issuer still rejects foreign claims outright (existing test unchanged)
- referrals do not chain (a referred document claiming yet another issuer fails)
- the referred document must self-claim at its own well-known location

New test encodes the Atlassian shape via a `resource_metadata_supported` flag on the fake auth server. Discovery logic additionally validated against recorded copies of Atlassian's real documents plus adversarial cases (PRM-named foreign claim, referral chain) — see #247 for the probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)