### PR TITLE
The mount context lends the shell's markdown renderer

### DIFF
--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -821,10 +821,11 @@ inside its own document, below the chrome. The scaffold ships a placeholder
   `el` and returns a dispose function. A missing `mount` or a version mismatch
   renders a visible error panel in the shell.
 - `ctx` carries `apiBase` (`/api/<name>`), `navigate(path)` for shell-side
-  navigation, and `theme.accent`. The app renders in the shell's document, so
-  the shell's CSS variables cascade into it. The shell re-broadcasts every
-  location change as a `popstate` event while the app is mounted; route by
-  reading `location.pathname` under `/<name>/`.
+  navigation, `theme.accent`, and `markdown(source)` — the shell's own
+  markdown renderer, so an app doesn't bundle one. The app renders in the
+  shell's document, so the shell's CSS variables cascade into it. The shell
+  re-broadcasts every location change as a `popstate` event while the app is
+  mounted; route by reading `location.pathname` under `/<name>/`.
 - `dist/style.css`, when present, is loaded while the app is mounted.
 - Build the bundle with `react`, `react-dom`, `react-dom/client`, and
   `react/jsx-runtime` externalized (Vite library mode); the shell's import map

--- a/frontend/src/extensions/InstalledAppHost.tsx
+++ b/frontend/src/extensions/InstalledAppHost.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useLocation } from 'wouter'
 
 import { EmptyState } from '../components/EmptyState'
+import { Markdown } from '../components/Markdown'
 import { Page } from '../components/Page'
 import { extensionAccent } from '../lib/extensionColors'
 import { registeredExtensions } from './registry'
@@ -25,6 +26,10 @@ export interface ShellContext {
   // theme is ambient: the app renders in the shell's document, so the shell's
   // CSS variables cascade into it.
   theme: { accent: string }
+  // The shell's own markdown renderer (GFM, raw HTML stripped, links open in
+  // a new tab) — platform surfaces show LLM-emitted markdown everywhere, so
+  // apps borrow the renderer instead of each bundling one.
+  markdown: (source: string) => ReactNode
 }
 
 interface EntryModule {
@@ -68,6 +73,7 @@ export function InstalledAppHost({ name }: { name: string }) {
       apiBase: `/api/${name}`,
       navigate: (path) => navigateRef.current(path),
       theme: { accent: extensionAccent(names)[name] ?? '' },
+      markdown: (source) => <Markdown source={source} />,
     }
 
     import(/* @vite-ignore */ `/app/${name}/entry.js`)


### PR DESCRIPTION
Platform surfaces show LLM-emitted markdown everywhere, so every dist app was going to bundle its own ~140 KB parser for the same job. `ctx.markdown(source)` now hands over the shell's own `Markdown` component — GFM, raw HTML stripped, links open in a new tab — the way the import map already hands over React. One renderer, one look, no per-app markdown stacks. Additive to `shellApi: 1`.