### PR TITLE
Workflows declare their sandbox: leased by content hash through drukbox templates

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -23,6 +23,7 @@ from druks.prompts import render_prompt
 from druks.sandbox import gate as sandbox_gate
 from druks.sandbox.client import sandbox_client
 from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
+from druks.sandbox.templates import get_template_id
 from druks.settings import load_settings
 from druks.usage.models import UsageScrape
 from druks.user_settings.models import SettingsOverride
@@ -50,7 +51,14 @@ async def _runner(
     if host_id:
         vm = sandbox_client.attach(host_id=host_id)
     else:
-        vm = sandbox_client.ephemeral(idempotency_key=f"{workflow_id}:{step}")
+        template = None
+        if workflow.sandbox:
+            template = await get_template_id(workflow.sandbox)
+            await set_run_phase("provisioning_vm")
+        vm = sandbox_client.ephemeral(
+            idempotency_key=f"{workflow_id}:{step}",
+            template=template,
+        )
     async with vm as box:
         yield await workflow.get_workspace(box)
 
@@ -275,7 +283,7 @@ class Agent:
         # rotation defers around it.
         async with sandbox_gate.use(connection_id, call_id):
             await set_run_phase("provisioning_vm")
-            host_id = await workflow._ensure_host()
+            host_id = await workflow._lease_host()
 
             # Record the call RUNNING once it has a host to run on (its id names
             # the on-disk transcript dir) so the live step shows while the agent

--- a/backend/druks/apps/base.py
+++ b/backend/druks/apps/base.py
@@ -506,6 +506,6 @@ class App:
     async def get_subject_activity(
         cls, subject: "Subject | StoredSubject"
     ) -> "SubjectActivity | None":
-        """The subject's live sub-phase, if any (e.g. "Building sandbox VM…"). Optional —
+        """The subject's live sub-phase, if any (e.g. "Provisioning sandbox VM…"). Optional —
         override to surface a transient signal the running run pushes."""
         return

--- a/backend/druks/browser/login.py
+++ b/backend/druks/browser/login.py
@@ -22,7 +22,7 @@ from druks.browser.models import StoredBrowserSession
 from druks.browser.sessions import SESSION_ROOT, seed_state
 from druks.redis import get_client
 from druks.sandbox.client import sandbox_client
-from druks.sandbox.host import Sandbox
+from druks.sandbox.host import Host
 from druks.settings import load_settings
 
 
@@ -154,7 +154,7 @@ async def _carry_screen(websocket: WebSocket, screen_reader: asyncssh.SSHReader[
 
 
 async def _launch(
-    browser: Sandbox, name: str, *, start_url: str, login_proxy: str, login_tz: str
+    browser: Host, name: str, *, start_url: str, login_proxy: str, login_tz: str
 ) -> None:
     # The launcher and its browser read these from the environment: the site to
     # open on so the operator lands where they log in, the egress proxy that
@@ -186,7 +186,7 @@ async def _launch(
         raise exceptions.BrowserLaunchError(name, ready.stderr.strip())
 
 
-async def _export(browser: Sandbox, name: str) -> bytes:
+async def _export(browser: Host, name: str) -> bytes:
     exported = await browser.exec(["session-export"], timeout=SESSION_EXPORT_TIMEOUT_SECONDS)
     if not exported.ok:
         raise exceptions.BrowserExportError(name, exported.stderr.strip())

--- a/backend/druks/contrib/review/workflows.py
+++ b/backend/druks/contrib/review/workflows.py
@@ -13,7 +13,7 @@ from druks.workflows import Workflow
 from druks.workspaces import RepoWorkspace
 
 if TYPE_CHECKING:
-    from druks.sandbox.host import Sandbox
+    from druks.sandbox.host import Host
 
 
 class ReviewWorkspace(RepoWorkspace):
@@ -23,7 +23,7 @@ class ReviewWorkspace(RepoWorkspace):
 
     @property
     def related_root(self) -> str:
-        return get_related_root(self.sandbox.ssh_username)
+        return get_related_root(self.host.ssh_username)
 
     def get_agent_run_kwargs(self, **kwargs: Any) -> dict[str, Any]:
         kwargs = super().get_agent_run_kwargs(**kwargs)
@@ -56,25 +56,25 @@ class PullRequestReview(Workflow):
     async def run(self, requested_by: str) -> None:
         await Review.review_pull_request()
 
-    async def get_workspace_kwargs(self, sandbox: "Sandbox") -> dict[str, Any]:
+    async def get_workspace_kwargs(self, host: "Host") -> dict[str, Any]:
         # Cloned at the default branch — the reviewer checks the pull request out itself.
         # The token is the review actor's: it authenticates the clone and ``gh``, so the
         # review is authored under that identity. Siblings stay uncloned — the reviewer
         # clones the ones it opens, into a directory that must exist for the grant to hold.
         repo = (await self.subject).repo
         github_token = await (await get_review_actor()).client.token_for_repo(repo)
-        await sandbox.write_secret(
-            secret=github_token, remote=get_github_token_remote_path(sandbox.ssh_username)
+        await host.write_secret(
+            secret=github_token, remote=get_github_token_remote_path(host.ssh_username)
         )
         await _repo.ensure(
-            sandbox,
+            host,
             repo_url=f"https://github.com/{repo}",
             ref=None,
-            target_path=get_repo_root(sandbox.ssh_username),
+            target_path=get_repo_root(host.ssh_username),
         )
-        await sandbox.exec(["mkdir", "-p", get_related_root(sandbox.ssh_username)], timeout=10.0)
+        await host.exec(["mkdir", "-p", get_related_root(host.ssh_username)], timeout=10.0)
         return {
-            **await super().get_workspace_kwargs(sandbox),
+            **await super().get_workspace_kwargs(host),
             "repo": repo,
             "github_token": github_token,
         }

--- a/backend/druks/contrib/ship/app.py
+++ b/backend/druks/contrib/ship/app.py
@@ -25,7 +25,8 @@ from druks.workflows import SubjectActivity
 # Only what the timeline can't already show. A running agent has an agent call
 # to name it, so the phase that clears provisioning maps to nothing.
 _PHASE_META: dict[str, SubjectActivity] = {
-    "provisioning_vm": SubjectActivity(label="Building sandbox VM…", kind="infra"),
+    "provisioning_vm": SubjectActivity(label="Provisioning sandbox VM…", kind="infra"),
+    "sandbox_building": SubjectActivity(label="Building sandbox…", kind="infra"),
 }
 
 

--- a/backend/druks/contrib/ship/workflows.py
+++ b/backend/druks/contrib/ship/workflows.py
@@ -36,7 +36,7 @@ from .policy import PlanGate, RepoPolicy
 from .prompt_context import BuildPromptContext
 
 if TYPE_CHECKING:
-    from druks.sandbox.host import Sandbox
+    from druks.sandbox.host import Host
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class BuildWorkspace(RepoWorkspace):
 
     @property
     def workspace_root(self) -> str:
-        return get_work_root(self.sandbox.ssh_username)
+        return get_work_root(self.host.ssh_username)
 
     def get_required_mcp_servers(self) -> tuple[RequiredMcpServer, ...]:
         return (RequiredMcpServer(name=GITHUB_MCP_NAME, url=GITHUB_MCP_URL, token=self.mcp_token),)
@@ -64,7 +64,7 @@ class BuildWorkspace(RepoWorkspace):
         # Codex has full FS access and ignores it). get_related_root is never the repo
         # cwd — Claude wedges (no stdout, forever) on ``--add-dir <cwd>``.
         kwargs = super().get_agent_run_kwargs(**kwargs)
-        kwargs["add_dirs"] = (get_related_root(self.sandbox.ssh_username),)
+        kwargs["add_dirs"] = (get_related_root(self.host.ssh_username),)
         kwargs["skills"] = self.skills
         return kwargs
 
@@ -166,7 +166,7 @@ class Build(Workflow):
         if await self._plan_phase():
             await self._implement_phase()
 
-    async def get_workspace_kwargs(self, sandbox: "Sandbox") -> dict[str, Any]:
+    async def get_workspace_kwargs(self, host: "Host") -> dict[str, Any]:
         # The BuildWorkspace fields: mint a fresh GitHub token, push it, and clone the
         # primary repo (at branch) into the VM. Re-runs per agent call — the clone is
         # idempotent (one test -d on a warm VM) so it's cheap, and the ~60min token
@@ -181,16 +181,16 @@ class Build(Workflow):
         # VMs clone the default branch; every agent after delivery gets the PR branch.
         branch = self.branch
         github_token = await (await get_github_client()).token_for_repo(repo)
-        await sandbox.write_secret(
-            secret=github_token, remote=get_github_token_remote_path(sandbox.ssh_username)
+        await host.write_secret(
+            secret=github_token, remote=get_github_token_remote_path(host.ssh_username)
         )
         await _repo.ensure(
-            sandbox,
+            host,
             repo_url=f"https://github.com/{repo}",
             ref=branch,
-            target_path=get_repo_root(sandbox.ssh_username),
+            target_path=get_repo_root(host.ssh_username),
         )
-        await sandbox.exec(["mkdir", "-p", get_related_root(sandbox.ssh_username)], timeout=10.0)
+        await host.exec(["mkdir", "-p", get_related_root(host.ssh_username)], timeout=10.0)
         try:
             mcp_token = await (await get_review_actor()).client.token_for_repo(repo)
         except Exception as error:
@@ -202,7 +202,7 @@ class Build(Workflow):
                 "for its github MCP server."
             ) from error
         return {
-            **await super().get_workspace_kwargs(sandbox),
+            **await super().get_workspace_kwargs(host),
             "repo": repo,
             "branch": branch,
             "github_token": github_token,
@@ -464,20 +464,20 @@ class Profile(Workflow):
             )
         await project_repo.set_profile(baseline=baseline, effective=effective)
 
-    async def get_workspace_kwargs(self, sandbox: "Sandbox") -> dict[str, Any]:
+    async def get_workspace_kwargs(self, host: "Host") -> dict[str, Any]:
         repo = (await ProjectRepo.get(self.input.repo_id)).full_name
         github_token = await (await get_github_client()).token_for_repo(repo)
-        await sandbox.write_secret(
-            secret=github_token, remote=get_github_token_remote_path(sandbox.ssh_username)
+        await host.write_secret(
+            secret=github_token, remote=get_github_token_remote_path(host.ssh_username)
         )
         await _repo.ensure(
-            sandbox,
+            host,
             repo_url=f"https://github.com/{repo}",
             ref=None,
-            target_path=get_repo_root(sandbox.ssh_username),
+            target_path=get_repo_root(host.ssh_username),
         )
         return {
-            **await super().get_workspace_kwargs(sandbox),
+            **await super().get_workspace_kwargs(host),
             "repo": repo,
             "github_token": github_token,
         }

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -26,6 +26,8 @@ from .database import create_async_engine_from_url, create_engine_from_url, sess
 from .harnesses.models import HarnessConnection
 from .harnesses.registry import get_harnesses
 from .sandbox.client import sandbox_client
+from .sandbox.exceptions import TemplateNotFound
+from .sandbox.templates import get_declared_sandboxes, prepare_sandbox_templates
 from .services import Service, ServiceNotConnectedError
 from .services.models import ServiceIdentity
 from .settings import Settings, load_settings
@@ -293,6 +295,53 @@ async def check_sandbox_e2e(settings: Settings) -> CheckResult:
     return CheckResult(name="sandbox_e2e", ok=True, detail=detail)
 
 
+async def check_declared_sandboxes(settings: Settings) -> CheckResult | list[CheckResult]:
+    try:
+        await prepare_sandbox_templates()
+        declared = get_declared_sandboxes()
+    except Exception as error:  # noqa: BLE001 — doctor reports, never raises
+        return CheckResult(
+            name="sandbox_templates",
+            ok=False,
+            detail=f"could not prepare declared sandbox templates: {error}",
+        )
+
+    if not declared:
+        return CheckResult(name="sandbox_templates", ok=True, detail="no declared sandboxes")
+
+    results = []
+    for requirements_hash, sandbox in declared.items():
+        name = f"sandbox:{requirements_hash[:12]}"
+        detail = f"{sandbox.setup}; hash {requirements_hash}"
+        try:
+            template = await sandbox_client.get_template(requirements_hash=requirements_hash)
+        except TemplateNotFound:
+            result = CheckResult(
+                name=name,
+                ok=False,
+                detail=f"{detail}; missing",
+            )
+        except Exception as error:  # noqa: BLE001 — one lookup failure is one result
+            result = CheckResult(
+                name=name,
+                ok=False,
+                detail=f"{detail}; lookup failed: {error}",
+            )
+        else:
+            ok, pending = {
+                "available": (True, False),
+                "building": (False, True),
+            }.get(template.status, (False, False))
+            result = CheckResult(
+                name=name,
+                ok=ok,
+                pending=pending,
+                detail=f"{detail}; {template.status}",
+            )
+        results.append(result)
+    return results
+
+
 async def _sandbox_e2e() -> str:
     start = time.monotonic()
     # acquire rolls its own host back on failure; once it yields, we own
@@ -482,6 +531,7 @@ CHECKS = (
     check_drukbox,
     check_capability_modules,
     check_apps,
+    check_declared_sandboxes,
 )
 
 

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -194,7 +194,7 @@ class SubjectList(BaseResponse):
 
 
 class SubjectActivity(BaseResponse):
-    # The running sub-phase the timeline can't show ("Building sandbox VM…"), supplied
+    # The running sub-phase the timeline can't show ("Provisioning sandbox VM…"), supplied
     # by the app; ``kind`` groups it for display ("infra" | "agent").
     label: str
     kind: str

--- a/backend/druks/sandbox/__init__.py
+++ b/backend/druks/sandbox/__init__.py
@@ -1,17 +1,3 @@
-from .datastructures import Credentials, ExecResult
-from .exceptions import ExecFailed, SandboxError, SandboxUnreachable
-from .host import Sandbox
-from .runner import Exec, Stream, attach, start_exec
+from .datastructures import Sandbox
 
-__all__ = [
-    "Credentials",
-    "Exec",
-    "ExecFailed",
-    "ExecResult",
-    "Sandbox",
-    "SandboxError",
-    "SandboxUnreachable",
-    "Stream",
-    "attach",
-    "start_exec",
-]
+__all__ = ["Sandbox"]

--- a/backend/druks/sandbox/client.py
+++ b/backend/druks/sandbox/client.py
@@ -19,8 +19,8 @@ from druks.harnesses.exceptions import HarnessSandboxProvisioningError
 from druks.settings import load_settings
 
 from .constants import SANDBOX_HOST_LEASE_SECONDS
-from .exceptions import HostGone, SandboxError, SandboxUnreachable
-from .host import Sandbox
+from .exceptions import HostGone, SandboxError, SandboxUnreachable, TemplateNotFound
+from .host import Host
 from .layout import get_helper_script_path, get_remote_home
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,8 @@ class Client:
         image_override: str | None = None,
         provider: str | None = None,
         sandbox_env: dict[str, str] | None = None,
-    ) -> AsyncIterator[Sandbox]:
+        template: str | None = None,
+    ) -> AsyncIterator[Host]:
         """One-shot lifecycle: acquire → yield → release. For callers
         whose sandbox is bound to a single context manager body."""
         host_id: str | None = None
@@ -64,9 +65,10 @@ class Client:
                 image_override=image_override,
                 provider=provider,
                 sandbox_env=sandbox_env,
-            ) as sandbox:
-                host_id = sandbox.id
-                yield sandbox
+                template=template,
+            ) as host:
+                host_id = host.id
+                yield host
         finally:
             if host_id:
                 await self.release(host_id=host_id)
@@ -79,7 +81,8 @@ class Client:
         image_override: str | None = None,
         provider: str | None = None,
         sandbox_env: dict[str, str] | None = None,
-    ) -> AsyncIterator[Sandbox]:
+        template: str | None = None,
+    ) -> AsyncIterator[Host]:
         """Create a new host (or reuse one matching ``idempotency_key``)
         and yield it with SSH connected. Closes SSH on exit but does NOT
         release the VM — pair with ``release`` for long-lived flows or
@@ -92,6 +95,10 @@ class Client:
             # Fixed lease: drukbox reaps the host when this lapses, so a run whose
             # worker dies frees its VM without a druks-side reconciler.
             expires_at = datetime.now(UTC) + timedelta(seconds=SANDBOX_HOST_LEASE_SECONDS)
+            create_host_kwargs = {}
+            if template:
+                # SDK 0.0.7 rejects template= even when unset, so ordinary leases omit it.
+                create_host_kwargs["template"] = template
             try:
                 record = await api.create_host(
                     expires_at=expires_at,
@@ -99,6 +106,7 @@ class Client:
                     idempotency_key=key,
                     image=image or None,
                     provider=provider,
+                    **create_host_kwargs,
                 )
             except (SandboxProvisioningError, SandboxUnavailableError) as exc:
                 # Transient control-plane failures — a 502 the service raises
@@ -117,26 +125,26 @@ class Client:
                 settings.sandbox_keys_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
                 key_path.write_text(record.private_key)
                 key_path.chmod(0o600)
-            sandbox = Sandbox(record=record)
+            host = Host(record=record)
             try:
-                await _upload_helper_script(sandbox)
+                await _upload_helper_script(host)
             except _ACQUIRE_SETUP_REACHABILITY_ERRORS as error:
                 # Fresh VM never became usable; roll back and classify as provisioning.
-                await sandbox.aclose()
+                await host.aclose()
                 await self._best_effort_delete(api, record.id)
                 key_path.unlink(missing_ok=True)
                 raise HarnessSandboxProvisioningError(
                     f"sandbox host {record.id} unreachable during setup: {error}"
                 ) from error
             except BaseException:
-                await sandbox.aclose()
+                await host.aclose()
                 await self._best_effort_delete(api, record.id)
                 key_path.unlink(missing_ok=True)
                 raise
             try:
-                yield sandbox
+                yield host
             finally:
-                await sandbox.aclose()
+                await host.aclose()
         finally:
             await api.aclose()
 
@@ -148,6 +156,27 @@ class Client:
         finally:
             await api.aclose()
 
+    async def create_template(self, *, base_image: str, script: bytes, requirements_hash: str):
+        api = self._api()
+        try:
+            return await api.create_template(
+                base_image=base_image,
+                script=script,
+                requirements_hash=requirements_hash,
+            )
+        finally:
+            await api.aclose()
+
+    async def get_template(self, *, requirements_hash: str):
+        api = self._api()
+        try:
+            for template in await api.list_templates():
+                if template.requirements_hash == requirements_hash:
+                    return template
+        finally:
+            await api.aclose()
+        raise TemplateNotFound(f"sandbox template {requirements_hash} does not exist")
+
     @staticmethod
     async def _best_effort_delete(api: SandboxAPI, host_id: str) -> None:
         try:
@@ -158,7 +187,7 @@ class Client:
             logger.exception("rollback delete failed for host %s", host_id)
 
     @asynccontextmanager
-    async def attach(self, *, host_id: str) -> AsyncIterator[Sandbox]:
+    async def attach(self, *, host_id: str) -> AsyncIterator[Host]:
         """Reattach to an existing host. Raises ``HostGone`` if the VM
         has been torn down. SSH closes on exit; the VM stays up."""
         api = self._api()
@@ -178,11 +207,11 @@ class Client:
                 raise HarnessSandboxProvisioningError(
                     f"sandbox host {host_id} lookup failed: {exc}"
                 ) from exc
-            sandbox = Sandbox(record=record)
+            host = Host(record=record)
             try:
-                yield sandbox
+                yield host
             finally:
-                await sandbox.aclose()
+                await host.aclose()
         finally:
             await api.aclose()
 
@@ -193,7 +222,8 @@ class Client:
         image_override: str | None = None,
         provider: str | None = None,
         sandbox_env: dict[str, str] | None = None,
-    ) -> Sandbox:
+        template: str | None = None,
+    ) -> Host:
         """Create a host and return its handle without holding an SSH connection —
         the handle reconnects lazily when used (its id and lease expiry are readable
         without one). Caller is responsible for ``release``."""
