### PR TITLE
noVNC as real ESM, one module shape for every bundler

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@novnc/novnc": "1.5.0",
+        "@novnc/novnc": "1.7.0",
         "@tanstack/react-query": "^5.101.4",
         "lucide-react": "^1.27.0",
         "react": "^19.2.8",
@@ -820,13 +820,10 @@
       }
     },
     "node_modules/@novnc/novnc": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.5.0.tgz",
-      "integrity": "sha512-4yGHOtUCnEJUCsgEt/L78eeJu00kthurLBWXFiaXfonNx0pzbs6R/3gJb1byZe6iAE8V9MF0syQb0xIL8MSOtQ==",
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=12.0.0"
-      }
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.7.0.tgz",
+      "integrity": "sha512-ucEJOx4T2avIRCleodk7YobZj5O2Ga2AeLfQ69A/yjG9HHba2+PDgwSkN3FttrmG+70ZGx21sElNFouK13RzyA==",
+      "license": "MPL-2.0"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.139.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "types:openapi": "openapi-typescript http://127.0.0.1:8000/openapi.json -o src/api/openapi.ts"
   },
   "dependencies": {
-    "@novnc/novnc": "1.5.0",
+    "@novnc/novnc": "1.7.0",
     "@tanstack/react-query": "^5.101.4",
     "lucide-react": "^1.27.0",
     "react": "^19.2.8",

--- a/frontend/src/novnc.d.ts
+++ b/frontend/src/novnc.d.ts
@@ -1,4 +1,4 @@
-declare module '@novnc/novnc/lib/rfb' {
+declare module '@novnc/novnc' {
   export default class RFB extends EventTarget {
     constructor(target: HTMLElement, url: string)
     scaleViewport: boolean

--- a/frontend/src/pages/LoginWindowPage.test.tsx
+++ b/frontend/src/pages/LoginWindowPage.test.tsx
@@ -8,7 +8,7 @@ const rfbState = vi.hoisted(() => ({
   instances: [] as Array<EventTarget & { url: string; disconnect: ReturnType<typeof vi.fn> }>,
 }))
 
-vi.mock('@novnc/novnc/lib/rfb', () => {
+vi.mock('@novnc/novnc', () => {
   class FakeRFB extends EventTarget {
     url: string
     scaleViewport = false

--- a/frontend/src/pages/LoginWindowPage.tsx
+++ b/frontend/src/pages/LoginWindowPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import RFB from '@novnc/novnc/lib/rfb'
+import RFB from '@novnc/novnc'
 
 import { api } from '../api/client'
 import { Page } from '../components/Page'


### PR DESCRIPTION
`@novnc/novnc` 1.5.0 ships only Babel CommonJS, and the bundlers disagree about what its default import means: dev and vitest unwrap `exports.default` to the class, while the production build (rolldown) follows Node's CJS-interop semantics and hands back the whole exports object. The login window page therefore worked everywhere except the deployed bundle, where `new RFB(...)` compiled to `new zi.default(...)` with `zi.default` being the exports object — the live error: `zi.default is not a constructor`.

1.7.0 is `type: module` with an exports map pointing the bare specifier at `core/rfb.js`. Real ESM ends the interop question: the bare `import RFB from '@novnc/novnc'` resolves the class identically in dev, vitest, and the build. The page's use of RFB (constructor, `scaleViewport`, `resizeSession`, connect/disconnect events) is unchanged across 1.5→1.7.

Verified in the built bundle: the construction site is now a direct `new <class>(...)` with no `.default` indirection, and the class resolves to RFB's real constructor. 117 frontend tests pass; lint and tsc clean.

Deploy: the fix rides the next druks image build — redeploy after merge.