### PR TITLE
An approved clean PR merges directly instead of looping the work gate

### DIFF
--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -327,6 +327,11 @@ class Build(Workflow):
         if self._policy.on_approval == "merge":
             if await self.declare_merge_intent():
                 return True
+            logger.warning(
+                "GitHub did not accept the merge of %s#%s; re-parking for review.",
+                self.subject.repo,
+                self.pr_number,
+            )
             return await self._work_gate()
         await self._clear_draft()
         return True

--- a/backend/druks/core/apis/github.py
+++ b/backend/druks/core/apis/github.py
@@ -141,7 +141,7 @@ class GitHubClient:
         id, serving the last-known set when GitHub hiccups."""
         cached = _INSTALLATION_ACCOUNTS_CACHE.get(self._app_id)
         now = time.monotonic()
-        if cached is not None and now - cached[0] < _INSTALLATION_ACCOUNTS_TTL_SECONDS:
+        if cached and now - cached[0] < _INSTALLATION_ACCOUNTS_TTL_SECONDS:
             return cached[1]
         try:
             accounts: list[str] = []
@@ -158,7 +158,7 @@ class GitHubClient:
                     break
                 page += 1
         except Exception:
-            if cached is not None:
+            if cached:
                 logger.warning(
                     "Could not refresh App installations; serving the last-known set.",
                     exc_info=True,
@@ -238,10 +238,8 @@ class GitHubClient:
 
     async def _invalidate_for_repo(self, repo: str) -> None:
         inst_id = self._installation_cache.pop(repo, None)
-        if inst_id is None:
-            return
-        gh = self._repo_gh_cache.pop(inst_id, None)
-        if gh is not None:
+        gh = self._repo_gh_cache.pop(inst_id, None) if inst_id else None
+        if gh:
             try:
                 await gh.__aexit__(None, None, None)
             except Exception:  # noqa: BLE001 — best-effort cleanup, log and move on
@@ -345,10 +343,15 @@ class GitHubClient:
         if pull_request["state"] == "closed":
             return True
 
-        await self.update_pull_request_branch(repo, pr_number)
-        if await self.enable_auto_merge(repo, pull_request["node_id"]):
+        # A clean pull request merges directly: GitHub refuses to arm auto-merge
+        # on one, and updating its branch first moves the head asynchronously,
+        # racing an immediate merge into a 409.
+        if await self.squash_merge_pull_request(repo, pr_number):
             return True
-        return await self.squash_merge_pull_request(repo, pr_number)
+        if await self.enable_auto_merge(repo, pull_request["node_id"]):
+            await self.update_pull_request_branch(repo, pr_number)
+            return True
+        return False
 
     @_retry_on_401
     async def update_pull_request_body(
@@ -447,7 +450,7 @@ class GitHubClient:
                 "event": event,
                 "body": body,
             }
-            if raw_comments is not None:
+            if raw_comments:
                 kwargs["comments"] = raw_comments
             response = await gh.rest.pulls.async_create_review(
                 owner,
@@ -517,7 +520,7 @@ def _build_review_comments(comments: list[ReviewComment]) -> list[dict[str, Any]
     result: list[dict[str, Any]] = []
     for c in comments:
         entry: dict[str, Any] = {"path": c.path, "line": c.line, "body": c.body}
-        if c.start_line is not None:
+        if c.start_line:
             entry["start_line"] = c.start_line
         result.append(entry)
     return result
@@ -527,7 +530,7 @@ def _fold_comments_into_body(body: str, comments: list[ReviewComment]) -> str:
     lines = [body, "", "---", ""]
     for c in comments:
         loc = f"`{c.path}:{c.line}`"
-        if c.start_line is not None:
+        if c.start_line:
             loc = f"`{c.path}:{c.start_line}-{c.line}`"
         lines.append(f"**{loc}**\n{c.body}\n")
     return "\n".join(lines)

--- a/backend/tests/ship/test_build_plan_phase.py
+++ b/backend/tests/ship/test_build_plan_phase.py
@@ -610,6 +610,8 @@ async def test_a_rejected_merge_intent_reparks_the_work_gate(monkeypatch):
     rather than finishing a run whose PR never merged."""
     flow = Build()
     flow._policy = RepoPolicy()
