### PR TITLE
Inspect older run transcripts, and never show a bare "failed"

### DIFF
--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -7,7 +7,7 @@ from dbos import DBOS
 from sqlalchemy import ForeignKey, Index, Select, String, func, select, update
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
+from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship, selectinload
 
 from druks.accounts.constants import SYSTEM_ACCOUNT_ID
 from druks.accounts.models import Account
@@ -77,6 +77,11 @@ class Run(Base):
     account: Mapped[Account] = relationship(
         lazy="joined", innerjoin=True, foreign_keys=[account_id]
     )
+    # The run's agent calls in execution order — lazy, so a parked board row that
+    # never reads them costs no query; the timeline read eager-loads them.
+    agent_calls: Mapped[list["AgentCall"]] = relationship(
+        back_populates="run", order_by="AgentCall.created_at, AgentCall.id"
+    )
 
     # When the run last changed — the newest of creation, the parked ask, and
     # DBOS's status write.
@@ -95,6 +100,14 @@ class Run(Base):
     @property
     def is_running(self) -> bool:
         return self.state == RunState.RUNNING.value
+
+    def failure_message(self) -> str | None:
+        # A crash leaves failure None by design; the terminal call's captured
+        # error is then the run's real reason.
+        if self.failure:
+            return self.failure
+        if self.state == RunState.FAILED.value and self.agent_calls:
+            return self.agent_calls[-1].last_error
 
     @classmethod
     def create_row(cls, engine, *, workflow_id: str, kind: str, account_id: str | None) -> None:
@@ -116,7 +129,12 @@ class Run(Base):
 
     @classmethod
     def list_for_subject(
-        cls, subject_type: str, subject_id: str, kind: str | None = None
+        cls,
+        subject_type: str,
+        subject_id: str,
+        kind: str | None = None,
+        *,
+        include_calls: bool = False,
     ) -> list["Run"]:
         # Every run about this subject (stamped at start), newest first — a
         # subject's lifecycle spans many runs, so its status is theirs
@@ -132,6 +150,8 @@ class Run(Base):
         )
         if kind:
             stmt = stmt.where(cls.kind == kind)
+        if include_calls:
+            stmt = stmt.options(selectinload(cls.agent_calls))
         return list(db_session().scalars(stmt))
 
     @classmethod
@@ -399,7 +419,7 @@ class AgentCall(Base, Uuid7Pk):
     model: Mapped[str] = mapped_column(String)
     # The run this LLM call ran in. ON DELETE CASCADE, so a call never outlives it.
     run_id: Mapped[str] = mapped_column(ForeignKey("durable_runs.id", ondelete="CASCADE"))
-    run: Mapped["Run"] = relationship()
+    run: Mapped["Run"] = relationship(back_populates="agent_calls")
     # Which agent (registry id: "scope", "implement", …) made this call — the
     # timeline's grouping label. An agent is what makes a call, so there is no
     # unattributed one: the row is written from the registered agent's own id.
@@ -546,18 +566,9 @@ class AgentCall(Base, Uuid7Pk):
 
     @classmethod
     def list_for_run(cls, run_id: str) -> list["AgentCall"]:
-        # Execution order, so the read side zips calls onto their runs.
+        # Execution order — the same order Run.agent_calls loads.
         stmt = select(cls).where(cls.run_id == run_id).order_by(cls.created_at, cls.id)
         return list(db_session().scalars(stmt))
-
-    @classmethod
-    def get_by_run(cls, run_ids: list[str]) -> dict[str, list["AgentCall"]]:
-        # The calls under each run, in execution order — one query for a timeline.
-        stmt = select(cls).where(cls.run_id.in_(run_ids)).order_by(cls.created_at, cls.id)
-        grouped: dict[str, list[AgentCall]] = {run_id: [] for run_id in run_ids}
-        for call in db_session().scalars(stmt):
-            grouped[call.run_id].append(call)
-        return grouped
 
     @classmethod
     def list_for_subject(cls, subject_type: str, subject_id: str) -> list["AgentCall"]:

--- a/backend/druks/durable/reads.py
+++ b/backend/druks/durable/reads.py
@@ -70,8 +70,8 @@ def get_agent_call_files(call_id: str) -> AgentCallFiles:
 def list_subject_timeline(subject_type: str, subject_id: str) -> list[RunResponse]:
     # The subject's whole timeline: every run about it, oldest first, each
     # with its agent calls.
