### PR TITLE
docker-sbx: mount and pre-create the sbx CLI settings store

### DIFF
--- a/deploy/compose.docker-sbx.yaml
+++ b/deploy/compose.docker-sbx.yaml
@@ -17,6 +17,9 @@ x-sbx-rig: &sbx-rig
     - ${DRUKS_SBX_HOME:?set DRUKS_SBX_HOME in .env — run install.sh}/.local/state/sandboxes/sandboxes/sandboxd/sandboxd.sock:/run/sandboxd.sock
     - /usr/bin/sbx:/usr/local/bin/sbx:ro
     - ${DRUKS_SBX_HOME:?}/.config/com.docker.sandboxes:${DRUKS_SBX_HOME:?}/.config/com.docker.sandboxes:ro
+    # The CLI settings store. The CLI writes it on first use, and it panics
+    # when it cannot. install.sh creates the directory with the correct owner.
+    - ${DRUKS_SBX_HOME:?}/.config/sandboxes:${DRUKS_SBX_HOME:?}/.config/sandboxes
     - ${DRUKS_SBX_HOME:?}/.drukbox:${DRUKS_SBX_HOME:?}/.drukbox
 
 # The image has no user with the deploy uid, and defaults that come from the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -162,7 +162,7 @@ main() {
       # engine would make it root-owned, and the deploy-uid services could
       # not write the workspaces or the gateway host key.
       set_env_var DRUKS_SBX_HOME "$HOME"
-      mkdir -p "$HOME/.drukbox/sbx-workspaces"
+      mkdir -p "$HOME/.drukbox/sbx-workspaces" "$HOME/.config/sandboxes"
       # sandboxd must run before the first compose command. A bind of a
       # missing socket path makes a root-owned directory there, and that
       # blocks the daemon itself.


### PR DESCRIPTION
sbx 0.39 keeps a settings store at `$XDG_CONFIG_HOME/sandboxes`, next to the `com.docker.sandboxes` auth store, and creates it on first use. The overlay mounted only the auth store; inside the container the parent `.config` is a root-owned mount point, so every CLI invocation panics (`settingskit.New: mkdir .../.config/sandboxes: permission denied`). Found by `druks doctor` on the first real docker-sbx deployment.

Two lines: the rig mounts the store writable, and install.sh pre-creates it with the correct owner (the compose bind would otherwise materialize it root-owned).

Verified on a live docker-sbx host: with the mount and the host directory present, the in-container CLI starts clean.