### PR TITLE
The GitHub client creates a repo from a template

### DIFF
--- a/backend/druks/core/apis/github.py
+++ b/backend/druks/core/apis/github.py
@@ -87,6 +87,20 @@ class GitHubClient:
         # would require entering the client context and closing it here.
         self._repo_gh_cache.clear()
 
+    async def _owner_installation_id(self, owner: str) -> int:
+        try:
+            response = await self._app.rest.apps.async_get_org_installation(owner)
+        except RequestFailed as error:
+            if error.response.status_code != 404:
+                raise
+            try:
+                response = await self._app.rest.apps.async_get_user_installation(owner)
+            except RequestFailed as error:
+                if error.response.status_code == 404:
+                    raise GitHubAppNotInstalledError(owner) from error
+                raise
+        return response.parsed_data.id
+
     async def list_repos_for_owner(self, owner: str) -> list[dict[str, Any]]:
         """Repos the GitHub App can see under ``owner``.
 
@@ -96,17 +110,9 @@ class GitHubClient:
         "add repo" affordance.
         """
         try:
-            installation_response = await self._app.rest.apps.async_get_org_installation(owner)
-        except RequestFailed as error:
-            if error.response.status_code != 404:
-                raise
-            try:
-                installation_response = await self._app.rest.apps.async_get_user_installation(owner)
-            except RequestFailed as error:
-                if error.response.status_code == 404:
-                    return []
-                raise
-        installation_id = installation_response.parsed_data.id
+            installation_id = await self._owner_installation_id(owner)
+        except GitHubAppNotInstalledError:
+            return []
 
         async with GitHub(
             AppInstallationAuthStrategy(self._app_id, self._private_key, installation_id),
@@ -133,6 +139,32 @@ class GitHubClient:
                     break
                 page += 1
             return repos
+
+    async def create_repo_from_template(self, owner: str, template_repo: str, name: str) -> str:
+        """A new private repo ``name`` under ``owner``, generated from the
+        ``owner/name`` template ``template_repo``; returns its ``full_name``.
+        Safe to retry: a name already taken reads as already created."""
+        installation_id = await self._owner_installation_id(owner)
+        template_owner, template_name = template_repo.split("/", 1)
+        full_name = f"{owner}/{name}"
+        async with GitHub(
+            AppInstallationAuthStrategy(self._app_id, self._private_key, installation_id),
+            base_url=self._base_url,
+        ) as gh:
+            try:
+                await gh.rest.repos.async_create_using_template(
+                    template_owner,
+                    template_name,
+                    name=name,
+                    owner=owner,
+                    private=True,
+                )
+            except RequestFailed as error:
+                # On a valid name GitHub's 422 is "already taken" — a retried create.
+                if error.response.status_code == 422:
+                    return full_name
+                raise
+        return full_name
 
     async def list_installation_accounts(self) -> tuple[str, ...]:
         """Account logins (orgs/users) this App is installed on — the

--- a/backend/tests/test_github.py
+++ b/backend/tests/test_github.py
@@ -235,8 +235,8 @@ class _OwnerReposClient(GitHubClient):
 
 
 class _InstallationGitHub:
-    def __init__(self, apps: Any) -> None:
-        self.rest = SimpleNamespace(apps=apps)
+    def __init__(self, **rest: Any) -> None:
+        self.rest = SimpleNamespace(**rest)
 
     async def __aenter__(self) -> "_InstallationGitHub":
         return self
@@ -270,7 +270,7 @@ async def test_list_repos_for_user_installation_falls_back_and_paginates(
             ]
         )
     )
-    installation_github = _InstallationGitHub(repo_apis)
+    installation_github = _InstallationGitHub(apps=repo_apis)
     monkeypatch.setattr(github_api, "GitHub", lambda *_args, **_kwargs: installation_github)
     client = _OwnerReposClient(app_apis)
 
@@ -312,7 +312,7 @@ async def test_list_repos_for_org_installation_does_not_consult_user_endpoint(
             )
         )
     )
-    installation_github = _InstallationGitHub(repo_apis)
+    installation_github = _InstallationGitHub(apps=repo_apis)
     monkeypatch.setattr(github_api, "GitHub", lambda *_args, **_kwargs: installation_github)
     client = _OwnerReposClient(app_apis)
 
@@ -600,3 +600,54 @@ async def test_get_bot_git_author_composes_the_public_bot_identity(
     )
     assert await client.get_bot_git_author() == author
     assert requested == ["example-app[bot]"]
+
+
+def _template_generating_client(
+    repo_apis: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> _OwnerReposClient:
+    monkeypatch.setattr(
+        github_api, "GitHub", lambda *_args, **_kwargs: _InstallationGitHub(repos=repo_apis)
+    )
+    return _OwnerReposClient(
+        SimpleNamespace(
+            async_get_org_installation=AsyncMock(
+                return_value=SimpleNamespace(parsed_data=SimpleNamespace(id=7))
+            )
+        )
+    )
+
+
+async def test_create_repo_from_template_generates_a_private_repo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_apis = SimpleNamespace(async_create_using_template=AsyncMock())
+    client = _template_generating_client(repo_apis, monkeypatch)
+
+    full_name = await client.create_repo_from_template(
+        "clawhaven", "clawhaven/shop-template", "acme-coffee"
+    )
+
+    assert full_name == "clawhaven/acme-coffee"
+    repo_apis.async_create_using_template.assert_awaited_once_with(
+        "clawhaven",
+        "shop-template",
+        name="acme-coffee",
+        owner="clawhaven",
+        private=True,
+    )
+
+
+async def test_create_repo_from_template_reads_a_taken_name_as_already_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo_apis = SimpleNamespace(
+        async_create_using_template=AsyncMock(side_effect=_make_request_failed(422))
+    )
+    client = _template_generating_client(repo_apis, monkeypatch)
+
+    full_name = await client.create_repo_from_template(
+        "clawhaven", "clawhaven/shop-template", "acme-coffee"
+    )
+
+    assert full_name == "clawhaven/acme-coffee"


### PR DESCRIPTION
`GitHubClient.create_repo_from_template(owner, template_repo, name)` generates a new **private** repo under `owner` from an `owner/name` GitHub template repo and returns the new repo's `full_name`. This is what an app needs to make one repo per unit of work — the site_builder app creates one repo per shop. Repos are private because the site is served via Cloudflare, not the repo.

- A `422` for a name already taken under `owner` returns the `full_name`, so a retry after a partial failure is idempotent rather than raising.
- No installation on `owner` raises `GitHubAppNotInstalledError` — the same typed error the repo-level lookup raises.
- Owner-installation resolution (org, then user fallback) is now shared with `list_repos_for_owner` through a `_owner_installation_id` helper.

**Setup:** creating a repo needs the GitHub App to hold **Administration: write** on the target org, on top of its existing Contents and Metadata access.
