### PR TITLE
A spend-controlled Codex plan reports its quota as a weekly window

### DIFF
--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -431,6 +431,16 @@ class CodexHarness(Harness):
         plan = data.get("plan_type") if isinstance(data.get("plan_type"), str) else None
         try:
             five_hour, weeks = _codex_windows(data)
+            spend = (data.get("spend_control") or {}).get("individual_limit")
+            if not five_hour and not weeks and spend:
+                # Group-based spend controls replace the rate-limit windows;
+                # their weeks-long quota cycle makes it a weekly window.
+                weeks = (
+                    ParsedMetric(
+                        percent_left=max(0, min(100, round(100 - spend["used_percent"]))),
+                        resets_at=datetime.fromtimestamp(spend["reset_at"], tz=UTC),
+                    ),
+                )
         except (AttributeError, KeyError, TypeError, ValueError):
             return ParsedUsage(ok=False, error="unexpected_payload", plan_tier=plan, raw=raw)
         if not five_hour and not weeks:

--- a/backend/tests/test_harness_usage_parsing.py
+++ b/backend/tests/test_harness_usage_parsing.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime
 
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
@@ -123,6 +124,40 @@ def test_codex_parse_treats_unlimited_credits_as_full_buckets() -> None:
     assert parsed.five_hour is not None and parsed.five_hour.percent_left == 100
     assert len(parsed.weeks) == 1 and parsed.weeks[0].percent_left == 100
     assert parsed.unlimited is True
+
+
+def test_codex_parse_reads_a_group_spend_control_as_a_weekly_window() -> None:
+    """Under group-based spend controls a business account carries no windows —
+    the spend quota is the metered limit, on a cycle that runs weeks."""
+    parsed = CodexHarness._parse_usage(
+        json.dumps(
+            {
+                "plan_type": "business",
+                "rate_limit": None,
+                "credits": {"has_credits": True, "unlimited": False, "balance": None},
+                "spend_control": {
+                    "reached": False,
+                    "individual_limit": {
+                        "source": "group_based_spend_controls",
+                        "limit": "100",
+                        "used": "1.23",
+                        "used_percent": 1,
+                        "remaining_percent": 99,
+                        "reset_after_seconds": 1681405,
+                        "reset_at": 1788220800,
+                    },
+                },
+            }
+        )
+    )
+
+    assert parsed.ok
+    assert parsed.plan_tier == "business"
+    assert parsed.five_hour is None
+    assert len(parsed.weeks) == 1
+    assert parsed.weeks[0].percent_left == 99
+    assert parsed.weeks[0].resets_at == datetime(2026, 9, 1, tzinfo=UTC)
+    assert parsed.unlimited is False
 
 
 def test_codex_parse_places_a_weekly_only_plan_in_the_week_window() -> None:


### PR DESCRIPTION
Business accounts under group-based spend controls carry `rate_limit: null` with `credits.unlimited: false` — the usage poll read that shape as `parse_failed`. The quota lives in `spend_control.individual_limit`, on a cycle that runs weeks, so it maps to a weekly window: `percent_left` from `used_percent`, `resets_at` from `reset_at`.

Payloads with neither windows, unlimited credits, nor a spend control still fail. A malformed spend control reads as `unexpected_payload`, like a malformed window.

Closes #245