### PR TITLE
Prompt templates await the async workflow subject

### DIFF
--- a/backend/druks/prompts/resolver.py
+++ b/backend/druks/prompts/resolver.py
@@ -22,6 +22,8 @@ def _environment() -> Environment:
     # ``os.system``, and being immutable it blocks mutating the live ``workflow``/
     # ``workspace`` objects in context. Bundled templates only read public attributes,
     # so the sandbox is invisible to them.
+    # ``enable_async``: attribute reads that return coroutines (the async
+    # ``workflow.subject``) are awaited during render.
     return ImmutableSandboxedEnvironment(
         loader=PrefixLoader(_app_template_roots()),
         autoescape=False,
@@ -29,6 +31,7 @@ def _environment() -> Environment:
         keep_trailing_newline=True,
         trim_blocks=True,
         lstrip_blocks=True,
+        enable_async=True,
     )
 
 
@@ -70,19 +73,17 @@ async def render_prompt(
         context.setdefault("repo", repo)
     override = await _resolve_override(name, repo=repo)
     if override:
-        return _environment().from_string(override).render(**context)
-    return _environment().get_template(name).render(**context)
+        return await _environment().from_string(override).render_async(**context)
+    return await _environment().get_template(name).render_async(**context)
 
 
 async def _resolve_override(name: str, *, repo: str | None) -> str | None:
     namespaced = _app_prompt_path(name)
-    if not repo or not namespaced:
-        return None
-    owner = repo.partition("/")[0]
-    body = await fetch_file(repo=repo, path=f".druks/{namespaced}")
-    if body:
-        return body
-    return await fetch_file(repo=f"{owner}/.druks", path=namespaced)
+    if repo and namespaced:
+        owner = repo.partition("/")[0]
+        body = await fetch_file(repo=repo, path=f".druks/{namespaced}")
+        return body or await fetch_file(repo=f"{owner}/.druks", path=namespaced)
+    return
 
 
 def _app_prompt_path(name: str) -> str | None:
@@ -91,6 +92,6 @@ def _app_prompt_path(name: str) -> str | None:
     so the override is ``<app>/prompts/<rest>`` — derived from the name, no table
     to keep in sync. A name with no app segment (no ``/``) isn't overridable."""
     app, _, rest = name.partition("/")
-    if not rest:
-        return None
-    return f"{app}/prompts/{rest}"
+    if rest:
+        return f"{app}/prompts/{rest}"
+    return

--- a/backend/tests/test_prompt_async_render.py
+++ b/backend/tests/test_prompt_async_render.py
@@ -1,0 +1,26 @@
+from druks.prompts import render_prompt
+
+
+class _Subject:
+    operator = "paulo"
+
+
+class _Workflow:
+    # Instance access returns a coroutine, like the declared-subject descriptor.
+    @property
+    def subject(self):
+        return self._load_subject()
+
+    async def _load_subject(self) -> _Subject:
+        return _Subject()
+
+
+async def test_render_awaits_async_subject(monkeypatch):
+    async def fetch_file(**_: object) -> str:
+        return "operator: {{ workflow.subject.operator }}"
+
+    monkeypatch.setattr("druks.prompts.resolver.fetch_file", fetch_file)
+    rendered = await render_prompt(
+        "ship/build/setup.md", repo="owner/repo", workflow=_Workflow()
+    )
+    assert rendered == "operator: paulo"


### PR DESCRIPTION
Since the async ORM migration, `workflow.subject` returns a coroutine on instance access. The prompt environment rendered synchronously, so a template that reads `{{ workflow.subject.* }}` failed with `UndefinedError: 'coroutine object' has no attribute ...`. Every scheduled run that renders such a template failed.

The environment now has `enable_async=True`, and `render_prompt` awaits `render_async` on both the override path and the bundled path. Async Jinja awaits the subject coroutine during render, so templates keep the `workflow.subject.attr` shape.

A regression test renders a template through `render_prompt` against a workflow whose subject resolves async, and asserts the field value lands in the output.