### PR TITLE
An installed app can draw a gate

### DIFF
--- a/frontend/src/components/RunControls.test.tsx
+++ b/frontend/src/components/RunControls.test.tsx
@@ -1,9 +1,8 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { InputRequest } from '../api/types'
-import { InAppReview } from './RunControls'
+import { CancelRun, InAppReview, RetryRun } from './RunControls'
 
 function stubFetch() {
   const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
@@ -13,13 +12,10 @@ function stubFetch() {
   return fetchMock
 }
 
+// No provider. These are lent to installed apps through @druks/ui, which mount
+// them outside the shell's tree — so anything they need has to be their own.
 function renderReview(ask: InputRequest) {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <InAppReview runId="run-123" ask={ask} />
-    </QueryClientProvider>,
-  )
+  return render(<InAppReview runId="run-123" ask={ask} />)
 }
 
 afterEach(() => {
@@ -94,5 +90,59 @@ describe('InAppReview', () => {
         'Approving with a note starts another plan pass instead of confirming the plan.',
       ),
     ).toBeTruthy()
+  })
+})
+
+describe('the lent run controls', () => {
+  it('render with no provider around them', () => {
+    stubFetch()
+    render(
+      <>
+        <CancelRun runId="run-123" />
+        <RetryRun runId="run-123" />
+        <InAppReview runId="run-123" ask={{ presentation: 'in_app', controls: ['approve'] }} />
+      </>,
+    )
+    expect(screen.getByText('cancel run')).toBeTruthy()
+    expect(screen.getByText('retry run')).toBeTruthy()
+    expect(screen.getByText('Approve')).toBeTruthy()
+  })
+
+  it('reads the ask artifact itself, without react-query', async () => {
+    const fetchMock = vi.fn<(url: string) => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ kind: 'plan', title: 'The plan', content: 'step one' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <InAppReview
+        runId="run-123"
+        ask={{ presentation: 'in_app', controls: ['approve'], artifact_id: 'art-1' }}
+      />,
+    )
+
+    expect(await screen.findByText('The plan')).toBeTruthy()
+    expect(screen.getByText('step one')).toBeTruthy()
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/artifacts/art-1')
+  })
+
+  it('renders the panel without the artifact when the read fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 404, statusText: 'Not Found' })),
+    )
+    render(
+      <InAppReview
+        runId="run-123"
+        ask={{ presentation: 'in_app', controls: ['approve'], artifact_id: 'gone' }}
+      />,
+    )
+    // The ask's own controls are what the operator answers; a missing artifact
+    // must not take the gate down with it.
+    expect(await screen.findByText('Approve')).toBeTruthy()
   })
 })

--- a/frontend/src/components/RunControls.tsx
+++ b/frontend/src/components/RunControls.tsx
@@ -1,8 +1,7 @@
-import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
 
 import { api } from '../api/client'
-import type { InputRequest } from '../api/types'
+import type { ArtifactContent, InputRequest } from '../api/types'
 import { Markdown } from './Markdown'
 
 // Cancel is a run-level action: end any active run, parked or running. A destructive
@@ -102,11 +101,27 @@ export function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }
   const [error, setError] = useState<string | null>(null)
   const critique = ask.context?.trim() ?? ''
 
-  const artifact = useQuery({
-    queryKey: ['artifact', ask.artifact_id],
-    queryFn: () => api.artifact(ask.artifact_id as string),
-    enabled: Boolean(ask.artifact_id),
-  })
+  // Fetched here rather than through react-query: an installed app borrows this
+  // component through the import map and mounts it outside the shell's tree,
+  // where there is no QueryClientProvider. One artifact, read once per ask.
+  // Held with the id it belongs to, so a new ask stops showing the old plan on
+  // the render that changes it rather than after its fetch lands.
+  const [fetched, setFetched] = useState<{ id: string; content: ArtifactContent } | null>(null)
+  const artifact = fetched && fetched.id === ask.artifact_id ? fetched.content : null
+  useEffect(() => {
+    const artifactId = ask.artifact_id
+    if (!artifactId) return
+    let live = true
+    // A missing artifact leaves the panel without it: the ask's own questions
+    // and controls are what the operator answers.
+    api
+      .artifact(artifactId)
+      .then((content) => live && setFetched({ id: artifactId, content }))
+      .catch(() => {})
+    return () => {
+      live = false
+    }
+  }, [ask.artifact_id])
 
   async function choose(control: string) {
     setPending(control)
@@ -129,10 +144,10 @@ export function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }
           <Markdown source={critique} />
         </div>
       )}
