### PR TITLE
The login window opens on the session's site

### DIFF
--- a/backend/druks/browser/login.py
+++ b/backend/druks/browser/login.py
@@ -55,6 +55,7 @@ class LoginWindow:
             await _launch(
                 browser,
                 session.name,
+                start_url=f"https://{session.site}",
                 login_proxy=settings.sandbox.browser_login_proxy,
                 login_tz=settings.sandbox.browser_login_tz,
             )
@@ -173,11 +174,18 @@ async def _seed(browser: Sandbox, session: StoredBrowserSession) -> None:
         await browser.upload_file(local=meta, remote=f"{SESSION_ROOT}/state.meta.json")
 
 
-async def _launch(browser: Sandbox, name: str, *, login_proxy: str, login_tz: str) -> None:
-    # The launcher and its browser read these from the environment: the egress
-    # proxy keeps the login off the box's own IP, and TZ aligns the browser's
-    # timezone with the exit's geography. Either empty is simply left unset.
-    env = {"TZ": login_tz, "DRUKS_BROWSER_LOGIN_PROXY": login_proxy}
+async def _launch(
+    browser: Sandbox, name: str, *, start_url: str, login_proxy: str, login_tz: str
+) -> None:
+    # The launcher and its browser read these from the environment: the site to
+    # open on so the operator lands where they log in, the egress proxy that
+    # keeps the login off the box's own IP, and TZ to align the browser's
+    # timezone with the exit's geography. An empty value is simply left unset.
+    env = {
+        "TZ": login_tz,
+        "DRUKS_BROWSER_LOGIN_PROXY": login_proxy,
+        "DRUKS_BROWSER_URL": start_url,
+    }
     assignments = " ".join(f"{key}={shlex.quote(value)}" for key, value in env.items() if value)
     env_prefix = f"env {assignments} " if assignments else ""
     ready = await browser.exec(

--- a/backend/tests/test_browser_session_login_window.py
+++ b/backend/tests/test_browser_session_login_window.py
@@ -100,6 +100,15 @@ async def test_login_launch_leaves_the_box_untouched_when_nothing_is_set(window_
     assert "TZ=" not in command
 
 
+async def test_login_launch_opens_on_the_session_site(window_runtime):
+    client = window_runtime
+
+    await LoginWindow.open(create_session())
+
+    command = client.browsers[0].launch_command or ""
+    assert "DRUKS_BROWSER_URL=https://x.com" in command
+
+
 def _runtime_with_sandbox(tmp_path, monkeypatch, **sandbox) -> FakeSandboxClient:
     settings = make_settings(tmp_path, sandbox=sandbox)
     client = FakeSandboxClient()
@@ -125,7 +134,7 @@ async def test_login_launch_sets_the_configured_timezone(tmp_path, monkeypatch):
     await LoginWindow.open(create_session())
 
     command = client.browsers[0].launch_command or ""
-    assert "env TZ=Europe/Madrid session-launch --headed" in command
+    assert "TZ=Europe/Madrid" in command
 
 
 async def test_login_launch_quotes_values_so_a_bad_one_cannot_inject(tmp_path, monkeypatch):

--- a/deploy/browser/session-launch
+++ b/deploy/browser/session-launch
@@ -122,6 +122,17 @@ async function main() {
       await context.setStorageState(STORAGE_STATE_PATH);
     }
 
+    // Open on the session's own site so the operator lands where they log in,
+    // not on a blank tab. Best-effort: a slow or blocked site still yields a
+    // usable window the operator can steer by hand.
+    const startUrl = process.env.DRUKS_BROWSER_URL;
+    if (startUrl) {
+      const page = context.pages()[0] || (await context.newPage());
+      await page
+        .goto(startUrl, { waitUntil: "domcontentloaded", timeout: 15000 })
+        .catch(() => {});
+    }
+
     fs.writeFileSync(
       READY_PATH,
       `${JSON.stringify({ cdp: "http://127.0.0.1:9222", headless })}\n`,


### PR DESCRIPTION
A browser session declares the site it logs into (`mysite = BrowserSession(site="mysite.com")`), but the login window opened `about:blank` and left the operator to type the address. `site` was stored on the row and shown in the sessions pane — never used to steer the browser.

The launcher (`session-launch`) now navigates its first page to `DRUKS_BROWSER_URL` when set; `LoginWindow._launch` sets it from `https://<session.site>`, alongside the proxy and timezone env it already passes. So opening the login window lands the operator on the login page. Best-effort — a slow or blocked site still yields a usable window the operator can drive by hand — so a bad site never fails the window.

Borrows are untouched: they use the separate launcher in `sessions.py` and drive their own navigation.

Rides the browser image rebuild + the install.sh browser-image pull (#275).