### PR TITLE
The login browser is real Chrome

### DIFF
--- a/.github/workflows/on-pull-request-images.yml
+++ b/.github/workflows/on-pull-request-images.yml
@@ -1,0 +1,49 @@
+name: PR Images
+
+# The sandbox and browser images publish only on push to main, so a change to
+# their build contexts reached main with no pre-merge check. This builds them on
+# the pull request — amd64 only and without pushing, so a broken Dockerfile
+# fails the PR instead of the deploy. arm64 stays covered by the publish build.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "deploy/sandbox/**"
+      - "deploy/browser/**"
+      - ".github/workflows/on-pull-request-images.yml"
+
+concurrency:
+  group: on-pull-request-images-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sandbox:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: deploy/sandbox
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=sandbox
+
+  browser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: deploy/browser
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=browser

--- a/deploy/browser/Dockerfile
+++ b/deploy/browser/Dockerfile
@@ -31,7 +31,8 @@ RUN apt-get update \
         > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        fonts-liberation fonts-noto-cjk fonts-noto-color-emoji nodejs x11vnc xvfb \
+        fonts-liberation fonts-noto-cjk fonts-noto-color-emoji \
+        nodejs tzdata x11vnc xvfb \
     && rm -rf /var/lib/apt/lists/* \
     && install -d -m 0755 /opt/druks-browser \
     && cd /opt/druks-browser \
@@ -51,6 +52,21 @@ RUN apt-get update \
         | sha256sum --check --strict - \
     && install -m 0755 /tmp/pinchtab /usr/local/bin/pinchtab \
     && rm -f /tmp/pinchtab /tmp/pinchtab-checksums.txt
+
+# Real Google Chrome, so the login browser presents Chrome's fingerprint rather
+# than the bundled chromium's — a login gate reads the difference. Google ships
+# no arm64 Linux build, so this is amd64-only; session-launch falls back to the
+# bundled chromium where Chrome is absent.
+# hadolint ignore=DL3008
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
+        curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
+            | gpg --dearmor -o /etc/apt/keyrings/google-chrome.gpg \
+        && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
+            > /etc/apt/sources.list.d/google-chrome.list \
+        && apt-get update \
+        && apt-get install -y --no-install-recommends google-chrome-stable \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
 
 RUN useradd --create-home --shell /bin/bash druks
 

--- a/deploy/browser/session-launch
+++ b/deploy/browser/session-launch
@@ -13,6 +13,11 @@ const META_PATH = path.join(SESSION_ROOT, "state.meta.json");
 const PROFILE_ARCHIVE_PATH = path.join(SESSION_ROOT, "state.tar.gz");
 const STORAGE_STATE_PATH = path.join(SESSION_ROOT, "state.json");
 const PROFILE_PATH = path.join(SESSION_ROOT, "profile");
+// Real Google Chrome when the image carries it (amd64), else the bundled
+// chromium (arm64). A login gate reads the Chromium-vs-Chrome brand split, so
+// the login browser must be real Chrome wherever it can be.
+const CHROME_PATH = "/opt/google/chrome/chrome";
+const channel = fs.existsSync(CHROME_PATH) ? "chrome" : undefined;
 const RUNTIME_PATH = path.join(SESSION_ROOT, ".runtime");
 const PID_PATH = path.join(RUNTIME_PATH, "launcher.pid");
 const READY_PATH = path.join(RUNTIME_PATH, "ready.json");
@@ -87,6 +92,7 @@ async function main() {
   let isReady = false;
   try {
     context = await chromium.launchPersistentContext(PROFILE_PATH, {
+      channel,
       args: [
         "--remote-debugging-address=127.0.0.1",
         "--remote-debugging-port=9222",


### PR DESCRIPTION
The login browser ran Playwright's bundled Chromium, which ships as Chrome for Testing. Its client hints report the `Chromium` brand while the user-agent string claims `Chrome/151` — a login gate reads that split. This installs real Google Chrome and launches it through Playwright's `chrome` channel, so the login browser presents Chrome's fingerprint.

Verified on a from-scratch amd64 build of this image: `navigator.userAgentData.brands` goes from `Chromium | Not=A?Brand` to `Not=A?Brand | Google Chrome | Chromium`.

Also in this change:

- **Paste into the login window works.** A bare X display had no clipboard owner, so pasting a password into the login window did nothing. `autocutsel` now owns both selections (`CLIPBOARD` and `PRIMARY`).
- **`TZ` is honored** on the container, so the browser's timezone can be aligned with the login egress.

## Arch note

Google ships no arm64 Linux build of Chrome, and the image is published multi-arch. Chrome is therefore installed on `amd64` only; `session-launch` falls back to the bundled chromium wherever Chrome is absent, so the arm64 image keeps working. Prod is amd64 and gets real Chrome.

## Not in scope

Egress. This is the browser-side fix and stands on its own. Whether the login also needs a residential egress IP is a separate, still-untested question.