### PR TITLE
Images live under the repo namespace

### DIFF
--- a/.github/workflows/build-release-images.yml
+++ b/.github/workflows/build-release-images.yml
@@ -42,7 +42,7 @@ jobs:
       - id: metadata
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/druks
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=long

--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -40,7 +40,7 @@ jobs:
       - id: metadata
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/druks-sandbox
+          images: ghcr.io/${{ github.repository }}/sandbox
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=long
@@ -79,7 +79,7 @@ jobs:
       - id: metadata
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/druks-sandbox-sbx
+          images: ghcr.io/${{ github.repository }}/sandbox-sbx
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=long
@@ -117,7 +117,7 @@ jobs:
       - id: metadata
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ghcr.io/${{ github.repository_owner }}/druks-browser
+          images: ghcr.io/${{ github.repository }}/browser
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-,format=long

--- a/backend/druks/sandbox/repo.py
+++ b/backend/druks/sandbox/repo.py
@@ -54,8 +54,9 @@ async def clone(
         # token never lives in the URL, but git could still echo a
         # cached credential in some future error path.
         sanitized = _strip_token(result.stderr.strip() or result.stdout.strip())
+        target = f"{repo_url}@{ref}" if ref else repo_url
         raise ExecFailed(
-            f"git clone {repo_url}@{ref} failed: {sanitized}",
+            f"git clone {target} failed: {sanitized}",
             exit_code=result.exit_code,
         )
 

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -160,7 +160,7 @@ class Sandbox(BaseModel):
     image: str = ""
     # The browser home: browser containers boot on this provider with this image.
     browser_sandbox_provider: str = "docker"
-    browser_sandbox_image: str = "ghcr.io/czpython/druks-browser:latest"
+    browser_sandbox_image: str = "ghcr.io/czpython/druks/browser:latest"
     # An HTTP proxy for the login window. The login then leaves from a different
     # IP than the box. Use it for sign-in flows that refuse the box IP. The value
     # can include a user name and password (http://user:pass@host:port); the

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -216,7 +216,7 @@ def _fresh_values(*, provider: str, home: str) -> tuple[tuple[tuple[str, ...], s
             (("urls", "endpoint"), "http://127.0.0.1:8001"),
             (("sandbox", "service_url"), "http://127.0.0.1:8780"),
             (("sandbox", "service_token"), "dev-token"),
-            (("sandbox", "image"), "ghcr.io/czpython/druks-sandbox:latest"),
+            (("sandbox", "image"), "ghcr.io/czpython/druks/sandbox:latest"),
         )
     elif provider == "exe":
         shape = (

--- a/backend/tests/test_browser_borrow.py
+++ b/backend/tests/test_browser_borrow.py
@@ -130,7 +130,7 @@ async def test_borrow_yields_a_tunneled_cdp_url(borrow, night_watch):
         assert cdp_url == "http://127.0.0.1:43987"
 
     assert browser.forwarded_port == 9222
-    assert browser.image == "ghcr.io/czpython/druks-browser:latest"
+    assert browser.image == "ghcr.io/czpython/druks/browser:latest"
     assert browser.provider == "docker"
     assert browser.files["/work/session/state.json"] == b"stored-state"
     assert json.loads(browser.files["/work/session/state.meta.json"]) == {

--- a/backend/tests/test_browser_session_login_window.py
+++ b/backend/tests/test_browser_session_login_window.py
@@ -164,7 +164,7 @@ async def test_open_seeds_a_blank_profile_and_records_the_container(window_runti
     assert PROFILE_PATH not in browser.files
     assert (await LoginWindow.get_for_session(session.name)).host_id == browser.id
     assert client.provisions == [
-        {"image_override": "ghcr.io/czpython/druks-browser:latest", "provider": "docker"}
+        {"image_override": "ghcr.io/czpython/druks/browser:latest", "provider": "docker"}
     ]
 
 

--- a/backend/tests/test_sandbox_lifecycle.py
+++ b/backend/tests/test_sandbox_lifecycle.py
@@ -294,12 +294,33 @@ async def test_clone_raises_exec_failed_on_clone_failure():
     sandbox = _FakeSandbox()
     sandbox.exec_results = {0: ExecResult(128, "", "fatal: not found")}
 
-    with pytest.raises(ExecFailed, match="git clone"):
+    with pytest.raises(ExecFailed) as excinfo:
         await repo.clone(
             sandbox,  # type: ignore[arg-type]
             repo_url="https://github.com/owner/missing.git",
             ref="main",
         )
+
+    assert "git clone https://github.com/owner/missing.git@main failed" in str(
+        excinfo.value
+    )
+
+
+async def test_clone_failure_message_omits_ref_when_none():
+    sandbox = _FakeSandbox()
+    sandbox.exec_results = {0: ExecResult(128, "", "fatal: not found")}
+
+    with pytest.raises(ExecFailed) as excinfo:
+        await repo.clone(
+            sandbox,  # type: ignore[arg-type]
+            repo_url="https://github.com/owner/missing.git",
+            ref=None,
+        )
+
+    assert "git clone https://github.com/owner/missing.git failed" in str(
+        excinfo.value
+    )
+    assert "@None" not in str(excinfo.value)
 
 
 async def test_clone_redacts_token_from_error_output():

--- a/deploy/browser/Dockerfile
+++ b/deploy/browser/Dockerfile
@@ -7,7 +7,7 @@
 # seeds a non-root user and starts the display stack.
 #
 # Published by .github/workflows/publish-sandbox-image.yml as
-# ghcr.io/czpython/druks-browser.
+# ghcr.io/czpython/druks/browser.
 FROM ghcr.io/czpython/drukbox/sandbox:latest@sha256:a5312ab8289cab543f30ec7ba1f1ada8e027c78c9fe06ed5d52c0459e5a2ffef
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/deploy/sandbox/Dockerfile
+++ b/deploy/sandbox/Dockerfile
@@ -5,13 +5,13 @@
 # the same tool layers to whichever base ``BASE`` selects:
 #
 #   - ``sandbox`` (the default target, on ``docker-base``) serves the drukbox
-#     docker provider, published as ghcr.io/czpython/druks-sandbox. It swaps
+#     docker provider, published as ghcr.io/czpython/druks/sandbox. It swaps
 #     the base entrypoint to seed the non-root ``druks`` user because Claude
 #     Code refuses ``--permission-mode bypassPermissions`` as root. Point
 #     DRUKS_SANDBOX_IMAGE at it and run drukbox with DOCKER_SSH_USERNAME=druks.
 #   - ``sbx`` (build with ``--build-arg BASE=sbx-base``) serves the drukbox
 #     docker-sbx provider as a Docker Sandboxes template, published as
-#     ghcr.io/czpython/druks-sandbox-sbx. The base's env-free entrypoint and
+#     ghcr.io/czpython/druks/sandbox-sbx. The base's env-free entrypoint and
 #     EXPOSE 22 stand unchanged: ``sbx create`` sends no environment
 #     variables, and drukbox injects the SSH key and caller environment over
 #     the exec channel after boot. Select the image with drukbox's

--- a/docs/development.md
+++ b/docs/development.md
@@ -159,7 +159,7 @@ Drukbox on the host from its own checkout
 [sandbox]
 service_url = "http://127.0.0.1:8000"
 service_token = "dev-token"
-image = "ghcr.io/czpython/druks-sandbox:latest"
+image = "ghcr.io/czpython/druks/sandbox:latest"
 ```
 
 `uv run druks doctor --sandbox` creates a real host. Run it deliberately; it is

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -136,7 +136,7 @@ development Druks environment and invoke its documented trigger or
 ## Sandbox image
 
 `[sandbox].image` selects the image Drukbox starts. The shipped
-`ghcr.io/czpython/druks-sandbox:latest` image contains the non-root `druks`
+`ghcr.io/czpython/druks/sandbox:latest` image contains the non-root `druks`
 user plus Git, GitHub CLI, Node, Claude, and Codex.
 
 Build it from the repository when changing the sandbox:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -195,7 +195,7 @@ main() {
   # it is not a compose service and `docker compose pull` misses it — pull it
   # here so a redeploy refreshes it rather than leaving the box on a cached tag.
   echo "→ pulling browser image"
-  docker pull -q ghcr.io/czpython/druks-browser:latest >/dev/null
+  docker pull -q ghcr.io/czpython/druks/browser:latest >/dev/null
 
   # The shared sandbox-keys volume: a fresh named volume mounts root-owned, but
   # the backend runs as the deploy user and must write the per-VM SSH keys here.


### PR DESCRIPTION
Every image this repo publishes is now `ghcr.io/czpython/druks/<name>` — `sandbox`, `sandbox-sbx`, `browser` — the convention drukbox already follows (`ghcr.io/czpython/drukbox/<name>`). Flat owner-level names collide with the owner-wide namespace and hide which repo publishes them.

Touches the two workflows plus every in-repo reference (setup defaults, settings default, install.sh browser pull, docs, Dockerfile comments, two tests). The old flat packages stay on ghcr, so existing deployments keep working until they adopt the new names.

After merge, the publish workflow (triggered by its own file change) creates the three new packages; they should land public like the previous workflow-created ones, worth a one-time check.