### PR TITLE
Set the canonical documentation domain (ENG-888)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,6 +3,11 @@
   "theme": "linden",
   "name": "Druks",
   "description": "Build and operate durable agent apps on your own infrastructure.",
+  "seo": {
+    "metatags": {
+      "canonical": "https://docs.druks.ai"
+    }
+  },
   "colors": {
     "primary": "#0F766E",
     "light": "#2DD4BF",


### PR DESCRIPTION
## Result

The hosted documentation now declares `https://docs.druks.ai` as its canonical URL.

## Verification

- `mint validate`
- `mint broken-links --check-anchors --check-redirects`
- Public DNS points `docs.druks.ai` to `cname.mintlify.builders`.
- Direct HTTPS access returns status 200.