### PR TITLE
Installed extensions surface in the shell

### DIFF
--- a/backend/druks/api/app.py
+++ b/backend/druks/api/app.py
@@ -23,6 +23,7 @@ from druks.durable.engine import init_dbos, launch, shutdown
 from druks.durable.exceptions import AgentCallNotFound
 from druks.events.routes import router as events_router
 from druks.extensions.loader import iter_extensions, load
+from druks.extensions.routes import router as extensions_router
 from druks.harnesses.routes import router as harness_connection_router
 from druks.mcp.catalog import load_mcp_catalog
 from druks.mcp.gateway import exceptions as gate_errors
@@ -242,6 +243,7 @@ app.include_router(webhooks_router)
 app.include_router(auth_router)
 app.include_router(harness_connection_router)
 app.include_router(settings_router, dependencies=_identity_gate)
+app.include_router(extensions_router, dependencies=_identity_gate)
 app.include_router(service_identities_router, dependencies=_identity_gate)
 app.include_router(skills_router, dependencies=_identity_gate)
 app.include_router(mcp_router, dependencies=_identity_gate)

--- a/backend/druks/extensions/routes.py
+++ b/backend/druks/extensions/routes.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter
+
+from .loader import iter_extensions
+from .schemas import ExtensionResponse
+
+router = APIRouter(prefix="/api/extensions", tags=["extensions"])
+
+
+@router.get("", response_model=list[ExtensionResponse], response_model_by_alias=True)
+async def list_extensions() -> list[ExtensionResponse]:
+    return [
+        ExtensionResponse(
+            name=extension.name,
+            icon=extension.icon,
+            description=extension.description,
+            builtin=extension.builtin,
+            subject_types=[subject.subject_type for subject in extension.subject_classes()],
+            has_frontend=bool(extension.frontend_dist()),
+        )
+        for extension in iter_extensions()
+    ]

--- a/backend/druks/extensions/schemas.py
+++ b/backend/druks/extensions/schemas.py
@@ -1,0 +1,10 @@
+from druks.schemas import BaseResponse
+
+
+class ExtensionResponse(BaseResponse):
+    name: str
+    icon: str
+    description: str
+    builtin: bool
+    subject_types: list[str]
+    has_frontend: bool

--- a/backend/tests/test_extension_roster.py
+++ b/backend/tests/test_extension_roster.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from druks.testing import configure_app_for_test, make_settings
+from fastapi.testclient import TestClient
+
+
+def test_roster_lists_installed_extensions_with_subject_types(tmp_path: Path):
+    with TestClient(configure_app_for_test(settings=make_settings(tmp_path))) as client:
+        roster = {entry["name"]: entry for entry in client.get("/api/extensions").json()}
+
+    ship = roster["ship"]
+    assert ship["builtin"] is False
+    assert "work_item" in ship["subjectTypes"]
+    assert ship["hasFrontend"] is False
+    assert ship["icon"]
+    field_notes = roster["field_notes"]
+    assert field_notes["subjectTypes"] == ["note"]

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -794,9 +794,17 @@ runs `FLUSHDB` on the test index.
 
 ## Frontends
 
-The scaffold ships a minimal `druks_night_watch/dist/index.html`. Replace that
-directory with a static frontend build to serve a standalone extension app at
-`/app/night_watch`; history fallback and cache headers are handled by FastAPI.
+An installed extension is visible in the dashboard without shipping any UI. The
+shell reads the installed roster from `/api/extensions` and gives every
+extension an entry in the app switcher plus generic pages: a board per subject
+type, and a subject page with the run timeline, transcripts, and gate controls.
+There is nothing to declare — the subject summary's fields are the board row.
+
+To go beyond the generic pages, ship a frontend. The scaffold ships a minimal
+`druks_night_watch/dist/index.html`. Replace that directory with a static
+frontend build to serve a standalone extension app at `/app/night_watch`; the
+app switcher links it, and history fallback and cache headers are handled by
+FastAPI.
 
 The bundled Druks SPA also has a shared React extension registry. Joining that
 shell requires compiling the extension's UI module into the dashboard image;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link, Route, Router, Switch, useLocation } from 'wouter'
 
@@ -14,6 +14,7 @@ import { SystemStrip } from './components/SystemStrip'
 import { UsagePage } from './pages/UsagePage'
 import { extensionAccent } from './lib/extensionColors'
 import './extensions'
+import { registerInstalledExtensions } from './extensions/installed'
 import { extensionHome, extensionOwning, getExtensionUI, registeredExtensions } from './extensions/registry'
 import type { ExtensionNavEntry } from './extensions/registry'
 
