### PR TITLE
install.sh seeds a compose.override.yaml that survives re-runs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,3 +60,25 @@ dashboard at <http://127.0.0.1:8001>: **Settings → Harnesses** connects
 Claude and Codex (agent runs refuse to start on an unconnected harness) and
 the GitHub App druks acts as. Then `docker compose exec web druks doctor
 --sandbox` proves the full sandbox path with a real container.
+
+## Local customizations
+
+Put host-local Docker Compose changes in `~/druks/compose.override.yaml`. Add
+local services, service overrides, and named volumes there. install.sh creates
+this file once and never changes it. Your changes survive every install and
+upgrade.
+
+install.sh refreshes the repo compose files on each run. So do not edit
+`compose.yaml`, `compose.local.yaml`, or `compose.remote.yaml` — those changes
+are lost on the next install.
+
+Example — bake locally-installed apps into the web image:
+
+```yaml
+services:
+  web:
+    image: druks-with-apps
+    build: ./appimage
+```
+
+Apply a change with `docker compose up -d` from `~/druks`.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -77,6 +77,12 @@ main() {
   fetch_from_repo deploy/compose.local.yaml compose.local.yaml
   fetch_from_repo deploy/compose.remote.yaml compose.remote.yaml
 
+  # compose.override.yaml holds the operator's local services and overrides;
+  # COMPOSE_FILE lists it, so it must exist. Seed it once and never touch it
+  # again, so nothing the operator adds is lost. INSTALL.md explains it.
+  [ -f compose.override.yaml ] \
+    || printf '# Host-local Compose overrides. See INSTALL.md.\n' > compose.override.yaml
+
   # The Caddyfile is bind-mounted by the remote overlay (stock caddy image, no
   # baked config), so it refreshes on every re-run.
   echo "→ fetching deploy/caddy/Caddyfile from $REPO@$REF"
@@ -135,10 +141,12 @@ main() {
   else
     set_env_var DRUKS_DOCKER_GID "$(stat -c '%g' /var/run/docker.sock)"
   fi
+  # compose.override.yaml loads last so operator additions win over the repo
+  # files and are never overwritten by them.
   if [ "$PROVIDER" = "docker" ]; then
-    set_env_var COMPOSE_FILE "compose.yaml:compose.local.yaml"
+    set_env_var COMPOSE_FILE "compose.yaml:compose.local.yaml:compose.override.yaml"
   else
-    set_env_var COMPOSE_FILE "compose.yaml:compose.remote.yaml"
+    set_env_var COMPOSE_FILE "compose.yaml:compose.remote.yaml:compose.override.yaml"
   fi
 
   echo "→ docker compose pull"


### PR DESCRIPTION
install.sh refreshes the repo compose files (`compose.yaml`, `compose.remote.yaml`, `compose.local.yaml`) on every run, so any host-local addition to them was silently wiped on the next install or upgrade. Two things operators add today got clobbered: the derived `web` image override (`image: druks-with-apps` + `build: ./appimage`), and extra services run alongside the stack plus their named volumes.

## Change

- Seed `compose.override.yaml` once — an empty, commented file — only if it does not already exist. install.sh never writes or regenerates it after that.
- Append it to the end of `COMPOSE_FILE` (`…:compose.override.yaml`), so it loads last and operator additions win.
- The repo compose files keep refreshing exactly as before; they carry no host-local content.

`compose.override.yaml` is named explicitly in `COMPOSE_FILE` — Compose only auto-loads it when `COMPOSE_FILE` is unset, which it is not here. No specific operator service is baked into the repo; the file is the operator's, the repo only guarantees it exists, is included, and is never touched.

## Docs

`INSTALL.md` gains a short section: put local additions and per-service overrides in `compose.override.yaml`; install.sh creates it once and never touches it again. The derived-image web override is the example.

## Verified locally

- Fresh seed is a comments-only file; `docker compose config` is valid (no-op override).
- A service defined only in `compose.override.yaml` appears in `docker compose config --services`.
- Re-run leaves an existing `compose.override.yaml` untouched (guarded by `[ ! -f … ]`).
