### PR TITLE
The webhook host can name the addresses it listens on

### DIFF
--- a/deploy/caddy/Caddyfile
+++ b/deploy/caddy/Caddyfile
@@ -75,6 +75,11 @@ http://:8000 {
 # loopback listener; deployments whose edge already carries webhooks (exe.dev
 # port-share) need nothing here.
 {$DRUKS_WEBHOOK_HOST:http://127.0.0.1:8081} {
+	# The default is every interface. A public webhook host needs that.
+	# When a second TLS terminator runs on this box, for example
+	# `tailscale serve` on the tailnet address, set one address here.
+	# Two listeners on one port collide, and one of them stops.
+	bind {$DRUKS_WEBHOOK_BIND_HOST:0.0.0.0 ::}
 	header {
 		X-Content-Type-Options "nosniff"
 		Referrer-Policy "no-referrer"

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -157,6 +157,9 @@ services:
       # default. Caddy reads a set-but-empty value as a real, broken site
       # address.
       DRUKS_WEBHOOK_HOST: ${DRUKS_WEBHOOK_HOST:-http://127.0.0.1:8081}
+      # The addresses where Caddy serves the webhook host. The default is
+      # every interface. Set one address to keep the other addresses free.
+      DRUKS_WEBHOOK_BIND_HOST: ${DRUKS_WEBHOOK_BIND_HOST:-0.0.0.0 ::}
     volumes:
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,13 @@ caches, and the sandbox provisioning gate.
 | `identity.jwt_audience` | `jwt` mode: required `aud` claim value |
 | `identity.jwt_identity_claim` | `jwt` mode: the claim mapped to the account (default `email`) |
 
+The `urls.webhook_host` listener binds every interface. A second TLS
+terminator on the same box, for example `tailscale serve` on the tailnet
+address, collides with it on port 443. One of the two stops. To keep the
+other addresses free, set `DRUKS_WEBHOOK_BIND_HOST` in `[env]` to the public
+address. Caddy then serves only that address. To keep IPv6, list the IPv4
+and the IPv6 addresses.
+
 `urls.endpoint` and `urls.webhook_host` are different. The first is where an
 operator's browser reaches Druks; the second is the public ingress webhook
 senders reach. They may share a hostname on exe.dev.


### PR DESCRIPTION
Caddy binds the public webhook host on every interface. That assumes that the
stack is the only TLS terminator on the box.

A deployment that also runs `tailscale serve` breaks the assumption. tailscaled
binds port 443 on the tailnet address. Caddy asks for port 443 on every
address. Caddy then crash-loops on a bind error that does not show the cause.
The exe shape puts the box on a tailnet, so the collision occurs in a
documented setup.

`DRUKS_WEBHOOK_BIND_HOST` sets the addresses for that listener, in the same
shape as `DRUKS_WEB_BIND_HOST` and `DRUKS_DRUKBOX_BIND_HOST`. The default is
every interface. A deployment that does not set it sees no change.

```toml
[env]
DRUKS_WEBHOOK_BIND_HOST = "203.0.113.10"
```

The key is not a name that druks owns. Thus `[env]` carries it, and `druks
setup` renders it with no change to the settings.