@@ -202,8 +232,9 @@ class Client:
             image_override=image_override,
             provider=provider,
             sandbox_env=sandbox_env,
-        ) as sandbox:
-            return sandbox
+            template=template,
+        ) as host:
+            return host
 
     async def release(self, *, host_id: str) -> None:
         """Terminate the VM. Idempotent and infallible — already-gone hosts
@@ -239,24 +270,24 @@ class Client:
         )
 
 
-async def _upload_helper_script(sandbox: Sandbox) -> None:
-    helper_path = get_helper_script_path(sandbox.ssh_username)
-    await sandbox.upload_file(
+async def _upload_helper_script(host: Host) -> None:
+    helper_path = get_helper_script_path(host.ssh_username)
+    await host.upload_file(
         local=_DRUKS_SANDBOX_LOCAL_SCRIPT,
         remote=helper_path,
     )
-    await sandbox.exec(["chmod", "755", helper_path], timeout=10.0)
+    await host.exec(["chmod", "755", helper_path], timeout=10.0)
 
     # Direct .gitconfig write — scope helper to github.com so it never
     # intercepts auth for other hosts. The ``!`` tells git to run the
     # value as a shell command rather than appending it to
     # ``git credential-``.
-    gitconfig_path = f"{get_remote_home(sandbox.ssh_username)}/.gitconfig"
+    gitconfig_path = f"{get_remote_home(host.ssh_username)}/.gitconfig"
     gitconfig_body = (
         f'[credential "https://github.com"]\n\thelper = !{helper_path} git-credential\n'
     )
     write_cmd = f"printf %s {shlex.quote(gitconfig_body)} > {shlex.quote(gitconfig_path)}"
-    write_result = await sandbox.exec(
+    write_result = await host.exec(
         ["sh", "-c", write_cmd],
         timeout=10.0,
     )

--- a/backend/druks/sandbox/credentials.py
+++ b/backend/druks/sandbox/credentials.py
@@ -9,7 +9,7 @@ from .layout import (
 )
 
 if TYPE_CHECKING:
-    from .host import Sandbox
+    from .host import Host
 
 # Tar excludes for credential-dir uploads. These never carry value into the
 # VM and dominate upload time when shipped naively:
@@ -31,28 +31,28 @@ DEFAULT_DIR_EXCLUDES: tuple[str, ...] = (
 )
 
 
-async def push(sandbox: "Sandbox", creds: Credentials) -> None:
+async def push(host: "Host", creds: Credentials) -> None:
     if creds.claude_credentials:
-        await sandbox.write_secret(
+        await host.write_secret(
             secret=creds.claude_credentials,
-            remote=get_claude_credentials_remote(sandbox.ssh_username),
+            remote=get_claude_credentials_remote(host.ssh_username),
         )
     if creds.codex_credentials:
-        await sandbox.write_secret(
+        await host.write_secret(
             secret=creds.codex_credentials,
-            remote=get_codex_auth_remote(sandbox.ssh_username),
+            remote=get_codex_auth_remote(host.ssh_username),
         )
     if creds.github_token is not None:
         # TODO: This token expires in ~60 min and is not refreshed, so a run
         # outliving it 401s on late git pushes. The in-VM credential helper
         # should mint on demand from a druks token-broker endpoint, retiring
         # this static file.
-        await sandbox.write_secret(
+        await host.write_secret(
             secret=creds.github_token,
-            remote=get_github_token_remote_path(sandbox.ssh_username),
+            remote=get_github_token_remote_path(host.ssh_username),
         )
 
-    home = get_remote_home(sandbox.ssh_username)
+    home = get_remote_home(host.ssh_username)
     for local, dest_suffix in creds.extra_config_files:
         # Optional — a dev box may not have config.toml etc., and a Docker bind
         # mount whose host file never existed leaves a directory at the path.
@@ -60,11 +60,11 @@ async def push(sandbox: "Sandbox", creds: Credentials) -> None:
         # own defaults in the VM).
         if not local.is_file():
             continue
-        await sandbox.upload_file(local=local, remote=f"{home}/{dest_suffix}")
+        await host.upload_file(local=local, remote=f"{home}/{dest_suffix}")
     for local, dest_suffix in creds.extra_config_dirs:
         if not local.is_dir():
             continue
-        await sandbox.upload_dir(
+        await host.upload_dir(
             local=local,
             remote=f"{home}/{dest_suffix}",
             excludes=DEFAULT_DIR_EXCLUDES + creds.extra_dir_excludes.get(dest_suffix, ()),

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -1,9 +1,16 @@
+import hashlib
+import importlib.util
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
+
+from druks.apps import loader
+from druks.settings import load_settings
+
+from .exceptions import SetupScriptError
 
 if TYPE_CHECKING:
     from druks.durable.enums import AgentCallStatus
@@ -19,6 +26,46 @@ class Profile(BaseModel):
     env: dict[str, str] = Field(default_factory=dict)
 
 
+def get_content_hash(base: str, script: bytes) -> str:
+    content = base.encode("utf-8") + b"\0" + script
+    return hashlib.sha256(content).hexdigest()
+
+
+@dataclass(frozen=True)
+class Sandbox:
+    # Path of the setup script inside the declaring app's package, by
+    # convention under ``sandboxes/``. The owning module is stamped when the
+    # declaration is assigned on a workflow class.
+    setup: str
+    module: str = field(init=False, compare=False, default="")
+
+    def __set_name__(self, owner: type, attr: str) -> None:
+        object.__setattr__(self, "module", owner.__module__)
+
+    def read_setup_script(self) -> bytes:
+        if not self.module:
+            raise SetupScriptError(
+                f"sandbox setup {self.setup!r} is not declared on a workflow class"
+            )
+        app = loader.get_app(loader.resolve_workflow_app(self.module))
+        spec = importlib.util.find_spec(app.package)
+        if not spec or not spec.submodule_search_locations:
+            raise SetupScriptError(
+                f"sandbox setup {self.setup!r} cannot find app package {app.package!r}"
+            )
+        path = Path(spec.submodule_search_locations[0]) / self.setup
+        try:
+            return path.read_bytes()
+        except OSError as error:
+            raise SetupScriptError(
+                f"sandbox setup {self.setup!r} cannot be read: {error}"
+            ) from error
+
+    @property
+    def content_hash(self) -> str:
+        return get_content_hash(load_settings().sandbox.image, self.read_setup_script())
+
+
 @dataclass(frozen=True)
 class ExecResult:
     exit_code: int
@@ -32,7 +79,7 @@ class ExecResult:
 
 @dataclass(frozen=True)
 class AgentResult:
-    """Result of one agent execution, what ``Sandbox.run_agent`` returns.
+    """Result of one agent execution, what ``Host.run_agent`` returns.
     the agent call records it as an ``AgentCall`` and parses ``output``."""
 
     output: Any
