### PR TITLE
Test and docstring examples use the neutral service names

### DIFF
--- a/backend/druks/browser/sessions.py
+++ b/backend/druks/browser/sessions.py
@@ -30,14 +30,14 @@ CDP_PORT = 9222
 class BrowserSession:
     """A named browser login the extension's runs borrow.
 
-    Declared on the Extension class — ``x = BrowserSession(site="x.com")`` — the
-    attribute name and the extension's name become the session's identity
-    (``x_me.x``). The operator signs in once through the login window; a
-    workflow then borrows the logged-in browser::
+    Declared on the Extension class — ``acme = BrowserSession(site="acme.example")``
+    — the attribute name and the extension's name become the session's identity
+    (``night_watch.acme``). The operator signs in once through the login window;
+    a workflow then borrows the logged-in browser::
 
-        async with XMe.x.playwright() as browser:
+        async with NightWatch.acme.playwright() as browser:
             page = await browser.new_page()
-            await page.goto("https://x.com/home")
+            await page.goto("https://acme.example/home")
     """
 
     site: str

--- a/backend/tests/test_browser_borrow.py
+++ b/backend/tests/test_browser_borrow.py
@@ -21,13 +21,13 @@ from druks.testing import make_settings
 
 
 @pytest.fixture
-def x_me(browser_session_declarations):
-    class XMe:
-        name = "x_me"
-        x = BrowserSession(site="x.com", persist=True)
+def night_watch(browser_session_declarations):
+    class NightWatch:
+        name = "night_watch"
+        acme = BrowserSession(site="acme.example", persist=True)
         docs = BrowserSession(site="docs.example")
 
-    return XMe
+    return NightWatch
 
 
 class FakeListener:
