### PR TITLE
Token delivery is get_access_token; mint means real issuance

### DIFF
--- a/backend/druks/mcp/oauth.py
+++ b/backend/druks/mcp/oauth.py
@@ -264,8 +264,8 @@ async def disconnect(name: str, account_id: str) -> None:
         registration.delete()
 
 
-async def mint_access_token(name: str, account_id: str) -> str:
-    """The delivery-side token for a connected server, minted by the shared
+async def get_access_token(name: str, account_id: str) -> str:
+    """The delivery-side token for a connected server, served by the shared
     engine from this server's grant — delivery never ships a server the agent
     can't authenticate to."""
     connection = get_connection(name, account_id)
@@ -285,6 +285,6 @@ async def mint_access_token(name: str, account_id: str) -> str:
         mint_wait_attempts=OAUTH_MINT_WAIT_ATTEMPTS,
     )
     try:
-        return await client.mint_access_token(connection=connection)
+        return await client.get_access_token(connection=connection)
     except OauthRefreshError as error:
         raise GrantRefreshError(name, error.reason) from error

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -206,7 +206,7 @@ class Workspace:
                     raise SourceEnvVarUnsetError(server["name"], server["source_env_var"])
             else:  # oauth
                 grant_account = get_grant_account(server["identity_mode"], run_account)
-                token = await oauth.mint_access_token(server["name"], grant_account)
+                token = await oauth.get_access_token(server["name"], grant_account)
             bearer_token_env_var = ""
             if token:
                 bearer_token_env_var = get_bearer_token_env_var(server["name"])

