### PR TITLE
The login browser doesn't announce itself as automation

### DIFF
--- a/deploy/browser/session-launch
+++ b/deploy/browser/session-launch
@@ -91,6 +91,10 @@ async function main() {
         "--remote-debugging-address=127.0.0.1",
         "--remote-debugging-port=9222",
         "--window-size=1920,1080",
+        // Clears navigator.webdriver, the automation flag a logged-in site
+        // reads to challenge the session. The operator drives a real login
+        // here, so the browser must not announce itself as driven.
+        "--disable-blink-features=AutomationControlled",
       ],
       handleSIGHUP: false,
       handleSIGINT: false,


### PR DESCRIPTION
The operator drives a real login in the browser-session window, but the browser advertised `navigator.webdriver = true` — the automation flag a logged-in site reads to escalate a session to a verification challenge. X did exactly that on the live box: the login form rendered, then the flow silently refused to advance (the `knowledge_check` screen the operator got stuck on).

Diagnosed by driving the real browser container on the deployed box: a clean load of X's login flow returned zero 4xx/5xx (the `viewer.json` 404 seen in DevTools is a normal flow probe, not the blocker), and the one automation tell present was `navigator.webdriver = true`. Tested both configs in the exact chrome build: default → true, `--disable-blink-features=AutomationControlled` → false.

This adds that flag to `session-launch`. Re-verified end to end: patched launcher booted in a container from the published image, driven through its real code path, `navigator.webdriver = false`.

Scope is deliberately the one proven lever. A datacenter egress IP may still draw a challenge; that's the next slice only if this doesn't clear it — re-test after deploy before widening.

Deploy: rebuild and publish `ghcr.io/czpython/druks-browser`, then re-pull on the box so the next login window uses it.

ENG (P6 browser stealth, evidence-driven first slice)