### PR TITLE
software_factory: a clearer app-card description

### DIFF
--- a/backend/druks/contrib/software_factory/app.py
+++ b/backend/druks/contrib/software_factory/app.py
@@ -55,9 +55,8 @@ class SoftwareFactory(App):
     prefix_tables = False
     icon = "factory"
     description = (
-        "Each stage of the build pipeline runs as its own agent. An agent runs its own "
-        "model, or inherits its harness default — the backend dispatches the harness "
-        "from the model you pick."
+        "Turns a ticket into a pull request — it plans the change, builds it, and "
+        "gates on you before shipping."
     )
     navigation = [
         ("/software_factory", "active"),


### PR DESCRIPTION
The software_factory app card described the pipeline's internals — agents, models, harness dispatch. That is plumbing, not what the app does.

New description states the outcome and the one safety point, matching the other apps' cards:

> Turns a ticket into a pull request — it plans the change, builds it, and gates on you before shipping.