-    runs = Run.list_for_subject(subject_type, subject_id)
-    return _timeline(runs, AgentCall.get_by_run([run.id for run in runs]))
+    runs = Run.list_for_subject(subject_type, subject_id, include_calls=True)
+    return _timeline(runs)
 
 
 def get_subject_status(
@@ -79,7 +79,7 @@ def get_subject_status(
 ) -> SubjectStatus:
     kind = workflow.kind if workflow else None
     latest = Run.get_latest_for_subject(subject_type, subject_id, kind=kind)
-    return _status(latest, _running_calls(latest))
+    return _status(latest)
 
 
 async def get_subject_phase(subject_type: str, subject_id: str) -> str | None:
@@ -97,40 +97,31 @@ def get_subject_response(
     summary: SubjectSummary,
     activity: SubjectActivity | None = None,
 ) -> SubjectResponse:
-    runs = Run.list_for_subject(subject_type, subject_id)
-    calls_by_run = AgentCall.get_by_run([run.id for run in runs])
-    latest = Run.get_latest_for_subject(subject_type, subject_id)
+    # list_for_subject is newest-first, so runs[0] is the driving run the status
+    # reads — the same row get_latest_for_subject would return, its calls already
+    # eager-loaded here.
+    runs = Run.list_for_subject(subject_type, subject_id, include_calls=True)
+    latest = runs[0] if runs else None
     return SubjectResponse(
         summary=summary,
-        status=_status(latest, calls_by_run.get(latest.id, []) if latest else []),
-        timeline=_timeline(runs, calls_by_run),
+        status=_status(latest),
+        timeline=_timeline(runs),
         activity=activity,
     )
 
 
-def _timeline(runs: list[Run], calls_by_run: dict[str, list[AgentCall]]) -> list[RunResponse]:
-    # get_by_run keys every run id, so the lookup is total.
+def _timeline(runs: list[Run]) -> list[RunResponse]:
     ordered = sorted(runs, key=lambda run: (run.created_at, run.id))
     return [
         RunResponse.from_run(
             run,
-            calls_by_run[run.id],
             input_request=run.get_ask() if run.input_request else None,
         )
         for run in ordered
     ]
 
 
-def _running_calls(run: Run | None) -> list[AgentCall]:
-    # A parked run's status carries its gate ask; only a running run surfaces its
-    # latest agent call. So a parked board row never queries agent_calls — the
-    # board runs this per subject.
-    if run and not run.is_parked:
-        return AgentCall.list_for_run(run.id)
-    return []
-
-
-def _status(driving_run: Run | None, calls: list[AgentCall]) -> SubjectStatus:
+def _status(driving_run: Run | None) -> SubjectStatus:
     # Facts only: the app's UI renders its copy from them.
     if not driving_run:
         return SubjectStatus(state=RunState.SCHEDULED)
@@ -138,18 +129,19 @@ def _status(driving_run: Run | None, calls: list[AgentCall]) -> SubjectStatus:
     # driving run alone decides parked-ness.
     parked = driving_run.state == RunState.PARKED.value
     # ``agent`` is the *running* run's latest agent — a parked run's calls are
-    # history, not the current step, whichever caller handed them in. ``gate``
-    # is the inverse: only a parked run's input_gate is a live ask (a timed-out
-    # run keeps the stale column).
+    # history, not the current step. Reading agent_calls only when not parked
+    # keeps a parked board row off the agent_calls query. ``gate`` is the
+    # inverse: only a parked run's input_gate is a live ask (a timed-out run
+    # keeps the stale column).
     agent = None
-    if calls and not parked:
-        agent = calls[-1].agent
+    if not parked and driving_run.agent_calls:
+        agent = driving_run.agent_calls[-1].agent
     return SubjectStatus(
         state=RunState(driving_run.state),
         kind=driving_run.kind,
         agent=agent,
         gate=driving_run.input_gate if parked else None,
-        failure=driving_run.failure,
+        failure=driving_run.failure_message(),
         reason=driving_run.failure_code,
         triggered_at=driving_run.created_at,
         account_username=driving_run.account.username,

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -16,7 +16,7 @@ from druks.schemas import BaseResponse
 from .enums import AgentCallStatus, RunState
 
 if TYPE_CHECKING:
-    from .models import AgentCall, Run
+    from .models import Run
 
 
 class TokenUsage(BaseResponse):
@@ -108,7 +108,6 @@ class RunResponse(BaseResponse):
     def from_run(
         cls,
         run: "Run",
-        calls: list["AgentCall"],
         *,
         input_request: dict[str, Any] | None,
     ) -> "RunResponse":
@@ -117,13 +116,13 @@ class RunResponse(BaseResponse):
             kind=run.kind,
             label=get_display_label(run.kind),
             state=run.state,  # type: ignore[arg-type]
-            failure=run.failure,
+            failure=run.failure_message(),
             gate=run.input_gate,
             input_request=input_request,
             created_at=run.created_at,
             updated_at=run.updated_at,
             account_username=run.account.username,
-            agent_calls=[AgentCallResponse.model_validate(call) for call in calls],
+            agent_calls=[AgentCallResponse.model_validate(call) for call in run.agent_calls],
         )
 
 

--- a/backend/tests/test_artifacts.py
+++ b/backend/tests/test_artifacts.py
@@ -100,7 +100,7 @@ def test_get_ask_resolves_the_review_artifact(druks_db, tmp_path):
     druks_db.flush()
     Artifact.record(call_dir=tmp_path, call_id="call-1", kind="markdown", title="Plan", content="x")
 
-    ask = RunResponse.from_run(run, [], input_request=run.get_ask()).input_request
+    ask = RunResponse.from_run(run, input_request=run.get_ask()).input_request
     assert ask == {
         "presentation": "in_app",
         "controls": ["approve"],
@@ -116,7 +116,7 @@ def test_get_ask_resolves_the_review_artifact(druks_db, tmp_path):
     )
     druks_db.add(external)
     druks_db.flush()
-    response = RunResponse.from_run(external, [], input_request=external.get_ask())
+    response = RunResponse.from_run(external, input_request=external.get_ask())
     assert response.input_request == {
         "presentation": "external",
         "label": "Review implementation",
@@ -126,7 +126,7 @@ def test_get_ask_resolves_the_review_artifact(druks_db, tmp_path):
 def test_run_response_projects_the_parked_gate(druks_db):
     run = seed_run(druks_db, kind=Summarize.kind, run_id="run-gate", input_gate="review")
 
-    response = RunResponse.from_run(run, [], input_request=None)
+    response = RunResponse.from_run(run, input_request=None)
     assert response.gate == "review"
 
 

--- a/backend/tests/test_attribution.py
+++ b/backend/tests/test_attribution.py
@@ -12,7 +12,7 @@ def test_run_projects_its_account(druks_db):
 
     run = druks_db.get(Run, "run-attr-1")
     assert run.account_id == account.id
-    response = RunResponse.from_run(run, [], input_request=None)
+    response = RunResponse.from_run(run, input_request=None)
     assert response.account_username == "dev@example.com"
 
 
@@ -22,5 +22,5 @@ def test_an_unowned_run_belongs_to_system(druks_db):
 
     run = druks_db.get(Run, "run-attr-2")
     assert run.account_id == "system"
-    response = RunResponse.from_run(run, [], input_request=None)
+    response = RunResponse.from_run(run, input_request=None)
     assert response.account_username == "system"

--- a/backend/tests/test_durable_schemas.py
+++ b/backend/tests/test_durable_schemas.py
@@ -13,6 +13,7 @@ def _run(
     input_gate: str | None = None,
     failure: str | None = None,
     failure_code: str | None = None,
+    agent_calls: list[AgentCall] | None = None,
 ) -> Run:
     return Run(
         id=id,
@@ -22,12 +23,13 @@ def _run(
         failure=failure,
         failure_code=failure_code,
         account=Account(username="op@example.com"),
+        agent_calls=agent_calls or [],
     )
 
 
-def _status_of(runs, calls=None):
+def _status_of(runs):
     # runs arrives newest-first, mirroring Run.list_for_subject.
-    return _status(runs[0], calls or [])
+    return _status(runs[0])
 
 
 def test_subject_state_takes_the_newest_run():
@@ -74,19 +76,30 @@ def test_status_carries_the_running_runs_kind_and_no_stale_gate():
 
 
 def test_status_carries_the_latest_agent_call_agent():
-    runs = [_run("new", "ship.build", RunState.RUNNING)]
-    calls = [AgentCall(agent="generate_plan"), AgentCall(agent="implement")]
-    assert _status_of(runs, calls).agent == "implement"
-
-
-def test_parked_status_carries_no_agent_even_when_calls_are_handed_in():
-    # The detail read passes the parked run's calls; the fact stays consistent
-    # with the board, where a parked row never queries them.
     runs = [
-        _run("new", "ship.build", RunState.PARKED, "review"),
+        _run(
+            "new",
+            "ship.build",
+            RunState.RUNNING,
+            agent_calls=[AgentCall(agent="generate_plan"), AgentCall(agent="implement")],
+        )
     ]
-    calls = [AgentCall(agent="implement")]
-    status = _status_of(runs, calls)
+    assert _status_of(runs).agent == "implement"
+
+
+def test_parked_status_carries_no_agent_even_when_the_run_has_calls():
+    # A parked run keeps its calls, but the status never reads them — the fact
+    # stays consistent with the board, where a parked row never queries them.
+    runs = [
+        _run(
+            "new",
+            "ship.build",
+            RunState.PARKED,
+            "review",
+            agent_calls=[AgentCall(agent="implement")],
+        )
+    ]
+    status = _status_of(runs)
     assert not status.agent
     assert status.gate == "review"
 
@@ -109,3 +122,17 @@ def test_status_carries_failure_but_no_reason_when_the_run_crashed():
     status = _status_of(runs)
     assert not status.reason
     assert status.failure == "boom"
+
+
+def test_status_falls_back_to_the_terminal_call_error_when_failure_is_null():
+    # A crash leaves run.failure null; the terminal call's captured error becomes
+    # the status reason so the board never shows a bare "failed".
+    runs = [
+        _run(
+            "new",
+            Summarize.kind,
+            RunState.FAILED,
+            agent_calls=[AgentCall(agent="implement", last_error="crashed in implement")],
+        )
+    ]
+    assert _status_of(runs).failure == "crashed in implement"

--- a/backend/tests/test_failure_message.py
+++ b/backend/tests/test_failure_message.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+from druks.durable.enums import RunState
+from druks.durable.models import Run
+
+
+def _run(failure=None, state=RunState.FAILED.value, agent_calls=()):
+    return SimpleNamespace(failure=failure, state=state, agent_calls=list(agent_calls))
+
+
+def test_explicit_failure_wins():
+    assert Run.failure_message(_run(failure="gate timed out")) == "gate timed out"
+
+
+def test_crash_falls_back_to_terminal_call_error():
+    run = _run(agent_calls=[SimpleNamespace(last_error="boom in step two")])
+    assert Run.failure_message(run) == "boom in step two"
+
+
+def test_running_run_stays_none():
+    assert Run.failure_message(_run(state=RunState.RUNNING.value)) is None
+
+
+def test_failed_without_calls_stays_none():
+    assert Run.failure_message(_run()) is None

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -12,7 +12,7 @@ from druks.testing import seed_dbos_status
 from fastapi import APIRouter
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
-from sqlalchemy import select
+from sqlalchemy import event, select
 from uuid_utils import uuid7
 
 
@@ -203,9 +203,9 @@ def test_status_carries_the_latest_run_failure(client: TestClient, druks_db):
     assert running["failure"] is None
 
 
-def test_parked_board_row_skips_the_agent_call_query(client: TestClient, druks_db, monkeypatch):
+def test_parked_board_row_skips_the_agent_call_query(client: TestClient, druks_db):
     # A parked row's status carries its gate ask, never its latest agent call, so
-    # the per-subject status read must not query agent_calls — the board runs it
+    # the per-subject status read must not load agent_calls — the board runs it
     # for every subject.
     run = _seed_run(
         druks_db,
@@ -216,16 +216,22 @@ def test_parked_board_row_skips_the_agent_call_query(client: TestClient, druks_d
     )
     _seed_call(druks_db, run, agent="generate_plan")
 
-    queried: list[str] = []
-    monkeypatch.setattr(
-        AgentCall,
-        "list_for_run",
-        classmethod(lambda cls, run_id: queried.append(run_id) or []),
-    )
+    call_reads: list[str] = []
 
-    rows = {row["summary"]["id"]: row for row in client.get("/api/faketest/thing").json()["rows"]}
+    def record(conn, cursor, statement, parameters, context, executemany):
+        if "agent_calls" in statement and statement.lstrip().upper().startswith("SELECT"):
+            call_reads.append(statement)
+
+    engine = druks_db.get_bind()
+    event.listen(engine, "before_cursor_execute", record)
+    try:
+        body = client.get("/api/faketest/thing").json()
+    finally:
+        event.remove(engine, "before_cursor_execute", record)
+
+    rows = {row["summary"]["id"]: row for row in body["rows"]}
     assert rows["1"]["status"]["gate"] == "approve_plan"
-    assert queried == []
+    assert call_reads == []
 
 
 def test_list_returns_every_subject_with_status(client: TestClient, druks_db):

--- a/frontend/src/pages/SubjectPage.tsx
+++ b/frontend/src/pages/SubjectPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Link } from 'wouter'
 
 import { subjectApi } from '../api/client'
@@ -86,7 +86,7 @@ export function SubjectPage({ app, subjectType, subjectId }: Props) {
         <EmptyState glyph="∅" msg="no runs yet" />
       ) : (
         runs.map((run, index) => (
-          <RunBlock key={run.id} app={app} run={run} withTranscript={index === 0} />
+          <RunBlock key={run.id} app={app} run={run} defaultOpen={index === 0} />
         ))
       )}
     </Page>
@@ -96,14 +96,15 @@ export function SubjectPage({ app, subjectType, subjectId }: Props) {
 function RunBlock({
   app,
   run,
-  withTranscript,
+  defaultOpen,
 }: {
   app: string
   run: RunSummary
-  withTranscript: boolean
+  defaultOpen: boolean
 }) {
   const ask = run.state === 'parked' ? run.inputRequest : null
   const call = run.agentCalls.at(-1)
+  const [open, setOpen] = useState(defaultOpen)
   return (
     <div className="subject-run mono">
       <div className="subject-run-head">
@@ -133,11 +134,24 @@ function RunBlock({
           <div className="ins-fail-body">{run.failure}</div>
         </div>
       )}
-      {withTranscript && call && (
+      {call && (
+        <button
+          type="button"
+          className="ins-run-link subject-run-more"
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+        >
+          {open ? '▾' : '▸'} transcript
+        </button>
+      )}
+      {open && call && (
         <RunTranscript
           basePath={subjectApi.transcriptBase(app, call.id)}
           isLive={call.status === 'running'}
         />
+      )}
+      {run.state === 'failed' && !call && !run.failure && (
+        <div className="ins-fail-body dim">failed before any agent step</div>
       )}
     </div>
   )

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2471,3 +2471,4 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .subject-facts { margin-bottom: 14px; }
 .subject-run { border: 1px solid var(--border-soft); border-radius: 6px; padding: 12px 14px; margin-bottom: 12px; }
 .subject-run-head { display: flex; align-items: center; gap: 10px; font-size: 12.5px; margin-bottom: 8px; }
+.subject-run-more { margin: 6px 0; }


### PR DESCRIPTION
The subject detail page only rendered a transcript for the newest run, so a failed run earlier in a subject's history could not be inspected. A crash that left no failure message read as a bare "failed" with no signal at all.

**Inspect any run.** Every run in the timeline now has a `transcript` toggle that loads that run's transcript on demand. The newest run stays open by default. `RunTranscript` already fetches on mount, so this is one gate flipped from "newest only" to per-run expand — no new fetch path.

**Always a reason.** `run.failure` is null for a crash by design; the machine classifier lives in `failure_code`. `Run.failure_message()` now falls back to the terminal agent call's captured `last_error`, so a failed run carries a real reason on both the subject status and the timeline — not only where a transcript is shown (apps that read `failure` alone got a generic string before). A run that crashed before any agent step — neither failure nor transcript — says exactly that.

**Read-side cleanup.** A run's agent calls now load through a `Run.agent_calls` relationship — eager-loaded for the timeline, lazy for the board so a parked row still reads no calls — instead of threading a `calls` dict through every read projection. So `run.failure_message()` reads its own calls off the object rather than taking them as an argument, matching how `ship` already loads `project.repos`.