--- a/backend/druks/services/base.py
+++ b/backend/druks/services/base.py
@@ -14,7 +14,8 @@ from .oauth import OauthClient
 
 class Connection:
     """One signed-in provider account, reached through the extension's
-    declared handle. Mint and disconnect act on this sign-in only."""
+    declared handle. ``get_access_token`` and ``disconnect`` act on this
+    sign-in only."""
 
     def __init__(self, service: "type[Service]", row: OauthConnection) -> None:
         self.service = service
@@ -32,8 +33,8 @@ class Connection:
     def connected_at(self):
         return self.row.connected_at
 
-    async def mint_access_token(self, scopes: tuple[str, ...] = (), cached: bool = True) -> str:
-        return await self.service.get_oauth_client().mint_access_token(
+    async def get_access_token(self, scopes: tuple[str, ...] = (), cached: bool = True) -> str:
+        return await self.service.get_oauth_client().get_access_token(
             connection=self.row, scopes=scopes, cached=cached
         )
 

--- a/backend/druks/services/oauth.py
+++ b/backend/druks/services/oauth.py
@@ -60,10 +60,10 @@ class OauthClient:
 
     ``begin_connect`` returns the consent URL to open; the module-level
     ``complete_connect`` consumes the callback's single-use state and
-    exchanges the code; ``mint_access_token`` serves delivery from the Redis
+    exchanges the code; ``get_access_token`` serves delivery from the Redis
     token cache, electing one refresher per connection. The caller stores an
     ``OauthConnection`` from the completed exchange and hands it back to
-    mint. A ``Service`` with declared OAuth endpoints hands back a
+    ``get_access_token``. A ``Service`` with declared OAuth endpoints hands back a
     configured client via ``get_oauth_client()`` — construct directly only
     when no service holds the client credentials.
 
@@ -156,7 +156,7 @@ class OauthClient:
         query.update(extra_authorize_params or {})
         return f"{self.authorization_endpoint}?{urlencode(query)}"
 
-    async def mint_access_token(
+    async def get_access_token(
         self,
         *,
         connection: OauthConnection,

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -320,7 +320,7 @@ async def test_complete_connect_exchanges_code_and_stores_the_grant(auth_server,
     # Nothing is cached at connect (the grant is real only once this commits);
     # the first delivery mints from it, carrying the grant's resource binding.
     assert not await get_client().get(_token_key(SYSTEM_ACCOUNT_ID))
-    assert await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID) == "at-1"
+    assert await oauth.get_access_token(_NAME, SYSTEM_ACCOUNT_ID) == "at-1"
     refresh = auth_server.token_requests[1]
     assert refresh["grant_type"] == "refresh_token"
     assert refresh["resource"] == _SERVER_URL
@@ -434,10 +434,10 @@ async def test_a_later_connect_stores_under_the_claimed_mode(auth_server, druks_
     assert grant_accounts == {SYSTEM_ACCOUNT_ID}
 
 
-# --- mint: cache, refresh, rotation, eviction -------------------------------
+# --- get_access_token: cache, refresh, rotation, eviction -------------------
 
 
-async def test_mint_refreshes_on_cache_miss_and_persists_rotation(auth_server, druks_db):
+async def test_get_refreshes_on_cache_miss_and_persists_rotation(auth_server, druks_db):
     _store_grant(refresh_token="rt-old")
     auth_server.token_response = {
         "access_token": "at-2",
@@ -445,7 +445,7 @@ async def test_mint_refreshes_on_cache_miss_and_persists_rotation(auth_server, d
         "expires_in": 300,
     }
 
-    token = await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
+    token = await oauth.get_access_token(_NAME, SYSTEM_ACCOUNT_ID)
 
     assert token == "at-2"
     refresh = auth_server.token_requests[0]
@@ -457,45 +457,45 @@ async def test_mint_refreshes_on_cache_miss_and_persists_rotation(auth_server, d
     stored = oauth.get_connection(_NAME, SYSTEM_ACCOUNT_ID)
     assert stored.refresh_token.decrypt() == "rt-new"
 
-    # A second mint within the TTL reuses the cache — no second refresh.
-    assert await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID) == "at-2"
+    # A second call within the TTL reuses the cache — no second refresh.
+    assert await oauth.get_access_token(_NAME, SYSTEM_ACCOUNT_ID) == "at-2"
     assert len(auth_server.token_requests) == 1
 
 
-async def test_mint_without_grant_fails_loudly(druks_db):
+async def test_get_without_grant_fails_loudly(druks_db):
     with pytest.raises(MissingGrantError, match=_NAME):
-        await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
+        await oauth.get_access_token(_NAME, SYSTEM_ACCOUNT_ID)
 
 
-async def test_mint_refresh_rejection_fails_loudly_and_evicts_the_cache(auth_server, druks_db):
+async def test_get_refresh_rejection_fails_loudly_and_evicts_the_cache(auth_server, druks_db):
     _store_grant()
     auth_server.token_status = 400
 
     with pytest.raises(GrantRefreshError, match=_NAME):
-        await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
+        await oauth.get_access_token(_NAME, SYSTEM_ACCOUNT_ID)
     assert not await get_client().get(_token_key(SYSTEM_ACCOUNT_ID))
 
 
-async def test_mint_rejects_a_malformed_token_response(auth_server, druks_db):
+async def test_get_rejects_a_malformed_token_response(auth_server, druks_db):
     _store_grant()
     auth_server.token_malformed = True
 
     with pytest.raises(GrantRefreshError, match="malformed JSON"):
-        await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
+        await oauth.get_access_token(_NAME, SYSTEM_ACCOUNT_ID)
 
 
-async def test_mint_rejects_a_token_response_without_an_access_token(auth_server, druks_db):
+async def test_get_rejects_a_token_response_without_an_access_token(auth_server, druks_db):
     _store_grant()
     auth_server.token_response = {"refresh_token": "rt-2", "expires_in": 3600}
 
     with pytest.raises(GrantRefreshError, match="no access token"):
-        await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
+        await oauth.get_access_token(_NAME, SYSTEM_ACCOUNT_ID)
 
 
-async def test_mint_losing_the_refresh_lock_polls_for_the_winners_token(
+async def test_get_losing_the_refresh_lock_polls_for_the_winners_token(
     auth_server, druks_db, monkeypatch
 ):
-    # A second minter never refreshes (one rotation spender per server) and
+    # A second caller never refreshes (one rotation spender per server) and
     # never blocks the event loop: it polls until the winner's token appears
     # in the cache. The winner here is a concurrent task holding the lock.
     _store_grant()
@@ -508,22 +508,22 @@ async def test_mint_losing_the_refresh_lock_polls_for_the_winners_token(
         await redis.delete(_lock_key(SYSTEM_ACCOUNT_ID))
 
     winner = asyncio.create_task(_winner_finishes())
-    assert await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID) == "at-winner"
+    assert await oauth.get_access_token(_NAME, SYSTEM_ACCOUNT_ID) == "at-winner"
     await winner
     assert not auth_server.token_requests
 
 
-async def test_mint_times_out_loudly_when_the_refresh_lock_never_frees(druks_db, monkeypatch):
+async def test_get_times_out_loudly_when_the_refresh_lock_never_frees(druks_db, monkeypatch):
     _store_grant()
     monkeypatch.setattr(oauth, "OAUTH_MINT_WAIT_INTERVAL_SECONDS", 0)
     monkeypatch.setattr(oauth, "OAUTH_MINT_WAIT_ATTEMPTS", 3)
     await get_client().set(_lock_key(SYSTEM_ACCOUNT_ID), "1")
 
     with pytest.raises(GrantRefreshError, match="concurrent refresh"):
-        await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
+        await oauth.get_access_token(_NAME, SYSTEM_ACCOUNT_ID)
 
 
-async def test_mint_cache_and_refresh_lock_are_per_account(auth_server, druks_db):
+async def test_get_cache_and_refresh_lock_are_per_account(auth_server, druks_db):
     first = Account.get_or_create("first@example.com")
     second = Account.get_or_create("second@example.com")
     _store_grant(account_id=first.id, identity_mode=IdentityMode.PER_USER)
@@ -531,7 +531,7 @@ async def test_mint_cache_and_refresh_lock_are_per_account(auth_server, druks_db
     redis = get_client()
     await redis.set(_lock_key(first.id), "1")
 
-    assert await oauth.mint_access_token(_NAME, second.id) == "at-1"
+    assert await oauth.get_access_token(_NAME, second.id) == "at-1"
     assert not await redis.get(_token_key(first.id))
     assert await redis.get(_token_key(second.id)) == b"at-1"
 
@@ -688,9 +688,9 @@ async def test_disconnect_route_drops_grant_and_cache(
 ):
     _register_oauth_server()
     _store_grant()
-    await oauth.mint_access_token(_NAME, SYSTEM_ACCOUNT_ID)
+    await oauth.get_access_token(_NAME, SYSTEM_ACCOUNT_ID)
     token_key = _token_key(SYSTEM_ACCOUNT_ID)
-    # The mint's Redis client is bound to this test's loop; close it so the
+    # The oauth engine's Redis client is bound to this test's loop; close it so the
     # route dials its own — the cached token lives in Redis either way.
     await close_client()
 

--- a/backend/tests/test_oauth_client.py
+++ b/backend/tests/test_oauth_client.py
@@ -74,21 +74,21 @@ def _lock_key(connection: OauthConnection) -> str:
     return f"{_PROVIDER}:refresh_lock:{connection.id}"
 
 
-async def test_mint_serves_the_cache_without_a_refresh(token_endpoint):
+async def test_get_serves_the_cache_without_a_refresh(token_endpoint):
     connection = _connection()
     await get_client().set(_token_key(connection), "at-cached")
 
-    token = await _client().mint_access_token(connection=connection)
+    token = await _client().get_access_token(connection=connection)
 
     assert token == "at-cached"
     assert not token_endpoint.requests
 
 
-async def test_mint_refreshes_persists_rotation_and_fills_with_skewed_ttl(token_endpoint):
+async def test_get_refreshes_persists_rotation_and_fills_with_skewed_ttl(token_endpoint):
     token_endpoint.response = {"access_token": "at-2", "refresh_token": "rt-new", "expires_in": 300}
     connection = _connection()
 
-    token = await _client().mint_access_token(connection=connection)
+    token = await _client().get_access_token(connection=connection)
 
     assert token == "at-2"
     db_session().expire_all()
@@ -105,7 +105,7 @@ async def test_mint_refreshes_persists_rotation_and_fills_with_skewed_ttl(token_
     assert not await redis.get(_lock_key(connection))
 
 
-async def test_mint_fills_the_cache_only_after_the_rotation_is_saved(token_endpoint, monkeypatch):
+async def test_get_fills_the_cache_only_after_the_rotation_is_saved(token_endpoint, monkeypatch):
     token_endpoint.response = {"access_token": "at-2", "refresh_token": "rt-new", "expires_in": 300}
     connection = _connection()
 
@@ -114,14 +114,14 @@ async def test_mint_fills_the_cache_only_after_the_rotation_is_saved(token_endpo
 
     monkeypatch.setattr(OauthConnection, "_save_refresh_token", _unsavable)
     with pytest.raises(RuntimeError, match="rotation write failed"):
-        await _client().mint_access_token(connection=connection)
+        await _client().get_access_token(connection=connection)
 
     redis = get_client()
     assert not await redis.get(_token_key(connection))
     assert not await redis.get(_lock_key(connection))
 
 
-async def test_mint_losing_the_lock_polls_for_the_winners_token(token_endpoint):
+async def test_get_losing_the_lock_polls_for_the_winners_token(token_endpoint):
     connection = _connection()
     redis = get_client()
     await redis.set(_lock_key(connection), "1")
@@ -131,27 +131,27 @@ async def test_mint_losing_the_lock_polls_for_the_winners_token(token_endpoint):
         await redis.delete(_lock_key(connection))
 
     winner = asyncio.create_task(_winner_finishes())
-    token = await _client().mint_access_token(connection=connection)
+    token = await _client().get_access_token(connection=connection)
     await winner
 
     assert token == "at-winner"
     assert not token_endpoint.requests
 
 
-async def test_mint_times_out_loudly_when_the_lock_never_frees(token_endpoint):
+async def test_get_times_out_loudly_when_the_lock_never_frees(token_endpoint):
     connection = _connection()
     await get_client().set(_lock_key(connection), "1")
 
     with pytest.raises(OauthRefreshError, match="concurrent refresh"):
-        await _client(mint_wait_attempts=3).mint_access_token(connection=connection)
+        await _client(mint_wait_attempts=3).get_access_token(connection=connection)
 
 
-async def test_mint_refresh_rejection_evicts_and_raises(token_endpoint):
+async def test_get_refresh_rejection_evicts_and_raises(token_endpoint):
     token_endpoint.status = 400
     connection = _connection()
 
     with pytest.raises(OauthRefreshError, match="HTTP 400"):
-        await _client().mint_access_token(connection=connection)
+        await _client().get_access_token(connection=connection)
 
     assert OauthConnection.get(connection.id).refresh_token.decrypt() == "rt-old"
     redis = get_client()
@@ -159,10 +159,10 @@ async def test_mint_refresh_rejection_evicts_and_raises(token_endpoint):
     assert not await redis.get(_lock_key(connection))
 
 
-async def test_mint_refresh_uses_basic_auth(token_endpoint):
+async def test_get_refresh_uses_basic_auth(token_endpoint):
     connection = _connection()
 
-    await _client(basic_auth=True).mint_access_token(connection=connection)
+    await _client(basic_auth=True).get_access_token(connection=connection)
 
     assert token_endpoint.authorizations[0].startswith("Basic ")
     # Basic auth keeps the client credentials out of the form body.
@@ -221,7 +221,7 @@ async def test_complete_connect_requires_a_refresh_token(token_endpoint):
         await complete_connect(state=state, code="code-1")
 
 
-async def test_downscoped_mint_asks_and_caches_apart_from_the_full_grant(token_endpoint):
+async def test_downscoped_get_asks_and_caches_apart_from_the_full_grant(token_endpoint):
     connection = _connection(scopes=["posts.write", "profile.read"])
     token_endpoint.response = {
         "access_token": "at-narrow",
@@ -230,7 +230,7 @@ async def test_downscoped_mint_asks_and_caches_apart_from_the_full_grant(token_e
         "scope": "profile.read",
     }
 
-    narrow = await _client().mint_access_token(connection=connection, scopes=("profile.read",))
+    narrow = await _client().get_access_token(connection=connection, scopes=("profile.read",))
 
     assert narrow == "at-narrow"
     assert token_endpoint.requests[0]["scope"] == "profile.read"
@@ -244,7 +244,7 @@ async def test_downscoped_mint_asks_and_caches_apart_from_the_full_grant(token_e
         "refresh_token": "rt-1",
         "expires_in": 3600,
     }
-    full = await _client().mint_access_token(connection=connection)
+    full = await _client().get_access_token(connection=connection)
 
     assert full == "at-full"
     assert "scope" not in token_endpoint.requests[1]
@@ -253,22 +253,22 @@ async def test_downscoped_mint_asks_and_caches_apart_from_the_full_grant(token_e
 
     # The scoped cache serves the scoped ask without another refresh.
     assert (
-        await _client().mint_access_token(connection=connection, scopes=("profile.read",))
+        await _client().get_access_token(connection=connection, scopes=("profile.read",))
         == "at-narrow"
     )
     assert len(token_endpoint.requests) == 2
 
 
-async def test_downscoped_mint_rejects_scopes_outside_the_grant(token_endpoint):
+async def test_downscoped_get_rejects_scopes_outside_the_grant(token_endpoint):
     connection = _connection(scopes=["profile.read"])
 
     with pytest.raises(OauthRefreshError, match="does not grant scope"):
-        await _client().mint_access_token(connection=connection, scopes=("posts.write",))
+        await _client().get_access_token(connection=connection, scopes=("posts.write",))
 
     assert not token_endpoint.requests
 
 
-async def test_downscoped_mint_rejects_a_provider_that_ignores_the_ask(token_endpoint):
+async def test_downscoped_get_rejects_a_provider_that_ignores_the_ask(token_endpoint):
     connection = _connection(scopes=["posts.write", "profile.read"])
     token_endpoint.response = {
         "access_token": "at-broad",
@@ -278,18 +278,18 @@ async def test_downscoped_mint_rejects_a_provider_that_ignores_the_ask(token_end
     }
 
     with pytest.raises(OauthRefreshError, match="came back with"):
-        await _client().mint_access_token(connection=connection, scopes=("profile.read",))
+        await _client().get_access_token(connection=connection, scopes=("profile.read",))
 
     scoped_key = _token_key(connection) + _scoped_suffix(("profile.read",))
     assert not await get_client().get(scoped_key)
 
 
-async def test_uncached_mint_refreshes_past_a_live_cache_and_refills_it(token_endpoint):
+async def test_uncached_get_refreshes_past_a_live_cache_and_refills_it(token_endpoint):
     connection = _connection()
     redis = get_client()
     await redis.set(_token_key(connection), "at-tail")
 
-    token = await _client().mint_access_token(connection=connection, cached=False)
+    token = await _client().get_access_token(connection=connection, cached=False)
 
     assert token == "at-1"
     assert len(token_endpoint.requests) == 1
@@ -303,7 +303,7 @@ async def test_refresher_election_is_per_scope_set(token_endpoint):
     await redis.set(_lock_key(connection) + _scoped_suffix(("profile.read",)), "1")
 
     # The scoped variant's lock never blocks the full-grant mint.
-    assert await _client().mint_access_token(connection=connection) == "at-1"
+    assert await _client().get_access_token(connection=connection) == "at-1"
     assert len(token_endpoint.requests) == 1
 
 

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -768,11 +768,11 @@ class NightWatch(Extension):
 A *connection* is one signed-in provider account. A user can hold many per
 provider — one per mailbox, handle, or workspace — and the platform stores
 each one: the refresh token, the granted scopes, the owner. Your workflow
-code reads them through the declaration and mints per connection:
+code reads them through the declaration and gets a token per connection:
 
 ```python
 for connection in NightWatch.acme.list_for_account(account_id):
-    token = await connection.mint_access_token()
+    token = await connection.get_access_token()
 ```
 
 `NightWatch.acme.get(connection_id)` returns one connection when your own
@@ -817,13 +817,13 @@ The user sees and revokes everything in Settings — every connection they
 hold, across services. Replacing a service's client credentials deletes its
 connections: a new client can never refresh the old client's tokens.
 
-`mint_access_token` serves a Redis-cached access token and lets only one
+`get_access_token` serves a Redis-cached access token and lets only one
 refresher run per connection and scope set. This is necessary: two
 refreshes at the same time can make the provider revoke the whole
 connection. It raises `OauthRefreshError` when the refresh fails. Then ask
 the user to reconnect.
 
-`mint_access_token(scopes=("profile.read",))` asks the provider for a token
+`get_access_token(scopes=("profile.read",))` asks the provider for a token
 narrower than the grant — pass it when the token goes to untrusted compute,
 with a subset of the connection's scopes. `cached=False` refreshes past the
 cache for a full-lifetime token.


### PR DESCRIPTION
`mint_access_token` becomes `get_access_token` on `OauthClient`, the `Service` connection handle, and the MCP delivery function. The default call serves the Redis cache — a mint that usually does not mint is a misleading name. The caller's contract is a get: hand back a valid token, refresh only on a cache miss.

`mint` stays the word for real issuance: the token-endpoint refresh, `mint_run_id`, PAT/JWT minting, and the `mint_wait_*` knobs that time the wait on the elected refresher. Test names and prose follow the same split.