### PR TITLE
Login window: set a timezone, drop the sandbox warning banner

### DIFF
--- a/backend/druks/browser/login.py
+++ b/backend/druks/browser/login.py
@@ -52,7 +52,12 @@ class LoginWindow:
             raise exceptions.BrowserLaunchError(session.name, str(error)) from error
         try:
             await _seed(browser, session)
-            await _launch(browser, session.name, settings.sandbox.browser_login_proxy)
+            await _launch(
+                browser,
+                session.name,
+                login_proxy=settings.sandbox.browser_login_proxy,
+                login_tz=settings.sandbox.browser_login_tz,
+            )
         except BaseException:
             await sandbox_client.release(host_id=browser.id)
             raise
@@ -168,15 +173,18 @@ async def _seed(browser: Sandbox, session: StoredBrowserSession) -> None:
         await browser.upload_file(local=meta, remote=f"{SESSION_ROOT}/state.meta.json")
 
 
-async def _launch(browser: Sandbox, name: str, login_proxy: str) -> None:
-    # A login-only egress proxy: the launcher reads it from its environment.
-    # Empty leaves the browser on the box's own IP.
-    proxy_env = f"env DRUKS_BROWSER_LOGIN_PROXY={shlex.quote(login_proxy)} " if login_proxy else ""
+async def _launch(browser: Sandbox, name: str, *, login_proxy: str, login_tz: str) -> None:
+    # The launcher and its browser read these from the environment: the egress
+    # proxy keeps the login off the box's own IP, and TZ aligns the browser's
+    # timezone with the exit's geography. Either empty is simply left unset.
+    env = {"TZ": login_tz, "DRUKS_BROWSER_LOGIN_PROXY": login_proxy}
+    assignments = " ".join(f"{key}={shlex.quote(value)}" for key, value in env.items() if value)
+    env_prefix = f"env {assignments} " if assignments else ""
     ready = await browser.exec(
         [
             "sh",
             "-c",
-            f"nohup setsid {proxy_env}session-launch --headed "
+            f"nohup setsid {env_prefix}session-launch --headed "
             f">{SESSION_ROOT}/launch.log 2>&1 </dev/null & "
             'launcher=$!; attempt=0; while [ "$attempt" -lt 300 ]; do '
             f"if [ -f {SESSION_ROOT}/.runtime/ready.json ]; then exit 0; fi; "

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -162,6 +162,10 @@ class Sandbox(BaseModel):
     # address. Authless address; credentials, if any, are terminated deploy-side.
     # Empty → the box's own IP. Only the login window uses it; borrows keep it.
     browser_login_proxy: str = ""
+    # The login browser's timezone, so it agrees with the egress proxy's
+    # geography (e.g. "Europe/Madrid"). An IANA zone name. Empty → the container
+    # default. Only the login window uses it.
+    browser_login_tz: str = ""
     # Sized for the slowest provisioner.
     timeout: float = 180.0
 

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -71,6 +71,7 @@ _KNOWN_TOML_KEYS = {
         "service_token",
         "image",
         "browser_login_proxy",
+        "browser_login_tz",
         "timeout",
     ),
     "env": (),
@@ -186,6 +187,9 @@ image = ""
 # address. Authless address, e.g. http://172.17.0.1:8888. Empty => the box's own
 # IP. Only the login window uses it; borrows keep it. See configuration.md.
 browser_login_proxy = ""
+# The login browser's timezone (an IANA zone, e.g. "Europe/Madrid"), so it
+# agrees with the egress proxy's geography. Empty => the container default.
+browser_login_tz = ""
 timeout = 180
 
 # Put drukbox environment in [sandbox.<provider>]. The table is passed through

--- a/backend/tests/test_browser_session_login_window.py
+++ b/backend/tests/test_browser_session_login_window.py
@@ -90,16 +90,18 @@ def create_session(name: str = "x-main") -> StoredBrowserSession:
     )
 
 
-async def test_login_launch_leaves_the_box_ip_when_no_proxy_is_set(window_runtime):
+async def test_login_launch_leaves_the_box_untouched_when_nothing_is_set(window_runtime):
     client = window_runtime
 
     await LoginWindow.open(create_session())
 
-    assert "DRUKS_BROWSER_LOGIN_PROXY" not in (client.browsers[0].launch_command or "")
+    command = client.browsers[0].launch_command or ""
+    assert "DRUKS_BROWSER_LOGIN_PROXY" not in command
+    assert "TZ=" not in command
 
 
-def _runtime_with_proxy(tmp_path, monkeypatch, proxy: str) -> FakeSandboxClient:
-    settings = make_settings(tmp_path, sandbox={"browser_login_proxy": proxy})
+def _runtime_with_sandbox(tmp_path, monkeypatch, **sandbox) -> FakeSandboxClient:
+    settings = make_settings(tmp_path, sandbox=sandbox)
     client = FakeSandboxClient()
     monkeypatch.setattr(login, "sandbox_client", client)
     monkeypatch.setattr(login, "load_settings", lambda: settings)
@@ -109,17 +111,26 @@ def _runtime_with_proxy(tmp_path, monkeypatch, proxy: str) -> FakeSandboxClient:
 
 async def test_login_launch_routes_through_the_configured_proxy(tmp_path, monkeypatch):
     proxy = "http://172.17.0.1:8888"
-    client = _runtime_with_proxy(tmp_path, monkeypatch, proxy)
+    client = _runtime_with_sandbox(tmp_path, monkeypatch, browser_login_proxy=proxy)
 
     await LoginWindow.open(create_session())
 
     command = client.browsers[0].launch_command or ""
-    assert f"env DRUKS_BROWSER_LOGIN_PROXY={shlex.quote(proxy)} session-launch --headed" in command
+    assert f"DRUKS_BROWSER_LOGIN_PROXY={shlex.quote(proxy)}" in command
 
 
-async def test_login_launch_quotes_the_proxy_so_a_bad_value_cannot_inject(tmp_path, monkeypatch):
+async def test_login_launch_sets_the_configured_timezone(tmp_path, monkeypatch):
+    client = _runtime_with_sandbox(tmp_path, monkeypatch, browser_login_tz="Europe/Madrid")
+
+    await LoginWindow.open(create_session())
+
+    command = client.browsers[0].launch_command or ""
+    assert "env TZ=Europe/Madrid session-launch --headed" in command
+
+
+async def test_login_launch_quotes_values_so_a_bad_one_cannot_inject(tmp_path, monkeypatch):
     proxy = "http://h:8888; rm -rf /"
-    client = _runtime_with_proxy(tmp_path, monkeypatch, proxy)
+    client = _runtime_with_sandbox(tmp_path, monkeypatch, browser_login_proxy=proxy)
 
     await LoginWindow.open(create_session())
 

--- a/deploy/browser/Dockerfile
+++ b/deploy/browser/Dockerfile
@@ -70,6 +70,17 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
 
 RUN useradd --create-home --shell /bin/bash druks
 
+# The browser runs unsandboxed (Docker's default seccomp blocks the sandbox's
+# namespace syscalls), so Playwright passes --no-sandbox and Chrome shows the
+# operator a "stability and security will suffer" banner in the login window.
+# This managed policy suppresses only that command-line-flag warning; it changes
+# no browser behavior a page could read. Installed in both channels' policy dirs
+# so the fallback chromium (arm64) is covered too.
+COPY chrome-policy.json /tmp/chrome-policy.json
+RUN install -D -m 0644 /tmp/chrome-policy.json /etc/opt/chrome/policies/managed/druks.json \
+    && install -D -m 0644 /tmp/chrome-policy.json /etc/chromium/policies/managed/druks.json \
+    && rm /tmp/chrome-policy.json
+
 COPY session-launch session-export /usr/local/bin/
 COPY entrypoint /usr/local/bin/druks-browser-entrypoint
 RUN chmod 0755 /usr/local/bin/session-launch /usr/local/bin/session-export \

--- a/deploy/browser/chrome-policy.json
+++ b/deploy/browser/chrome-policy.json
@@ -1,0 +1,3 @@
+{
+  "CommandLineFlagSecurityWarningsEnabled": false
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -261,6 +261,7 @@ connected.
 | `sandbox.timeout` | Control-plane request timeout; default 180 seconds |
 | `sandbox.image` | Optional provider image override |
 | `sandbox.browser_login_proxy` | Login-window egress proxy; empty keeps the box IP |
+| `sandbox.browser_login_tz` | Login-window timezone (IANA zone); empty keeps the container default |
 
 `DRUKS_SANDBOX_KEYS_DIR` remains a process environment override for the
 per-host SSH private-key directory.
@@ -277,6 +278,12 @@ reachable over the tailnet, or run a local `gost` relay
 proxy you provide. Leaving it empty keeps today's behavior. A fixed proxy fails
 closed — if the exit is unreachable the login browser errors rather than falling
 back to the box IP.
+
+`[sandbox].browser_login_tz` sets the login browser's timezone to an IANA zone
+name (e.g. `Europe/Madrid`), so it agrees with where `browser_login_proxy`
+egresses — a browser reporting one region while its IP is in another is an
+inconsistency some sign-in flows check. It applies to the login window only.
+Empty leaves the container's default timezone.
 
 `[sandbox].provider` accepts any Drukbox provider name. `docker` selects the
 local install shape, `exe` selects the exe.dev + tailnet shape, and every other


### PR DESCRIPTION
Two small login-window improvements, both login-only.

## Timezone

When the login window egresses through a proxy in another region (via `browser_login_proxy`), the browser's own timezone should agree with it — a browser reporting one region while its IP is in another is an inconsistency some sign-in flows check. Adds `sandbox.browser_login_tz` (an IANA zone, e.g. `Europe/Madrid`) that the login launcher applies alongside the egress proxy. Empty leaves the container default. Login window only; borrows are unchanged.

## Warning banner

The browser runs unsandboxed (Docker's default seccomp profile blocks the namespace syscalls Chrome's sandbox needs), so Playwright passes `--no-sandbox`, and Chrome shows the operator a "stability and security will suffer" banner in the login window — it reads like a bug. A managed policy (`CommandLineFlagSecurityWarningsEnabled: false`) suppresses that one command-line-flag warning. It changes no browser behavior a page can observe, and is installed in both channels' policy directories so the fallback chromium is covered too.

## Verification

Built the browser image and confirmed on a running container: the launcher applies `TZ` (browser reports the configured zone) and egresses through the configured proxy; and a framebuffer screenshot of the login window shows the banner gone with the policy in place, present without it. Unit tests cover the login command (proxy and TZ injected when set, omitted when unset, shell-quoted so a bad value can't inject).