-      {artifact.data && (
+      {artifact && (
         <div className="review-artifact">
-          <div className="review-artifact-title">{artifact.data.title}</div>
-          <Markdown source={artifact.data.content} />
+          <div className="review-artifact-title">{artifact.title}</div>
+          <Markdown source={artifact.content} />
         </div>
       )}
       {ask.questions?.map((question) => {

--- a/frontend/src/runtime/druks-ui.test.ts
+++ b/frontend/src/runtime/druks-ui.test.ts
@@ -10,11 +10,14 @@ import * as ui from './druks-ui'
 // Red means stop and ask. Never edit the list to match the code.
 const LENT = [
   'Button',
+  'CancelRun',
   'EmptyState',
   'Field',
+  'InAppReview',
   'Page',
   'PageHeader',
   'RelTime',
+  'RetryRun',
   'SectionHead',
   'Select',
   'StatusGlyph',

--- a/frontend/src/runtime/druks-ui.ts
+++ b/frontend/src/runtime/druks-ui.ts
@@ -14,5 +14,9 @@ export { EmptyState } from '../components/EmptyState'
 export { StatusGlyph } from '../components/StatusGlyph'
 export { RelTime } from '../components/RelTime'
 export { Button, Field, Select, TextInput } from '../components/Control'
+// A run's operator actions. Gates are a platform pillar, so an app that ships a
+// frontend has to be able to draw one — it loses the generic subject page that
+// would otherwise carry it.
+export { CancelRun, InAppReview, RetryRun } from '../components/RunControls'
 
-export type { RunState } from '../api/types'
+export type { InputRequest, RunState } from '../api/types'


### PR DESCRIPTION
Gates are a pillar, and an app that shipped its own frontend could not render one.

`installed.tsx` is a hard either/or: a package containing `dist/entry.js` takes its
whole namespace and loses the generic subject page — the only place outside ship's
hand-built `WorkItemPage` where `InAppReview` renders. It was not among the ten lent
names either, so there was nothing to borrow. The app either went without a frontend
or went without the screen where its work gets approved.

`CancelRun`, `RetryRun` and `InAppReview` join `@druks/ui`, with the `InputRequest`
type the ask arrives as. All three rather than just the gate: they are the same
category — platform run actions keyed by a run id, sitting on the same page — and
lending one would have left the next hole. The pinned list goes from 10 to 13.

`InAppReview` drops react-query. It was one optional artifact read, and an app mounts
these outside the shell's tree where no `QueryClientProvider` exists. The fetch is
held with the id it belongs to, so a new ask stops showing the old plan on the render
that changes it rather than after the next fetch lands.

Its calls were never the blocker the ENG-850 notes claimed. `GET /api/artifacts/{id}`
and `POST /api/runs/{id}/resume` are *platform* paths, so same-origin app code reaches
them directly — that is why lending works, not why it was blocked.

Placement stays the app's. Rendering the gate as shell chrome above the mounted app
was considered and rejected: for a gate-heavy app the gate is the screen, and a
detached band above the app's own list is worse than the app placing it inline.

## Verification

The existing `InAppReview` tests lose their `QueryClientProvider`. That removal is the
proof — if anything still needed react-query they would be red. Three tests added for
the borrowed case: all three controls rendering with no provider at all, the artifact
read landing without react-query, and a failed artifact read leaving the gate
answerable rather than taking the panel down.

Costs the shell nothing: `main` drops 8.6 kB into the shared `druks-ui` chunk
(6.86 → 15.58 kB). The chunk now also pulls `markdown-vendor`, which the shell's own
`main` already imports statically and `index.html` preloads, so an app pays nothing
extra for it.

Closes ENG-851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
