### PR TITLE
drukbox-python-sdk 0.1.0: template identity matches the service

### DIFF
--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -310,11 +310,11 @@ async def check_declared_sandboxes(settings: Settings) -> CheckResult | list[Che
         return CheckResult(name="sandbox_templates", ok=True, detail="no declared sandboxes")
 
     results = []
-    for requirements_hash, sandbox in declared.items():
-        name = f"sandbox:{requirements_hash[:12]}"
-        detail = f"{sandbox.setup}; hash {requirements_hash}"
+    for setup_script_hash, sandbox in declared.items():
+        name = f"sandbox:{setup_script_hash[:12]}"
+        detail = f"{sandbox.setup}; hash {setup_script_hash}"
         try:
-            template = await sandbox_client.get_template(requirements_hash=requirements_hash)
+            template = await sandbox_client.get_template(setup_script_hash=setup_script_hash)
         except TemplateNotFound:
             result = CheckResult(
                 name=name,

--- a/backend/druks/sandbox/client.py
+++ b/backend/druks/sandbox/client.py
@@ -95,10 +95,6 @@ class Client:
             # Fixed lease: drukbox reaps the host when this lapses, so a run whose
             # worker dies frees its VM without a druks-side reconciler.
             expires_at = datetime.now(UTC) + timedelta(seconds=SANDBOX_HOST_LEASE_SECONDS)
-            create_host_kwargs = {}
-            if template:
-                # SDK 0.0.7 rejects template= even when unset, so ordinary leases omit it.
-                create_host_kwargs["template"] = template
             try:
                 record = await api.create_host(
                     expires_at=expires_at,
@@ -106,7 +102,7 @@ class Client:
                     idempotency_key=key,
                     image=image or None,
                     provider=provider,
-                    **create_host_kwargs,
+                    template=template,
                 )
             except (SandboxProvisioningError, SandboxUnavailableError) as exc:
                 # Transient control-plane failures — a 502 the service raises
@@ -156,26 +152,31 @@ class Client:
         finally:
             await api.aclose()
 
-    async def create_template(self, *, base_image: str, script: bytes, requirements_hash: str):
+    async def create_template(self, *, setup_script: str, base_image: str | None, label: str):
         api = self._api()
         try:
             return await api.create_template(
+                setup_script=setup_script,
                 base_image=base_image,
-                script=script,
-                requirements_hash=requirements_hash,
+                label=label,
             )
         finally:
             await api.aclose()
 
-    async def get_template(self, *, requirements_hash: str):
+    async def get_template(self, *, setup_script_hash: str, base_image: str = ""):
+        # Newest first from drukbox, so a base change finds its fresh template
+        # while the old base's twin ages out.
         api = self._api()
         try:
             for template in await api.list_templates():
-                if template.requirements_hash == requirements_hash:
-                    return template
+                if template.setup_script_hash != setup_script_hash:
+                    continue
+                if base_image and template.base_image != base_image:
+                    continue
+                return template
         finally:
             await api.aclose()
-        raise TemplateNotFound(f"sandbox template {requirements_hash} does not exist")
+        raise TemplateNotFound(f"sandbox template {setup_script_hash} does not exist")
 
     @staticmethod
     async def _best_effort_delete(api: SandboxAPI, host_id: str) -> None:

--- a/backend/druks/sandbox/client.py
+++ b/backend/druks/sandbox/client.py
@@ -163,9 +163,7 @@ class Client:
         finally:
             await api.aclose()
 
-    async def get_template(self, *, setup_script_hash: str, base_image: str = ""):
-        # Newest first from drukbox, so a base change finds its fresh template
-        # while the old base's twin ages out.
+    async def get_template(self, *, base_image: str = "", setup_script_hash: str):
         api = self._api()
         try:
             for template in await api.list_templates():

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel, Field
 
 from druks.apps import loader
-from druks.settings import load_settings
 
 from .exceptions import SetupScriptError
 
@@ -24,11 +23,6 @@ class Profile(BaseModel):
 
     image: str | None = None
     env: dict[str, str] = Field(default_factory=dict)
-
-
-def get_content_hash(base: str, script: bytes) -> str:
-    content = base.encode("utf-8") + b"\0" + script
-    return hashlib.sha256(content).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -62,8 +56,10 @@ class Sandbox:
             ) from error
 
     @property
-    def content_hash(self) -> str:
-        return get_content_hash(load_settings().sandbox.image, self.read_setup_script())
+    def setup_script_hash(self) -> str:
+        # Drukbox's template identity: sha256 of the script text. Base image and
+        # provider are the other two columns of its unique key, resolved there.
+        return hashlib.sha256(self.read_setup_script()).hexdigest()
 
 
 @dataclass(frozen=True)

--- a/backend/druks/sandbox/templates.py
+++ b/backend/druks/sandbox/templates.py
@@ -35,7 +35,7 @@ async def get_template_id(sandbox: Sandbox) -> str:
     base_image = load_settings().sandbox.image
     try:
         template = await sandbox_client.get_template(
-            setup_script_hash=setup_script_hash, base_image=base_image
+            base_image=base_image, setup_script_hash=setup_script_hash
         )
     except TemplateNotFound as error:
         raise TemplateUnavailable(

--- a/backend/druks/sandbox/templates.py
+++ b/backend/druks/sandbox/templates.py
@@ -16,27 +16,30 @@ def get_declared_sandboxes() -> dict[str, Sandbox]:
     for app in loader.iter_apps():
         for workflow in app.workflows():
             if sandbox := workflow.sandbox:
-                declared[sandbox.content_hash] = sandbox
+                declared[sandbox.setup_script_hash] = sandbox
     return declared
 
 
 async def prepare_sandbox_templates() -> None:
     base_image = load_settings().sandbox.image
-    for requirements_hash, sandbox in get_declared_sandboxes().items():
+    for sandbox in get_declared_sandboxes().values():
         await sandbox_client.create_template(
-            base_image=base_image,
-            script=sandbox.read_setup_script(),
-            requirements_hash=requirements_hash,
+            setup_script=sandbox.read_setup_script().decode("utf-8"),
+            base_image=base_image or None,
+            label=f"{loader.resolve_workflow_app(sandbox.module)}/{sandbox.setup}",
         )
 
 
 async def get_template_id(sandbox: Sandbox) -> str:
-    requirements_hash = sandbox.content_hash
+    setup_script_hash = sandbox.setup_script_hash
+    base_image = load_settings().sandbox.image
     try:
-        template = await sandbox_client.get_template(requirements_hash=requirements_hash)
+        template = await sandbox_client.get_template(
+            setup_script_hash=setup_script_hash, base_image=base_image
+        )
     except TemplateNotFound as error:
         raise TemplateUnavailable(
-            f"sandbox template {requirements_hash} is missing. "
+            f"sandbox template {setup_script_hash} is missing. "
             "Reinstall the app or run `druks doctor`."
         ) from error
 
@@ -44,12 +47,14 @@ async def get_template_id(sandbox: Sandbox) -> str:
         await set_run_phase("sandbox_building")
         while template.status == "building":
             await asyncio.sleep(_TEMPLATE_POLL_SECONDS)
-            template = await sandbox_client.get_template(requirements_hash=requirements_hash)
+            template = await sandbox_client.get_template(
+                setup_script_hash=setup_script_hash, base_image=base_image
+            )
 
     if template.status == "available":
         return template.id
 
     raise TemplateUnavailable(
-        f"sandbox template {requirements_hash} has status {template.status!r}. "
+        f"sandbox template {setup_script_hash} has status {template.status!r}. "
         "Fix its setup and run `druks doctor`."
     )

--- a/backend/tests/test_declared_sandboxes.py
+++ b/backend/tests/test_declared_sandboxes.py
@@ -10,12 +10,12 @@ import pytest
 from druks.contrib.ship.app import _PHASE_META
 from druks.sandbox import datastructures, templates
 from druks.sandbox.client import Client
-from druks.sandbox.datastructures import Sandbox, get_content_hash
+from druks.sandbox.datastructures import Sandbox
 from druks.sandbox.exceptions import TemplateNotFound, TemplateUnavailable
 from druks.workflows import Workflow
 
 
-def test_sandbox_resolves_package_bytes_and_hashes_base_with_script(monkeypatch, tmp_path):
+def test_sandbox_reads_package_bytes_and_hashes_the_script(monkeypatch, tmp_path):
     package = tmp_path / "site_builder"
     (package / "sandboxes").mkdir(parents=True)
     (package / "__init__.py").write_text("")
@@ -29,11 +29,6 @@ def test_sandbox_resolves_package_bytes_and_hashes_base_with_script(monkeypatch,
             get_app=lambda name: SimpleNamespace(name="site_builder", package="site_builder"),
         ),
     )
-    monkeypatch.setattr(
-        datastructures,
-        "load_settings",
-        lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base-image")),
-    )
 
     class BuildSite:
         sandbox = Sandbox(setup="sandboxes/build.sh")
@@ -41,7 +36,7 @@ def test_sandbox_resolves_package_bytes_and_hashes_base_with_script(monkeypatch,
     script = BuildSite.sandbox.read_setup_script()
 
     assert script.startswith(b"#!/bin/sh\n")
-    assert BuildSite.sandbox.content_hash == hashlib.sha256(b"base-image\0" + script).hexdigest()
+    assert BuildSite.sandbox.setup_script_hash == hashlib.sha256(script).hexdigest()
 
 
 def test_get_declared_sandboxes_deduplicates_by_content(monkeypatch):
@@ -58,15 +53,10 @@ def test_get_declared_sandboxes_deduplicates_by_content(monkeypatch):
     app = SimpleNamespace(workflows=lambda: [First, Second])
     monkeypatch.setattr(templates, "loader", SimpleNamespace(iter_apps=lambda: [app]))
     monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
-    monkeypatch.setattr(
-        datastructures,
-        "load_settings",
-        lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
-    )
 
     declared = templates.get_declared_sandboxes()
 
-    assert declared == {get_content_hash("base", b"setup"): shared}
+    assert declared == {hashlib.sha256(b"setup").hexdigest(): shared}
 
 
 def test_ship_maps_the_sandbox_building_phase():
@@ -76,7 +66,7 @@ def test_ship_maps_the_sandbox_building_phase():
 
 async def test_prepare_sandbox_templates_requests_each_declaration(monkeypatch):
     sandbox = Sandbox(setup="sandboxes/setup.sh")
-    requirements_hash = get_content_hash("base", b"setup")
+    object.__setattr__(sandbox, "module", "druks_notes.workflows")
     create_template = AsyncMock()
     monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
     monkeypatch.setattr(
@@ -86,8 +76,13 @@ async def test_prepare_sandbox_templates_requests_each_declaration(monkeypatch):
     )
     monkeypatch.setattr(
         templates,
+        "loader",
+        SimpleNamespace(resolve_workflow_app=lambda module: "notes"),
+    )
+    monkeypatch.setattr(
+        templates,
         "get_declared_sandboxes",
-        lambda: {requirements_hash: sandbox},
+        lambda: {sandbox.setup_script_hash: sandbox},
     )
     monkeypatch.setattr(
         templates,
@@ -98,11 +93,10 @@ async def test_prepare_sandbox_templates_requests_each_declaration(monkeypatch):
     await templates.prepare_sandbox_templates()
 
     create_template.assert_awaited_once_with(
+        setup_script="setup",
         base_image="base",
-        script=b"setup",
-        requirements_hash=requirements_hash,
+        label="notes/sandboxes/setup.sh",
     )
-
 
 
 async def test_get_template_id_uses_available_template(monkeypatch):
@@ -111,7 +105,7 @@ async def test_get_template_id_uses_available_template(monkeypatch):
     get_template = AsyncMock(return_value=template)
     monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
     monkeypatch.setattr(
-        datastructures,
+        templates,
         "load_settings",
         lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
     )
@@ -122,7 +116,9 @@ async def test_get_template_id_uses_available_template(monkeypatch):
     )
 
     assert await templates.get_template_id(sandbox) == "template-1"
-    get_template.assert_awaited_once_with(requirements_hash=get_content_hash("base", b"setup"))
+    get_template.assert_awaited_once_with(
+        setup_script_hash=hashlib.sha256(b"setup").hexdigest(), base_image="base"
+    )
 
 
 async def test_get_template_id_waits_with_visible_phase(monkeypatch):
@@ -137,7 +133,7 @@ async def test_get_template_id_waits_with_visible_phase(monkeypatch):
     sleep = AsyncMock()
     monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
     monkeypatch.setattr(
-        datastructures,
+        templates,
         "load_settings",
         lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
     )
@@ -159,7 +155,7 @@ async def test_get_template_id_rejects_missing_template(monkeypatch):
     sandbox = Sandbox(setup="sandboxes/setup.sh")
     monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
     monkeypatch.setattr(
-        datastructures,
+        templates,
         "load_settings",
         lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
     )
@@ -177,7 +173,7 @@ async def test_get_template_id_rejects_failed_template(monkeypatch):
     sandbox = Sandbox(setup="sandboxes/setup.sh")
     monkeypatch.setattr(Sandbox, "read_setup_script", lambda self: b"setup")
     monkeypatch.setattr(
-        datastructures,
+        templates,
         "load_settings",
         lambda: SimpleNamespace(sandbox=SimpleNamespace(image="base")),
     )
@@ -253,16 +249,17 @@ async def test_ephemeral_lease_uses_workflow_template(monkeypatch):
 
 async def test_client_template_primitives_use_sdk_contract(monkeypatch):
     created = SimpleNamespace(id="template-1", status="building")
+    other_base = SimpleNamespace(
+        id="template-0", status="available", setup_script_hash="hash-1", base_image="older"
+    )
     listed = SimpleNamespace(
-        id="template-1",
-        status="available",
-        requirements_hash="requirements-1",
+        id="template-1", status="available", setup_script_hash="hash-1", base_image="base"
     )
 
     class FakeAPI:
         def __init__(self):
             self.create_template = AsyncMock(return_value=created)
-            self.list_templates = AsyncMock(return_value=[listed])
+            self.list_templates = AsyncMock(return_value=[other_base, listed])
             self.aclose = AsyncMock()
 
     api = FakeAPI()
@@ -270,18 +267,14 @@ async def test_client_template_primitives_use_sdk_contract(monkeypatch):
     monkeypatch.setattr(Client, "_api", lambda self: api)
 
     assert (
-        await client.create_template(
-            base_image="base",
-            script=b"setup",
-            requirements_hash="requirements-1",
-        )
+        await client.create_template(setup_script="setup", base_image="base", label="notes")
         is created
     )
-    assert await client.get_template(requirements_hash="requirements-1") is listed
+    assert await client.get_template(setup_script_hash="hash-1", base_image="base") is listed
+    assert await client.get_template(setup_script_hash="hash-1") is other_base
+    with pytest.raises(TemplateNotFound):
+        await client.get_template(setup_script_hash="hash-2")
     api.create_template.assert_awaited_once_with(
-        base_image="base",
-        script=b"setup",
-        requirements_hash="requirements-1",
+        setup_script="setup", base_image="base", label="notes"
     )
-    api.list_templates.assert_awaited_once_with()
-    assert api.aclose.await_count == 2
+    assert api.aclose.await_count == 4

--- a/backend/tests/test_declared_sandboxes.py
+++ b/backend/tests/test_declared_sandboxes.py
@@ -117,7 +117,7 @@ async def test_get_template_id_uses_available_template(monkeypatch):
 
     assert await templates.get_template_id(sandbox) == "template-1"
     get_template.assert_awaited_once_with(
-        setup_script_hash=hashlib.sha256(b"setup").hexdigest(), base_image="base"
+        base_image="base", setup_script_hash=hashlib.sha256(b"setup").hexdigest()
     )
 
 
@@ -270,7 +270,7 @@ async def test_client_template_primitives_use_sdk_contract(monkeypatch):
         await client.create_template(setup_script="setup", base_image="base", label="notes")
         is created
     )
-    assert await client.get_template(setup_script_hash="hash-1", base_image="base") is listed
+    assert await client.get_template(base_image="base", setup_script_hash="hash-1") is listed
     assert await client.get_template(setup_script_hash="hash-1") is other_base
     with pytest.raises(TemplateNotFound):
         await client.get_template(setup_script_hash="hash-2")

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -246,7 +246,7 @@ async def test_declared_sandboxes_report_template_status(
     results = await doctor.check_declared_sandboxes(settings)
 
     request_templates.assert_awaited_once_with()
-    lookup.assert_awaited_once_with(requirements_hash="requirements-1")
+    lookup.assert_awaited_once_with(setup_script_hash="requirements-1")
     assert len(results) == 1
     assert results[0].ok is ok
     assert results[0].pending is pending

--- a/backend/tests/test_sandbox_aws_direct.py
+++ b/backend/tests/test_sandbox_aws_direct.py
@@ -215,7 +215,7 @@ async def test_acquire_passes_template_to_drukbox(
     assert calls[0]["template"] == "template-1"
 
 
-async def test_acquire_omits_unset_template_from_drukbox(
+async def test_acquire_sends_no_template_by_default(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
@@ -224,4 +224,4 @@ async def test_acquire_omits_unset_template_from_drukbox(
     async with client.acquire(idempotency_key="op"):
         pass
 
-    assert "template" not in calls[0]
+    assert calls[0]["template"] is None

--- a/backend/tests/test_sandbox_lifecycle.py
+++ b/backend/tests/test_sandbox_lifecycle.py
@@ -102,6 +102,7 @@ class _FakeAPI:
         idempotency_key: str | None = None,
         expires_at: datetime | None = None,
         provider: str | None = None,
+        template: str | None = None,
     ) -> SandboxHostRecord:
         self.created_envs.append(env)
         self.created_expires_at.append(expires_at)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "asyncssh>=2.22",
-    "drukbox-python-sdk>=0.0.6",
+    "drukbox-python-sdk>=0.1.0",
     # 0.138 adds app.frontend(), which serves an app's shipped dist/.
     "fastapi>=0.138.0",
     "githubkit[auth-app]>=0.15.5",

--- a/uv.lock
+++ b/uv.lock
@@ -522,14 +522,14 @@ wheels = [
 
 [[package]]
 name = "drukbox-python-sdk"
-version = "0.0.7"
+version = "0.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/3f/ce6179b6135f304e830aeabef60c73d082c1b0b039c26f302b6becb9347d/drukbox_python_sdk-0.0.7.tar.gz", hash = "sha256:a4baed3e7190aced215b0a0041d4f816b741f3ac78e97adf88f2b63c721cbeed", size = 17350, upload-time = "2026-07-12T11:52:54.731Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/01/73e978566c3c6670ec2f5fcbd4829508f4f3edb992fa01856a120ef4f7b0/drukbox_python_sdk-0.1.0.tar.gz", hash = "sha256:d81cb31f865f67c01b28d531989525f9367bbbae0a335835aa61ad4400756715", size = 18394, upload-time = "2026-08-26T19:44:28.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/86/29b6b900de63d2e05c760c09c9163782607fb7aeda76e16ebfd373cd9f6a/drukbox_python_sdk-0.0.7-py3-none-any.whl", hash = "sha256:8b8d9087d3fc1e75da9fdd99fdd88632d6af5548a6782cdc0e554f69dd1ae2eb", size = 11728, upload-time = "2026-07-12T11:52:53.748Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f7/70dc580b901cbb6eec1fd6aa12cfa5c87f9ba8854840793ce59c534b8a11/drukbox_python_sdk-0.1.0-py3-none-any.whl", hash = "sha256:9a72cc443404d40bbdb23b08e691ff89746130b88e5bc2ac2e375f93eafebe04", size = 12186, upload-time = "2026-08-26T19:44:27.836Z" },
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "dbos", specifier = ">=2.30" },
-    { name = "drukbox-python-sdk", specifier = ">=0.0.6" },
+    { name = "drukbox-python-sdk", specifier = ">=0.1.0" },
     { name = "fastapi", specifier = ">=0.138.0" },
     { name = "fastmcp", specifier = ">=3.4.4,<4" },
     { name = "githubkit", extras = ["auth-app"], specifier = ">=0.15.5" },


### PR DESCRIPTION
Bumps drukbox-python-sdk to 0.1.0 and aligns the druks template half with the shipped contract.

- Lease audit for 0.1.0's `expires_at` change (explicit None no longer means permanent): the single `create_host` call always passes a literal expiry datetime, so no call site changes semantics. `renew_host` has no callers.
- Template identity follows the service: drukbox computes `setup_script_hash` from the script text and keys templates on `(provider, base_image, hash)`, so druks no longer folds the base into its own hash — `Sandbox.setup_script_hash` mirrors the wire.
- `create_template` sends `(setup_script, base_image, label)`; the service's create is an idempotent get-or-create. `label` is `<app>/<setup path>` for dashboards.
- Template lookup filters the newest-first listing by hash and base image, so a base change finds its fresh template while the old one ages out.
- `create_host(template=...)` is passed directly now that the SDK carries the argument.