### PR TITLE
Commits keep loaded objects readable

### DIFF
--- a/backend/druks/database.py
+++ b/backend/druks/database.py
@@ -97,7 +97,7 @@ def create_engine_from_url(database_url: str):
 
 
 def get_session(engine) -> Session:
-    return Session(engine, autocommit=False, autoflush=True)
+    return Session(engine, autocommit=False, autoflush=True, expire_on_commit=False)
 
 
 def _session_scope() -> object | None:
@@ -107,7 +107,7 @@ def _session_scope() -> object | None:
         return None
 
 
-_session_factory = sessionmaker(class_=Session, autoflush=True)
+_session_factory = sessionmaker(class_=Session, autoflush=True, expire_on_commit=False)
 db_session: scoped_session = scoped_session(_session_factory, scopefunc=_session_scope)
 
 


### PR DESCRIPTION
Both session constructions set `expire_on_commit=False`: reading an attribute after commit returns what was loaded instead of issuing a refresh query — a refresh that async sessions turn into an error. Model methods already re-select when they need fresh state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)