### PR TITLE
An expired credential reads as disconnected, not Connected

### DIFF
--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -47,6 +47,9 @@ class HarnessResponse(BaseResponse):
         connection: "HarnessConnection | None",
         account: "Account",
     ) -> "HarnessResponse":
+        connected = bool(connection) and (
+            not connection.expires_at or connection.expires_at > datetime.now(UTC)
+        )
         return cls(
             name=settings.name,
             provider=settings.provider,
@@ -55,7 +58,7 @@ class HarnessResponse(BaseResponse):
             timeout=settings.timeout,
             fast_mode=settings.fast_mode,
             allowed_models=settings.allowed_models,
-            connected=bool(connection),
+            connected=connected,
             kind=connection.kind if connection else None,
             account=account.username if connection else None,
             provider_email=connection.provider_email if connection else None,

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -78,6 +78,24 @@ def test_harness_card_reports_identity(tmp_path: Path, druks_db):
     assert claude["providerEmail"] == "seat@corp.com"
 
 
+def test_harness_card_reads_expired_token_as_not_connected(tmp_path: Path, druks_db):
+    from datetime import UTC, datetime, timedelta
+
+    from druks.accounts.models import Account
+    from druks.harnesses.models import HarnessConnection
+
+    HarnessConnection.connect(
+        harness="claude",
+        account=Account.get_or_create("op@example.com"),
+        payload={"claudeAiOauth": {"accessToken": "x"}},
+        expires_at=datetime.now(UTC) - timedelta(hours=1),
+        provider_email="seat@corp.com",
+    )
+    with _build_client(tmp_path) as client:
+        claude = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}["claude"]
+    assert claude["connected"] is False
+
+
 def test_disconnect_removes_only_the_requesting_accounts_connection(tmp_path: Path, druks_db):
     from conftest import connect_harness
     from druks.harnesses.claude import ClaudeHarness

--- a/frontend/src/components/BrowserSessionsPane.tsx
+++ b/frontend/src/components/BrowserSessionsPane.tsx
@@ -56,7 +56,7 @@ export function BrowserSessionsPane() {
   return (
     <div className="set-pane mcp-pane browser-sessions-pane">
       <header className="mcp-pane-head">
-        <h2 className="mcp-pane-title">Browser sessions</h2>
+        <h2 className="mcp-pane-title">Browser</h2>
         <p className="mcp-pane-sub">
           Sign-ins your extensions declare, kept as encrypted browser state.
         </p>

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -185,9 +185,9 @@ describe('SettingsModal extension fields', () => {
     stubFetch()
     renderModal()
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Browser sessions' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Browser' }))
 
-    expect(await screen.findByRole('heading', { name: 'Browser sessions' })).toBeTruthy()
+    expect(await screen.findByRole('heading', { name: 'Browser' })).toBeTruthy()
     expect(
       await screen.findByText('No installed extension declares a browser session.'),
     ).toBeTruthy()

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -350,7 +350,7 @@ export function SettingsModal({ open, onClose }: Props) {
             <RailItem icon="general" label="General" active={section === 'general'} onClick={() => setSection('general')} />
             <RailItem icon="harnesses" label="Harnesses" active={section === 'harnesses'} onClick={() => setSection('harnesses')} />
             <RailItem icon="services" label="Services" active={section === 'services'} onClick={() => setSection('services')} />
-            <RailItem icon="browser-sessions" label="Browser sessions" active={section === 'browser-sessions'} onClick={() => setSection('browser-sessions')} />
+            <RailItem icon="browser-sessions" label="Browser" active={section === 'browser-sessions'} onClick={() => setSection('browser-sessions')} />
             <RailItem icon="skills" label="Skills" active={section === 'skills'} onClick={() => setSection('skills')} />
             <RailItem icon="mcp" label="MCP" active={section === 'mcp'} onClick={() => setSection('mcp')} />
             <RailItem icon="agent-access" label="Tokens" active={section === 'agent-access'} onClick={() => setSection('agent-access')} />


### PR DESCRIPTION
## What

The Settings → Services harness panel showed a Claude credential as **Connected** even after its token had expired, disagreeing with `druks doctor` (which reported the same credential as expired).

`HarnessResponse.from_row` derived connection state from row-existence alone (`bool(connection)`), so any credential row read as Connected regardless of `expires_at`. This now applies the same expiry check `doctor` makes: a credential is connected only when it exists and is unexpired. An expired token reads as **Not connected** and prompts a reconnect.

Also shortens the settings rail item and pane heading from **Browser sessions** to **Browser**.

## Test

- Added `test_harness_card_reads_expired_token_as_not_connected` — a past `expires_at` reports `connected: false`.
- Existing settings and SettingsModal tests updated/passing.

Closes ENG-859.