### PR TITLE
Usage is a platform surface, not an installed app

### DIFF
--- a/backend/druks/usage/extension.py
+++ b/backend/druks/usage/extension.py
@@ -5,3 +5,4 @@ class Usage(Extension):
     name = "usage"
     icon = "gauge"
     description = "Harness usage metering — quota and spend per account."
+    builtin = True

--- a/backend/tests/test_extensions.py
+++ b/backend/tests/test_extensions.py
@@ -26,6 +26,12 @@ def test_iter_extensions_discovers_the_bundled_extensions():
     assert {extension.name for extension in iter_extensions()} >= {"core", "ship", "usage"}
 
 
+def test_platform_extensions_are_builtin():
+    """``builtin`` is what keeps a platform surface out of the shell's app switcher."""
+    builtin = {extension.name for extension in iter_extensions() if extension.builtin}
+    assert builtin >= {"core", "usage"}
+
+
 def test_ship_app_derives_its_package_from_the_defining_module():
     ship = next(extension for extension in iter_extensions() if extension.name == "ship")
     assert ship.package == "druks.contrib.ship"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -204,13 +204,8 @@ function AppShell() {
       <main className="extension-main" data-extension={extension ?? undefined}>
         {wantsStrip && health && <SystemStrip health={health} />}
         <Switch>
-          {registered.flatMap((name) =>
-            (getExtensionUI(name)?.routes ?? []).map((route) => (
-              <Route key={`${name}:${route.path}`} path={route.path}>
-                {(params) => route.render(params as Record<string, string>)}
-              </Route>
-            )),
-          )}
+          {/* Shell-owned paths first, so an extension named after one of them can't
+              shadow the platform surface. */}
           <Route path="/usage">
             <UsagePage />
           </Route>
@@ -220,6 +215,13 @@ function AppShell() {
           <Route path="/browser-sessions/:sessionId/login">
             {(params) => <LoginWindowPage sessionId={params.sessionId} />}
           </Route>
+          {registered.flatMap((name) =>
+            (getExtensionUI(name)?.routes ?? []).map((route) => (
+              <Route key={`${name}:${route.path}`} path={route.path}>
+                {(params) => route.render(params as Record<string, string>)}
+              </Route>
+            )),
+          )}
           <Route>
             <NotFound />
           </Route>


### PR DESCRIPTION
The shell reads an extension's `builtin` flag as "this is an app": every non-builtin roster entry is registered into the UI registry, which gives it a switcher entry and mounts generic pages at `/<name>`.

Usage never set the flag, so it showed up as an app in the dropdown, and the generic home page it got at `/usage` shadowed the shell's own usage route — clicking the quota pill landed on an empty subject board instead of the usage panel.

Usage now declares `builtin = True`, alongside core.

The shell's own routes also move ahead of the extension routes in the switch, so a platform path stays with the platform even if an extension is named after one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