@@ -115,16 +115,16 @@ def stored_session(
     return row
 
 
-def test_declaration_carries_the_extension_namespace(x_me):
-    assert x_me.x.name == "x_me.x"
-    assert x_me.docs.name == "x_me.docs"
+def test_declaration_carries_the_extension_namespace(night_watch):
+    assert night_watch.acme.name == "night_watch.acme"
+    assert night_watch.docs.name == "night_watch.docs"
 
 
-async def test_borrow_yields_a_tunneled_cdp_url(borrow, x_me):
+async def test_borrow_yields_a_tunneled_cdp_url(borrow, night_watch):
     browser, redis = borrow
-    stored_session(x_me.docs)
+    stored_session(night_watch.docs)
 
-    async with x_me.docs.cdp() as cdp_url:
+    async with night_watch.docs.cdp() as cdp_url:
         assert cdp_url == "http://127.0.0.1:43987"
 
     assert browser.forwarded_port == 9222
@@ -138,14 +138,14 @@ async def test_borrow_yields_a_tunneled_cdp_url(borrow, x_me):
     launch_script = browser.commands[0][2]
     assert "session-launch --headed" in launch_script
     assert not redis.values
-    assert StoredBrowserSession.get_for_name(x_me.docs.name).last_used_at
+    assert StoredBrowserSession.get_for_name(night_watch.docs.name).last_used_at
 
 
 async def test_headless_declaration_launches_headless(borrow):
     browser, _ = borrow
     quiet = BrowserSession(site="docs.example")
     quiet.headless = True
-    quiet.name = "x_me.quiet"
+    quiet.name = "night_watch.quiet"
     stored_session(quiet)
 
     async with quiet.cdp():
@@ -154,92 +154,96 @@ async def test_headless_declaration_launches_headless(borrow):
     assert "session-launch --headless" in browser.commands[0][2]
 
 
-async def test_persisting_borrow_locks_exports_and_stores(borrow, x_me):
+async def test_persisting_borrow_locks_exports_and_stores(borrow, night_watch):
     browser, redis = borrow
-    row = stored_session(x_me.x)
+    row = stored_session(night_watch.acme)
 
-    async with x_me.x.cdp():
+    async with night_watch.acme.cdp():
         assert redis.values
 
     assert not redis.values
     assert browser.commands[-1] == ["session-export"]
     db_session().expire_all()
-    stored = StoredBrowserSession.get_for_name(x_me.x.name)
+    stored = StoredBrowserSession.get_for_name(night_watch.acme.name)
     assert stored.payload.decrypt() == b"exported-profile"
     assert stored.payload_format == BrowserSessionPayloadFormat.PROFILE_DIR.value
     assert stored.id == row.id
 
 
-async def test_persisting_borrow_refuses_a_second_writer(borrow, x_me):
+async def test_persisting_borrow_refuses_a_second_writer(borrow, night_watch):
     browser, redis = borrow
-    stored_session(x_me.x)
-    redis.values[f"browser_session:{StoredBrowserSession.get_for_name(x_me.x.name).id}"] = "other"
+    stored_session(night_watch.acme)
+    redis.values[
+        f"browser_session:{StoredBrowserSession.get_for_name(night_watch.acme.name).id}"
+    ] = "other"
 
     with pytest.raises(BrowserSessionWriterLockedError):
-        async with x_me.x.cdp():
+        async with night_watch.acme.cdp():
             pass
 
     assert browser.commands == []
 
 
 async def test_first_borrow_writes_the_declared_session_and_asks_for_a_login(
-    borrow, x_me, druks_db
+    borrow, night_watch, druks_db
 ):
     """The first borrow materializes the row and refuses to open a browser:
     the session is declared, but nobody has signed into it yet."""
-    assert not StoredBrowserSession.get_for_name(x_me.docs.name)
+    assert not StoredBrowserSession.get_for_name(night_watch.docs.name)
 
     with pytest.raises(BrowserSessionNotReadyError):
-        async with x_me.docs.cdp():
+        async with night_watch.docs.cdp():
             pass
 
-    row = StoredBrowserSession.get_for_name(x_me.docs.name)
+    row = StoredBrowserSession.get_for_name(night_watch.docs.name)
     assert row.status == BrowserSessionStatus.NEEDS_LOGIN.value
-    assert row.site == x_me.docs.site
+    assert row.site == night_watch.docs.site
 
     with pytest.raises(BrowserSessionNotReadyError):
-        async with x_me.docs.cdp():
+        async with night_watch.docs.cdp():
             pass
 
     assert StoredBrowserSession.list_all() == [row]
 
 
-async def test_launch_failure_raises_and_releases_the_lock(borrow, x_me):
+async def test_launch_failure_raises_and_releases_the_lock(borrow, night_watch):
     browser, redis = borrow
-    stored_session(x_me.x)
+    stored_session(night_watch.acme)
     browser.launch_exit = 1
 
     with pytest.raises(BrowserLaunchError, match="launch stderr"):
-        async with x_me.x.cdp():
+        async with night_watch.acme.cdp():
             pass
 
     assert not redis.values
 
 
-async def test_signed_out_borrow_stamps_the_session_and_stores_nothing(borrow, x_me):
+async def test_signed_out_borrow_stamps_the_session_and_stores_nothing(borrow, night_watch):
     """The extension raises through the borrow when the site bounced the login:
     the door stamps which session bounced, and the dead state is never stored."""
     browser, redis = borrow
-    stored_session(x_me.x, payload=b"live-state")
+    stored_session(night_watch.acme, payload=b"live-state")
 
     with pytest.raises(BrowserSessionSignedOutError) as caught:
-        async with x_me.x.cdp():
+        async with night_watch.acme.cdp():
             raise BrowserSessionSignedOutError("the site bounced the login")
 
-    assert caught.value.session_name == "x_me.x"
+    assert caught.value.session_name == "night_watch.acme"
     db_session().expire_all()
-    assert StoredBrowserSession.get_for_name(x_me.x.name).payload.decrypt() == b"live-state"
+    assert (
+        StoredBrowserSession.get_for_name(night_watch.acme.name).payload.decrypt() == b"live-state"
+    )
     assert ["session-export"] not in browser.commands
     assert not redis.values  # the writer lock released on the way out
 
 
-async def test_playwright_yields_the_logged_in_context(borrow, x_me, monkeypatch):
+async def test_playwright_yields_the_logged_in_context(borrow, night_watch, monkeypatch):
     import sys
     import types
     from contextlib import asynccontextmanager as acm
 
     browser, _ = borrow
-    stored_session(x_me.docs)
+    stored_session(night_watch.docs)
     seen = {}
     logged_in_context = object()
 
@@ -263,19 +267,19 @@ async def test_playwright_yields_the_logged_in_context(borrow, x_me, monkeypatch
     monkeypatch.setitem(sys.modules, "playwright", types.ModuleType("playwright"))
     monkeypatch.setitem(sys.modules, "playwright.async_api", playwright_module)
 
-    async with x_me.docs.playwright() as context:
+    async with night_watch.docs.playwright() as context:
         assert context is logged_in_context
 
     assert seen == {"url": "http://127.0.0.1:43987", "closed": True}
 
 
-async def test_playwright_without_the_dependency_names_the_fix(borrow, x_me, monkeypatch):
+async def test_playwright_without_the_dependency_names_the_fix(borrow, night_watch, monkeypatch):
     import sys
 
-    stored_session(x_me.docs)
+    stored_session(night_watch.docs)
     monkeypatch.setitem(sys.modules, "playwright", None)
     monkeypatch.setitem(sys.modules, "playwright.async_api", None)
 
     with pytest.raises(BrowserClientMissingError, match="add playwright"):
-        async with x_me.docs.playwright():
+        async with night_watch.docs.playwright():
             pass

--- a/backend/tests/test_browser_session_login_window.py
+++ b/backend/tests/test_browser_session_login_window.py
@@ -82,11 +82,11 @@ def window_runtime(tmp_path, monkeypatch):
     return client
 
 
-def create_session(name: str = "x-main") -> StoredBrowserSession:
+def create_session(name: str = "acme-main") -> StoredBrowserSession:
     return StoredBrowserSession.get_or_create(
         name=name,
         payload_format=BrowserSessionPayloadFormat.STORAGE_STATE,
-        site="x.com",
+        site="acme.example",
     )
 
 
@@ -106,7 +106,7 @@ async def test_login_launch_opens_on_the_session_site(window_runtime):
     await LoginWindow.open(create_session())
 
     command = client.browsers[0].launch_command or ""
-    assert "DRUKS_BROWSER_URL=https://x.com" in command
+    assert "DRUKS_BROWSER_URL=https://acme.example" in command
 
 
 def _runtime_with_sandbox(tmp_path, monkeypatch, **sandbox) -> FakeSandboxClient:

--- a/backend/tests/test_browser_sessions.py
+++ b/backend/tests/test_browser_sessions.py
@@ -16,13 +16,13 @@ from sqlalchemy import text
 
 
 @pytest.fixture
-def x_me(browser_session_declarations):
-    class XMe:
-        name = "x_me"
-        x = BrowserSession(site="x.com")
+def night_watch(browser_session_declarations):
+    class NightWatch:
+        name = "night_watch"
+        acme = BrowserSession(site="acme.example")
         docs = BrowserSession(site="docs.example")
 
-    return XMe
+    return NightWatch
 
 
 @pytest.fixture
@@ -46,20 +46,20 @@ class FakeLoginWindow:
         cls.opened.append(session.name)
 
 
-def test_declared_sessions_list_without_a_row_and_the_pane_read_writes_nothing(client, x_me):
+def test_declared_sessions_list_without_a_row_and_the_pane_read_writes_nothing(client, night_watch):
     listed = client.get("/api/browser-sessions").json()
 
-    assert [entry["name"] for entry in listed] == ["x_me.docs", "x_me.x"]
-    entry = listed[1]
+    assert [entry["name"] for entry in listed] == ["night_watch.acme", "night_watch.docs"]
+    entry = listed[0]
     assert entry["status"] == BrowserSessionStatus.NEEDS_LOGIN
     assert entry["isDeclared"] is True
     assert entry["payloadFormat"] is None
     assert entry["createdAt"] is None
-    assert entry["site"] == "x.com"
+    assert entry["site"] == "acme.example"
     assert not StoredBrowserSession.list_all()
 
 
-def test_leftover_rows_list_as_undeclared_and_refuse_the_login_window(client, x_me):
+def test_leftover_rows_list_as_undeclared_and_refuse_the_login_window(client, night_watch):
     StoredBrowserSession.get_or_create(
         name="gone_ext.old",
         payload_format=BrowserSessionPayloadFormat.PROFILE_DIR,
@@ -68,8 +68,8 @@ def test_leftover_rows_list_as_undeclared_and_refuse_the_login_window(client, x_
 
     listed = client.get("/api/browser-sessions").json()
     assert [(entry["name"], entry["isDeclared"]) for entry in listed] == [
-        ("x_me.docs", True),
-        ("x_me.x", True),
+        ("night_watch.acme", True),
+        ("night_watch.docs", True),
         ("gone_ext.old", False),
     ]
 
@@ -78,37 +78,37 @@ def test_leftover_rows_list_as_undeclared_and_refuse_the_login_window(client, x_
     assert not StoredBrowserSession.list_all()
 
 
-def test_opening_the_login_window_materializes_the_declared_row(client, x_me, monkeypatch):
+def test_opening_the_login_window_materializes_the_declared_row(client, night_watch, monkeypatch):
     monkeypatch.setattr(routes, "LoginWindow", FakeLoginWindow)
     monkeypatch.setattr(FakeLoginWindow, "opened", [])
 
-    opened = client.post("/api/browser-sessions/x_me.x/login-window")
+    opened = client.post("/api/browser-sessions/night_watch.acme/login-window")
 
     assert opened.status_code == 204
-    assert FakeLoginWindow.opened == ["x_me.x"]
-    row = StoredBrowserSession.get_for_name("x_me.x")
+    assert FakeLoginWindow.opened == ["night_watch.acme"]
+    row = StoredBrowserSession.get_for_name("night_watch.acme")
     assert row.status == BrowserSessionStatus.NEEDS_LOGIN.value
-    assert row.site == "x.com"
+    assert row.site == "acme.example"
 
     assert client.post("/api/browser-sessions/nobody.home/login-window").status_code == 404
 
 
 def test_import_materializes_the_row_survives_restart_and_delete_removes_it(
-    client, x_me, tmp_path, monkeypatch
+    client, night_watch, tmp_path, monkeypatch
 ):
     payload = b'{"cookies":[{"name":"auth_token","value":"secret"}],"origins":[]}'
     uploaded = client.put(
-        "/api/browser-sessions/x_me.x/state?payloadFormat=storage_state",
+        "/api/browser-sessions/night_watch.acme/state?payloadFormat=storage_state",
         content=payload,
         headers={"Content-Type": "application/octet-stream"},
     )
     assert uploaded.status_code == 204
     listed = {entry["name"]: entry for entry in client.get("/api/browser-sessions").json()}
-    assert listed["x_me.x"]["status"] == BrowserSessionStatus.READY
-    assert listed["x_me.x"]["payloadFormat"] == BrowserSessionPayloadFormat.STORAGE_STATE
-    assert listed["x_me.x"]["lastRefreshedAt"]
+    assert listed["night_watch.acme"]["status"] == BrowserSessionStatus.READY
+    assert listed["night_watch.acme"]["payloadFormat"] == BrowserSessionPayloadFormat.STORAGE_STATE
+    assert listed["night_watch.acme"]["lastRefreshedAt"]
 
-    row = StoredBrowserSession.get_for_name("x_me.x")
+    row = StoredBrowserSession.get_for_name("night_watch.acme")
     stored = (
         db_session()
         .execute(
@@ -130,7 +130,7 @@ def test_import_materializes_the_row_survives_restart_and_delete_removes_it(
             row.payload.decrypt()
 
     db_session().expire_all()
-    restarted = StoredBrowserSession.get_for_name("x_me.x")
+    restarted = StoredBrowserSession.get_for_name("night_watch.acme")
     assert restarted.payload.decrypt() == payload
 
     undeclared = client.put(
@@ -138,37 +138,38 @@ def test_import_materializes_the_row_survives_restart_and_delete_removes_it(
     )
     assert undeclared.status_code == 404
 
-    deleted = client.delete("/api/browser-sessions/x_me.x")
+    deleted = client.delete("/api/browser-sessions/night_watch.acme")
     assert deleted.status_code == 204
     assert not StoredBrowserSession.list_all()
 
 
-def test_upload_rejects_payloads_above_the_cap(client, x_me, monkeypatch):
+def test_upload_rejects_payloads_above_the_cap(client, night_watch, monkeypatch):
     monkeypatch.setattr(routes, "MAX_PAYLOAD_BYTES", 3)
 
     response = client.put(
-        "/api/browser-sessions/x_me.x/state?payloadFormat=storage_state", content=b"four"
+        "/api/browser-sessions/night_watch.acme/state?payloadFormat=storage_state", content=b"four"
     )
 
     assert response.status_code == 413
     assert "256 MB" in response.json()["detail"]
     listed = {entry["name"]: entry for entry in client.get("/api/browser-sessions").json()}
-    assert listed["x_me.x"]["status"] == BrowserSessionStatus.NEEDS_LOGIN
+    assert listed["night_watch.acme"]["status"] == BrowserSessionStatus.NEEDS_LOGIN
 
 
-def test_upload_warns_at_the_product_threshold(client, x_me, monkeypatch, caplog):
+def test_upload_warns_at_the_product_threshold(client, night_watch, monkeypatch, caplog):
     monkeypatch.setattr(routes, "PAYLOAD_WARNING_BYTES", 3)
 
     with caplog.at_level("WARNING"):
         response = client.put(
-            "/api/browser-sessions/x_me.x/state?payloadFormat=storage_state", content=b"three"
+            "/api/browser-sessions/night_watch.acme/state?payloadFormat=storage_state",
+            content=b"three",
         )
 
     assert response.status_code == 204
     assert "received a 5-byte payload" in caplog.text
 
 
-def test_bearer_pat_reads_sessions_but_cannot_mutate_them(tmp_path, druks_db, x_me):
+def test_bearer_pat_reads_sessions_but_cannot_mutate_them(tmp_path, druks_db, night_watch):
     settings = make_settings(
         tmp_path,
         identity={"mode": "header", "header": "X-Edge-Email"},
@@ -182,12 +183,12 @@ def test_bearer_pat_reads_sessions_but_cannot_mutate_them(tmp_path, druks_db, x_
         assert pat_client.get("/api/browser-sessions", headers=headers).status_code == 200
         mutations = (
             pat_client.put(
-                "/api/browser-sessions/x_me.x/state?payloadFormat=storage_state",
+                "/api/browser-sessions/night_watch.acme/state?payloadFormat=storage_state",
                 content=b"blocked",
                 headers=headers,
             ),
-            pat_client.post("/api/browser-sessions/x_me.x/login-window", headers=headers),
-            pat_client.delete("/api/browser-sessions/x_me.x", headers=headers),
+            pat_client.post("/api/browser-sessions/night_watch.acme/login-window", headers=headers),
+            pat_client.delete("/api/browser-sessions/night_watch.acme", headers=headers),
         )
 
     assert [response.status_code for response in mutations] == [401, 401, 401]

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -494,9 +494,9 @@ async def test_signed_out_run_fails_and_marks_the_session_stale(rt):
     try:
         session.add(
             StoredBrowserSession(
-                name="x_me.x",
+                name="night_watch.acme",
                 payload_format=BrowserSessionPayloadFormat.STORAGE_STATE.value,
-                site="x.com",
+                site="acme.example",
             )
         )
         session.commit()
@@ -506,7 +506,7 @@ async def test_signed_out_run_fails_and_marks_the_session_stale(rt):
     class BounceFlow(Workflow):
         async def run(self) -> None:
             error = BrowserSessionSignedOutError("the site bounced the login")
-            error.session_name = "x_me.x"
+            error.session_name = "night_watch.acme"
             raise error
 
     try:
@@ -517,7 +517,7 @@ async def test_signed_out_run_fails_and_marks_the_session_stale(rt):
         session = get_session(rt.engine)
         try:
             stored = session.execute(
-                select(StoredBrowserSession).where(StoredBrowserSession.name == "x_me.x")
+                select(StoredBrowserSession).where(StoredBrowserSession.name == "night_watch.acme")
             ).scalar_one()
             assert stored.status == BrowserSessionStatus.STALE.value
         finally:

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -101,7 +101,9 @@ def test_header_mode_requires_exactly_one_nonblank_assertion(tmp_path, druks_db)
         assert client.get("/api/auth/me").status_code == 401
         assert client.get("/api/settings").status_code == 401
         assert client.get("/api/auth/me", headers={HEADER: "   "}).status_code == 401
-        two = client.get("/api/auth/me", headers=[(HEADER, "a@x.com"), (HEADER, "b@x.com")])
+        two = client.get(
+            "/api/auth/me", headers=[(HEADER, "a@example.com"), (HEADER, "b@example.com")]
+        )
         assert two.status_code == 401
     # Rejection never enrolls anyone.
     assert {account.username for account in _all_accounts()} == {"system"}

--- a/frontend/src/components/BrowserSessionsPane.test.tsx
+++ b/frontend/src/components/BrowserSessionsPane.test.tsx
@@ -7,10 +7,10 @@ import { BrowserSessionsPane } from './BrowserSessionsPane'
 
 function browserSession(overrides: Partial<BrowserSession> = {}): BrowserSession {
   return {
-    name: 'x_me.x',
+    name: 'night_watch.acme',
     status: 'ready',
     payloadFormat: 'storage_state',
-    site: 'x.com',
+    site: 'acme.example',
     isDeclared: true,
     createdAt: new Date().toISOString(),
     lastRefreshedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
@@ -27,8 +27,8 @@ function stubFetch(initial: BrowserSession[]) {
       if (url === '/api/browser-sessions' && method === 'GET') {
         return new Response(JSON.stringify(sessions), { status: 200 })
       }
-      if (url === '/api/browser-sessions/x_me.x' && method === 'DELETE') {
-        sessions = sessions.filter((session) => session.name !== 'x_me.x')
+      if (url === '/api/browser-sessions/night_watch.acme' && method === 'DELETE') {
+        sessions = sessions.filter((session) => session.name !== 'night_watch.acme')
         return new Response(null, { status: 204 })
       }
       return new Response('{}', { status: 404 })
@@ -68,14 +68,14 @@ describe('BrowserSessionsPane', () => {
     ])
     renderPane()
 
-    expect(await screen.findByText('x_me.x')).toBeTruthy()
+    expect(await screen.findByText('night_watch.acme')).toBeTruthy()
     expect(screen.getByText('Ready')).toBeTruthy()
     expect(screen.getByText('Stale')).toBeTruthy()
     expect(screen.getByRole('link', { name: 'Reconnect' }).getAttribute('href')).toBe(
       '/druks/browser-sessions/linked_in.jobs/login',
     )
     expect(screen.getByRole('link', { name: 'Open window' }).getAttribute('href')).toBe(
-      '/druks/browser-sessions/x_me.x/login',
+      '/druks/browser-sessions/night_watch.acme/login',
     )
     expect(screen.queryByRole('link', { name: 'Log in' })).toBeNull()
     expect(screen.getByText('Storage state')).toBeTruthy()
@@ -95,10 +95,10 @@ describe('BrowserSessionsPane', () => {
     ])
     renderPane()
 
-    expect(await screen.findByText('x_me.x')).toBeTruthy()
+    expect(await screen.findByText('night_watch.acme')).toBeTruthy()
     expect(screen.getByText('Needs login')).toBeTruthy()
     expect(screen.getByRole('link', { name: 'Log in' }).getAttribute('href')).toBe(
-      '/browser-sessions/x_me.x/login',
+      '/browser-sessions/night_watch.acme/login',
     )
     expect(screen.queryByText('Delete')).toBeNull()
   })
@@ -108,19 +108,19 @@ describe('BrowserSessionsPane', () => {
     const confirm = vi.fn(() => true)
     vi.stubGlobal('confirm', confirm)
     renderPane()
-    await screen.findByText('x_me.x')
+    await screen.findByText('night_watch.acme')
 
     expect(screen.getByText('No longer declared')).toBeTruthy()
     expect(screen.queryByRole('link', { name: 'Open window' })).toBeNull()
 
     fireEvent.click(screen.getByText('Delete'))
     expect(confirm).toHaveBeenCalledWith(
-      'Delete x_me.x? Its saved browser state will be destroyed.',
+      'Delete night_watch.acme? Its saved browser state will be destroyed.',
     )
-    await waitFor(() => expect(screen.queryByText('x_me.x')).toBeNull())
+    await waitFor(() => expect(screen.queryByText('night_watch.acme')).toBeNull())
     expect(
       fetchMock.mock.calls.some(
-        ([url, init]) => url === '/api/browser-sessions/x_me.x' && init?.method === 'DELETE',
+        ([url, init]) => url === '/api/browser-sessions/night_watch.acme' && init?.method === 'DELETE',
       ),
     ).toBe(true)
   })

--- a/frontend/src/pages/LoginWindowPage.test.tsx
+++ b/frontend/src/pages/LoginWindowPage.test.tsx
@@ -27,7 +27,7 @@ vi.mock('@novnc/novnc', () => {
 function renderPage() {
   render(
     <StrictMode>
-      <LoginWindowPage name="x_me.x" />
+      <LoginWindowPage name="night_watch.acme" />
     </StrictMode>,
   )
 }
@@ -43,10 +43,10 @@ describe('LoginWindowPage', () => {
   it('opens the one-use bridge and saves the browser profile', async () => {
     const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
       async (url) => {
-        if (url === '/api/browser-sessions/x_me.x/login-window') {
+        if (url === '/api/browser-sessions/night_watch.acme/login-window') {
           return new Response(null, { status: 204 })
         }
-        if (url === '/api/browser-sessions/x_me.x/login-window/save') {
+        if (url === '/api/browser-sessions/night_watch.acme/login-window/save') {
           return new Response(null, { status: 204 })
         }
         return new Response('{}', { status: 404 })
@@ -57,11 +57,11 @@ describe('LoginWindowPage', () => {
 
     renderPage()
 
-    expect(await screen.findByText('x_me.x')).toBeTruthy()
+    expect(await screen.findByText('night_watch.acme')).toBeTruthy()
     await waitFor(() => expect(rfbState.instances).toHaveLength(1))
     expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/login-window'))).toHaveLength(1)
     expect(rfbState.instances[0]?.url).toBe(
-      'ws://localhost:3000/api/browser-sessions/x_me.x/login-window/ws',
+      'ws://localhost:3000/api/browser-sessions/night_watch.acme/login-window/ws',
     )
     rfbState.instances[0]?.dispatchEvent(new Event('connect'))
     expect(await screen.findByText('Connected')).toBeTruthy()
@@ -72,7 +72,7 @@ describe('LoginWindowPage', () => {
     expect(
       fetchMock.mock.calls.some(
         ([url, init]) =>
-          url === '/api/browser-sessions/x_me.x/login-window/save' && init?.method === 'POST',
+          url === '/api/browser-sessions/night_watch.acme/login-window/save' && init?.method === 'POST',
       ),
     ).toBe(true)
   })

--- a/scripts/import_browser_session.py
+++ b/scripts/import_browser_session.py
@@ -16,7 +16,7 @@ def parse_args() -> argparse.Namespace:
         description="Capture a headed Chromium login and import it into the Druks session vault."
     )
     parser.add_argument(
-        "--name", required=True, help="Declared browser-session name, for example x_me.x."
+        "--name", required=True, help="Declared browser-session name, for example night_watch.acme."
     )
     parser.add_argument("--site-url", required=True, help="Login page to open in Chromium.")
     parser.add_argument(


### PR DESCRIPTION
The browser-session docstring in `backend/druks/browser/sessions.py` and the browser/identity test fixtures (backend and frontend) now use the same neutral example cast as the docs — the NightWatch extension, handle names like `acme`/`docs`, and `acme.example` sites — along with the `import_browser_session.py` help text. Renames only; two list assertions flipped order because the registry sorts session names and the new handle sorts first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)