@@ -57,7 +104,7 @@ class AgentResult:
 
 @dataclass
 class HarnessRunResult:
-    """Raw outcome of one CLI execution in the VM — what ``Sandbox._exec``
+    """Raw outcome of one CLI execution in the VM — what ``Host._exec``
     returns and a harness's ``parse`` consumes."""
 
     returncode: int
@@ -67,7 +114,7 @@ class HarnessRunResult:
 
 @dataclass(frozen=True)
 class AgentInvocation:
-    """A fully-built CLI invocation, ready for ``Sandbox._exec``.
+    """A fully-built CLI invocation, ready for ``Host._exec``.
 
     Produced by a harness's ``build_invocation`` — the harness is a pure
     planner (argv in, parsed payload out) and never touches the live

--- a/backend/druks/sandbox/exceptions.py
+++ b/backend/druks/sandbox/exceptions.py
@@ -2,6 +2,18 @@ class SandboxError(Exception):
     """Base for everything ``druks.sandbox`` raises out of its layer."""
 
 
+class SetupScriptError(SandboxError):
+    """A declared setup path cannot resolve to package bytes."""
+
+
+class TemplateNotFound(SandboxError):
+    """Drukbox has no template for a requirements hash."""
+
+
+class TemplateUnavailable(SandboxError):
+    """A declared template cannot be leased."""
+
+
 class SandboxUnreachable(SandboxError):
     """The SSH connection to the VM cannot be (re-)established.
 

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -71,7 +71,7 @@ _CONNECT_TIMEOUT_SECONDS = 30.0
 _KEEPALIVE_INTERVAL_SECONDS = 15.0
 
 
-class Sandbox:
+class Host:
     def __init__(
         self,
         *,
@@ -538,7 +538,7 @@ class Sandbox:
         cwd: str | None = None,
         stdin_data: bytes | None = None,
     ) -> "Exec":
-        # cycle: each sibling imports Sandbox from this module
+        # cycle: each sibling imports Host from this module
         from . import credentials as _credentials
         from . import runner as _runner
 
@@ -651,7 +651,7 @@ class Sandbox:
                     "client_keys": [str(key_path)],
                 }
         raise RuntimeError(
-            f"Sandbox {self.record.id}: no reachable address on the record.",
+            f"Host {self.record.id}: no reachable address on the record.",
         )
 
 

--- a/backend/druks/sandbox/repo.py
+++ b/backend/druks/sandbox/repo.py
@@ -2,7 +2,7 @@ import re
 import shlex
 
 from .exceptions import ExecFailed
-from .host import Sandbox
+from .host import Host
 from .layout import get_repo_root
 
 # Reasonable cap for the clone-fetch-checkout chain. Most internal
@@ -13,7 +13,7 @@ CLONE_TIMEOUT_SECONDS = 600.0
 
 
 async def clone(
-    sandbox: Sandbox,
+    host: Host,
     *,
     repo_url: str,
     ref: str | None,
@@ -25,7 +25,7 @@ async def clone(
         )
 
     if not target_path:
-        target_path = get_repo_root(sandbox.ssh_username)
+        target_path = get_repo_root(host.ssh_username)
     quoted_url = shlex.quote(repo_url)
     quoted_target = shlex.quote(target_path)
     parent = target_path.rsplit("/", 1)[0]
@@ -47,7 +47,7 @@ async def clone(
             f" && git checkout -B {quoted_ref} FETCH_HEAD"
             f" && git config push.default current"
         )
-    result = await sandbox.exec(["sh", "-c", cmd], timeout=CLONE_TIMEOUT_SECONDS)
+    result = await host.exec(["sh", "-c", cmd], timeout=CLONE_TIMEOUT_SECONDS)
     if not result.ok:
         # Strip any token that somehow surfaced in error output before
         # surfacing — belt-and-braces. With the credential-helper the
@@ -62,7 +62,7 @@ async def clone(
 
 
 async def ensure(
-    sandbox: Sandbox,
+    host: Host,
     *,
     repo_url: str,
     ref: str | None,
@@ -74,14 +74,14 @@ async def ensure(
         )
 
     if not target_path:
-        target_path = get_repo_root(sandbox.ssh_username)
-    present = await sandbox.exec(
+        target_path = get_repo_root(host.ssh_username)
+    present = await host.exec(
         ["test", "-d", f"{target_path}/.git"],
         timeout=10.0,
     )
     if not present.ok:
         # Fresh VM (or first run on this PR) — full clone.
-        await clone(sandbox, repo_url=repo_url, ref=ref, target_path=target_path)
+        await clone(host, repo_url=repo_url, ref=ref, target_path=target_path)
         return
 
     if not ref:
@@ -97,7 +97,7 @@ async def ensure(
         f" && git checkout -fB {quoted_ref} FETCH_HEAD"
         f" && git config push.default current"
     )
-    result = await sandbox.exec(["sh", "-c", cmd], timeout=CLONE_TIMEOUT_SECONDS)
+    result = await host.exec(["sh", "-c", cmd], timeout=CLONE_TIMEOUT_SECONDS)
     if not result.ok:
         sanitized = _strip_token(result.stderr.strip() or result.stdout.strip())
         raise ExecFailed(

--- a/backend/druks/sandbox/runner.py
+++ b/backend/druks/sandbox/runner.py
@@ -9,7 +9,7 @@ from typing import Literal, NamedTuple
 import asyncssh
 
 from .exceptions import ExecFailed, SandboxUnreachable
-from .host import Sandbox
+from .host import Host
 from .layout import get_helper_script_path, get_runs_root
 
 # Polling cadence for tail() and wait(). 500ms is the cap on how stale
@@ -49,7 +49,7 @@ class Exec:
     def __init__(
         self,
         *,
-        host: Sandbox,
+        host: Host,
         run_id: str,
         run_dir: str,
     ) -> None:
@@ -221,7 +221,7 @@ class Exec:
 
 async def start_exec(
     *,
-    host: Sandbox,
+    host: Host,
     run_id: str,
     cmd: list[str],
     cwd: str,
@@ -309,7 +309,7 @@ async def start_exec(
 
 async def attach(
     *,
-    host: Sandbox,
+    host: Host,
     run_id: str,
 ) -> Exec:
     runs_root_path = get_runs_root(host.ssh_username)

--- a/backend/druks/sandbox/templates.py
+++ b/backend/druks/sandbox/templates.py
@@ -1,0 +1,55 @@
+import asyncio
+
+from druks.apps import loader
+from druks.durable.activity import set_run_phase
+from druks.settings import load_settings
+
+from .client import sandbox_client
+from .datastructures import Sandbox
+from .exceptions import TemplateNotFound, TemplateUnavailable
+
+_TEMPLATE_POLL_SECONDS = 5
+
+
+def get_declared_sandboxes() -> dict[str, Sandbox]:
+    declared = {}
+    for app in loader.iter_apps():
+        for workflow in app.workflows():
+            if sandbox := workflow.sandbox:
+                declared[sandbox.content_hash] = sandbox
+    return declared
+
+
+async def prepare_sandbox_templates() -> None:
+    base_image = load_settings().sandbox.image
+    for requirements_hash, sandbox in get_declared_sandboxes().items():
+        await sandbox_client.create_template(
+            base_image=base_image,
+            script=sandbox.read_setup_script(),
+            requirements_hash=requirements_hash,
+        )
+
+
+async def get_template_id(sandbox: Sandbox) -> str:
+    requirements_hash = sandbox.content_hash
+    try:
+        template = await sandbox_client.get_template(requirements_hash=requirements_hash)
+    except TemplateNotFound as error:
+        raise TemplateUnavailable(
+            f"sandbox template {requirements_hash} is missing. "
+            "Reinstall the app or run `druks doctor`."
+        ) from error
+
+    if template.status == "building":
+        await set_run_phase("sandbox_building")
+        while template.status == "building":
+            await asyncio.sleep(_TEMPLATE_POLL_SECONDS)
+            template = await sandbox_client.get_template(requirements_hash=requirements_hash)
+
+    if template.status == "available":
+        return template.id
+
+    raise TemplateUnavailable(
+        f"sandbox template {requirements_hash} has status {template.status!r}. "
+        "Fix its setup and run `druks doctor`."
+    )

--- a/backend/druks/scaffolding/app_template/package/workflows.py-tpl
+++ b/backend/druks/scaffolding/app_template/package/workflows.py-tpl
@@ -6,6 +6,9 @@ from druks.workflows import FatalError, Gate, Workflow, step  # noqa: F401
 # The parameters ARE the workflow's input: plain typed params, validated at start().
 # Set ``every = "<cron>"`` to schedule one; raise ``FatalError`` for a clean domain
 # stop; a ``Gate`` subclass parks the run for human input.
+# Set ``sandbox = Sandbox(setup="sandboxes/setup.sh")`` (from druks.sandbox) when the
+# workflow needs an environment beyond the platform base. Ship the shell file under the
+# package's sandboxes/.
 #
 # Declare what a workflow's runs are about with ``subject = YourSubject`` — the class,
 # with a table or without — and druks gives that subject a board and a page.

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -152,8 +152,6 @@ class Sandbox(BaseModel):
     # over Tailscale to execute the CLI inside it. See
     # ``docs/design/sandboxed-execution.md`` for the full architecture.
     #
-    # An empty URL disables sandbox-backed execution; workflows that call an
-    # agent then fail when they try to acquire a host.
     service_url: str = ""
     service_token: str = ""
     # Empty → drukbox decides.

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -53,6 +53,8 @@ from druks.models import StoredSubject, snake_name
 from druks.notifications.outbox import notifications_queue, send_notification
 from druks.sandbox.client import sandbox_client
 from druks.sandbox.constants import SANDBOX_HOST_ROTATE_BEFORE_SECONDS
+from druks.sandbox.datastructures import Sandbox
+from druks.sandbox.templates import get_template_id
 from druks.signals import publish
 from druks.user_settings.models import SettingsOverride, UserSettings
 from druks.workspaces import Workspace
@@ -82,7 +84,7 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:
-    from druks.sandbox.host import Sandbox
+    from druks.sandbox.host import Host
 
 # A human gate can park for days; a long recv TTL still caps zombie parks.
 GATE_TTL_SECONDS = 14 * 24 * 60 * 60
@@ -683,6 +685,8 @@ class Workflow:
     # True holds one warm VM across the run's agent calls (released at gate parks);
     # False gives each call a throwaway VM.
     steps_reuse_sandbox: ClassVar[bool] = False
+    # The environment this workflow's agents need. None uses the platform base.
+    sandbox: ClassVar[Sandbox | None] = None
     # The Workspace subclass agents run in; an app sets it (default: the bare VM).
     workspace_class: ClassVar[type[Workspace]] = Workspace
     # The Journal subclass the run keeps; an app sets it for named projections.
@@ -770,7 +774,7 @@ class Workflow:
         self.journal = self.journal_class()
         # The run's warm VM, provisioned lazily and reaped at segment boundaries;
         # its lease expiry decides when it must rotate.
-        self._host: Sandbox | None = None
+        self._host: Host | None = None
 
     async def announce(self, topic: str, **facts: Any) -> None:
         # The workflow announcing a domain event in its app's vocabulary
@@ -819,17 +823,17 @@ class Workflow:
         # values (expensive derived prose); the call's own kwargs win on collision.
         return dict(context)
 
-    async def get_workspace_kwargs(self, sandbox: "Sandbox") -> dict[str, Any]:
+    async def get_workspace_kwargs(self, host: "Host") -> dict[str, Any]:
         # Extend via super() to add the fields workspace_class needs (an app clones + mints
         # here). Base: just the VM.
-        return {"sandbox": sandbox}
+        return {"host": host}
 
-    async def get_workspace(self, sandbox: "Sandbox") -> Workspace:
+    async def get_workspace(self, host: "Host") -> Workspace:
         # What an agent runs in on this run's VM, built per agent call from workspace_class
         # + the app's kwargs — so short-lived tokens (git) mint fresh each call.
-        return self.workspace_class(**await self.get_workspace_kwargs(sandbox))
+        return self.workspace_class(**await self.get_workspace_kwargs(host))
 
-    async def _ensure_host(self) -> str | None:
+    async def _lease_host(self) -> str | None:
         # The warm VM, provisioned once per segment; state is carried in git, so
         # only the host-id matters across steps — held-across-steps never fights replay.
         if not self.steps_reuse_sandbox:
@@ -842,8 +846,13 @@ class Workflow:
                 # host it lands on (state lives in git), so a bare VM is fine.
                 await self._reap_run()
         if not self._host:
+            template = None
+            if self.sandbox:
+                template = await get_template_id(self.sandbox)
+                await set_run_phase("provisioning_vm")
             self._host = await sandbox_client.provision(
-                idempotency_key=f"{self._workflow_id}:sandbox"
+                idempotency_key=f"{self._workflow_id}:sandbox",
+                template=template,
             )
         return self._host.id
 

--- a/backend/druks/workspaces.py
+++ b/backend/druks/workspaces.py
@@ -18,7 +18,7 @@ from druks.sandbox.layout import get_repo_root
 from druks.user_settings.models import UserSettings
 
 if TYPE_CHECKING:
-    from druks.sandbox.host import Sandbox
+    from druks.sandbox.host import Host
 
 
 @dataclass(frozen=True)
@@ -26,11 +26,11 @@ class Workspace:
     # What an agent runs in: the VM it abstracts. An app subclasses this and
     # overrides get_agent_run_kwargs for its project scaffolding (repo token, dirs)
     # and get_required_mcp_servers for MCP servers it credentials itself.
-    sandbox: "Sandbox"
+    host: "Host"
 
     @property
     def host_id(self) -> str:
-        return self.sandbox.id
+        return self.host.id
 
     def get_agent_run_kwargs(self, **kwargs: Any) -> dict[str, Any]:
         # Override to add what the agent's run needs on this workspace (github_token,
@@ -47,7 +47,7 @@ class Workspace:
         # with_mcp_servers is the run's last DB read; commit so the step's
         # connection isn't held idle through the minutes the agent runs.
         await db_session().commit()
-        return await self.sandbox.run_agent(**run_kwargs)
+        return await self.host.run_agent(**run_kwargs)
 
     async def with_mcp_servers(self, account_id: str | None, **kwargs: Any) -> dict[str, Any]:
         # Fold every MCP server into this call — the workspace's required
@@ -136,7 +136,7 @@ class RepoWorkspace(Workspace):
 
     @property
     def repo_path(self) -> str:
-        return get_repo_root(self.sandbox.ssh_username)
+        return get_repo_root(self.host.ssh_username)
 
     def get_agent_run_kwargs(self, **kwargs: Any) -> dict[str, Any]:
         kwargs["github_token"] = self.github_token
@@ -170,7 +170,7 @@ class RepoWorkspace(Workspace):
                 f"printf %s {shlex.quote(hook)} > .git/hooks/prepare-commit-msg",
                 "chmod 755 .git/hooks/prepare-commit-msg",
             ]
-        result = await self.sandbox.exec(["sh", "-c", " && ".join(steps)], timeout=10.0)
+        result = await self.host.exec(["sh", "-c", " && ".join(steps)], timeout=10.0)
         if not result.ok:
             raise ExecFailed(
                 f"failed to set the workspace git identity: "

--- a/backend/tests/druks-field_notes/druks_field_notes/sandboxes/setup.sh
+++ b/backend/tests/druks-field_notes/druks_field_notes/sandboxes/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+apt-get update
+apt-get install -y jq

--- a/backend/tests/druks-field_notes/druks_field_notes/workflows.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/workflows.py
@@ -1,3 +1,4 @@
+from druks.sandbox import Sandbox
 from druks.workflows import Workflow
 
 from druks_field_notes.app import FieldNotes
@@ -9,6 +10,7 @@ class Summarize(Workflow):
     produces the line, and the run stores it on the note."""
 
     subject = Note
