### PR TITLE
The sandbox toolchain boots as a Docker Sandboxes template

### DIFF
--- a/.github/workflows/on-pull-request-images.yml
+++ b/.github/workflows/on-pull-request-images.yml
@@ -30,9 +30,50 @@ jobs:
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: deploy/sandbox
+          target: sandbox
           platforms: linux/amd64
           push: false
           cache-from: type=gha,scope=sandbox
+
+  # The Docker Sandboxes template must keep its base's boot contract after
+  # the toolchain layers: `sbx create` sends no environment variables, drukbox
+  # writes the SSH key and /etc/environment over the exec channel after boot,
+  # and pam_env serves that file to SSH sessions. Assert each piece on the
+  # built image.
+  sandbox-sbx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: deploy/sandbox
+          target: sbx
+          build-args: BASE=sbx-base
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: druks-sandbox-sbx:pr
+          cache-from: type=gha,scope=sandbox-sbx
+      - name: The agent toolchain is on PATH
+        run: >
+          docker run --rm --entrypoint sh druks-sandbox-sbx:pr
+          -ec 'for tool in git node gh claude codex; do command -v "$tool"; done'
+      - name: An env-free boot leaves sshd running as PID 1
+        run: |
+          docker run -d --name sbx-boot druks-sandbox-sbx:pr
+          sleep 5
+          docker inspect -f '{{.State.Running}}' sbx-boot | grep -x true
+          docker exec sbx-boot cat /proc/1/comm | grep -x sshd
+      - name: sshd hands /etc/environment to sessions and lets root log in
+        run: |
+          docker exec sbx-boot /usr/sbin/sshd -T | grep -ix 'usepam yes'
+          docker exec sbx-boot grep -E '^session[[:space:]]+required[[:space:]]+pam_env\.so' /etc/pam.d/sshd
+          # sshd -T prints the legacy spelling "without-password" for
+          # prohibit-password; both allow the key login drukbox injects.
+          docker exec sbx-boot /usr/sbin/sshd -T | grep -iEx 'permitrootlogin (prohibit-password|without-password|yes)'
 
   browser:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -48,12 +48,53 @@ jobs:
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: deploy/sandbox
+          target: sandbox
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           cache-from: type=gha,scope=sandbox
           cache-to: type=gha,scope=sandbox,mode=max
+
+  # The Docker Sandboxes template: the same toolchain layers on drukbox's
+  # sbx base, whose env-free boot contract stands unchanged.
+  sandbox-sbx:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # arm64 too: the image's home is a developer laptop (the drukbox
+      # docker-sbx provider on Apple silicon), not just amd64 servers.
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/druks-sandbox-sbx
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-,format=long
+            type=ref,event=tag
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: deploy/sandbox
+          target: sbx
+          build-args: BASE=sbx-base
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=sandbox-sbx
+          cache-to: type=gha,scope=sandbox-sbx,mode=max
 
   browser:
     runs-on: ubuntu-latest

--- a/deploy/sandbox/Dockerfile
+++ b/deploy/sandbox/Dockerfile
@@ -1,17 +1,29 @@
-# Sandbox image for local druks development: the drukbox docker provider
-# boots these containers as per-run "VMs" and druks drives the harnesses
-# inside over SSH. Same contract as a real exe/aws VM — sshd plus the
-# tools the build prompts assume are on PATH (git, gh, node, claude,
-# codex).
+# Sandbox images for druks agents: a drukbox base (sshd and its boot
+# contract) plus the tools the build prompts assume are on PATH (git, gh,
+# node, claude, codex). drukbox publishes one base per provider, and each
+# druks image builds on the matching one — the ``toolchain`` stage applies
+# the same tool layers to whichever base ``BASE`` selects:
 #
-# Built from the drukbox sandbox base (Ubuntu + sshd + key-seeding
-# entrypoint); we swap the entrypoint to seed a non-root user because
-# Claude Code refuses ``--permission-mode bypassPermissions`` as root.
+#   - ``sandbox`` (the default target, on ``docker-base``) serves the drukbox
+#     docker provider, published as ghcr.io/czpython/druks-sandbox. It swaps
+#     the base entrypoint to seed the non-root ``druks`` user because Claude
+#     Code refuses ``--permission-mode bypassPermissions`` as root. Point
+#     DRUKS_SANDBOX_IMAGE at it and run drukbox with DOCKER_SSH_USERNAME=druks.
+#   - ``sbx`` (build with ``--build-arg BASE=sbx-base``) serves the drukbox
+#     docker-sbx provider as a Docker Sandboxes template, published as
+#     ghcr.io/czpython/druks-sandbox-sbx. The base's env-free entrypoint and
+#     EXPOSE 22 stand unchanged: ``sbx create`` sends no environment
+#     variables, and drukbox injects the SSH key and caller environment over
+#     the exec channel after boot. Select the image with drukbox's
+#     DOCKER_SBX_DEFAULT_IMAGE or the per-host image field.
 #
