### PR TITLE
Files accept user uploads, not only agent outputs

### DIFF
--- a/backend/druks/files/datastructures.py
+++ b/backend/druks/files/datastructures.py
@@ -1,11 +1,14 @@
 import asyncio
+import hashlib
 from typing import Any
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import CoreSchema, core_schema
 
+from druks.core.models import uuid7_str
 from druks.database import db_session
-from druks.files.exceptions import FileUnavailableError
+from druks.files.constants import MAX_FILE_BYTES
+from druks.files.exceptions import FileTooLargeError, FileUnavailableError
 from druks.files.models import FileRecord
 from druks.files.storage import get_file_storage
 from druks.models import Base
@@ -29,6 +32,45 @@ class File:
         self.name = name
         self.size = size
         self.content_type = content_type
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        name: str,
+        content_type: str,
+        content: bytes,
+        app: str,
+        origin_id: str,
+    ) -> "File":
+        if len(content) > MAX_FILE_BYTES:
+            raise FileTooLargeError(f"{name} is {len(content)} bytes; the cap is {MAX_FILE_BYTES}")
+        file_id = uuid7_str()
+        storage = get_file_storage()
+        temp = storage.new_temp(file_id)
+        try:
+            await asyncio.to_thread(temp.write_bytes, content)
+            digest = await asyncio.to_thread(hashlib.sha256, content)
+            record = FileRecord(
+                id=file_id,
+                name=name,
+                size=len(content),
+                content_type=content_type,
+                sha256=digest.hexdigest(),
+                app=app,
+                origin_type="user_upload",
+                origin_id=origin_id,
+            )
+            db_session().add(record)
+            await db_session().flush()
+            storage.save(temp, file_id)
+        except BaseException:
+            storage.discard(temp)
+            storage.delete(file_id)
+            raise
+        file = cls()
+        file._hydrate(record)
+        return file
 
     @classmethod
     def _validate(cls, value: str, info: core_schema.ValidationInfo) -> "File":

--- a/backend/druks/files/datastructures.py
+++ b/backend/druks/files/datastructures.py
@@ -68,9 +68,9 @@ class File:
             storage.discard(temp)
             storage.delete(file_id)
             raise
-        file = cls()
-        file._hydrate(record)
-        return file
+        return cls(
+            id=record.id, name=record.name, size=record.size, content_type=record.content_type
+        )
 
     @classmethod
     def _validate(cls, value: str, info: core_schema.ValidationInfo) -> "File":

--- a/backend/druks/files/exceptions.py
+++ b/backend/druks/files/exceptions.py
@@ -4,3 +4,7 @@ class FileError(Exception):
 
 class FileUnavailableError(FileError):
     pass
+
+
+class FileTooLargeError(FileError):
+    pass

--- a/backend/druks/files/models.py
+++ b/backend/druks/files/models.py
@@ -10,7 +10,9 @@ from druks.models import Base
 class FileRecord(Base, Uuid7Pk):
     __tablename__ = "files"
     __table_args__ = (
-        CheckConstraint("origin_type IN ('agent_call')", name="files_origin_type_check"),
+        CheckConstraint(
+            "origin_type IN ('agent_call', 'user_upload')", name="files_origin_type_check"
+        ),
         Index("files_deleted_at_idx", "deleted_at"),
     )
 

--- a/backend/migrations/versions/fe80e8bdf661_allow_user_upload_origin.py
+++ b/backend/migrations/versions/fe80e8bdf661_allow_user_upload_origin.py
@@ -1,0 +1,33 @@
+"""Allow user_upload origin.
+
+Revision ID: fe80e8bdf661
+Revises: e7b2c9d4f601
+Create Date: 2026-08-27
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "fe80e8bdf661"
+down_revision: str | Sequence[str] | None = "e7b2c9d4f601"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("files_origin_type_check", "files")
+    op.create_check_constraint(
+        "files_origin_type_check",
+        "files",
+        "origin_type IN ('agent_call', 'user_upload')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("files_origin_type_check", "files")
+    op.create_check_constraint(
+        "files_origin_type_check",
+        "files",
+        "origin_type IN ('agent_call')",
+    )

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from druks.agents import AgentOutput
 from druks.files import File, FileField
-from druks.files.exceptions import FileUnavailableError
+from druks.files.exceptions import FileTooLargeError, FileUnavailableError
 from druks.files.models import FileRecord
 from druks.files.storage import LocalFileStorage, reap_deleted_file_bytes
 from druks.models import Base
@@ -50,6 +50,66 @@ async def _hydrate_file(tmp_path, monkeypatch, *, name="home.png", content=b"ima
         agent_call_id="call-1",
     )
     return output.shots[0].image
+
+
+async def test_create_stores_a_user_upload(druks_db, tmp_path, monkeypatch):
+    """File.create stores bytes and a user_upload record and returns a live handle."""
+    monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
+
+    file = await File.create(
+        name="shopfront.jpg",
+        content_type="image/jpeg",
+        content=b"jpeg bytes",
+        app="site_builder",
+        origin_id="site-1",
+    )
+
+    record = await druks_db.get(FileRecord, file.id)
+    assert (file.name, file.size, file.content_type, file.url) == (
+        "shopfront.jpg",
+        10,
+        "image/jpeg",
+        f"/api/files/{file.id}",
+    )
+    assert record.app == "site_builder"
+    assert record.origin_type == "user_upload"
+    assert record.origin_id == "site-1"
+    assert record.sha256 == hashlib.sha256(b"jpeg bytes").hexdigest()
+    assert await file.open() == b"jpeg bytes"
+
+
+async def test_create_refuses_an_oversized_upload(monkeypatch):
+    """An upload past the byte cap raises before any byte or row lands."""
+    monkeypatch.setattr("druks.files.datastructures.MAX_FILE_BYTES", 4)
+
+    with pytest.raises(FileTooLargeError, match="cap"):
+        await File.create(
+            name="shopfront.jpg",
+            content_type="image/jpeg",
+            content=b"jpeg bytes",
+            app="site_builder",
+            origin_id="site-1",
+        )
+
+
+async def test_uploaded_file_delete_and_reap(druks_db, tmp_path, monkeypatch):
+    """A deleted upload loses its bytes to the reaper and keeps its tombstone."""
+    monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
+    file = await File.create(
+        name="shopfront.jpg",
+        content_type="image/jpeg",
+        content=b"jpeg bytes",
+        app="site_builder",
+        origin_id="site-1",
+    )
+    await file.delete()
+    record = await druks_db.get(FileRecord, file.id)
+    record.deleted_at = Base.utc_now() - timedelta(days=2)
+    await druks_db.flush()
+
+    assert await reap_deleted_file_bytes() == 1
+    assert await druks_db.get(FileRecord, file.id) is record
+    assert not LocalFileStorage(tmp_path / "files").path(file.id).exists()
 
 
 def test_file_contract_is_a_strict_nested_workspace_path():


### PR DESCRIPTION
An app with an upload door could not keep user files on the platform: the files table only accepted origin_type 'agent_call', and the only writer was harness hydration.

- Widen the check constraint to `('agent_call', 'user_upload')`, with a migration.
- `File.create(name=, content_type=, content=, app=, origin_id=)` writes the bytes through file storage, inserts the record with `origin_type='user_upload'`, and returns a hydrated File. It enforces the byte cap and computes the sha256.
- Delete and the reaper treat uploaded files like any other file.

Extends the files primitive (ENG-886).