+    sandbox = Sandbox(setup="sandboxes/setup.sh")
 
     async def run(self) -> None:
         note = await self.subject

--- a/backend/tests/ship/test_api_work_items.py
+++ b/backend/tests/ship/test_api_work_items.py
@@ -244,7 +244,7 @@ async def test_timeline_shows_every_build_attempt(druks_db):
 
 async def test_subject_activity_surfaces_running_phase(druks_db, monkeypatch):
     # A running build run pushes a transient phase; the detail view's live activity
-    # surfaces it ("Building sandbox VM…") — finer than the lifecycle status.
+    # surfaces it ("Provisioning sandbox VM…") — finer than the lifecycle status.
     from druks.contrib.ship import app as ship_app
 
     item = await make_test_work_item(repo="ClawHaven/acme-app", title="x")
@@ -256,7 +256,7 @@ async def test_subject_activity_surfaces_running_phase(druks_db, monkeypatch):
     monkeypatch.setattr("druks.durable.reads.get_run_phase", phase)
     activity = await ship_app.Ship.get_subject_activity(item)
     assert activity is not None
-    assert activity.label == "Building sandbox VM…"
+    assert activity.label == "Provisioning sandbox VM…"
     assert activity.kind == "infra"
 
 

--- a/backend/tests/ship/test_build_workspace.py
+++ b/backend/tests/ship/test_build_workspace.py
@@ -24,7 +24,7 @@ def test_build_workspace_grants_related_root_add_dir():
     # file-tool grant, no per-repo threading. MCP delivery is the fold's job —
     # scaffolding kwargs never carry it.
     workspace = BuildWorkspace(
-        sandbox=_FakeSandbox(),  # type: ignore[arg-type]
+        host=_FakeSandbox(),  # type: ignore[arg-type]
         repo="o/main",
         branch="b",
         github_token="t",
@@ -47,7 +47,7 @@ async def test_build_workspace_declares_its_github_mcp(druks_db):
     # is no build without github). Delivery ships it whole: wire shape + token
     # in the run env.
     workspace = BuildWorkspace(
-        sandbox=_FakeSandbox(),  # type: ignore[arg-type]
+        host=_FakeSandbox(),  # type: ignore[arg-type]
         repo="o/main",
         branch="b",
         github_token="t",
@@ -79,8 +79,8 @@ def _workspace_kwargs_stubs(monkeypatch: pytest.MonkeyPatch, *, review_actor):
         execs.append(argv)
         return SimpleNamespace(ok=True, exit_code=0, stdout="", stderr="")
 
-    monkeypatch.setattr(host_mod.Sandbox, "write_secret", _noop)
-    monkeypatch.setattr(host_mod.Sandbox, "exec", fake_exec)
+    monkeypatch.setattr(host_mod.Host, "write_secret", _noop)
+    monkeypatch.setattr(host_mod.Host, "exec", fake_exec)
 
     async def _github_client():
         return SimpleNamespace(token_for_repo=_token)
@@ -108,7 +108,7 @@ async def test_get_workspace_kwargs_clones_primary_only(monkeypatch: pytest.Monk
             client=SimpleNamespace(token_for_repo=_review_token), mode="approve"
         ),
     )
-    sandbox = host_mod.Sandbox(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
+    sandbox = host_mod.Host(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
 
     workflow = Build()
     workflow.input = Build._run_input_model()
@@ -138,7 +138,7 @@ async def test_get_workspace_kwargs_fails_loudly_when_the_token_wont_mint(
             client=SimpleNamespace(token_for_repo=_no_token), mode="comment"
         ),
     )
-    sandbox = host_mod.Sandbox(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
+    sandbox = host_mod.Host(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
 
     workflow = Build()
     workflow.input = Build._run_input_model()
@@ -185,7 +185,7 @@ async def test_set_git_identity_stamps_the_workspace_repo(
 ) -> None:
     repo_path = tmp_path / "repo"
     subprocess.run(["git", "init", "-q", str(repo_path)], check=True)
-    workspace = RepoWorkspace(sandbox=_IdentitySandbox(repo_path), repo="o/main", github_token="t")  # type: ignore[arg-type]
+    workspace = RepoWorkspace(host=_IdentitySandbox(repo_path), repo="o/main", github_token="t")  # type: ignore[arg-type]
     hook = repo_path / ".git" / "hooks" / "prepare-commit-msg"
     message = repo_path / "COMMIT_EDITMSG"
 

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -706,8 +706,8 @@ async def test_reused_host_retry_presents_a_stable_idempotency_key(monkeypatch, 
     monkeypatch.setattr("druks.sandbox.client.Client.provision", fake_provision)
 
     with pytest.raises(HarnessSandboxProvisioningError):
-        await current_run._ensure_host()
-    host_id = await current_run._ensure_host()
+        await current_run._lease_host()
+    host_id = await current_run._lease_host()
 
     assert host_id == "warm-host"
     assert keys == ["wf-9:sandbox", "wf-9:sandbox"]

--- a/backend/tests/test_author_surface.py
+++ b/backend/tests/test_author_surface.py
@@ -15,6 +15,7 @@ AUTHOR_SURFACE = {
         "ServiceConnectError",
         "ServiceNotConnectedError",
     },
+    "druks.sandbox": {"Sandbox"},
     "druks.agents": {"Agent", "AgentOutput"},
     "druks.workflows": {
         "AgentCall",

--- a/backend/tests/test_declared_sandboxes.py
+++ b/backend/tests/test_declared_sandboxes.py
@@ -1,0 +1,287 @@
+import hashlib
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import druks.agents as agent_module
+import druks.workflows as workflow_module
+import pytest
+from druks.contrib.ship.app import _PHASE_META
+from druks.sandbox import datastructures, templates
+from druks.sandbox.client import Client
+from druks.sandbox.datastructures import Sandbox, get_content_hash
+from druks.sandbox.exceptions import TemplateNotFound, TemplateUnavailable
+from druks.workflows import Workflow
+
+
+def test_sandbox_resolves_package_bytes_and_hashes_base_with_script(monkeypatch, tmp_path):
+    package = tmp_path / "site_builder"
+    (package / "sandboxes").mkdir(parents=True)
+    (package / "__init__.py").write_text("")
+    (package / "sandboxes" / "build.sh").write_bytes(b"#!/bin/sh\ninstall-tool\n")
+    monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.setattr(
+        datastructures,
+        "loader",
+        SimpleNamespace(
+            resolve_workflow_app=lambda module: "site_builder",
+            get_app=lambda name: SimpleNamespace(name="site_builder", package="site_builder"),
+        ),
+    )
+    monkeypatch.setattr(
+        datastructures,
+        "load_settings",
+        lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base-image")),
+    )
+
+    class BuildSite:
+        sandbox = Sandbox(setup="sandboxes/build.sh")
+
+    script = BuildSite.sandbox.read_setup_script()
+
+    assert script.startswith(b"#!/bin/sh\n")
+    assert BuildSite.sandbox.content_hash == hashlib.sha256(b"base-image\0" + script).hexdigest()
+
+
+def test_get_declared_sandboxes_deduplicates_by_content(monkeypatch):
+    shared = Sandbox(setup="sandboxes/setup.sh")
+
+    class First:
+        kind = "notes.first"
+        sandbox = shared
+
+    class Second:
+        kind = "notes.second"
+        sandbox = shared
+
+    app = SimpleNamespace(workflows=lambda: [First, Second])
+    monkeypatch.setattr(templates, "loader", SimpleNamespace(iter_apps=lambda: [app]))
+    monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
+    monkeypatch.setattr(
+        datastructures,
+        "load_settings",
+        lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
+    )
+
+    declared = templates.get_declared_sandboxes()
+
+    assert declared == {get_content_hash("base", b"setup"): shared}
+
+
+def test_ship_maps_the_sandbox_building_phase():
+    assert _PHASE_META["sandbox_building"].label == "Building sandbox…"
+    assert _PHASE_META["sandbox_building"].kind == "infra"
+
+
+async def test_prepare_sandbox_templates_requests_each_declaration(monkeypatch):
+    sandbox = Sandbox(setup="sandboxes/setup.sh")
+    requirements_hash = get_content_hash("base", b"setup")
+    create_template = AsyncMock()
+    monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
+    monkeypatch.setattr(
+        templates,
+        "load_settings",
+        lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
+    )
+    monkeypatch.setattr(
+        templates,
+        "get_declared_sandboxes",
+        lambda: {requirements_hash: sandbox},
+    )
+    monkeypatch.setattr(
+        templates,
+        "sandbox_client",
+        SimpleNamespace(create_template=create_template),
+    )
+
+    await templates.prepare_sandbox_templates()
+
+    create_template.assert_awaited_once_with(
+        base_image="base",
+        script=b"setup",
+        requirements_hash=requirements_hash,
+    )
+
+
+
+async def test_get_template_id_uses_available_template(monkeypatch):
+    sandbox = Sandbox(setup="sandboxes/setup.sh")
+    template = SimpleNamespace(id="template-1", status="available")
+    get_template = AsyncMock(return_value=template)
+    monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
+    monkeypatch.setattr(
+        datastructures,
+        "load_settings",
+        lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
+    )
+    monkeypatch.setattr(
+        templates,
+        "sandbox_client",
+        SimpleNamespace(get_template=get_template),
+    )
+
+    assert await templates.get_template_id(sandbox) == "template-1"
+    get_template.assert_awaited_once_with(requirements_hash=get_content_hash("base", b"setup"))
+
+
+async def test_get_template_id_waits_with_visible_phase(monkeypatch):
+    sandbox = Sandbox(setup="sandboxes/setup.sh")
+    get_template = AsyncMock(
+        side_effect=[
+            SimpleNamespace(id="template-1", status="building"),
+            SimpleNamespace(id="template-1", status="available"),
+        ]
+    )
+    set_run_phase = AsyncMock()
+    sleep = AsyncMock()
+    monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
+    monkeypatch.setattr(
+        datastructures,
+        "load_settings",
+        lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
+    )
+    monkeypatch.setattr(
+        templates,
+        "sandbox_client",
+        SimpleNamespace(get_template=get_template),
+    )
+    monkeypatch.setattr(templates, "set_run_phase", set_run_phase)
+    monkeypatch.setattr(templates.asyncio, "sleep", sleep)
+
+    assert await templates.get_template_id(sandbox) == "template-1"
+    set_run_phase.assert_awaited_once_with("sandbox_building")
+    sleep.assert_awaited_once_with(templates._TEMPLATE_POLL_SECONDS)
+    assert get_template.await_count == 2
+
+
+async def test_get_template_id_rejects_missing_template(monkeypatch):
+    sandbox = Sandbox(setup="sandboxes/setup.sh")
+    monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
+    monkeypatch.setattr(
+        datastructures,
+        "load_settings",
+        lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
+    )
+    monkeypatch.setattr(
+        templates,
+        "sandbox_client",
+        SimpleNamespace(get_template=AsyncMock(side_effect=TemplateNotFound("missing"))),
+    )
+
+    with pytest.raises(TemplateUnavailable, match="missing.*druks doctor"):
+        await templates.get_template_id(sandbox)
+
+
+async def test_get_template_id_rejects_failed_template(monkeypatch):
+    sandbox = Sandbox(setup="sandboxes/setup.sh")
+    monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
+    monkeypatch.setattr(
+        datastructures,
+        "load_settings",
+        lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
+    )
+    monkeypatch.setattr(
+        templates,
+        "sandbox_client",
+        SimpleNamespace(
+            get_template=AsyncMock(return_value=SimpleNamespace(id="template-1", status="failed"))
+        ),
+    )
+
+    with pytest.raises(TemplateUnavailable, match="failed.*druks doctor"):
+        await templates.get_template_id(sandbox)
+
+
+async def test_warm_lease_uses_workflow_template(monkeypatch):
+    sandbox = Sandbox(setup="sandboxes/setup.sh")
+    host = SimpleNamespace(
+        id="host-1",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    provision = AsyncMock(return_value=host)
+    resolve = AsyncMock(return_value="template-1")
+    workflow = Workflow.__new__(Workflow)
+    workflow.steps_reuse_sandbox = True
+    workflow.sandbox = sandbox
+    workflow._workflow_id = "run-1"
+    workflow._host = None
+    monkeypatch.setattr(
+        workflow_module,
+        "sandbox_client",
+        SimpleNamespace(provision=provision),
+    )
+    monkeypatch.setattr(workflow_module, "get_template_id", resolve)
+    monkeypatch.setattr(workflow_module, "set_run_phase", AsyncMock())
+
+    assert await workflow._lease_host() == "host-1"
+    resolve.assert_awaited_once_with(sandbox)
+    provision.assert_awaited_once_with(
+        idempotency_key="run-1:sandbox",
+        template="template-1",
+    )
+
+
+async def test_ephemeral_lease_uses_workflow_template(monkeypatch):
+    sandbox = Sandbox(setup="sandboxes/setup.sh")
+    calls = []
+    box = SimpleNamespace(id="host-1")
+
+    @asynccontextmanager
+    async def ephemeral(**kwargs):
+        calls.append(kwargs)
+        yield box
+
+    workflow = SimpleNamespace(
+        sandbox=sandbox,
+        get_workspace=AsyncMock(return_value="workspace"),
+    )
+    resolve = AsyncMock(return_value="template-1")
+    monkeypatch.setattr(
+        agent_module,
+        "sandbox_client",
+        SimpleNamespace(ephemeral=ephemeral),
+    )
+    monkeypatch.setattr(agent_module, "get_template_id", resolve)
+
+    async with agent_module._runner(workflow, None, "run-1", "summarize") as runner:
+        assert runner == "workspace"
+
+    resolve.assert_awaited_once_with(sandbox)
+    assert calls == [{"idempotency_key": "run-1:summarize", "template": "template-1"}]
+
+
+async def test_client_template_primitives_use_sdk_contract(monkeypatch):
+    created = SimpleNamespace(id="template-1", status="building")
+    listed = SimpleNamespace(
+        id="template-1",
+        status="available",
+        requirements_hash="requirements-1",
+    )
+
+    class FakeAPI:
+        def __init__(self):
+            self.create_template = AsyncMock(return_value=created)
+            self.list_templates = AsyncMock(return_value=[listed])
+            self.aclose = AsyncMock()
+
+    api = FakeAPI()
+    client = Client()
+    monkeypatch.setattr(Client, "_api", lambda self: api)
+
+    assert (
+        await client.create_template(
+            base_image="base",
+            script=b"setup",
+            requirements_hash="requirements-1",
+        )
+        is created
+    )
+    assert await client.get_template(requirements_hash="requirements-1") is listed
+    api.create_template.assert_awaited_once_with(
+        base_image="base",
+        script=b"setup",
+        requirements_hash="requirements-1",
+    )
+    api.list_templates.assert_awaited_once_with()
+    assert api.aclose.await_count == 2

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -1,11 +1,14 @@
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
 from druks import doctor
 from druks.database import db_session
+from druks.sandbox.exceptions import TemplateNotFound
 from druks.services.models import ServiceIdentity
 from druks.testing import make_settings
 
@@ -192,6 +195,90 @@ async def test_drukbox_passes_when_unconfigured(tmp_path: Path) -> None:
 
     assert result.ok
     assert "not configured" in result.detail
+
+
+async def test_declared_sandboxes_pass_when_none_are_declared(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_templates = AsyncMock()
+    monkeypatch.setattr(doctor, "prepare_sandbox_templates", request_templates)
+    monkeypatch.setattr(doctor, "get_declared_sandboxes", lambda: {})
+    settings = make_settings(tmp_path, sandbox={"service_url": "http://drukbox"})
+
+    result = await doctor.check_declared_sandboxes(settings)
+
+    assert result == doctor.CheckResult(
+        name="sandbox_templates",
+        ok=True,
+        detail="no declared sandboxes",
+    )
+    request_templates.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    ("status", "ok", "pending"),
+    [
+        ("available", True, False),
+        ("building", False, True),
+        ("failed", False, False),
+    ],
+)
+async def test_declared_sandboxes_report_template_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    ok: bool,
+    pending: bool,
+) -> None:
+    declared = {"requirements-1": SimpleNamespace(setup="sandboxes/setup.sh")}
+    request_templates = AsyncMock()
+    lookup = AsyncMock(return_value=SimpleNamespace(status=status))
+    monkeypatch.setattr(doctor, "prepare_sandbox_templates", request_templates)
+    monkeypatch.setattr(doctor, "get_declared_sandboxes", lambda: declared)
+    monkeypatch.setattr(
+        doctor,
+        "sandbox_client",
+        SimpleNamespace(get_template=lookup),
+    )
+    settings = make_settings(tmp_path, sandbox={"service_url": "http://drukbox"})
+
+    results = await doctor.check_declared_sandboxes(settings)
+
+    request_templates.assert_awaited_once_with()
+    lookup.assert_awaited_once_with(requirements_hash="requirements-1")
+    assert len(results) == 1
+    assert results[0].ok is ok
+    assert results[0].pending is pending
+    assert "sandboxes/setup.sh" in results[0].detail
+    assert "requirements-1" in results[0].detail
+    assert status in results[0].detail
+
+
+async def test_declared_sandboxes_report_missing_template(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(doctor, "prepare_sandbox_templates", AsyncMock())
+    monkeypatch.setattr(
+        doctor,
+        "get_declared_sandboxes",
+        lambda: {"requirements-1": SimpleNamespace(setup="sandboxes/setup.sh")},
+    )
+    monkeypatch.setattr(
+        doctor,
+        "sandbox_client",
+        SimpleNamespace(get_template=AsyncMock(side_effect=TemplateNotFound("missing"))),
+    )
+    settings = make_settings(tmp_path, sandbox={"service_url": "http://drukbox"})
+
+    result = (await doctor.check_declared_sandboxes(settings))[0]
+
+    assert not result.ok
+    assert not result.pending
+    assert "sandboxes/setup.sh" in result.detail
+    assert "requirements-1" in result.detail
+    assert "missing" in result.detail
 
 
 async def test_run_checks_covers_all_check_names(tmp_path: Path) -> None:

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -593,7 +593,7 @@ async def test_delivery_mints_and_injects_the_oauth_token(registry_state, auth_s
     _register_oauth_server()
     await _store_grant()
 
-    kwargs = await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+    kwargs = await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
         SYSTEM_ACCOUNT_ID
     )
 
@@ -613,7 +613,7 @@ async def test_delivery_fails_loudly_for_an_unconnected_enabled_oauth_server(
     server.identity_mode = IdentityMode.SHARED
 
     with pytest.raises(MissingGrantError, match=_NAME):
-        await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+        await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
             SYSTEM_ACCOUNT_ID
         )
 
@@ -624,7 +624,7 @@ async def test_delivery_names_the_account_missing_its_per_user_grant(druks_db):
     server.identity_mode = IdentityMode.PER_USER
 
     with pytest.raises(MissingGrantError) as error:
-        await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+        await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
             account.id
         )
 
@@ -639,7 +639,7 @@ async def test_delivery_without_a_run_account_uses_the_fallback(auth_server, dru
     await (await UserSettings.get()).set_fallback_account(fallback.id)
     await _store_grant(account_id=fallback.id, identity_mode=IdentityMode.PER_USER)
 
-    kwargs = await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+    kwargs = await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
         None
     )
 
@@ -653,7 +653,7 @@ async def test_delivery_with_a_named_account_does_not_use_the_fallback(auth_serv
     await _store_grant(account_id=fallback.id, identity_mode=IdentityMode.PER_USER)
 
     with pytest.raises(MissingGrantError) as error:
-        await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+        await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
             named.id
         )
 

--- a/backend/tests/test_mcp_servers.py
+++ b/backend/tests/test_mcp_servers.py
@@ -42,7 +42,7 @@ def _sandbox_config() -> SandboxSettings:
 async def _delivery(**kwargs) -> dict:
     # Delivery is resolved at the workspace seam: the enabled servers become wire
     # shapes on ``mcp_servers`` and their tokens land in ``extra_env``.
-    return await Workspace(sandbox=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
+    return await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
         None, **kwargs
     )
 
@@ -54,7 +54,7 @@ def _requiring_workspace(*servers: RequiredMcpServer) -> Workspace:
         def get_required_mcp_servers(self) -> tuple[RequiredMcpServer, ...]:
             return servers
 
-    return _Requiring(sandbox=_FakeSandbox())  # type: ignore[arg-type]
+    return _Requiring(host=_FakeSandbox())  # type: ignore[arg-type]
 
 
 # --- custom servers: CRUD + enable/disable -------------------------------

--- a/backend/tests/test_sandbox_aws_direct.py
+++ b/backend/tests/test_sandbox_aws_direct.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 from drukbox_sdk import SandboxHost as SandboxHostRecord
 from druks.sandbox import client as client_module
-from druks.sandbox.host import Sandbox
+from druks.sandbox.host import Host
 
 
 def _tailscale_record() -> SandboxHostRecord:
@@ -69,7 +69,7 @@ def _patch_import_known_hosts(monkeypatch: pytest.MonkeyPatch):
 
 def test_ssh_connect_kwargs_picks_tailscale_when_internal_ssh_host_is_set():
     """Tailnet record dials MagicDNS without client keys."""
-    kwargs = Sandbox(record=_tailscale_record())._ssh_connect_kwargs()
+    kwargs = Host(record=_tailscale_record())._ssh_connect_kwargs()
     assert kwargs["host"] == "ts.tailnet.ts.net"
     assert kwargs["port"] == 22
     assert "client_keys" not in kwargs
@@ -85,7 +85,7 @@ def test_ssh_connect_kwargs_picks_aws_direct_when_key_is_persisted(
         lambda: type("_S", (), {"sandbox_keys_dir": tmp_path})(),
     )
     (tmp_path / "host-aws").write_text("fakekey")
-    kwargs = Sandbox(record=_aws_direct_record())._ssh_connect_kwargs()
+    kwargs = Host(record=_aws_direct_record())._ssh_connect_kwargs()
     assert kwargs["host"] == "ec2-1-2-3-4.compute.amazonaws.com"
     assert kwargs["port"] == 22
     assert kwargs["client_keys"] == [str(tmp_path / "host-aws")]
@@ -104,7 +104,7 @@ def test_ssh_connect_kwargs_dials_a_reattached_record_via_persisted_key(
     )
     (tmp_path / "host-aws").write_text("fakekey")
     reattached = replace(_aws_direct_record(), private_key=None)
-    kwargs = Sandbox(record=reattached)._ssh_connect_kwargs()
+    kwargs = Host(record=reattached)._ssh_connect_kwargs()
     assert kwargs["host"] == "ec2-1-2-3-4.compute.amazonaws.com"
     assert kwargs["client_keys"] == [str(tmp_path / "host-aws")]
 
@@ -119,7 +119,7 @@ def test_ssh_connect_kwargs_raises_when_the_key_was_never_persisted(
         lambda: type("_S", (), {"sandbox_keys_dir": tmp_path})(),
     )
     with pytest.raises(RuntimeError, match="no reachable address"):
-        Sandbox(record=_aws_direct_record())._ssh_connect_kwargs()
+        Host(record=_aws_direct_record())._ssh_connect_kwargs()
 
 
 def _stub_acquire_settings(
@@ -201,3 +201,27 @@ async def test_acquire_persists_private_key_when_returned(
     key_path = tmp_path / "host-aws"
     assert key_path.read_text().startswith("-----BEGIN OPENSSH")
     assert oct(os.stat(key_path).st_mode & 0o777) == "0o600"
+
+
+async def test_acquire_passes_template_to_drukbox(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    client, calls = _stub_acquire_settings(monkeypatch, tmp_path, sandbox_image="base")
+
+    async with client.acquire(idempotency_key="op", template="template-1"):
+        pass
+
+    assert calls[0]["template"] == "template-1"
+
+
+async def test_acquire_omits_unset_template_from_drukbox(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    client, calls = _stub_acquire_settings(monkeypatch, tmp_path, sandbox_image="base")
+
+    async with client.acquire(idempotency_key="op"):
+        pass
+
+    assert "template" not in calls[0]

--- a/backend/tests/test_sandbox_host.py
+++ b/backend/tests/test_sandbox_host.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 from drukbox_sdk import SandboxHost as SandboxHostRecord
 from druks.sandbox.exceptions import SandboxError
-from druks.sandbox.host import ExecResult, Sandbox, _stream_local_tar_into
+from druks.sandbox.host import ExecResult, Host, _stream_local_tar_into
 
 
 @dataclass
@@ -121,9 +121,9 @@ def patched_asyncssh(
 
 def test_expires_at_parses_the_record_lease(fake_record: SandboxHostRecord):
     """expires_at reads the record's ISO lease as an aware datetime, None when absent."""
-    leased = Sandbox(record=replace(fake_record, expires_at="2026-05-28T12:00:00+00:00"))
+    leased = Host(record=replace(fake_record, expires_at="2026-05-28T12:00:00+00:00"))
     assert leased.expires_at == datetime(2026, 5, 28, 12, 0, tzinfo=UTC)
-    assert Sandbox(record=fake_record).expires_at is None
+    assert Host(record=fake_record).expires_at is None
 
 
 async def test_connect_is_lazy(
@@ -131,7 +131,7 @@ async def test_connect_is_lazy(
     patched_asyncssh: tuple[AsyncMock, _FakeConnection],
 ):
     connect_mock, _ = patched_asyncssh
-    Sandbox(record=fake_record)
+    Host(record=fake_record)
     connect_mock.assert_not_called()
 
 
@@ -140,7 +140,7 @@ async def test_first_call_opens_connection_with_record_details(
     patched_asyncssh: tuple[AsyncMock, _FakeConnection],
 ):
     connect_mock, _ = patched_asyncssh
-    sandbox = Sandbox(record=replace(fake_record, ssh_username="druks"))
+    sandbox = Host(record=replace(fake_record, ssh_username="druks"))
 
     await sandbox.exec(["true"])
 
@@ -165,7 +165,7 @@ async def test_connection_is_reused_across_calls(
     tmp_path: Path,
 ):
     connect_mock, _ = patched_asyncssh
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     local = tmp_path / "payload"
     local.write_text("(dummy)")
@@ -182,7 +182,7 @@ async def test_concurrent_first_callers_do_not_open_two_connections(
     patched_asyncssh: tuple[AsyncMock, _FakeConnection],
 ):
     connect_mock, _ = patched_asyncssh
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     await asyncio.gather(
         sandbox.exec(["echo", "1"]),
@@ -198,7 +198,7 @@ async def test_aclose_closes_and_is_idempotent(
     patched_asyncssh: tuple[AsyncMock, _FakeConnection],
 ):
     connect_mock, fake_conn = patched_asyncssh
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     # Before first use: nothing to close, nothing dialed.
     await sandbox.aclose()
@@ -223,7 +223,7 @@ async def test_async_context_manager_closes_on_exception(
     _, fake_conn = patched_asyncssh
 
     with pytest.raises(RuntimeError):
-        async with Sandbox(
+        async with Host(
             record=fake_record,
         ) as sandbox:
             await sandbox.exec(["true"])
@@ -238,7 +238,7 @@ async def test_upload_pushes_via_sftp(
     tmp_path: Path,
 ):
     _, fake_conn = patched_asyncssh
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     local = tmp_path / "credentials.json"
     local.write_text('{"token": "..."}')
@@ -253,7 +253,7 @@ async def test_download_fetches_via_sftp_and_creates_parent_dir(
     tmp_path: Path,
 ):
     _, fake_conn = patched_asyncssh
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     local = tmp_path / "nested" / "subdir" / "out.jsonl"
     await sandbox.download(remote="/work/runs/42/stdout.jsonl", local=local)
@@ -267,7 +267,7 @@ async def test_exec_oneshot_shell_quotes_argv(
     patched_asyncssh: tuple[AsyncMock, _FakeConnection],
 ):
     _, fake_conn = patched_asyncssh
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     await sandbox.exec(["git", "commit", "-m", "hello world; rm -rf /"])
 
@@ -287,7 +287,7 @@ async def test_exec_oneshot_returns_typed_result_with_ok_helper(
         stdout="abc123\n",
         stderr="",
     )
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     result = await sandbox.exec(["git", "rev-parse", "HEAD"])
 
@@ -307,7 +307,7 @@ async def test_exec_oneshot_nonzero_exit_returns_not_raises(
         stdout="",
         stderr="rg: backend/missing: No such file or directory\n",
     )
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     result = await sandbox.exec(["rg", "needle", "backend/missing"])
 
@@ -329,7 +329,7 @@ async def test_exec_signal_killed_command_is_not_ok(
         stdout="",
         stderr="",
     )
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     result = await sandbox.exec(["sh", "-c", "git clone https://example/big"])
 
@@ -345,7 +345,7 @@ async def test_exec_closed_channel_without_status_is_not_ok(
     # fall back to the -1 sentinel rather than a success.
     _, fake_conn = patched_asyncssh
     fake_conn.run_result = _FakeCompletedProcess(exit_status=None)
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     result = await sandbox.exec(["true"])
 
@@ -442,7 +442,7 @@ async def test_upload_dir_tar_honours_excludes(tmp_path: Path):
 async def test_write_secret_raises_when_the_remote_write_fails(fake_record):
     # push() now writes the harness OAuth credential through write_secret, so a
     # failed remote write must fail the run, not start the agent unauthenticated.
-    sandbox = Sandbox(record=fake_record)
+    sandbox = Host(record=fake_record)
 
     async def failing_exec(cmd, *, timeout=30.0):
         return ExecResult(1, "", "permission denied")

--- a/backend/tests/test_sandbox_lifecycle.py
+++ b/backend/tests/test_sandbox_lifecycle.py
@@ -29,8 +29,8 @@ class _FakeUpload:
 
 class _FakeSandbox:
     def __init__(self, host_id: str = "host-xyz") -> None:
-        self.id = host_id  # mirrors real Sandbox.id (== record.id)
-        self.ssh_username = "root"  # mirrors real Sandbox.ssh_username
+        self.id = host_id  # mirrors real Host.id (== record.id)
+        self.ssh_username = "root"  # mirrors real Host.ssh_username
         self.exec_log: list[tuple[list[str], float]] = []
         self.uploads: list[_FakeUpload] = []
         self.secrets: list[tuple[str, str]] = []  # (secret, remote)
@@ -51,7 +51,7 @@ class _FakeSandbox:
         remote: str,
         mode: int = 0o600,
     ) -> None:
-        del mode  # tested at the Sandbox level, not via the fake
+        del mode  # tested at the Host level, not via the fake
         self.uploads.append(_FakeUpload(local=local, remote=remote))
 
     async def upload_dir(
@@ -72,7 +72,7 @@ class _FakeSandbox:
         remote: str,
         mode: int = 0o600,
     ) -> None:
-        del mode  # tested at the Sandbox level, not via the fake
+        del mode  # tested at the Host level, not via the fake
         self.secrets.append((secret, remote))
 
     async def aclose(self) -> None:
@@ -153,9 +153,9 @@ def _record(
     )
 
 
-# NOTE: ``Sandbox.upload_file`` (mkdir + sftp + chmod) and
-# ``Sandbox.write_secret`` (printf with shell quoting) are exercised
-# against the real Sandbox in test_sandbox_host.py — the fake here
+# NOTE: ``Host.upload_file`` (mkdir + sftp + chmod) and
+# ``Host.write_secret`` (printf with shell quoting) are exercised
+# against the real Host in test_sandbox_host.py — the fake here
 # just records the calls. Tests below cover the credentials.push
 # orchestration that drives them.
 
@@ -432,10 +432,10 @@ def patched_real_sandbox(monkeypatch: pytest.MonkeyPatch) -> list[_FakeSandbox]:
         built.append(fake)
         return fake
 
-    # Patch in both places: client.py constructs the Sandbox (lifecycle
+    # Patch in both places: client.py constructs the Host (lifecycle
     # tests want the fake) and host.py is where the real class lives.
-    monkeypatch.setattr("druks.sandbox.client.Sandbox", make_sandbox)
-    monkeypatch.setattr("druks.sandbox.host.Sandbox", make_sandbox)
+    monkeypatch.setattr("druks.sandbox.client.Host", make_sandbox)
+    monkeypatch.setattr("druks.sandbox.host.Host", make_sandbox)
     return built
 
 

--- a/backend/tests/test_sandbox_runner.py
+++ b/backend/tests/test_sandbox_runner.py
@@ -111,7 +111,7 @@ class _FakeSandbox:
         self.exec_results = exec_results or [ExecResult(0, "", "")]
         self.conn = _FakeConnection(self.vm)
         self.aclose_calls = 0
-        # Matches the real ``Sandbox`` interface — the runner reads this
+        # Matches the real ``Host`` interface — the runner reads this
         # to derive the per-user druks-sandbox helper path. Tests pin
         # ``root`` by default so existing path assertions stay simple.
         self.ssh_username = ssh_username

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -30,7 +30,7 @@ from druks.sandbox.datastructures import (
     HarnessRunResult,
 )
 from druks.sandbox.exceptions import SandboxUnreachable
-from druks.sandbox.host import Sandbox
+from druks.sandbox.host import Host
 
 
 @dataclass
@@ -66,9 +66,9 @@ class _LifecycleCall:
 
 
 def _fake_sandbox(run: _FakeRun) -> SimpleNamespace:
-    """Build a Sandbox-stub for the flat exec path.
+    """Build a Host-stub for the flat exec path.
 
-    ``Sandbox._exec`` / ``Sandbox.run_prompt`` are invoked unbound with this
+    ``Host._exec`` / ``Host.run_prompt`` are invoked unbound with this
     stub as ``self`` — they only touch ``_start_instruction`` /
     ``_download_artifacts`` / ``ssh_username``. The ``calls`` list captures
     every start's kwargs; ``downloads`` the artifact pulls.
@@ -127,7 +127,7 @@ async def test_returns_harness_run_result_with_stdout_stderr(
     )
     sandbox = _fake_sandbox(run)
 
-    result = await Sandbox._exec(
+    result = await Host._exec(
         sandbox,
         _inv(("claude", "--print", "hi")),
         run_id=_DEFAULT_RUN_ID,
@@ -146,7 +146,7 @@ async def test_writes_log_files_in_dashboard_convention(
     run = _FakeRun(stdout_chunks=[b"hello\n"], stderr_chunks=[b"oops\n"])
     sandbox = _fake_sandbox(run)
 
-    await Sandbox._exec(
+    await Host._exec(
         sandbox,
         _inv(("claude",)),
         run_id=_DEFAULT_RUN_ID,
@@ -176,7 +176,7 @@ async def test_forwards_invocation_to_lifecycle(
     run = _FakeRun(stdout_chunks=[b""])
     sandbox = _fake_sandbox(run)
 
-    await Sandbox._exec(
+    await Host._exec(
         sandbox,
         _inv(
             ("codex", "exec", "--print"),
@@ -226,7 +226,7 @@ async def test_overall_timeout_raises_harness_timeout_error(
     monkeypatch.setattr("druks.sandbox.host.asyncio.wait_for", fast_wait_for)
 
     with pytest.raises(HarnessTimeoutError, match="timed out"):
-        await Sandbox._exec(
+        await Host._exec(
             sandbox,
             _inv(("claude",)),
             run_id=_DEFAULT_RUN_ID,
@@ -266,7 +266,7 @@ async def test_first_byte_kill_raises_typed_error(
     monkeypatch.setattr("druks.sandbox.host.asyncio.wait_for", fast_wait_for)
 
     with pytest.raises(HarnessFirstByteTimeoutError, match="no output"):
-        await Sandbox._exec(
+        await Host._exec(
             sandbox,
             _inv(("claude",)),
             run_id=_DEFAULT_RUN_ID,
@@ -294,7 +294,7 @@ async def test_sandbox_unreachable_translates_to_harness_error(
     sandbox._download_artifacts = _download_artifacts
 
     with pytest.raises(HarnessSandboxError, match="sandbox failure") as excinfo:
-        await Sandbox._exec(
+        await Host._exec(
             sandbox,
             _inv(("claude",)),
             run_id=_DEFAULT_RUN_ID,
@@ -319,7 +319,7 @@ async def test_run_prompt_builds_executes_and_parses(
     run = _FakeRun(stdout_chunks=[b"streamed\n"], exit_code=0)
     sandbox = _fake_sandbox(run)
     # run_prompt delegates to self._exec — bind the real one onto the stub.
-    sandbox._exec = lambda *args, **kwargs: Sandbox._exec(sandbox, *args, **kwargs)
+    sandbox._exec = lambda *args, **kwargs: Host._exec(sandbox, *args, **kwargs)
     seen: dict[str, Any] = {}
 
     class _FakeHarness:
@@ -341,7 +341,7 @@ async def test_run_prompt_builds_executes_and_parses(
             seen["parse"] = {"result": result, "artifact_dir": artifact_dir, "run_id": run_id}
             return {"answer": 42}
 
-    payload = await Sandbox.run_prompt(
+    payload = await Host.run_prompt(
         sandbox,
         _FakeHarness(),
         prompt="do the thing",
@@ -520,7 +520,7 @@ async def test_run_agent_carries_foreign_failures_as_harness_errors(
         raise original
 
     sandbox.run_prompt = run_prompt
-    result = await Sandbox.run_agent(
+    result = await Host.run_agent(
         sandbox,
         model="claude-opus-4-7",
         prompt="p",
@@ -549,7 +549,7 @@ async def test_run_agent_carries_a_taxonomy_failure_as_itself(
         raise timeout
 
     sandbox.run_prompt = run_prompt
-    result = await Sandbox.run_agent(
+    result = await Host.run_agent(
         sandbox,
         model="claude-opus-4-7",
         prompt="p",

--- a/backend/tests/test_warm_host_rotation.py
+++ b/backend/tests/test_warm_host_rotation.py
@@ -19,7 +19,8 @@ class _FakeSandboxClient:
         self.provisions: list[str] = []
         self.released: list[str] = []
 
-    async def provision(self, *, idempotency_key: str) -> _FakeSandbox:
+    async def provision(self, *, idempotency_key: str, template: str | None) -> _FakeSandbox:
+        assert template is None
         self.provisions.append(idempotency_key)
         host_id = f"host-{len(self.provisions)}"
         return _FakeSandbox(id=host_id, expires_at=datetime.now(UTC) + self.lease)
@@ -30,7 +31,7 @@ class _FakeSandboxClient:
 
 def _warm_workflow(*, reuse: bool = True) -> Workflow:
     # __new__ skips __init__/__init_subclass__ so the host logic can be exercised
-    # without standing up DBOS; we set only what _ensure_host reads.
+    # without standing up DBOS; we set only what _lease_host reads.
     flow = Workflow.__new__(Workflow)
     flow.steps_reuse_sandbox = reuse
     flow._host = None
@@ -45,8 +46,8 @@ async def test_warm_host_reused_while_lease_covers_another_call(monkeypatch):
     monkeypatch.setattr(sdk, "sandbox_client", fake)
     flow = _warm_workflow()
 
-    first = await flow._ensure_host()
-    second = await flow._ensure_host()
+    first = await flow._lease_host()
+    second = await flow._lease_host()
 
     assert first == second == "host-1"
     assert fake.provisions == ["wf-1:sandbox"]
@@ -61,8 +62,8 @@ async def test_warm_host_rotates_when_lease_cannot_cover_a_call(monkeypatch):
     monkeypatch.setattr(sdk, "sandbox_client", fake)
     flow = _warm_workflow()
 
-    first = await flow._ensure_host()
-    second = await flow._ensure_host()
+    first = await flow._lease_host()
+    second = await flow._lease_host()
 
     assert first == "host-1"
     assert second == "host-2"
@@ -78,5 +79,5 @@ async def test_no_warm_host_when_reuse_disabled(monkeypatch):
     monkeypatch.setattr(sdk, "sandbox_client", fake)
     flow = _warm_workflow(reuse=False)
 
-    assert await flow._ensure_host() is None
+    assert await flow._lease_host() is None
     assert fake.provisions == []

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -130,6 +130,29 @@ decorate its side-effecting operations instead. An agent called directly from
 the orchestration body gets its own step. An agent called inside `@step` or
 `run()` shares that enclosing checkpoint.
 
+### Declare the sandbox environment
+
+A workflow can ship the environment its agents need as a plain shell file:
+
+```python
+from druks.sandbox import Sandbox
+from druks.workflows import Workflow
+
+
+class BuildSite(Workflow):
+    sandbox = Sandbox(setup="sandboxes/build.sh")
+```
+
+The path is relative to the app package: place the file at
+`site_builder/sandboxes/build.sh`. Druks reads the raw bytes. It does not render
+the file or run it during import. Drukbox builds a reusable template from the
+platform base and the script.
+A run waits with a visible sandbox-building phase when that template is still
+building. A workflow with no declaration uses the platform base unchanged.
+
+The content hash of the base and script identifies the template. App authors do
+not name provider images.
+
 Completed checkpoints are reused on recovery. An interrupted operation can run
 again, so use provider idempotency keys for writes. Keep decisions in replayable
 control flow and I/O inside steps. See
@@ -1139,6 +1162,7 @@ Import from concern namespaces, not from `druks.durable` or internal modules:
 | `druks.secrets.fields` | `EncryptedJsonField`, `SecretsMapping` |
 | `druks.agents` | `Agent`, `AgentOutput` |
 | `druks.workflows` | `Workflow`, `Gate`, `step`, run/agent response types, lifecycle enums and workflow errors |
+| `druks.sandbox` | `Sandbox` |
 | `druks.db` | `Base`, `StoredSubject`, `db_session` |
 | `druks.schemas` | `BaseResponse` |
 | `druks.signals` | `subscribe` |

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -55,7 +55,7 @@ export interface SubjectStatus {
   accountUsername: string | null
 }
 
-// The live sub-phase a running run pushes ("Building sandbox VM…", "Working…") —
+// The live sub-phase a running run pushes ("Provisioning sandbox VM…", "Working…") —
 // finer than the lifecycle status; null unless something is actively running.
 export interface SubjectActivity {
   label: string

--- a/frontend/src/apps/ship/statusLine.test.ts
+++ b/frontend/src/apps/ship/statusLine.test.ts
@@ -102,14 +102,14 @@ describe('runSubLine', () => {
 
   it('leaves the step to its own row when the calls are split out', () => {
     const many = run({ agentCalls: [call({ status: 'succeeded' }), call({ id: 'c2' })] })
-    expect(runSubLine(many, { label: 'Building sandbox VM…', kind: 'infra' }, false)).toBe(
-      'Building sandbox VM…',
+    expect(runSubLine(many, { label: 'Provisioning sandbox VM…', kind: 'infra' }, false)).toBe(
+      'Provisioning sandbox VM…',
     )
   })
 
   it('shows the infra phase while no agent has started', () => {
-    expect(runSubLine(run(), { label: 'Building sandbox VM…', kind: 'infra' }, true)).toBe(
-      'Building sandbox VM…',
+    expect(runSubLine(run(), { label: 'Provisioning sandbox VM…', kind: 'infra' }, true)).toBe(
+      'Provisioning sandbox VM…',
     )
   })
 


### PR DESCRIPTION
ENG-882 — the druks half of the sandbox-needs design.

A workflow ships the environment its agents need as a plain shell file:

```python
from druks.sandbox import Sandbox
from druks.workflows import Workflow

class BuildSite(Workflow):
    sandbox = Sandbox(setup="sandboxes/build.sh")
```

- The path is package-relative; the declaration stamps its owning workflow's app at class creation. Identity is the content hash of `(base, script bytes)`. Apps never name images.
- `druks doctor` asks drukbox to build a template for each declared sandbox (async 202) and reports each one: available, building (pending), missing, or failed. Druks never builds on a lease miss.
- Both lease paths (warm run host and per-call ephemeral) resolve the declaration to its template and fork from it. A run whose template is still building waits with a visible "Building sandbox…" phase.
- The internal SSH handle is renamed `Host` (`druks.sandbox.host`); the author declaration owns the `Sandbox` name.

Activates when drukbox ENG-877/ENG-879 and their drukbox-python-sdk mirror land; until then the new client calls (`create_template`, `list_templates`, `create_host(template=...)`) are exercised only by tests, and ordinary leases are unchanged on the current SDK.