-# Published by .github/workflows/publish-sandbox-image.yml as
-# ghcr.io/czpython/druks-sandbox; point DRUKS_SANDBOX_IMAGE at it and
-# run drukbox with DOCKER_SSH_USERNAME=druks.
-FROM ghcr.io/czpython/drukbox/sandbox:latest@sha256:a5312ab8289cab543f30ec7ba1f1ada8e027c78c9fe06ed5d52c0459e5a2ffef
+# Both targets are published by .github/workflows/publish-sandbox-image.yml.
+ARG BASE=docker-base
+
+FROM ghcr.io/czpython/drukbox/sandbox:latest@sha256:a5312ab8289cab543f30ec7ba1f1ada8e027c78c9fe06ed5d52c0459e5a2ffef AS docker-base
+FROM ghcr.io/czpython/drukbox/sbx-sandbox:latest@sha256:ba4d9dc7454931b3f8c432855733453b005162a4c0c805f321bbef22a74b5ac6 AS sbx-base
+
+FROM ${BASE} AS toolchain
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -42,6 +54,14 @@ RUN npm install -g \
     "@openai/codex@${CODEX_VERSION}"
 
 RUN useradd --create-home --shell /bin/bash druks
+
+# The Docker Sandboxes template is the toolchain on sbx-base, boot contract
+# untouched. Only valid with ``--build-arg BASE=sbx-base``.
+FROM toolchain AS sbx
+
+# Docker provider image, the default target: ``docker build deploy/sandbox``
+# builds this one.
+FROM toolchain AS sandbox
 
 COPY entrypoint.sh /usr/local/bin/druks-sandbox-entrypoint
 RUN chmod +x /usr/local/bin/druks-sandbox-entrypoint


### PR DESCRIPTION
## What changed

Closes #331.

A docker-sbx deployment provisioned fine but the first workflow that clones a repo died in the guest with `git: not found`: druks published no Docker Sandboxes template with the agent toolchain, so microVMs booted drukbox's bare template. The docker provider's `druks-sandbox` image cannot serve as one — its entrypoint requires boot-time environment variables, and `sbx create` sends none.

drukbox publishes one base per provider (`drukbox/sandbox` for the docker provider, `drukbox/sbx-sandbox` for the Docker Sandboxes template), and each druks image now builds on the matching one:

- `deploy/sandbox/Dockerfile` pins both bases and defines the toolchain once (git, curl, gnupg, nodejs, gh, claude, codex, the `druks` user) in a `toolchain` stage whose base the `BASE` build arg selects. The default build stays the docker-provider image, unchanged: `docker build deploy/sandbox` from the docs keeps working.
- The `sbx` target (built with `BASE=sbx-base`) is the toolchain on drukbox's template base, boot contract untouched — drukbox's own env-free entrypoint and `EXPOSE 22` stand; no entrypoint of ours in the path. drukbox injects the caller's SSH key and `/etc/environment` over the exec channel after boot, and pam_env hands that file to SSH sessions. Published as `ghcr.io/czpython/druks-sandbox-sbx`.
- `publish-sandbox-image.yml` gains a `sandbox-sbx` job: same triggers, `linux/amd64` + `linux/arm64`, same tag scheme.
- `on-pull-request-images.yml` builds the template on PRs and asserts the boot contract without a sandboxd (see Verification).
- `deploy/README.md` docker-sbx section names the template image and how operators select it: drukbox's `DOCKER_SBX_DEFAULT_IMAGE` in `[sandbox.docker-sbx]`, or per host through `[sandbox].image`.

## Risk

- No application code, migrations, or replay-affecting changes.
- The published `druks-sandbox` image is byte-for-byte the same content; the only build-side change is the explicit `target: sandbox` in both workflows.
- The publish workflow pushes a new package (`druks-sandbox-sbx`); first publish creates it private in GHCR and it needs the same visibility flip as `druks-sandbox`.
- Existing docker-sbx hosts keep their configured image; nothing changes until an operator points `DOCKER_SBX_DEFAULT_IMAGE` or the per-host image field at the new template.

## Verification

- `uv run python -c "yaml.safe_load(...)"` over both workflow files — parses, jobs `sandbox`, `sandbox-sbx`, `browser`.
- `docker build --target sbx --build-arg BASE=sbx-base deploy/sandbox` — builds; the image carries drukbox's `/usr/local/bin/drukbox-entrypoint` and `EXPOSE 22` from the sbx base.
- `docker build deploy/sandbox` (no target, no args) — still produces the docker-provider entrypoint.
- The three PR-check assertions, run locally against the built template:
  - `docker run --rm --entrypoint sh … -ec 'for tool in git node gh claude codex; do command -v "$tool"; done'` — all five resolve (a plain `command -v a b c` only checks the first operand under dash, hence the loop).
  - Booted with no environment and no args: container stays running, `/proc/1/comm` is `sshd`.
  - `sshd -T` reports `usepam yes` and root key login (`permitrootlogin without-password` — `sshd -T` normalizes `prohibit-password` to the legacy spelling, the grep accepts both); `/etc/pam.d/sshd` carries the `pam_env` stanza.
- End-to-end acceptance replay: booted the template env-free, ran drukbox's `_bootstrap_script` equivalent over `docker exec` (authorized_keys for root + a marker in `/etc/environment`), then `ssh root@…`: the marker arrived via pam_env, `git --version`, `node --version`, `claude --version`, `codex --version` all resolved, `mkdir -p /root/work/repo` (druks's work root for `ssh_username=root`) succeeded, and login still worked after `docker restart`.
- Not run: ruff/pyright/pytest (no Python touched) and a real sandboxd acceptance pass on a docker-sbx host — that needs the image published first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