+    flow.subject = SimpleNamespace(repo="clawhaven/example")
+    flow.journal = SimpleNamespace(implementations=[])
     reparked = []
 
     async def declined():

--- a/backend/tests/test_github.py
+++ b/backend/tests/test_github.py
@@ -190,26 +190,25 @@ async def test_merge_when_ready_short_circuits_closed_pull_request() -> None:
     assert operations.mock_calls == [call.get_pull_request("ClawHaven/example", 7)]
 
 
-async def test_merge_when_ready_queues_after_updating_branch() -> None:
+async def test_merge_when_ready_merges_clean_pull_request_directly() -> None:
     client, operations = _merge_when_ready_client()
 
     assert await client.merge_when_ready("ClawHaven/example", 7)
     assert operations.mock_calls == [
         call.get_pull_request("ClawHaven/example", 7),
-        call.update_pull_request_branch("ClawHaven/example", 7),
-        call.enable_auto_merge("ClawHaven/example", "PR_node"),
+        call.squash_merge_pull_request("ClawHaven/example", 7),
     ]
 
 
-async def test_merge_when_ready_falls_back_to_direct_merge() -> None:
-    client, operations = _merge_when_ready_client(auto_merge_accepted=False)
+async def test_merge_when_ready_arms_auto_merge_before_updating_branch() -> None:
+    client, operations = _merge_when_ready_client(squash_merge_accepted=False)
 
     assert await client.merge_when_ready("ClawHaven/example", 7)
     assert operations.mock_calls == [
         call.get_pull_request("ClawHaven/example", 7),
-        call.update_pull_request_branch("ClawHaven/example", 7),
-        call.enable_auto_merge("ClawHaven/example", "PR_node"),
         call.squash_merge_pull_request("ClawHaven/example", 7),
+        call.enable_auto_merge("ClawHaven/example", "PR_node"),
+        call.update_pull_request_branch("ClawHaven/example", 7),
     ]
 
 
@@ -222,9 +221,8 @@ async def test_merge_when_ready_reports_unsettled_merge() -> None:
     assert not await client.merge_when_ready("ClawHaven/example", 7)
     assert operations.mock_calls == [
         call.get_pull_request("ClawHaven/example", 7),
-        call.update_pull_request_branch("ClawHaven/example", 7),
-        call.enable_auto_merge("ClawHaven/example", "PR_node"),
         call.squash_merge_pull_request("ClawHaven/example", 7),
+        call.enable_auto_merge("ClawHaven/example", "PR_node"),
     ]
 
 


### PR DESCRIPTION
## The loop

Approving a ship PR resumed the run at `merge_when_ready`, which did three GitHub calls in a doomed order:

1. **update-branch** — GitHub returns 202 and applies the merge-main commit asynchronously.
2. **enable auto-merge** — GitHub refuses to arm auto-merge on a PR already in clean status (CI green, approved), so this always failed for exactly the PRs ready to merge.
3. **direct squash merge** — fired ~1s after the async branch update, so GitHub answered 409 ("head branch was modified") every time.

The swallowed `False` sent `_approved_work` back to the work gate: every approval produced a merge-main commit, a re-requested review, and a re-parked run — with nothing logged and the work item never closing.

## The fix

Invert the order. A clean PR squash-merges directly, on the spot. Only a PR with unmet requirements falls back to arming auto-merge — which GitHub accepts in that state — followed by the branch update, so GitHub owns the finish. A declined merge intent now logs a warning before re-parking instead of looping silently.

Neighboring None-sentinel checks in the GitHub client drop to truthiness.

## Tests

`merge_when_ready` order tests reshaped to the new sequence; the re-park test now provides the subject/journal the warning reads. `test_github.py` + `test_build_plan_phase.py`: 47 passed. Ruff clean; pyright matches main's baseline.