### PR TITLE
The login proxy can carry credentials for an authenticated proxy

### DIFF
--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -157,15 +157,15 @@ class Sandbox(BaseModel):
     # The browser home: browser containers boot on this provider with this image.
     browser_sandbox_provider: str = "docker"
     browser_sandbox_image: str = "ghcr.io/czpython/druks-browser:latest"
-    # An HTTP proxy the login window routes through, so the login egresses from a
-    # different IP than the box — for sign-in flows that reject the box's own
-    # address. May carry credentials (http://user:pass@host:port) for an
-    # authenticated proxy; the login browser authenticates it directly. Empty →
-    # the box's own IP. Only the login window uses it; borrows keep it.
+    # An HTTP proxy for the login window. The login then leaves from a different
+    # IP than the box. Use it for sign-in flows that refuse the box IP. The value
+    # can include a user name and password (http://user:pass@host:port); the
+    # login browser authenticates the proxy. If it is empty, the login uses the
+    # box IP. Only the login window uses the proxy. Borrows keep the box IP.
     browser_login_proxy: str = ""
-    # The login browser's timezone, so it agrees with the egress proxy's
-    # geography (e.g. "Europe/Madrid"). An IANA zone name. Empty → the container
-    # default. Only the login window uses it.
+    # The timezone of the login browser. Set it to the region of the login proxy.
+    # Use an IANA zone name, for example "Europe/Madrid". If it is empty, the
+    # browser keeps the container default. Only the login window uses it.
     browser_login_tz: str = ""
     # Sized for the slowest provisioner.
     timeout: float = 180.0

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -159,8 +159,9 @@ class Sandbox(BaseModel):
     browser_sandbox_image: str = "ghcr.io/czpython/druks-browser:latest"
     # An HTTP proxy the login window routes through, so the login egresses from a
     # different IP than the box — for sign-in flows that reject the box's own
-    # address. Authless address; credentials, if any, are terminated deploy-side.
-    # Empty → the box's own IP. Only the login window uses it; borrows keep it.
+    # address. May carry credentials (http://user:pass@host:port) for an
+    # authenticated proxy; the login browser authenticates it directly. Empty →
+    # the box's own IP. Only the login window uses it; borrows keep it.
     browser_login_proxy: str = ""
     # The login browser's timezone, so it agrees with the egress proxy's
     # geography (e.g. "Europe/Madrid"). An IANA zone name. Empty → the container

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -182,14 +182,15 @@ provider = ""
 service_url = ""
 service_token = ""
 image = ""
-# An HTTP proxy the login window routes through, so the login egresses from a
-# different IP than the box — for sign-in flows that reject the box's own
-# address. e.g. http://172.17.0.1:8888, or http://user:pass@host:port for an
-# authenticated proxy. Empty => the box's own IP. Only the login window uses it;
-# borrows keep it. See configuration.md.
+# An HTTP proxy for the login window. The login then leaves from a different IP
+# than the box. Use it for sign-in flows that refuse the box IP. Examples:
+# http://172.17.0.1:8888, or http://user:pass@host:port for a proxy with a user
+# name and password. If it is empty, the login uses the box IP. Only the login
+# window uses it. See configuration.md.
 browser_login_proxy = ""
-# The login browser's timezone (an IANA zone, e.g. "Europe/Madrid"), so it
-# agrees with the egress proxy's geography. Empty => the container default.
+# The timezone of the login browser. Use an IANA zone, for example
+# "Europe/Madrid". Set it to the region of the login proxy. If it is empty, the
+# browser keeps the container default.
 browser_login_tz = ""
 timeout = 180
 

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -184,8 +184,9 @@ service_token = ""
 image = ""
 # An HTTP proxy the login window routes through, so the login egresses from a
 # different IP than the box — for sign-in flows that reject the box's own
