### PR TITLE
The shared review gate reads app-neutral, not ship-specific

### DIFF
--- a/frontend/src/components/RunControls.test.tsx
+++ b/frontend/src/components/RunControls.test.tsx
@@ -81,15 +81,11 @@ describe('InAppReview', () => {
     expect(requestChanges.disabled).toBe(false)
   })
 
-  it('explains approval with a note', () => {
+  it('explains what a note does', () => {
     stubFetch()
     renderReview({ presentation: 'in_app', controls: ['approve'], questions: [] })
 
-    expect(
-      screen.getByText(
-        'Approving with a note starts another plan pass instead of confirming the plan.',
-      ),
-    ).toBeTruthy()
+    expect(screen.getByText('A note is sent to the agent as feedback.')).toBeTruthy()
   })
 })
 

--- a/frontend/src/components/RunControls.tsx
+++ b/frontend/src/components/RunControls.tsx
@@ -90,10 +90,10 @@ const CONTROL_LABEL: Record<string, string> = {
   revise_contract: 'Revise contract',
 }
 
-// The in-app review: the artifact (the plan), structured question options, one
+// The in-app review: the reviewed artifact, structured question options, one
 // note, and the workflow's controls. A click resumes the run with
-// {control, answers, note}; free text is content for the next plan pass, never a
-// control.
+// {control, answers, note}; free text is content for the next agent prompt,
+// never a control.
 export function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }) {
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [note, setNote] = useState('')
@@ -140,7 +140,7 @@ export function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }
     <div className="ins-needs">
       {critique && (
         <div className="review-artifact">
-          <div className="review-artifact-title">Plan reviewer critique</div>
+          <div className="review-artifact-title">Critique</div>
           <Markdown source={critique} />
         </div>
       )}
@@ -176,12 +176,12 @@ export function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }
       })}
       <textarea
         className="review-note"
-        placeholder="optional note — what should the next pass change?"
+        placeholder="optional note — what should change?"
         value={note}
         onChange={(e) => setNote(e.target.value)}
       />
       <div className="review-helper">
-        Approving with a note starts another plan pass instead of confirming the plan.
+        A note is sent to the agent as feedback.
       </div>
       <div className="review-controls">
         {ask.controls?.map((control) => {


### PR DESCRIPTION
The in-app review component is borrowed by every installed app through the import map, but it carried ship vocabulary — and one line asserted ship behavior that is false elsewhere.

That line told the operator a note "starts another plan pass instead of confirming the plan." That rule is `Plan.is_confirmed_by()` (approve + no note + recommended answers → confirmed), which lives on the ship Plan contract. A triage gate that archives an email or acts on an alert has no plan and no such rule, so the sentence was wrong there.

The shared surface now states only what holds for every gate — the note is content for the next agent prompt:

- `Plan reviewer critique` → `Critique`
- `optional note — what should the next pass change?` → `optional note — what should change?`
- `Approving with a note starts another plan pass instead of confirming the plan.` → `A note is sent to the agent as feedback.`

Per-app copy is not pushed through the ask (the wire stays copy-free), and `revise_contract` stays keyed so it only renders when ship declares it.
