### PR TITLE
docker-sbx: the auth store mount is writable

### DIFF
--- a/deploy/compose.docker-sbx.yaml
+++ b/deploy/compose.docker-sbx.yaml
@@ -16,7 +16,10 @@ x-sbx-rig: &sbx-rig
   volumes:
     - ${DRUKS_SBX_HOME:?set DRUKS_SBX_HOME in .env — run install.sh}/.local/state/sandboxes/sandboxes/sandboxd/sandboxd.sock:/run/sandboxd.sock
     - /usr/bin/sbx:/usr/local/bin/sbx:ro
-    - ${DRUKS_SBX_HOME:?}/.config/com.docker.sandboxes:${DRUKS_SBX_HOME:?}/.config/com.docker.sandboxes:ro
+    # The auth store must be writable: the credential store takes a lock file
+    # inside it (.posixage.lock) also for reads, and every create loads
+    # registry credentials. A read-only mount fails each create.
+    - ${DRUKS_SBX_HOME:?}/.config/com.docker.sandboxes:${DRUKS_SBX_HOME:?}/.config/com.docker.sandboxes
     # The CLI settings store. The CLI writes it on first use, and it panics
     # when it cannot. install.sh creates the directory with the correct owner.
     - ${DRUKS_SBX_HOME:?}/.config/sandboxes:${DRUKS_SBX_HOME:?}/.config/sandboxes


### PR DESCRIPTION
The sbx credential store takes a lock file inside the store (`.posixage.lock`) for reads too, and every `create` loads registry credentials before it looks at the template cache. With the `:ro` mount, each create fails: `store is locked … read-only file system`. Found on the first real sandbox creation of a docker-sbx deployment.

Verified A/B on the same host: with `:ro`, create fails even when the template is already in the daemon store; with the writable mount, the full create → exec → rm loop passes (microVM boots, exec returns the guest kernel).

One caveat this removes from the previous comment's promise: a container can now write the host's CLI login state. The CLI's lock mechanics leave no way to keep the store read-only.