### PR TITLE
The free board shows a subject's name, not its primary key

### DIFF
--- a/backend/druks/contrib/review/datastructures.py
+++ b/backend/druks/contrib/review/datastructures.py
@@ -38,6 +38,7 @@ class PullRequest(Subject):
     def get_summary(self) -> ReviewSummary:
         return ReviewSummary(
             id=self.id,
+            label=self.label,
             repo=self.repo,
             pr_number=self.number,
             pull_request_url=self.url,

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -132,6 +132,11 @@ class SubjectSummary(BaseResponse):
     model_config = ConfigDict(from_attributes=True)
 
     id: SubjectId
+    # The one line the board row and the detail page show this subject as. Free
+    # from the subject's own ``label`` when the summary is built with
+    # ``model_validate(self)``; required, so a hand-built summary that forgets it
+    # fails on its board route rather than titling every row with a primary key.
+    label: str
 
 
 class SubjectStatus(BaseResponse):

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -1,7 +1,15 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from pydantic import AliasPath, BeforeValidator, ConfigDict, Field, SerializeAsAny, computed_field
+from pydantic import (
+    AliasPath,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    SerializeAsAny,
+    StringConstraints,
+    computed_field,
+)
 
 from druks.schemas import BaseResponse
 
@@ -124,6 +132,11 @@ class RunResponse(BaseResponse):
 # takes either and is always a string.
 SubjectId = Annotated[str, BeforeValidator(str)]
 
+# The one line a board row and a detail page show a subject as. Blank is rejected
+# rather than rendered: a title nobody can read is the thing this field exists to
+# prevent.
+SubjectLabel = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
 
 class SubjectSummary(BaseResponse):
     # The base an extension's subject header subclasses; ``id`` keys the subject's
@@ -132,11 +145,7 @@ class SubjectSummary(BaseResponse):
     model_config = ConfigDict(from_attributes=True)
 
     id: SubjectId
-    # The one line the board row and the detail page show this subject as. Free
-    # from the subject's own ``label`` when the summary is built with
-    # ``model_validate(self)``; required, so a hand-built summary that forgets it
-    # fails on its board route rather than titling every row with a primary key.
-    label: str
+    label: SubjectLabel
 
 
 class SubjectStatus(BaseResponse):

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -26,7 +26,7 @@ class Thing(StoredSubject):
     __tablename__ = "faketest_things"
 
     def get_summary(self) -> _ThingSummary:
-        return _ThingSummary(id=self.id, title=TITLES[self.id])
+        return _ThingSummary(id=self.id, label=self.label, title=TITLES[self.id])
 
     @classmethod
     def list_summaries(cls) -> list[_ThingSummary]:
@@ -44,7 +44,7 @@ class Ticket(Subject):
         return
 
     def get_summary(self) -> _ThingSummary:
-        return _ThingSummary(id=self.id, title=self.id.rpartition("#")[2])
+        return _ThingSummary(id=self.id, label=self.label, title=self.id.rpartition("#")[2])
 
     @classmethod
     def list_summaries(cls) -> list[_ThingSummary]:
@@ -128,7 +128,19 @@ def test_a_subject_id_is_a_string_whatever_the_row_is_keyed_by(druks_db):
 
     # Only the id widens: a title that arrives as a number is still a mistake.
     with pytest.raises(ValidationError):
-        _ThingSummary(id=7, title=7)
+        _ThingSummary(id=7, label="7", title=7)
+
+
+def test_a_summary_carries_the_subjects_own_label(druks_db):
+    # Built off the subject, the label comes free from its ``label`` — both subject
+    # bases have one, so neither board titles its rows with a primary key.
+    assert SubjectSummary.model_validate(Thing(id=7)).label == "thing 7"
+    assert SubjectSummary.model_validate(Ticket(id="owner/repo#7")).label == "owner/repo#7"
+
+    # Required, not defaulted: a hand-built summary that forgets it fails here,
+    # rather than rendering a blank title on every row of its board.
+    with pytest.raises(ValidationError):
+        _ThingSummary(id=1, title="First")
 
 
 def test_status_aggregates_across_runs_and_timeline_spans_them(client: TestClient, druks_db):
@@ -141,7 +153,7 @@ def test_status_aggregates_across_runs_and_timeline_spans_them(client: TestClien
     _seed_call(druks_db, live, agent="implement", status="running")
 
     detail = client.get("/api/faketest/thing/1").json()
-    assert detail["summary"] == {"id": "1", "title": "First"}
+    assert detail["summary"] == {"id": "1", "label": "thing 1", "title": "First"}
     assert detail["status"]["state"] == "running"
     assert [entry["kind"] for entry in detail["timeline"]] == ["faketest.prepare", "faketest.flow"]
     # Calls group under their own run, not the subject at large.
@@ -232,7 +244,7 @@ def test_an_id_spanning_separators_reaches_the_board_and_its_page(client: TestCl
     assert [row["summary"]["id"] for row in board["rows"]] == ["owner/repo#7"]
 
     detail = client.get("/api/faketest/ticket/owner/repo%237").json()
-    assert detail["summary"] == {"id": "owner/repo#7", "title": "7"}
+    assert detail["summary"] == {"id": "owner/repo#7", "label": "owner/repo#7", "title": "7"}
     assert detail["status"]["state"] == "parked"
     assert [entry["kind"] for entry in detail["timeline"]] == ["faketest.flow"]
 

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -132,15 +132,15 @@ def test_a_subject_id_is_a_string_whatever_the_row_is_keyed_by(druks_db):
 
 
 def test_a_summary_carries_the_subjects_own_label(druks_db):
-    # Built off the subject, the label comes free from its ``label`` — both subject
-    # bases have one, so neither board titles its rows with a primary key.
     assert SubjectSummary.model_validate(Thing(id=7)).label == "thing 7"
     assert SubjectSummary.model_validate(Ticket(id="owner/repo#7")).label == "owner/repo#7"
 
-    # Required, not defaulted: a hand-built summary that forgets it fails here,
-    # rather than rendering a blank title on every row of its board.
+    # A title nobody can read is what this field exists to prevent, so a missing
+    # one and a blank one fail the same way.
     with pytest.raises(ValidationError):
         _ThingSummary(id=1, title="First")
+    with pytest.raises(ValidationError):
+        _ThingSummary(id=1, label="   ", title="First")
 
 
 def test_status_aggregates_across_runs_and_timeline_spans_them(client: TestClient, druks_db):

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -34,8 +34,6 @@ export type RunState =
 // timeline, and detail URL.
 export interface SubjectSummary {
   id: string
-  // The one line this subject shows itself as; the row title and the detail
-  // page's first fact.
   label: string
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -34,6 +34,9 @@ export type RunState =
 // timeline, and detail URL.
 export interface SubjectSummary {
   id: string
+  // The one line this subject shows itself as; the row title and the detail
+  // page's first fact.
+  label: string
 }
 
 export interface SubjectStatus {

--- a/frontend/src/lib/summary.ts
+++ b/frontend/src/lib/summary.ts
@@ -3,12 +3,13 @@ import { relTimeFromIso } from './format'
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}T/
 
 // A subject summary's scalar fields as label/text pairs — what the generic board
-// row and subject facts render. ``id`` is the row key, not a field. Typed on the
+// row and subject facts render. ``id`` is the row key and ``label`` is the title,
+// so neither is a field here. Typed on the
 // wire's base shape; the extension's extra fields are what this walks.
 export function summaryEntries(summary: object): [string, string][] {
   const entries: [string, string][] = []
   for (const [key, value] of Object.entries(summary)) {
-    if (key === 'id' || value === null || value === undefined || value === '') continue
+    if (key === 'id' || key === 'label' || value === null || value === undefined || value === '') continue
     if (!['string', 'number', 'boolean'].includes(typeof value)) continue
     const label = key.replace(/([A-Z])/g, ' $1').toLowerCase()
     const text =

--- a/frontend/src/lib/summary.ts
+++ b/frontend/src/lib/summary.ts
@@ -3,9 +3,9 @@ import { relTimeFromIso } from './format'
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}T/
 
 // A subject summary's scalar fields as label/text pairs — what the generic board
-// row and subject facts render. ``id`` is the row key and ``label`` is the title,
-// so neither is a field here. Typed on the
-// wire's base shape; the extension's extra fields are what this walks.
+// row and subject facts render. ``id`` and ``label`` are the row key and the title,
+// not fields. Typed on the wire's base shape; the extension's extra fields are
+// what this walks.
 export function summaryEntries(summary: object): [string, string][] {
   const entries: [string, string][] = []
   for (const [key, value] of Object.entries(summary)) {

--- a/frontend/src/pages/ExtensionHomePage.tsx
+++ b/frontend/src/pages/ExtensionHomePage.tsx
@@ -66,7 +66,7 @@ function SubjectBoard({ extension, subjectType }: { extension: string; subjectTy
           onClick={() => navigate(`/${extension}/${subjectType}/${row.summary.id}`)}
         >
           <StatusGlyph state={row.status.state} />
-          <span className="row-title">{row.summary.id}</span>
+          <span className="row-title">{row.summary.label}</span>
           <span className="subject-row-meta mono dim">
             {summaryEntries(row.summary)
               .map(([key, value]) => `${key} ${value}`)

--- a/frontend/src/pages/SubjectPage.tsx
+++ b/frontend/src/pages/SubjectPage.tsx
@@ -74,7 +74,7 @@ export function SubjectPage({ extension, subjectType, subjectId }: Props) {
   return (
     <Page scroll="internal" className="ins page-subject" header={crumb}>
       <Facts className="subject-facts">
-        <Fact k="id">{data.summary.id}</Fact>
+        <Fact k={label}>{data.summary.label}</Fact>
         {summaryEntries(data.summary).map(([key, value]) => (
           <Fact key={key} k={key}>
             {value}


### PR DESCRIPTION
An extension that ships no frontend gets the generic board and subject page for
free, and both titled a subject with `summary.id` — an integer for a row-backed
subject. inbox-manager's board read `1`, `2`, `3`. The subject already knew
better: both bases carry a `label`, and every app that has a name for its subject
overrides `get_label`.

`SubjectSummary` carries it now. `from_attributes` means `model_validate(self)`
picks it up with no app change — that is every implementation across druks and
druks-apps except `review`'s, which builds its summary by hand, so one line.

Required, not defaulted. A hand-built summary that forgets it raises on its board
route, which is the loud version; defaulting to `""` would title every row with
nothing and say so nowhere.

The detail page's first fact was `id`; it is now the subject type in words —
`pull request: owner/repo#7` rather than `id: owner/repo#7`. `summaryEntries`
skips `label` the way it already skipped `id`, so the title never repeats itself
among the facts.

inbox-manager, which ships no frontend at all, gets a readable board on the next
deploy with no app change.

Closes ENG-849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
