### PR TITLE
A connection carries the account that signed it in

### DIFF
--- a/backend/druks/services/base.py
+++ b/backend/druks/services/base.py
@@ -34,6 +34,10 @@ class Connection:
         return self.row.identity
 
     @property
+    def account_id(self) -> str:
+        return self.row.account_id
+
+    @property
     def connected_at(self):
         return self.row.connected_at
 

--- a/backend/tests/test_services.py
+++ b/backend/tests/test_services.py
@@ -520,6 +520,7 @@ def test_with_scopes_declares_the_union_and_reads_connections(declared_services,
     assert [connection.id for connection in connections] == [row.id]
     assert connections[0].scopes == ["profile.read"]
     assert connections[0].identity == {"email": "night@acme.test"}
+    assert connections[0].account_id == SYSTEM_ACCOUNT_ID
     assert NightWatch.acme.get(row.id).id == row.id
     assert not NightWatch.acme.get("missing")
 

--- a/docs/writing-an-extension.md
+++ b/docs/writing-an-extension.md
@@ -842,7 +842,8 @@ for connection in NightWatch.acme.list_for_account(account_id):
 `current_account_id.get()` in a route, the handler's argument in a
 subscriber. `NightWatch.acme.get(connection_id)` returns one connection
 when your own row stored its id. Each connection carries `id`, `scopes`, `identity` — the
-provider's facts for the sign-in — and `connected_at`. The handle serves
+provider's facts for the sign-in — `account_id` — the druks account that
+signed it in — and `connected_at`. The handle serves
 live connections only. A revoked connection drops out of `get` and
 `list_for_account`, but its platform row survives with its owner and
 identity. Your rows never need tombstone copies of either.


### PR DESCRIPTION
The `Connection` handle exposes `id`, `scopes`, `identity`, and `connected_at`, but not the druks account that owns the sign-in. Extensions that need the owner had to reach into `connection.row`.

- `Connection.account_id` reads the owner off the row.
- The Connections section of writing-an-extension.md lists the new field.
- The handle test asserts the owner comes back.