### PR TITLE
Redeploy pulls the browser image

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -144,6 +144,12 @@ main() {
   echo "→ docker compose pull"
   docker compose pull
 
+  # The browser image is provisioned on demand by drukbox's docker provider, so
+  # it is not a compose service and `docker compose pull` misses it — pull it
+  # here so a redeploy refreshes it rather than leaving the box on a cached tag.
+  echo "→ pulling browser image"
+  docker pull -q ghcr.io/czpython/druks-browser:latest >/dev/null
+
   # The shared sandbox-keys volume: a fresh named volume mounts root-owned, but
   # the backend runs as the deploy user and must write the per-VM SSH keys here.
   # Chown it to the deploy uid:gid (a root-in-container chown, no host sudo).


### PR DESCRIPTION
The browser image (`ghcr.io/czpython/druks-browser:latest`) is provisioned on demand by drukbox's docker provider, so it is not a compose service — `docker compose pull` never touches it, and `docker run` only pulls a missing image. So a box that cached the tag once kept running it forever, and a rebuilt image (e.g. #274's login-automation fix) never reached it.

`install.sh` — the idempotent redeploy path — already pulls the backend image and the compose services; this adds the browser image beside them. Re-running install now refreshes it.

The ref is the same hardcoded default drukbox uses (`backend/druks/settings.py` `browser_sandbox_image`), which has no env override, so a plain pull with no fallback is correct for both shapes.