@@ -33,12 +34,20 @@ export function App() {
 function AppShell() {
   const [location, navigate] = useLocation()
 
-  // Every UI-contributing extension, in registration order — read synchronously from
-  // the local registry, which is the source of truth for what UI ships in this bundle
-  // (an extension can't register UI without being installed). Routes, accent, nav, the
-  // dropdown, and the default landing all derive from it, so they resolve on a cold
-  // load without waiting on any fetch. No extension name is hardcoded.
-  const registered = useMemo(() => registeredExtensions().map((e) => e.name), [])
+  // Every extension with a place in the shell, in registration order: the bundled
+  // ones synchronously (routes, accent, and landing resolve on a cold load without
+  // any fetch), then the installed roster — each backend-only extension gets the
+  // generic pages, a dist-shipping one gets its external home. Bundled first, roster
+  // extras A→Z. No extension name is hardcoded.
+  const rosterQuery = useQuery({
+    queryKey: ['extensions'],
+    queryFn: api.listExtensions,
+    staleTime: 60_000,
+  })
+  const registered = useMemo(() => {
+    registerInstalledExtensions(rosterQuery.data)
+    return registeredExtensions().map((e) => e.name)
+  }, [rosterQuery.data])
   // Accent per extension, handed out by registration order (the harness-colour
   // pattern) — no per-name CSS, and stable from first paint.
   const accent = useMemo(() => extensionAccent(registered), [registered])
@@ -79,6 +88,20 @@ function AppShell() {
   useEffect(() => {
     navCount.current += 1
   }, [location])
+
+  // An extension whose home is its own shipped dist lives outside this SPA —
+  // reaching it is a document load, not a wouter navigation.
+  const go = useCallback(
+    (name: string) => {
+      const home = extensionHome(name)
+      if (getExtensionUI(name)?.external) {
+        window.location.assign(home)
+      } else {
+        navigate(home)
+      }
+    },
+    [navigate],
+  )
 
   // Root URL deeplinks to the default extension so the in-extension nav and the URL
   // bar agree. Waits for the registry so it lands on a real home, not a guess.
@@ -158,7 +181,7 @@ function AppShell() {
             extensions={registered}
             extension={extension}
             accent={accent}
-            onChange={(next) => navigate(extensionHome(next))}
+            onChange={go}
           />
 
           <ExtensionSubNav location={location} nav={ui?.nav} accent={accentColor} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,6 +4,7 @@ import type {
   ArtifactContent,
   ConnectChallenge,
   DashboardHealth,
+  Extension,
   FeedResponse,
   ExtensionsSettingsResponse,
   Harness,
@@ -180,6 +181,7 @@ export const subjectApi = {
 
 export const api = {
   systemHealth: () => getJSON<DashboardHealth>('/api/system/health'),
+  listExtensions: () => getJSON<Extension[]>('/api/extensions'),
   artifact: (id: string) => getJSON<ArtifactContent>(`/api/artifacts/${id}`),
   resumeRun: (
     runId: string,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -182,6 +182,18 @@ export interface TranscriptChunk {
   text: string
 }
 
+// One installed extension, from the backend registry — what the shell derives
+// nav and generic pages from. ``hasFrontend`` means the package ships its own
+// built UI, served at /app/<name>.
+export interface Extension {
+  name: string
+  icon: string
+  description: string
+  builtin: boolean
+  subjectTypes: string[]
+  hasFrontend: boolean
+}
+
 // --- System health ---------------------------------------------------------
 
 export interface WebhookSource {

--- a/frontend/src/components/ExtensionDropdown.tsx
+++ b/frontend/src/components/ExtensionDropdown.tsx
@@ -18,21 +18,21 @@ export function ExtensionDropdown({ extensions, extension, accent, onChange }: P
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
-  // Icon + description come from the extension registry the backend already serves
-  // (same query key as the shell, so this reads the cache — no extra request).
-  const settingsQuery = useQuery({
-    queryKey: ['extensionSettings'],
-    queryFn: api.getExtensionSettings,
+  // Icon + description come from the roster the shell already fetched (same query
+  // key, so this reads the cache — no extra request).
+  const rosterQuery = useQuery({
+    queryKey: ['extensions'],
+    queryFn: api.listExtensions,
     staleTime: 60_000,
   })
   const meta = useMemo(() => {
-    const byName = new Map((settingsQuery.data?.extensions ?? []).map((e) => [e.name, e]))
+    const byName = new Map((rosterQuery.data ?? []).map((e) => [e.name, e]))
     return extensions.map((name) => ({
       name,
       icon: byName.get(name)?.icon ?? 'box',
       desc: byName.get(name)?.description ?? '',
     }))
-  }, [settingsQuery.data, extensions])
+  }, [rosterQuery.data, extensions])
 
   useEffect(() => {
     if (!open) return undefined

--- a/frontend/src/components/RunControls.test.tsx
+++ b/frontend/src/components/RunControls.test.tsx
@@ -2,8 +2,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { InputRequest } from '../../api/types'
-import { InAppReview } from './WorkItemPage'
+import type { InputRequest } from '../api/types'
+import { InAppReview } from './RunControls'
 
 function stubFetch() {
   const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(

--- a/frontend/src/components/RunControls.tsx
+++ b/frontend/src/components/RunControls.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+import { api } from '../api/client'
+import type { InputRequest } from '../api/types'
+import { Markdown } from './Markdown'
+
+// Cancel is a run-level action: end any active run, parked or running. A destructive
+// stop, so it confirms first and takes an optional reason (the recorded cancel note).
+// The detail stream re-emits the snapshot on the state flip, so this control unmounts
+// itself — no local success handling.
+export function CancelRun({ runId }: { runId: string }) {
+  const [confirming, setConfirming] = useState(false)
+  const [reason, setReason] = useState('')
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function cancel() {
+    setPending(true)
+    setError(null)
+    try {
+      await api.cancelRun(runId, reason.trim() || 'cancelled by operator')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'could not cancel')
+      setPending(false)
+    }
+  }
+
+  if (!confirming) {
+    return (
+      <button type="button" className="ins-run-link ins-cancel" onClick={() => setConfirming(true)}>
+        cancel run
+      </button>
+    )
+  }
+  return (
+    <span className="ins-cancel-confirm">
+      <input
+        type="text"
+        className="ins-cancel-reason mono"
+        placeholder="reason (optional)"
+        maxLength={500}
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+      />
+      <button type="button" className="ins-run-link ins-cancel" disabled={pending} onClick={cancel}>
+        confirm cancel
+      </button>
+      <button
+        type="button"
+        className="ins-run-link"
+        disabled={pending}
+        onClick={() => setConfirming(false)}
+      >
+        back
+      </button>
+      {error && <span className="review-error">{error}</span>}
+    </span>
+  )
+}
+
+export function RetryRun({ runId }: { runId: string }) {
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function retry() {
+    setPending(true)
+    setError(null)
+    try {
+      await api.retryRun(runId)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'could not retry')
+      setPending(false)
+    }
+  }
+
+  return (
+    <>
+      <button type="button" className="ins-run-link" disabled={pending} onClick={retry}>
+        {pending ? 'retrying…' : 'retry run'}
+      </button>
+      {error && <span className="review-error">{error}</span>}
+    </>
+  )
+}
+
+// Button label per control verb; the ask's controls are a fixed workflow vocabulary.
+const CONTROL_LABEL: Record<string, string> = {
+  approve: 'Approve',
+  request_changes: 'Request changes',
+  revise_contract: 'Revise contract',
+}
+
+// The in-app review: the artifact (the plan), structured question options, one
+// note, and the workflow's controls. A click resumes the run with
+// {control, answers, note}; free text is content for the next plan pass, never a
+// control.
+export function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }) {
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [note, setNote] = useState('')
+  const [pending, setPending] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const critique = ask.context?.trim() ?? ''
+
+  const artifact = useQuery({
+    queryKey: ['artifact', ask.artifact_id],
+    queryFn: () => api.artifact(ask.artifact_id as string),
+    enabled: Boolean(ask.artifact_id),
+  })
+
+  async function choose(control: string) {
+    setPending(control)
+    setError(null)
+    try {
+      // The run un-parks; the subject's SSE stream re-emits the snapshot and this
+      // banner clears itself.
+      await api.resumeRun(runId, { control, answers, note: note.trim() })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'could not submit')
+      setPending(null)
+    }
+  }
+
+  return (
+    <div className="ins-needs">
+      {critique && (
+        <div className="review-artifact">
+          <div className="review-artifact-title">Plan reviewer critique</div>
+          <Markdown source={critique} />
+        </div>
+      )}
+      {artifact.data && (
+        <div className="review-artifact">
+          <div className="review-artifact-title">{artifact.data.title}</div>
+          <Markdown source={artifact.data.content} />
+        </div>
+      )}
+      {ask.questions?.map((question) => {
+        const picked = answers[question.id] ?? ''
+        return (
+          <fieldset key={question.id} className="review-question">
+            <legend>{question.prompt}</legend>
+            {question.options.map((option) => (
+              <label key={option.id} className="review-option">
+                <input
+                  type="radio"
+                  name={question.id}
+                  checked={picked === option.id}
+                  onChange={() =>
+                    setAnswers((prev) => ({ ...prev, [question.id]: option.id }))
+                  }
+                />
+                {option.label}
+                {option.recommended && (
+                  <span className="review-recommended">recommended</span>
+                )}
+              </label>
+            ))}
+          </fieldset>
+        )
+      })}
+      <textarea
+        className="review-note"
+        placeholder="optional note — what should the next pass change?"
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+      />
+      <div className="review-helper">
+        Approving with a note starts another plan pass instead of confirming the plan.
+      </div>
+      <div className="review-controls">
+        {ask.controls?.map((control) => {
+          const needsGuidance =
+            control === 'request_changes' &&
+            !critique &&
+            note.trim() === '' &&
+            Object.keys(answers).length === 0
+          return (
+            <button
+              key={control}
+              className={`review-btn review-btn-${control}`}
+              disabled={pending !== null || needsGuidance}
+              title={needsGuidance ? 'add an answer or a note first' : undefined}
+              onClick={() => choose(control)}
+            >
+              {CONTROL_LABEL[control] ?? control}
+            </button>
+          )
+        })}
+      </div>
+      {error && <div className="review-error">{error}</div>}
+    </div>
+  )
+}

--- a/frontend/src/extensions/installed.tsx
+++ b/frontend/src/extensions/installed.tsx
@@ -1,0 +1,52 @@
+import type { Extension } from '../api/types'
+import { ExtensionHomePage } from '../pages/ExtensionHomePage'
+import { SubjectPage } from '../pages/SubjectPage'
+import { getExtensionUI, registerExtensionUI } from './registry'
+
+// Registers the backend roster into the same UI registry the bundled extensions
+// use: an installed extension without bundled UI gets the generic pages; one that
+// ships its own dist gets an external home at /app/<name>. Bundled registration
+// wins — a name already present is left alone. Idempotent, called on every roster
+// response.
+export function registerInstalledExtensions(roster: Extension[] | undefined): void {
+  const apps = (roster ?? []).filter((info) => !info.builtin)
+  apps.sort((a, b) => a.name.localeCompare(b.name))
+  for (const info of apps) {
+    if (!getExtensionUI(info.name)) registerExtensionUI(installedUI(info))
+  }
+}
+
+function installedUI(info: Extension) {
+  const name = info.name
+  if (info.hasFrontend) {
+    return { name, home: `/app/${name}`, external: true, routes: [] }
+  }
+  return {
+    name,
+    routes: [
+      {
+        path: `/${name}`,
+        render: () => (
+          <ExtensionHomePage
+            extension={name}
+            description={info.description}
+            subjectTypes={info.subjectTypes}
+          />
+        ),
+      },
+      {
+        // Wildcard, not :id — a subject id can contain slashes ("owner/repo#7").
+        path: `/${name}/:subjectType/*`,
+        render: (params: Record<string, string>) => (
+          <SubjectPage
+            extension={name}
+            subjectType={params.subjectType ?? ''}
+            subjectId={params['*'] ?? ''}
+          />
+        ),
+      },
+    ],
+    subjectPath: ({ type, id }: { type: string; id: string }) =>
+      info.subjectTypes.includes(type) ? `/${name}/${type}/${id}` : undefined,
+  }
+}

--- a/frontend/src/extensions/registry.tsx
+++ b/frontend/src/extensions/registry.tsx
@@ -37,6 +37,9 @@ export interface ExtensionUI {
   // extension's list and detail surfaces. Opt-in — an extension that doesn't track
   // code hosts leaves it off and the band never renders.
   systemStrip?: boolean
+  // The extension's home is its own page outside this SPA (a shipped dist under
+  // /app/<name>) — reaching it is a full document load, not a wouter navigation.
+  external?: boolean
 }
 
 const REGISTRY = new Map<string, ExtensionUI>()

--- a/frontend/src/extensions/ship/WorkItemPage.tsx
+++ b/frontend/src/extensions/ship/WorkItemPage.tsx
@@ -2,22 +2,20 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useMemo, useState } from 'react'
 import { Link, useLocation } from 'wouter'
 
-import { api } from '../../api/client'
 import { useSSE } from '../../api/sse'
 import { buildApi } from './api'
 import type { PRResolution, WorkItemDetail, WorkItemSummary } from './api'
 import type {
   AgentCallSummary,
-  InputRequest,
   RunState,
   RunSummary,
   SubjectActivity,
   SubjectStatus,
 } from '../../api/types'
 import { DetailLayout } from '../../components/DetailLayout'
-import { Markdown } from '../../components/Markdown'
 import { Page } from '../../components/Page'
 import { queryGate } from '../../components/QueryGate'
+import { CancelRun, InAppReview, RetryRun } from '../../components/RunControls'
 import { RunTranscript } from '../../components/RunTranscript'
 import { computeElapsed, dur, formatTokenCount, relTime, secondsSince } from '../../lib/format'
 import { parkedLine, runSubLine, statusLine } from './statusLine'
@@ -557,85 +555,6 @@ function RunHeader({
   )
 }
 
-// Cancel is a run-level action: end any active run, parked or running. A destructive
-// stop, so it confirms first and takes an optional reason (the recorded cancel note).
-// The detail stream re-emits the snapshot on the state flip, so this control unmounts
-// itself — no local success handling.
-function CancelRun({ runId }: { runId: string }) {
-  const [confirming, setConfirming] = useState(false)
-  const [reason, setReason] = useState('')
-  const [pending, setPending] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  async function cancel() {
-    setPending(true)
-    setError(null)
-    try {
-      await api.cancelRun(runId, reason.trim() || 'cancelled by operator')
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'could not cancel')
-      setPending(false)
-    }
-  }
-
-  if (!confirming) {
-    return (
-      <button type="button" className="ins-run-link ins-cancel" onClick={() => setConfirming(true)}>
-        cancel run
-      </button>
-    )
-  }
-  return (
-    <span className="ins-cancel-confirm">
-      <input
-        type="text"
-        className="ins-cancel-reason mono"
-        placeholder="reason (optional)"
-        maxLength={500}
-        value={reason}
-        onChange={(e) => setReason(e.target.value)}
-      />
-      <button type="button" className="ins-run-link ins-cancel" disabled={pending} onClick={cancel}>
-        confirm cancel
-      </button>
-      <button
-        type="button"
-        className="ins-run-link"
-        disabled={pending}
-        onClick={() => setConfirming(false)}
-      >
-        back
-      </button>
-      {error && <span className="review-error">{error}</span>}
-    </span>
-  )
-}
-
-function RetryRun({ runId }: { runId: string }) {
-  const [pending, setPending] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  async function retry() {
-    setPending(true)
-    setError(null)
-    try {
-      await api.retryRun(runId)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'could not retry')
-      setPending(false)
-    }
-  }
-
-  return (
-    <>
-      <button type="button" className="ins-run-link" disabled={pending} onClick={retry}>
-        {pending ? 'retrying…' : 'retry run'}
-      </button>
-      {error && <span className="review-error">{error}</span>}
-    </>
-  )
-}
-
 // Shown for any failed run — the full failure text.
 function RunFailure({ run }: { run: RunSummary }) {
   if (run.state !== 'failed' || !run.failure) return null
@@ -647,13 +566,6 @@ function RunFailure({ run }: { run: RunSummary }) {
       <div className="ins-fail-body">{run.failure}</div>
     </div>
   )
-}
-
-// Button label per control verb; the ask's controls are a fixed workflow vocabulary.
-const CONTROL_LABEL: Record<string, string> = {
-  approve: 'Approve',
-  request_changes: 'Request changes',
-  revise_contract: 'Revise contract',
 }
 
 // A run parked on an external ask (PR review, ticket comment): a one-line
@@ -678,108 +590,6 @@ function RunNeedsInput({ run, prUrl }: { run: RunSummary; prUrl?: string | null 
           </>
         )}
       </div>
-    </div>
-  )
-}
-
-// The in-app review: the artifact (the plan), structured question options, one
-// note, and the workflow's controls. A click resumes the run with
-// {control, answers, note}; free text is content for the next plan pass, never a
-// control.
-export function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }) {
-  const [answers, setAnswers] = useState<Record<string, string>>({})
-  const [note, setNote] = useState('')
-  const [pending, setPending] = useState<string | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const critique = ask.context?.trim() ?? ''
-
-  const artifact = useQuery({
-    queryKey: ['artifact', ask.artifact_id],
-    queryFn: () => api.artifact(ask.artifact_id as string),
-    enabled: Boolean(ask.artifact_id),
-  })
-
-  async function choose(control: string) {
-    setPending(control)
-    setError(null)
-    try {
-      // The run un-parks; the subject's SSE stream re-emits the snapshot and this
-      // banner clears itself.
-      await api.resumeRun(runId, { control, answers, note: note.trim() })
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'could not submit')
-      setPending(null)
-    }
-  }
-
-  return (
-    <div className="ins-needs">
-      {critique && (
-        <div className="review-artifact">
-          <div className="review-artifact-title">Plan reviewer critique</div>
-          <Markdown source={critique} />
-        </div>
-      )}
-      {artifact.data && (
-        <div className="review-artifact">
-          <div className="review-artifact-title">{artifact.data.title}</div>
-          <Markdown source={artifact.data.content} />
-        </div>
-      )}
-      {ask.questions?.map((question) => {
-        const picked = answers[question.id] ?? ''
-        return (
-          <fieldset key={question.id} className="review-question">
-            <legend>{question.prompt}</legend>
-            {question.options.map((option) => (
-              <label key={option.id} className="review-option">
-                <input
-                  type="radio"
-                  name={question.id}
-                  checked={picked === option.id}
-                  onChange={() =>
-                    setAnswers((prev) => ({ ...prev, [question.id]: option.id }))
-                  }
-                />
-                {option.label}
-                {option.recommended && (
-                  <span className="review-recommended">recommended</span>
-                )}
-              </label>
-            ))}
-          </fieldset>
-        )
-      })}
-      <textarea
-        className="review-note"
-        placeholder="optional note — what should the next pass change?"
-        value={note}
-        onChange={(e) => setNote(e.target.value)}
-      />
-      <div className="review-helper">
-        Approving with a note starts another plan pass instead of confirming the plan.
-      </div>
-      <div className="review-controls">
-        {ask.controls?.map((control) => {
-          const needsGuidance =
-            control === 'request_changes' &&
-            !critique &&
-            note.trim() === '' &&
-            Object.keys(answers).length === 0
-          return (
-            <button
-              key={control}
-              className={`review-btn review-btn-${control}`}
-              disabled={pending !== null || needsGuidance}
-              title={needsGuidance ? 'add an answer or a note first' : undefined}
-              onClick={() => choose(control)}
-            >
-              {CONTROL_LABEL[control] ?? control}
-            </button>
-          )
-        })}
-      </div>
-      {error && <div className="review-error">{error}</div>}
     </div>
   )
 }

--- a/frontend/src/lib/summary.ts
+++ b/frontend/src/lib/summary.ts
@@ -1,0 +1,19 @@
+import { relTimeFromIso } from './format'
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}T/
+
+// A subject summary's scalar fields as label/text pairs — what the generic board
+// row and subject facts render. ``id`` is the row key, not a field. Typed on the
+// wire's base shape; the extension's extra fields are what this walks.
+export function summaryEntries(summary: object): [string, string][] {
+  const entries: [string, string][] = []
+  for (const [key, value] of Object.entries(summary)) {
+    if (key === 'id' || value === null || value === undefined || value === '') continue
+    if (!['string', 'number', 'boolean'].includes(typeof value)) continue
+    const label = key.replace(/([A-Z])/g, ' $1').toLowerCase()
+    const text =
+      typeof value === 'string' && ISO_DATE.test(value) ? relTimeFromIso(value) : String(value)
+    entries.push([label, text])
+  }
+  return entries
+}

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -161,18 +161,18 @@ function ExtensionFilter({
   filter: string | null
   onPick: (extension: string | null) => void
 }) {
-  // The local registry paints the pills on a cold load; the installed list adds
-  // the extensions that ship no UI — the platform's own chores and webhooks emit
-  // events too. Same query key as the extension dropdown, so this reads its cache
-  // rather than issuing a request of its own.
+  // The local registry paints the pills on a cold load; the roster adds the
+  // extensions that ship no UI — builtins included, the platform's own chores
+  // and webhooks emit events too. Same query key as the shell, so this reads
+  // its cache rather than issuing a request of its own.
   const installed = useQuery({
-    queryKey: ['extensionSettings'],
-    queryFn: api.getExtensionSettings,
+    queryKey: ['extensions'],
+    queryFn: api.listExtensions,
     staleTime: 60_000,
   })
   const options = useMemo(() => {
     const names = new Set(registeredExtensions().map((e) => e.name))
-    for (const entry of installed.data?.extensions ?? []) names.add(entry.name)
+    for (const entry of installed.data ?? []) names.add(entry.name)
     // Leading null is the unfiltered view the bare URL lands on.
     return [null, ...names]
   }, [installed.data])

--- a/frontend/src/pages/ExtensionHomePage.tsx
+++ b/frontend/src/pages/ExtensionHomePage.tsx
@@ -1,0 +1,90 @@
+import { useMemo, useState } from 'react'
+import { useLocation } from 'wouter'
+
+import { subjectApi } from '../api/client'
+import { useSSE } from '../api/sse'
+import type { SubjectRow } from '../api/types'
+import { EmptyState } from '../components/EmptyState'
+import { Page } from '../components/Page'
+import { PageHeader } from '../components/PageHeader'
+import { StatusGlyph } from '../components/StatusGlyph'
+import { summaryEntries } from '../lib/summary'
+
+// The generic home an installed extension gets without shipping UI: its subject
+// boards, stacked. Each row is the platform status plus the summary's own fields —
+// the summary is the author's curated projection, so it is the row.
+
+interface Props {
+  extension: string
+  description: string
+  subjectTypes: string[]
+}
+
+export function ExtensionHomePage({ extension, description, subjectTypes }: Props) {
+  return (
+    <Page
+      scroll="internal"
+      className="page-subjects"
+      header={<PageHeader eyebrow={extension.replaceAll('_', ' ')} />}
+    >
+      {subjectTypes.length === 0 ? (
+        <EmptyState glyph="◳" msg="nothing to show yet" sub={description} />
+      ) : (
+        subjectTypes.map((subjectType) => (
+          <SubjectBoard key={subjectType} extension={extension} subjectType={subjectType} />
+        ))
+      )}
+    </Page>
+  )
+}
+
+function SubjectBoard({ extension, subjectType }: { extension: string; subjectType: string }) {
+  const [rows, setRows] = useState<SubjectRow[] | null>(null)
+  const [, navigate] = useLocation()
+
+  useSSE(subjectApi.boardStream(extension, subjectType), {
+    handlers: useMemo(
+      () => ({ snapshot: (data) => setRows((data as { rows: SubjectRow[] }).rows) }),
+      [],
+    ),
+  })
+
+  const label = subjectType.replaceAll('_', ' ')
+  return (
+    <div className="wi-group">
+      <div className="wi-group-head mono dim">
+        {label} {rows && <span className="wi-group-count">({rows.length})</span>}
+      </div>
+      {!rows && <div className="subject-board-empty mono dim">loading…</div>}
+      {rows && rows.length === 0 && (
+        <div className="subject-board-empty mono dim">no {label} yet</div>
+      )}
+      {rows?.map((row) => (
+        <div
+          key={row.summary.id}
+          className="row subject-row"
+          onClick={() => navigate(`/${extension}/${subjectType}/${row.summary.id}`)}
+        >
+          <StatusGlyph
+            state={row.status.state}
+            pulse={row.status.state === 'running' || row.status.state === 'parked'}
+          />
+          <span className="row-title">{row.summary.id}</span>
+          <span className="subject-row-meta mono dim">
+            {summaryEntries(row.summary)
+              .map(([key, value]) => `${key} ${value}`)
+              .join(' · ')}
+          </span>
+          <span className="wi-updated mono dim">{statusText(row)}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function statusText(row: SubjectRow): string {
+  const { state, gate, failure } = row.status
+  if (state === 'parked' && gate) return `parked · ${gate.replaceAll('_', ' ')}`
+  if (state === 'failed' && failure) return `failed · ${failure.slice(0, 60)}`
+  return state
+}

--- a/frontend/src/pages/SubjectPage.tsx
+++ b/frontend/src/pages/SubjectPage.tsx
@@ -1,0 +1,144 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useMemo } from 'react'
+import { Link } from 'wouter'
+
+import { subjectApi } from '../api/client'
+import { useSSE } from '../api/sse'
+import type { RunSummary, SubjectResponse } from '../api/types'
+import { EmptyState } from '../components/EmptyState'
+import { Fact, Facts } from '../components/Facts'
+import { Page } from '../components/Page'
+import { queryGate } from '../components/QueryGate'
+import { CancelRun, InAppReview, RetryRun } from '../components/RunControls'
+import { RunTranscript } from '../components/RunTranscript'
+import { StatusGlyph } from '../components/StatusGlyph'
+import { relTimeFromIso } from '../lib/format'
+import { summaryEntries } from '../lib/summary'
+
+// The generic subject page any installed extension gets without shipping UI: the
+// summary as facts, the run timeline, the newest run's transcript, and the gate
+// controls when a run parks on the operator.
+
+interface Props {
+  extension: string
+  subjectType: string
+  subjectId: string
+}
+
+const isActiveRun = (run: RunSummary) =>
+  run.state === 'running' || run.state === 'parked' || run.state === 'scheduled'
+
+export function SubjectPage({ extension, subjectType, subjectId }: Props) {
+  const queryClient = useQueryClient()
+  const queryKey = useMemo(
+    () => ['subject', extension, subjectType, subjectId] as const,
+    [extension, subjectType, subjectId],
+  )
+  const query = useQuery({
+    queryKey,
+    queryFn: () => subjectApi.read(extension, subjectType, subjectId),
+  })
+
+  // Push-driven cache, same as every detail page: the stream re-emits the whole
+  // snapshot on change; a dropped stream falls back to one refetch.
+  const patchSnapshot = useCallback(
+    (payload: unknown) => {
+      queryClient.setQueryData<SubjectResponse>(queryKey, payload as SubjectResponse)
+    },
+    [queryClient, queryKey],
+  )
+  useSSE(subjectApi.stream(extension, subjectType, subjectId), {
+    handlers: useMemo(() => ({ snapshot: patchSnapshot }), [patchSnapshot]),
+    onError: () => {
+      queryClient.invalidateQueries({ queryKey }).catch(() => {})
+    },
+  })
+
+  const label = subjectType.replaceAll('_', ' ')
+  const gate = queryGate(query, {
+    loadingMsg: `loading ${label}`,
+    errorMsg: `could not load ${label} ${subjectId}`,
+  })
+  if (gate) return <Page scroll="internal" className="ins">{gate}</Page>
+
+  const data = query.data!
+  const runs = [...data.timeline].reverse()
+  const crumb = (
+    <div className="ins-crumb">
+      <Link href={`/${extension}`} className="ins-crumb-back">
+        ← {label}
+      </Link>
+    </div>
+  )
+
+  return (
+    <Page scroll="internal" className="ins page-subject" header={crumb}>
+      <Facts className="subject-facts">
+        <Fact k="id">{data.summary.id}</Fact>
+        {summaryEntries(data.summary).map(([key, value]) => (
+          <Fact key={key} k={key}>
+            {value}
+          </Fact>
+        ))}
+        {data.activity && <Fact k="now">{data.activity.label}</Fact>}
+      </Facts>
+      {runs.length === 0 ? (
+        <EmptyState glyph="∅" msg="no runs yet" />
+      ) : (
+        runs.map((run, index) => (
+          <RunBlock key={run.id} extension={extension} run={run} withTranscript={index === 0} />
+        ))
+      )}
+    </Page>
+  )
+}
+
+function RunBlock({
+  extension,
+  run,
+  withTranscript,
+}: {
+  extension: string
+  run: RunSummary
+  withTranscript: boolean
+}) {
+  const ask = run.state === 'parked' ? run.inputRequest : null
+  const call = run.agentCalls.at(-1)
+  return (
+    <div className="subject-run mono">
+      <div className="subject-run-head">
+        <StatusGlyph state={run.state} pulse={isActiveRun(run)} />
+        <span>{run.label}</span>
+        <span className="dim">{run.state}</span>
+        <span className="dim">{relTimeFromIso(run.updatedAt)}</span>
+        {isActiveRun(run) && <CancelRun runId={run.id} />}
+        {(run.state === 'failed' || run.state === 'cancelled') && <RetryRun runId={run.id} />}
+      </div>
+      {ask?.presentation === 'in_app' && <InAppReview runId={run.id} ask={ask} />}
+      {ask?.presentation === 'external' && (
+        <div className="ins-needs">
+          <div className="ins-needs-k">
+            <span>◆</span> needs you
+          </div>
+          <div className="ins-needs-body">
+            {run.gate ? `Waiting on ${run.gate.replaceAll('_', ' ')}.` : 'This run is waiting on you.'}
+          </div>
+        </div>
+      )}
+      {run.state === 'failed' && run.failure && (
+        <div className="ins-fail">
+          <div className="ins-fail-k">
+            <span>✕</span> failed
+          </div>
+          <div className="ins-fail-body">{run.failure}</div>
+        </div>
+      )}
+      {withTranscript && call && (
+        <RunTranscript
+          basePath={subjectApi.transcriptBase(extension, call.id)}
+          isLive={call.status === 'running'}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2470,3 +2470,13 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .landing-err-x { flex: none; font-family: var(--font-mono); font-weight: 700; color: var(--outcome-failed); }
 .landing-panel .landing-err { margin-top: 14px; }
 @keyframes landing-shake { 0%, 100% { transform: translateX(0); } 20% { transform: translateX(-4px); } 40% { transform: translateX(4px); } 60% { transform: translateX(-2px); } 80% { transform: translateX(2px); } }
+
+/* ============================================================
+   GENERIC SUBJECT PAGES — the floor an installed extension gets
+   ============================================================ */
+.subject-row { grid-template-columns: 14px minmax(60px, auto) 1fr auto; }
+.subject-row-meta { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11.5px; }
+.subject-board-empty { padding: 10px 12px; font-size: 12px; }
+.subject-facts { margin-bottom: 14px; }
+.subject-run { border: 1px solid var(--border-soft); border-radius: 6px; padding: 12px 14px; margin-bottom: 12px; }
+.subject-run-head { display: flex; align-items: center; gap: 10px; font-size: 12.5px; margin-bottom: 8px; }


### PR DESCRIPTION
## What

An extension installed against the published image is now visible and usable from the dashboard without shipping any frontend.

- **`GET /api/extensions`** — the installed roster: name, icon, description, builtin, subject types, has-frontend. The extension dropdown and the events filter read it (the settings projection is filtered to knob-carrying extensions and was the wrong wire for nav).
- **Shell registration** — every roster entry lands in the same UI registry the bundled extensions use. Bundled registration wins per extension; roster extras follow A→Z, so the default landing is unchanged.
- **Generic pages** — a backend-only extension gets a home page with its subject boards stacked (one row per subject: status, id, the summary's own fields) and a subject page with summary facts, the run timeline, the newest run's transcript, and gate answer/cancel/retry via the platform run routes.
- **Shipped dist** — an extension whose wheel carries `dist/` (already served at `/app/<name>`) gets its app-switcher entry linked there; reaching it is a document load, not an SPA navigation.
- The in-app review, cancel, and retry controls move from ship's work-item page to shared components; ship renders them from the new location, and the generic subject page uses the same UI.

## Why

The backend treats every installed extension uniformly — boards, timelines, transcripts, and gate answering are all platform wire — but the shell derived nav, routes, and landing only from the import-time bundle registry. `uv pip install <app>` registered everything except a way for the operator to find it.

## Acceptance

Stock deploy, `uv pip install` a druks-apps extension, restart: the dropdown lists it, its boards render, a parked run's gate is answerable from its subject page. No typed URL, no SPA rebuild.