-# address. Authless address, e.g. http://172.17.0.1:8888. Empty => the box's own
-# IP. Only the login window uses it; borrows keep it. See configuration.md.
+# address. e.g. http://172.17.0.1:8888, or http://user:pass@host:port for an
+# authenticated proxy. Empty => the box's own IP. Only the login window uses it;
+# borrows keep it. See configuration.md.
 browser_login_proxy = ""
 # The login browser's timezone (an IANA zone, e.g. "Europe/Madrid"), so it
 # agrees with the egress proxy's geography. Empty => the container default.

--- a/deploy/browser/session-launch
+++ b/deploy/browser/session-launch
@@ -18,18 +18,18 @@ const PROFILE_PATH = path.join(SESSION_ROOT, "profile");
 // the login browser must be real Chrome wherever it can be.
 const CHROME_PATH = "/opt/google/chrome/chrome";
 const channel = fs.existsSync(CHROME_PATH) ? "chrome" : undefined;
-// A login-only egress proxy, set by druks only when the operator configured
-// one. Empty leaves the browser on the box's own IP.
+// The proxy for the login only. druks sets it only when the operator gives one.
+// If it is empty, the browser uses the box IP.
 const loginProxy = process.env.DRUKS_BROWSER_LOGIN_PROXY;
 const RUNTIME_PATH = path.join(SESSION_ROOT, ".runtime");
 const PID_PATH = path.join(RUNTIME_PATH, "launcher.pid");
 const READY_PATH = path.join(RUNTIME_PATH, "ready.json");
 const CLOSED_PATH = path.join(RUNTIME_PATH, "closed");
 
