### PR TITLE
The writer lock's TTL outlasts a real borrow

### DIFF
--- a/backend/druks/browser/constants.py
+++ b/backend/druks/browser/constants.py
@@ -5,13 +5,14 @@ BROWSER_SESSION_NAME_MAX_LENGTH = 64
 BROWSER_SESSION_NAME_PATTERN = r"^[a-z](?:[a-z0-9-]*[a-z0-9])?$"
 SITE_MAX_LENGTH = 255
 
-WRITER_LOCK_TTL_SECONDS = 60
+# TTL-only, no renewal: must outlast the longest borrow, bounded by the
+# browser container's 150-minute lease.
+WRITER_LOCK_TTL_SECONDS = 3 * 60 * 60
 SESSION_LAUNCH_TIMEOUT_SECONDS = 45
 SESSION_EXPORT_TIMEOUT_SECONDS = 5 * 60
 
-# A login window holds the session's writer lock and its Redis record for as
-# long as it may stay open; both lapse together if the operator walks away, and
-# the container's own lease reaps it — nothing sweeps.
+# A login window keeps only this Redis record; if the operator walks away it
+# lapses and the container's own lease reaps the browser — nothing sweeps.
 LOGIN_WINDOW_TTL_SECONDS = 30 * 60
 LOGIN_WINDOW_KEY_PREFIX = "browser_login_window:"
 


### PR DESCRIPTION
TTL-only is the lock's settled design: no renewal, one expiry that covers the whole borrow. The 60-second value predates that settlement — it was the short half of a renew-every-20s pair whose renewal machinery was cut, and a persist borrow runs for minutes (the export step alone allows five), so a live borrow could silently lose its lock. The TTL is now three hours, past the browser container's 150-minute lease, so an orphaned lock still clears on its own.

The login-window comment claimed the window holds the session's writer lock; the window deliberately takes no lock, and the comment now describes what actually bounds it: its Redis record and the container lease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)