### PR TITLE
The remote shape mounts the Docker socket for browser containers

### DIFF
--- a/deploy/compose.remote.yaml
+++ b/deploy/compose.remote.yaml
@@ -7,10 +7,19 @@
 x-drukbox: &drukbox
   image: ${DRUKS_SANDBOX_SERVICE_IMAGE:-ghcr.io/czpython/drukbox:latest}
   network_mode: host
+  # Cloud VMs are the sandbox home; the mounted socket serves the docker
+  # provider that browser-session containers run on. install.sh records the
+  # socket's gid so drukbox's non-root appuser may use it.
+  group_add:
+    - "${DRUKS_DOCKER_GID:-0}"
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
   env_file:
     - ./.env
   environment:
     DATABASE_URL: postgresql+psycopg://${DRUKS_POSTGRES_USER:-druks}:${DRUKS_POSTGRES_PASSWORD}@127.0.0.1:5432/drukbox
+    # Browser containers run sshd for the druks user, not root.
+    DOCKER_SSH_USERNAME: druks
   depends_on:
     postgres:
       condition: service_healthy

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -124,17 +124,19 @@ main() {
 
   # COMPOSE_FILE → .env, so plain `docker compose` in this dir loads the right
   # overlay. `local` drives sandboxes on the host Docker daemon (dashboard on
-  # :8001, no Caddy); `remote` runs the cloud provider + Caddy. For local, the
-  # socket's gid rides along so drukbox's non-root appuser may use it — on
-  # macOS the host path is a user-owned symlink, but the socket Docker Desktop
-  # mounts into containers is group root, so the host gid would grant nothing.
+  # :8001, no Caddy); `remote` runs the cloud provider + Caddy. Both shapes
+  # mount the Docker socket — sandboxes on local, browser-session containers
+  # on remote — so the socket's gid rides along and drukbox's non-root appuser
+  # may use it. On macOS the host path is a user-owned symlink, but the socket
+  # Docker Desktop mounts into containers is group root, so the host gid would
+  # grant nothing.
+  if [ "$(uname -s)" = "Darwin" ]; then
+    set_env_var DRUKS_DOCKER_GID "0"
+  else
+    set_env_var DRUKS_DOCKER_GID "$(stat -c '%g' /var/run/docker.sock)"
+  fi
   if [ "$PROVIDER" = "docker" ]; then
     set_env_var COMPOSE_FILE "compose.yaml:compose.local.yaml"
-    if [ "$(uname -s)" = "Darwin" ]; then
-      set_env_var DRUKS_DOCKER_GID "0"
-    else
-      set_env_var DRUKS_DOCKER_GID "$(stat -c '%g' /var/run/docker.sock)"
-    fi
   else
     set_env_var COMPOSE_FILE "compose.yaml:compose.remote.yaml"
   fi


### PR DESCRIPTION
Remote meant cloud sandboxes, so only the local overlay mounted the Docker socket. Browser-session containers run on the box's own daemon through the docker provider in either shape — seen on the live box after the drukbox tailnet fix (czpython/drukbox#9): `ProviderTransportError: failed to connect to the docker API at unix:///var/run/docker.sock`, because the drukbox containers had no socket at all.

The `x-drukbox` anchor in compose.remote.yaml now mounts `/var/run/docker.sock`, joins the socket's group (`DRUKS_DOCKER_GID`, the same knob the local overlay uses), and sets `DOCKER_SSH_USERNAME: druks` — the browser image runs sshd for the druks user, not the provider's root default. install.sh stamps `DRUKS_DOCKER_GID` for both shapes instead of only the local one.

Verified by rendering the merged config: both drukbox services (API + janitor) carry the mount, the gid, and the ssh user.

Live-box migration (one-time, current deploys don't refresh compose): copy the updated compose.remote.yaml, add `DRUKS_DOCKER_GID=<socket gid>` to .env, `docker compose up -d drukbox drukbox-janitor`.