-// Chrome's --proxy-server cannot carry a password, but Playwright authenticates
-// the proxy itself when handed username/password — so credentials in the proxy
-// URL (http://user:pass@host:port) let an authenticated ISP proxy work with no
-// external relay. A bare URL yields server-only, unchanged.
+// Chrome's --proxy-server cannot carry a password. Playwright authenticates the
+// proxy when you give it a user name and password. So a proxy URL with a user
+// name and password (http://user:pass@host:port) works with no external relay.
+// A URL with no user name and password gives a server-only proxy.
 function proxyFromUrl(raw) {
   const url = new URL(raw);
   const option = { server: `${url.protocol}//${url.host}` };

--- a/deploy/browser/session-launch
+++ b/deploy/browser/session-launch
@@ -26,6 +26,20 @@ const PID_PATH = path.join(RUNTIME_PATH, "launcher.pid");
 const READY_PATH = path.join(RUNTIME_PATH, "ready.json");
 const CLOSED_PATH = path.join(RUNTIME_PATH, "closed");
 
+// Chrome's --proxy-server cannot carry a password, but Playwright authenticates
+// the proxy itself when handed username/password — so credentials in the proxy
+// URL (http://user:pass@host:port) let an authenticated ISP proxy work with no
+// external relay. A bare URL yields server-only, unchanged.
+function proxyFromUrl(raw) {
+  const url = new URL(raw);
+  const option = { server: `${url.protocol}//${url.host}` };
+  if (url.username) option.username = decodeURIComponent(url.username);
+  if (url.password) option.password = decodeURIComponent(url.password);
+  return option;
+}
+
+const proxyOption = loginProxy ? proxyFromUrl(loginProxy) : undefined;
+
 const [mode] = process.argv.slice(2);
 if (!mode || process.argv.length !== 3 || !["--headed", "--headless"].includes(mode)) {
   console.error("usage: session-launch --headed|--headless");
@@ -96,7 +110,7 @@ async function main() {
   try {
     context = await chromium.launchPersistentContext(PROFILE_PATH, {
       channel,
-      proxy: loginProxy ? { server: loginProxy } : undefined,
+      proxy: proxyOption,
       args: [
         "--remote-debugging-address=127.0.0.1",
         "--remote-debugging-port=9222",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,14 +270,26 @@ per-host SSH private-key directory.
 HTTP proxy, so the login egresses from a different IP than the box — for sign-in
 flows that reject a login from the box's own address. It applies to the login
 window only — borrows keep the box IP, which is enough once the session is
-minted. The value is an authless proxy address, e.g. `http://172.17.0.1:8888`;
-credentials, if any, are terminated deploy-side, so no proxy secret enters
-Druks. Two ways to stand an exit up: run a CONNECT proxy on an always-on device
-reachable over the tailnet, or run a local `gost` relay
-(`gost -L=http://172.17.0.1:8888 -F=http://USER:PASS@host:PORT`) in front of a
-proxy you provide. Leaving it empty keeps today's behavior. A fixed proxy fails
-closed — if the exit is unreachable the login browser errors rather than falling
-back to the box IP.
+minted. Leaving it empty keeps today's behavior. A set proxy fails closed — if
+the exit is unreachable the login browser errors rather than falling back to the
+box IP. The value may include credentials
+(`http://user:pass@host:port`); the login browser authenticates the proxy
+itself, so no external relay is needed.
+
+Druks does not run the exit — you point this at one you provide. Two common
+shapes:
+
+- **Your own connection.** Run Tailscale on a home device and advertise it as an
+  exit node (from the Tailscale app). Add a `tailscale/tailscale` container to
+  the deploy in userspace mode (`TS_USERSPACE=true`,
+  `TS_OUTBOUND_HTTP_PROXY_LISTEN=:8080`,
+  `TS_EXTRA_ARGS=--exit-node=<your-device>`), and set
+  `browser_login_proxy = http://172.17.0.1:8080`. The login egresses from your
+  home connection; the box's own traffic is untouched. No credentials.
+- **A rented static-residential (ISP) proxy.** Point straight at it with
+  credentials: `browser_login_proxy = http://user:pass@isp-host:port`. Verify
+  the specific IP is not already flagged as a proxy before you trust it (an ISP
+  IP passes the datacenter-ASN check but can still be attributed as a proxy).
 
 `[sandbox].browser_login_tz` sets the login browser's timezone to an IANA zone
 name (e.g. `Europe/Madrid`), so it agrees with where `browser_login_proxy`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -266,36 +266,45 @@ connected.
 `DRUKS_SANDBOX_KEYS_DIR` remains a process environment override for the
 per-host SSH private-key directory.
 
-`[sandbox].browser_login_proxy` routes the browser **login window** through an
-HTTP proxy, so the login egresses from a different IP than the box — for sign-in
-flows that reject a login from the box's own address. It applies to the login
-window only — borrows keep the box IP, which is enough once the session is
-minted. Leaving it empty keeps today's behavior. A set proxy fails closed — if
-the exit is unreachable the login browser errors rather than falling back to the
-box IP. The value may include credentials
-(`http://user:pass@host:port`); the login browser authenticates the proxy
-itself, so no external relay is needed.
+`[sandbox].browser_login_proxy` sends the browser **login window** through an
+HTTP proxy. The login then leaves from a different IP than the box. Use it for
+sign-in flows that refuse a login from the box IP. Only the login window uses the
+proxy. Borrows keep the box IP. This is enough after Druks makes the session.
 
-Druks does not run the exit — you point this at one you provide. Two common
-shapes:
+If you do not set the proxy, the login uses the box IP. If you set the proxy and
+the exit is not available, the login browser fails. It does not fall back to the
+box IP.
 
-- **Your own connection.** Run Tailscale on a home device and advertise it as an
-  exit node (from the Tailscale app). Add a `tailscale/tailscale` container to
-  the deploy in userspace mode (`TS_USERSPACE=true`,
-  `TS_OUTBOUND_HTTP_PROXY_LISTEN=:8080`,
-  `TS_EXTRA_ARGS=--exit-node=<your-device>`), and set
-  `browser_login_proxy = http://172.17.0.1:8080`. The login egresses from your
-  home connection; the box's own traffic is untouched. No credentials.
-- **A rented static-residential (ISP) proxy.** Point straight at it with
-  credentials: `browser_login_proxy = http://user:pass@isp-host:port`. Verify
-  the specific IP is not already flagged as a proxy before you trust it (an ISP
-  IP passes the datacenter-ASN check but can still be attributed as a proxy).
+The value can include a user name and password (`http://user:pass@host:port`).
+The login browser authenticates the proxy. You do not need an external relay.
 
-`[sandbox].browser_login_tz` sets the login browser's timezone to an IANA zone
-name (e.g. `Europe/Madrid`), so it agrees with where `browser_login_proxy`
-egresses — a browser reporting one region while its IP is in another is an
-inconsistency some sign-in flows check. It applies to the login window only.
-Empty leaves the container's default timezone.
+Druks does not run the exit. You supply the exit and set this value to it. There
+are two common types.
+
+**Your own connection.** Do these steps:
+
+1. Install Tailscale on a home device.
+2. Make the device an exit node from the Tailscale app.
+3. Add a `tailscale/tailscale` container to the deployment in userspace mode. Set
+   these variables: `TS_USERSPACE=true`, `TS_OUTBOUND_HTTP_PROXY_LISTEN=:8080`,
+   and `TS_EXTRA_ARGS=--exit-node=<your-device>`.
+4. Set `browser_login_proxy = http://172.17.0.1:8080`.
+
+The login then leaves from your home connection. The box keeps its own IP for all
+other traffic. This exit needs no user name or password.
+
+**A rented static-residential (ISP) proxy.** Set the value to the proxy with its
+user name and password: `browser_login_proxy = http://user:pass@isp-host:port`.
+First make sure that a detection service does not already know the IP as a proxy.
+An ISP IP passes the datacenter-ASN check. A detection service can still find it
+and mark it as a proxy.
+
+`[sandbox].browser_login_tz` sets the timezone of the login browser. Use an IANA
+zone name, for example `Europe/Madrid`. The browser reports a region, and the IP
+has a region. Set both to the same region. Some sign-in flows check this. If the
+two regions are different, a flow can refuse the login. Only the login window
+uses this value. If you do not set it, the browser keeps the container default
+timezone.
 
 `[sandbox].provider` accepts any Drukbox provider name. `docker` selects the
 local install shape, `exe` selects the exe.dev + tailnet shape, and every other


### PR DESCRIPTION
The login-window proxy (`browser_login_proxy`) was server-only. That's fine for a home-connection exit (authless), but a rented **authenticated** proxy — a static-residential IP with `user:pass` — couldn't be used without an external relay to hold the credentials, since Chrome's `--proxy-server` can't carry a password.

But Playwright authenticates the proxy itself when given a username and password. So this parses any credentials out of the proxy URL and hands them to Playwright — no relay needed.

- `browser_login_proxy = http://172.17.0.1:8080` → server-only, unchanged.
- `browser_login_proxy = http://user:pass@isp-host:port` → Playwright authenticates the proxy.

## Verification

Built the browser image and tested on a running container against an auth-requiring proxy:
- Correct credentials → the login browser authenticates and egresses through the proxy.
- Wrong password → blocked (the proxy 407), with **no fallback** to the box IP — fail-closed still holds with credentials.

The URL parsing (`proxyFromUrl` in `session-launch`) is a couple of lines; a bare URL yields server-only exactly as before.

## Docs

Dropped the `gost` relay recipe (no longer needed) and describe the two exits directly:
- **Your own connection** — a `tailscale/tailscale` userspace sidecar advertising an HTTP proxy the login browser points at. Druks builds nothing; it's one deploy-side service pointed at the existing knob.
- **A rented static-residential (ISP) proxy** — point straight at it with credentials, and verify the specific IP isn't already flagged as a proxy before trusting it.
