### PR TITLE
One declared field, drawn once, wherever a field is declared

### DIFF
--- a/frontend/src/components/BrowserSessionsPane.tsx
+++ b/frontend/src/components/BrowserSessionsPane.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { api } from '../api/client'
+import { TextInput } from './Control'
 import type {
   BrowserSession,
   BrowserSessionPayloadFormat,
@@ -115,9 +116,8 @@ export function BrowserSessionsPane() {
             <label className="mcp-label" htmlFor="browser-session-name">
               Name
             </label>
-            <input
+            <TextInput
               id="browser-session-name"
-              className="skill-add-input"
               placeholder="x-main"
               value={name}
               onChange={(event) => setName(event.target.value)}
@@ -128,9 +128,8 @@ export function BrowserSessionsPane() {
             <label className="mcp-label" htmlFor="browser-session-site">
               Site
             </label>
-            <input
+            <TextInput
               id="browser-session-site"
-              className="skill-add-input"
               placeholder="x.com"
               value={site}
               onChange={(event) => setSite(event.target.value)}
@@ -195,8 +194,7 @@ export function BrowserSessionsPane() {
                 </dl>
                 {renamingId === session.id ? (
                   <div className="browser-session-rename">
-                    <input
-                      className="skill-add-input"
+                    <TextInput
                       aria-label={`New name for ${session.name}`}
                       value={renamedName}
                       onChange={(event) => setRenamedName(event.target.value)}

--- a/frontend/src/components/CronField.test.tsx
+++ b/frontend/src/components/CronField.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { CronField } from './SettingsModal'
+import { CronField } from './CronField'
 
 afterEach(cleanup)
 

--- a/frontend/src/components/CronField.tsx
+++ b/frontend/src/components/CronField.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+
+import { Select, TextInput } from './Control'
+
+// The cadences an operator actually picks from; anything else is "custom".
+const CRON_PRESETS: [cron: string, label: string][] = [
+  ['*/5 * * * *', 'Every 5 minutes'],
+  ['*/15 * * * *', 'Every 15 minutes'],
+  ['*/30 * * * *', 'Every 30 minutes'],
+  ['0 * * * *', 'Every hour'],
+  ['0 */6 * * *', 'Every 6 hours'],
+  ['0 0 * * *', 'Daily at midnight'],
+]
+
+export function CronField({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string
+  onChange: (v: string) => void
+  disabled: boolean
+}) {
+  // A value outside the presets opens in the raw-cron input, so nothing an
+  // operator (or the API) stored is ever hidden or clobbered. The select
+  // stays visible as the mode switcher, so custom is never a one-way door.
+  const [custom, setCustom] = useState(() => !CRON_PRESETS.some(([cron]) => cron === value))
+  return (
+    <>
+      <Select
+        value={custom ? 'custom' : value}
+        onChange={(e) => {
+          if (e.target.value === 'custom') {
+            setCustom(true)
+          } else {
+            setCustom(false)
+            onChange(e.target.value)
+          }
+        }}
+        disabled={disabled}
+      >
+        {CRON_PRESETS.map(([cron, label]) => (
+          <option key={cron} value={cron}>
+            {label}
+          </option>
+        ))}
+        <option value="custom">Custom cron…</option>
+      </Select>
+      {custom && (
+        <TextInput
+          type="text"
+          value={value}
+          placeholder="cron, e.g. */15 * * * *"
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/src/components/ServicesPane.test.tsx
+++ b/frontend/src/components/ServicesPane.test.tsx
@@ -134,6 +134,9 @@ describe('ServicesPane', () => {
     expect(screen.getByLabelText('App ID')).toBeTruthy()
     expect(screen.getByLabelText('Private key (PEM)')).toBeTruthy()
     expect(screen.getByLabelText('Webhook secret')).toBeTruthy()
+    // Nothing is connected yet, so the server genuinely holds no secret —
+    // unlike the Replace-connection case, "not set" is the true placeholder.
+    expect(screen.getAllByPlaceholderText('not set')).toHaveLength(2)
   })
 
   it('submits the spec-named values, keeps PEM newlines, and refreshes to the connected facts', async () => {
@@ -202,7 +205,14 @@ describe('ServicesPane', () => {
     expect(screen.queryByLabelText('Private key (PEM)')).toBeNull()
 
     fireEvent.click(screen.getByText('Replace connection'))
+    // The box is blank — the paste form is write-only — but its placeholder
+    // must say what the server already has, since this is a connected
+    // service the operator is replacing, not connecting fresh.
     expect(screen.getByLabelText('Private key (PEM)')).toBeTruthy()
+    // Both private_key and webhook_secret are secret fields; a connected
+    // service has both stored, so both show the set-ness placeholder.
+    expect(screen.getAllByPlaceholderText('•••••••• (set)')).toHaveLength(2)
+    expect(screen.queryByPlaceholderText('not set')).toBeNull()
   })
 
   it('opens the manifest page and refreshes on the callback broadcast', async () => {

--- a/frontend/src/components/SettingField.test.tsx
+++ b/frontend/src/components/SettingField.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SettingField } from './SettingField'
+
+afterEach(cleanup)
+
+describe('SettingField', () => {
+  it('renders a textarea for a multiline field regardless of type', () => {
+    // multiline is declared independent of type on the wire — a pasted long
+    // description, not only a pasted secret, can carry newlines.
+    render(
+      <SettingField
+        label="Notes"
+        type="str"
+        multiline
+        value="line one\nline two"
+        onChange={vi.fn()}
+      />,
+    )
+    expect(screen.getByLabelText('Notes').tagName).toBe('TEXTAREA')
+  })
+
+  it('renders a password input for a non-multiline secret, with a set-ness placeholder', () => {
+    render(
+      <SettingField label="API key" type="secret" secretSet value="" onChange={vi.fn()} />,
+    )
+    const input = screen.getByLabelText('API key') as HTMLInputElement
+    expect(input.tagName).toBe('INPUT')
+    expect(input.type).toBe('password')
+    expect(input.placeholder).toBe('•••••••• (set)')
+  })
+
+  it('shows the not-set placeholder when the secret has no stored value', () => {
+    render(
+      <SettingField label="API key" type="secret" secretSet={false} value="" onChange={vi.fn()} />,
+    )
+    expect(screen.getByPlaceholderText('not set')).toBeTruthy()
+  })
+
+  it('renders a textarea for a multiline secret, keeping the set-ness placeholder', () => {
+    render(
+      <SettingField label="Private key" type="secret" multiline secretSet value="" onChange={vi.fn()} />,
+    )
+    const field = screen.getByLabelText('Private key')
+    expect(field.tagName).toBe('TEXTAREA')
+    expect((field as HTMLTextAreaElement).placeholder).toBe('•••••••• (set)')
+  })
+
+  it('says so when an enum declares no choices, instead of a silent text box', () => {
+    render(<SettingField label="Effort" type="enum" choices={[]} value="" onChange={vi.fn()} />)
+    expect(screen.getByText('Effort declares no choices')).toBeTruthy()
+    expect(screen.queryByLabelText('Effort')).toBeNull()
+  })
+})

--- a/frontend/src/components/SettingField.tsx
+++ b/frontend/src/components/SettingField.tsx
@@ -1,0 +1,102 @@
+import { CronField } from './CronField'
+import { Field, Select, Textarea, TextInput } from './Control'
+
+// One declared field, rendered from its kind. Both places that draw a declared
+// field go through here: the settings panes and a service's connect form, which
+// speak the same field vocabulary on the wire.
+interface SettingFieldProps {
+  label: string
+  help?: string
+  // The wire's field kind: str | int | bool | enum | secret | cron. ``bool`` is
+  // not drawn here — a toggle is a row, not a labelled control, so the panes
+  // pull those out and render them as switches.
+  type: string
+  choices?: string[] | null
+  multiline?: boolean
+  // For a secret: whether one is already stored. The value itself never leaves
+  // the backend, so the box shows set-ness and takes a replacement.
+  secretSet?: boolean | null
+  value: string
+  onChange: (next: string) => void
+  error?: string
+  disabled?: boolean
+}
+
+export function SettingField({ label, help, error, ...field }: SettingFieldProps) {
+  return (
+    <Field label={label} help={help} error={error}>
+      <FieldControl label={label} {...field} />
+    </Field>
+  )
+}
+
+type ControlProps = Omit<SettingFieldProps, 'help' | 'error'>
+
+function FieldControl({
+  label,
+  type,
+  choices,
+  multiline = false,
+  secretSet,
+  value,
+  onChange,
+  disabled,
+}: ControlProps) {
+  if (type === 'enum') {
+    // An enum without its choice set is a broken declaration, not a text field —
+    // say so rather than drawing a box that silently accepts anything.
+    if (!choices?.length) {
+      return <span className="set-field-error">{label} declares no choices</span>
+    }
+    return (
+      <Select value={value} onChange={(e) => onChange(e.target.value)} disabled={disabled}>
+        {choices.map((choice) => (
+          <option key={choice} value={choice}>
+            {choice}
+          </option>
+        ))}
+      </Select>
+    )
+  }
+
+  if (type === 'cron') {
+    return <CronField value={value} onChange={onChange} disabled={disabled ?? false} />
+  }
+
+  // The stored secret never reaches the client, so the box shows only whether
+  // one is set. A multiline secret (a pasted PEM) needs its newlines kept.
+  if (type === 'secret') {
+    const placeholder = secretSet ? '•••••••• (set)' : 'not set'
+    if (multiline) {
+      return (
+        <Textarea
+          value={value}
+          placeholder={placeholder}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          aria-label={label}
+        />
+      )
+    }
+    return (
+      <TextInput
+        type="password"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        aria-label={label}
+      />
+    )
+  }
+
+  return (
+    <TextInput
+      type={type === 'int' ? 'number' : 'text'}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      aria-label={label}
+    />
+  )
+}

--- a/frontend/src/components/SettingField.tsx
+++ b/frontend/src/components/SettingField.tsx
@@ -64,23 +64,17 @@ function FieldControl({
   }
 
   // The stored secret never reaches the client, so the box shows only whether
-  // one is set. A multiline secret (a pasted PEM) needs its newlines kept.
-  if (type === 'secret') {
-    const placeholder = secretSet ? '•••••••• (set)' : 'not set'
-    if (multiline) {
-      return (
-        <Textarea
-          value={value}
-          placeholder={placeholder}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          aria-label={label}
-        />
-      )
-    }
+  // one is set — every other kind shows the resolved value itself.
+  const secret = type === 'secret'
+  const placeholder = secret ? (secretSet ? '•••••••• (set)' : 'not set') : undefined
+
+  // multiline is declared independent of type (field_multiline in the backend
+  // reads a separate json_schema_extra key), so it governs textarea-vs-input
+  // for any kind, not only secrets — a pasted PEM and a pasted long
+  // description both need their newlines kept.
+  if (multiline) {
     return (
-      <TextInput
-        type="password"
+      <Textarea
         value={value}
         placeholder={placeholder}
         onChange={(e) => onChange(e.target.value)}
@@ -92,8 +86,9 @@ function FieldControl({
 
   return (
     <TextInput
-      type={type === 'int' ? 'number' : 'text'}
+      type={secret ? 'password' : type === 'int' ? 'number' : 'text'}
       value={value}
+      placeholder={placeholder}
       onChange={(e) => onChange(e.target.value)}
       disabled={disabled}
       aria-label={label}

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1073,9 +1073,12 @@ function ServiceDetail({ service, onBack }: { service: Service; onBack: () => vo
               help={field.help}
               type={field.type}
               multiline={field.multiline}
-              // A connect form is write-only: it takes the credential to store,
-              // never one already stored, so nothing is ever pre-set.
-              secretSet={false}
+              // The box itself is always blank — a connect form is write-only —
+              // but "Replace connection" opens on an already-connected service,
+              // whose fields the server does hold. secretSet drives only the
+              // placeholder, so it must say what the server has, not what this
+              // box holds.
+              secretSet={service.connected}
               value={values[field.name] ?? ''}
               onChange={(next) => setValues({ ...values, [field.name]: next })}
               disabled={busy}

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -3,6 +3,8 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { ApiError, api } from '../api/client'
 import { BrowserSessionsPane } from './BrowserSessionsPane'
+import { TextInput } from './Control'
+import { SettingField } from './SettingField'
 import { ExtensionGlyph } from './ExtensionGlyph'
 import { ConnectSteps, useHarnessConnect } from './HarnessConnectFlow'
 import {
@@ -1065,27 +1067,19 @@ function ServiceDetail({ service, onBack }: { service: Service; onBack: () => vo
             </>
           )}
           {service.fields.map((field) => (
-            <div className="mcp-field" key={field.name}>
-              <span className="mcp-label">{field.label}</span>
-              {field.multiline ? (
-                <textarea
-                  className="skill-add-input svc-textarea"
-                  aria-label={field.label}
-                  value={values[field.name] ?? ''}
-                  onChange={(e) => setValues({ ...values, [field.name]: e.target.value })}
-                  disabled={busy}
-                />
-              ) : (
-                <input
-                  className="skill-add-input"
-                  type={field.type === 'secret' ? 'password' : 'text'}
-                  aria-label={field.label}
-                  value={values[field.name] ?? ''}
-                  onChange={(e) => setValues({ ...values, [field.name]: e.target.value })}
-                  disabled={busy}
-                />
-              )}
-            </div>
+            <SettingField
+              key={field.name}
+              label={field.label}
+              help={field.help}
+              type={field.type}
+              multiline={field.multiline}
+              // A connect form is write-only: it takes the credential to store,
+              // never one already stored, so nothing is ever pre-set.
+              secretSet={false}
+              value={values[field.name] ?? ''}
+              onChange={(next) => setValues({ ...values, [field.name]: next })}
+              disabled={busy}
+            />
           ))}
           <div className="svc-actions">
             <button className="set-btn ghost" onClick={closeForm} disabled={busy}>
@@ -1260,9 +1254,8 @@ export function SkillsPane() {
             Repository URL
           </label>
           <div className="skill-add">
-            <input
+            <TextInput
               id={`${fieldId}-repo`}
-              className="skill-add-input"
               type="url"
               placeholder="github.com/org/repo"
               value={repo}
@@ -1585,9 +1578,8 @@ function McpServersPane() {
           <label className="mcp-sr-only" htmlFor={`${fieldId}-search`}>
             Search the MCP registry
           </label>
-          <input
+          <TextInput
             id={`${fieldId}-search`}
-            className="skill-add-input"
             placeholder="grafana, sentry, …"
             value={registryQuery}
             onChange={(e) => setRegistryQuery(e.target.value)}
@@ -1645,9 +1637,8 @@ function McpServersPane() {
                           {header.name}
                           {header.isRequired && <span className="mcp-req"> (required)</span>}
                         </label>
-                        <input
+                        <TextInput
                           id={`${fieldId}-${header.name}`}
-                          className="skill-add-input"
                           type={header.isSecret ? 'password' : 'text'}
                           placeholder={header.placeholder}
                           required={header.isRequired}
@@ -1700,9 +1691,8 @@ function McpServersPane() {
               <label className="mcp-label" htmlFor={`${fieldId}-name`}>
                 Name <span className="mcp-req">(required)</span>
               </label>
-              <input
+              <TextInput
                 id={`${fieldId}-name`}
-                className="skill-add-input"
                 placeholder="linear"
                 required
                 value={name}
@@ -1717,9 +1707,8 @@ function McpServersPane() {
               <label className="mcp-label" htmlFor={`${fieldId}-url`}>
                 URL <span className="mcp-req">(required)</span>
               </label>
-              <input
+              <TextInput
                 id={`${fieldId}-url`}
-                className="skill-add-input"
                 placeholder="https://mcp.linear.app/mcp"
                 required
                 value={url}
@@ -1734,9 +1723,8 @@ function McpServersPane() {
               <label className="mcp-label" htmlFor={`${fieldId}-token`}>
                 Bearer token <span className="mcp-req">(required)</span>
               </label>
-              <input
+              <TextInput
                 id={`${fieldId}-token`}
-                className="skill-add-input"
                 type="password"
                 required
                 value={token}
@@ -1982,8 +1970,7 @@ export function AgentAccessPane() {
       <div className="set-group">
         <div className="set-group-label">mint token</div>
         <div className="skill-add">
-          <input
-            className="skill-add-input"
+          <TextInput
             placeholder="What will hold it?  e.g. claude on my laptop"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -2009,8 +1996,7 @@ export function AgentAccessPane() {
         <div className="set-group">
           <div className="set-group-label">{minted.name} — copy it now</div>
           <div className="skill-add">
-            <input
-              className="skill-add-input"
+            <TextInput
               readOnly
               value={minted.token}
               onFocus={(e) => e.currentTarget.select()}
@@ -2087,65 +2073,6 @@ function PatRow({
 // Extension pane — blurb, workflow toggles, agent table
 // ---------------------------------------------------------------------------
 
-// The cadences an operator actually picks from; anything else is "custom".
-const CRON_PRESETS: [cron: string, label: string][] = [
-  ['*/5 * * * *', 'Every 5 minutes'],
-  ['*/15 * * * *', 'Every 15 minutes'],
-  ['*/30 * * * *', 'Every 30 minutes'],
-  ['0 * * * *', 'Every hour'],
-  ['0 */6 * * *', 'Every 6 hours'],
-  ['0 0 * * *', 'Daily at midnight'],
-]
-
-export function CronField({
-  value,
-  onChange,
-  disabled,
-}: {
-  value: string
-  onChange: (v: string) => void
-  disabled: boolean
-}) {
-  // A value outside the presets opens in the raw-cron input, so nothing an
-  // operator (or the API) stored is ever hidden or clobbered. The select
-  // stays visible as the mode switcher, so custom is never a one-way door.
-  const [custom, setCustom] = useState(() => !CRON_PRESETS.some(([cron]) => cron === value))
-  return (
-    <>
-      <select
-        className="set-select"
-        value={custom ? 'custom' : value}
-        onChange={(e) => {
-          if (e.target.value === 'custom') {
-            setCustom(true)
-          } else {
-            setCustom(false)
-            onChange(e.target.value)
-          }
-        }}
-        disabled={disabled}
-      >
-        {CRON_PRESETS.map(([cron, label]) => (
-          <option key={cron} value={cron}>
-            {label}
-          </option>
-        ))}
-        <option value="custom">Custom cron…</option>
-      </select>
-      {custom && (
-        <input
-          className="set-select"
-          type="text"
-          value={value}
-          placeholder="cron, e.g. */15 * * * *"
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-        />
-      )}
-    </>
-  )
-}
-
 function ExtensionPane({
   extension,
   edits,
@@ -2212,6 +2139,16 @@ function ExtensionPane({
   )
   const setOption = (o: (typeof optionFields)[number], value: unknown) =>
     o.scope === 'workflow' ? onWorkflowField(o.kind, o.f.name, value) : onExtensionSetting(o.kind, o.f.name, value)
+  // The control speaks strings; the override store keeps the declared type.
+  // Clearing a secret's box records no edit, so the stored secret stays. An int
+  // mid-edit that does not parse records nothing, so the box can be emptied and
+  // retyped without writing a bad value.
+  const setTypedOption = (o: (typeof optionFields)[number], next: string) => {
+    if (o.f.type === 'secret') return setOption(o, next || undefined)
+    if (o.f.type !== 'int') return setOption(o, next)
+    const parsed = Number.parseInt(next, 10)
+    if (Number.isFinite(parsed)) setOption(o, parsed)
+  }
   return (
     <div className="set-pane">
       <div className="set-pane-head">
@@ -2266,70 +2203,24 @@ function ExtensionPane({
                         const cur = optionValue(o)
                         const fieldError =
                           o.scope === 'extension' ? fieldErrors[o.f.name] : undefined
+                        const secret = o.f.type === 'secret'
                         return (
-                          <div key={o.scope + '.' + o.kind + '.' + o.f.name} className="set-field">
-                            <span className="set-field-label">{o.f.label}</span>
-                            {o.f.help && <span className="set-field-help">{o.f.help}</span>}
-                            {o.f.type === 'enum' ? (
-                              <select
-                                className="set-select"
-                                value={String(cur ?? '')}
-                                onChange={(e) => setOption(o, e.target.value)}
-                                disabled={busy}
-                              >
-                                {(o.f.choices ?? []).map((choice) => (
-                                  <option key={choice} value={choice}>
-                                    {choice}
-                                  </option>
-                                ))}
-                              </select>
-                            ) : o.f.type === 'cron' ? (
-                              <CronField
-                                value={String(cur ?? '')}
-                                onChange={(v) => setOption(o, v)}
-                                disabled={busy}
-                              />
-                            ) : o.f.type === 'secret' && o.f.multiline ? (
-                              // A pasted multiline secret (a PEM): same write-only
-                              // semantics as the secret input, but a textarea so the
-                              // paste keeps its newlines.
-                              <textarea
-                                className="set-select set-textarea"
-                                value={override !== undefined ? String(override ?? '') : ''}
-                                placeholder={o.f.secretSet ? '•••••••• (set)' : 'not set'}
-                                onChange={(e) => setOption(o, e.target.value || undefined)}
-                                disabled={busy}
-                              />
-                            ) : o.f.type === 'secret' ? (
-                              // The stored secret never reaches the client — the field shows
-                              // only whether one is set. Clearing the box records no edit (the
-                              // previous secret stays); typing a non-empty value replaces it.
-                              <input
-                                className="set-select"
-                                type="password"
-                                value={override !== undefined ? String(override ?? '') : ''}
-                                placeholder={o.f.secretSet ? '•••••••• (set)' : 'not set'}
-                                onChange={(e) => setOption(o, e.target.value || undefined)}
-                                disabled={busy}
-                              />
-                            ) : (
-                              <input
-                                className="set-select"
-                                type={o.f.type === 'int' ? 'number' : 'text'}
-                                value={String(cur ?? '')}
-                                onChange={(e) => {
-                                  if (o.f.type === 'int') {
-                                    const parsed = Number.parseInt(e.target.value, 10)
-                                    if (Number.isFinite(parsed)) setOption(o, parsed)
-                                  } else {
-                                    setOption(o, e.target.value)
-                                  }
-                                }}
-                                disabled={busy}
-                              />
-                            )}
-                            {fieldError && <span className="set-field-error">{fieldError}</span>}
-                          </div>
+                          <SettingField
+                            key={o.scope + '.' + o.kind + '.' + o.f.name}
+                            label={o.f.label}
+                            help={o.f.help}
+                            type={o.f.type}
+                            choices={o.f.choices}
+                            multiline={o.f.multiline}
+                            secretSet={o.f.secretSet}
+                            // A secret's stored value never reaches the client, so its
+                            // box shows the pending edit only; every other kind shows
+                            // the resolved value.
+                            value={secret ? String(override ?? '') : String(cur ?? '')}
+                            onChange={(next) => setTypedOption(o, next)}
+                            error={fieldError}
+                            disabled={busy}
+                          />
                         )
                       })}
                     </div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1112,10 +1112,7 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .set-btn.danger.quiet:hover { color: var(--bucket-dead); }
 
 .skill-add { display: flex; align-items: center; gap: 10px; }
-.skill-add-input { flex: 1; height: 36px; border: 1px solid var(--border); border-radius: 5px; background: var(--bg); outline: none; color: var(--text); font-family: var(--font-mono); font-size: 13px; padding: 0 12px; }
-.skill-add-input:focus { border-color: var(--accent); }
-.skill-add-input::placeholder { color: var(--text-faint); }
-.skill-add .set-btn { height: 36px; flex-shrink: 0; }
+.skill-add input { flex: 1; min-width: 0; }
 .skill-cols { display: flex; flex-direction: column; gap: 8px; }
 .skill-col { overflow: hidden; }
 .skill-col-head { display: flex; align-items: center; gap: 10px; padding-right: 14px; border-bottom: 1px solid var(--border-soft); }
@@ -1129,7 +1126,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .sc-repo { font-family: var(--font-mono); font-size: 13px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .sc-meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .sc-actions { display: flex; gap: 8px; flex-shrink: 0; }
-.skills-pane .sc-actions .set-btn { height: 30px; padding: 0 11px; font-size: 12px; }
 .sc-skills { display: flex; flex-direction: column; }
 .sc-empty { padding: 10px 14px 12px 33px; }
 .skill-row { display: grid; grid-template-columns: minmax(130px, 0.8fr) minmax(0, 1.5fr) auto; gap: 14px; align-items: center; padding: 10px 14px 10px 33px; border-bottom: 1px solid var(--border-soft); }
@@ -1173,17 +1169,12 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .mcp-label.tech { font-family: var(--font-mono); font-size: 11.5px; }
 .mcp-req { font-weight: 400; color: var(--text-faint); }
 .mcp-sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
-/* skill-add-input's flex: 1 means "grow wide" in the skills row; inside a
-   column-flex field the axis flips and its basis: 0 collapses the fixed
-   height. Neutralize it so height: 36px holds. */
-.mcp-pane .skill-add-input { flex: none; width: 100%; }
-.mcp-pane .set-btn { display: inline-flex; align-items: center; height: 36px; padding: 0 14px; font-family: var(--font-sans); font-size: 12.5px; letter-spacing: 0; }
 .mcp-pane :is(button, input, summary):focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .mcp-pane button:disabled { opacity: 0.45; cursor: default; }
 .mcp-pane input:disabled { opacity: 0.6; cursor: default; }
 
 .mcp-reg-search { display: flex; gap: 10px; }
-.mcp-pane :is(.mcp-reg-search, .skill-add) .skill-add-input { flex: 1; min-width: 0; }
+.mcp-reg-search input { flex: 1; min-width: 0; }
 .mcp-reg-results { display: flex; flex-direction: column; gap: 8px; }
 .mcp-reg-row { display: flex; flex-direction: column; gap: 3px; width: 100%; padding: 10px 13px; cursor: pointer; text-align: left; font: inherit; }
 .mcp-reg-row:hover { border-color: var(--border-loud); background: var(--surface-3); }
@@ -1250,7 +1241,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .svc-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .svc-alt { align-self: flex-start; padding: 0; border: none; background: none; font: inherit; font-size: 12.5px; color: var(--text-mid); cursor: pointer; text-decoration: underline; text-underline-offset: 3px; }
 .svc-alt:hover { color: var(--text); }
-.svc-textarea { height: auto; min-height: 96px; padding: 8px 12px; line-height: 1.45; resize: vertical; white-space: pre; font-size: 12px; }
 .svc-pane a.set-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .browser-session-create { display: grid; grid-template-columns: minmax(150px, 0.8fr) minmax(180px, 1fr) minmax(150px, 0.8fr) auto; gap: 12px; align-items: end; }
@@ -1272,7 +1262,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .browser-session-times dd { margin: 0; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-mid); }
 .browser-session-actions { display: flex; justify-content: flex-end; gap: 8px; }
 .browser-session-rename { grid-column: 1 / -1; display: grid; grid-template-columns: minmax(0, 1fr) auto auto; gap: 8px; }
-.browser-session-rename .skill-add-input { width: 100%; }
 
 @media (max-width: 720px) {
   .set-extension-toggles { grid-template-columns: 1fr; }


### PR DESCRIPTION
The settings modal drew a declared field twice, from two switches that had
drifted apart. The pane's was a five-deep ternary covering enum, cron, multiline
secret, secret and text. A service's connect form had its own loop that knew only
multiline and secret: every other kind fell through to a text box, so a service
declaring a bool, an int or a `Literal` would have rendered a free-text field for
it. Both switches read the same wire vocabulary — `connect_fields()` derives its
kinds from the same `field_kind()` the settings form uses — so there was never a
reason for two.

`SettingField` draws it, once, on the `Control` primitives. An enum that arrives
without its choice set now says so instead of quietly becoming a text box. The
connect form is write-only, so it passes `secretSet` false and its fields keep
taking a replacement credential rather than showing a stored one.

`CronField` moves into the file its test was already named for. It only lived in
`SettingsModal` because that is where it was written.

`.skill-add-input` goes. Thirteen call sites across the modal and the browser
sessions pane wore the skills pane's class for want of a text input, and it
carried `flex: 1` for the one row it was born in — which two later panes then had
to neutralize, one with a comment explaining the fight. The control is
`width: 100%`; the row says who grows.

Three `.set-btn` ancestor overrides go with it. One class rendered four heights
depending on which pane it landed in.

One visible change: the connect form's labels. `.mcp-label` was 12px sans;
`.set-field-label` is the small mono caps every other declared field already
wore.

Closes ENG-848.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
