### PR TITLE
Add app-owned page declarations and discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,8 @@ For app-surface changes, inspect the proof app at
   context object, or one-use helper module.
 - Do not import an app from an author-surface module. Import only
   `druks.workflows`, `druks.agents`, `druks.events`, `druks.signals`, `druks.db`,
-  `druks.schemas`, `druks.prompts`, `druks.durable`, `druks.apps`, and
-  `druks.webhooks`. A reference to `druks.build` or another app in these modules
+  `druks.schemas`, `druks.prompts`, `druks.durable`, `druks.apps`, `druks.ui`,
+  and `druks.webhooks`. A reference to `druks.build` or another app in these modules
   inverts the platform.
 - Derive liveness from run state. Do not mirror it in a column. Store an external
   outcome after its owner announces it. Do not infer that outcome from run

--- a/backend/druks/apps/base.py
+++ b/backend/druks/apps/base.py
@@ -9,9 +9,10 @@ from pydantic import BaseModel, Field, SecretStr
 
 from druks.events.models import Event
 from druks.models import StoredSubject
+from druks.ui.exceptions import PageRouteError
 from druks.user_settings.models import SettingsOverride
 
-from .exceptions import AppSubjectContractError, SettingsDeclarationError
+from .exceptions import AppRouteConflict, AppSubjectContractError, SettingsDeclarationError
 from .registry import agents as agent_registry
 from .registry import autodiscover
 from .registry import workflows as workflow_registry
@@ -29,6 +30,7 @@ if TYPE_CHECKING:
     from druks.doctor import CheckResult
     from druks.durable.datastructures import Subject
     from druks.durable.schemas import SubjectActivity
+    from druks.ui.page import PageRoute
     from druks.workflows import Workflow
 
     # A check the app owns returns a verdict on one of its own preconditions
@@ -40,6 +42,11 @@ if TYPE_CHECKING:
 # be a lowercase SQL/URL-safe identifier. Public: the scaffolder validates against the
 # same rule so ``druks create app`` can't emit a package that fails this check.
 NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# Segments under ``/api/<name>`` the platform serves for every app: the
+# agent-call reads and the page snapshots. Neither a subject type nor an app
+# router can take one, so an app can never shadow a platform read.
+RESERVED_SEGMENTS = frozenset({"transcripts", "pages"})
 
 
 # A secret-kind settings field: unset is an empty ``SecretStr`` — falsy, so
@@ -84,10 +91,11 @@ class App:
     icon: ClassVar[str] = "box"
     # One-line blurb shown in the settings pane when the app is selected.
     description: ClassVar[str] = ""
-    # The app's appbar subnav tabs, as (url, name) pairs. The switcher
-    # label itself is derived from ``name`` (underscores become spaces), so an
-    # app only declares destinations, never a title.
-    navigation: ClassVar[list[tuple[str, str]]] = []
+    # The app's appbar subnav tabs, as page names in the order they show. Each
+    # names a static top-level page, and the tab wears that page's label, so an
+    # app never spells a label twice. An app that ships its own frontend
+    # declares its tabs there instead.
+    navigation: ClassVar[list[str]] = []
     # The app's top-level package, walked by ``discover``. Defaults to the
     # package the subclass is defined in — the ``<package>/app.py`` convention
     # means that's always the app's root — so it's only set explicitly when the
@@ -195,10 +203,10 @@ class App:
         stubs = {Subject.list_summaries.__func__, StoredSubject.list_summaries.__func__}
         declared = {workflow.subject for workflow in cls.workflows() if workflow.subject}
         for subject_class in declared:
-            if subject_class.subject_type == "transcripts":
+            if subject_class.subject_type in RESERVED_SEGMENTS:
                 raise AppSubjectContractError(
-                    f"{subject_class.__name__} is a 'transcripts' subject; that segment "
-                    "serves every app's agent-call reads. Name it for what it is"
+                    f"{subject_class.__name__} is a {subject_class.subject_type!r} subject; "
+                    "that segment serves every app's platform reads. Name it for what it is"
                 )
             if subject_class.list_summaries.__func__ in stubs:
                 raise AppSubjectContractError(
@@ -207,6 +215,35 @@ class App:
                     f"list_summaries() on {subject_class.__name__}."
                 )
         return sorted(declared, key=lambda subject_class: subject_class.subject_type)
+
+    @classmethod
+    def pages(cls) -> "list[PageRoute]":
+        """The pages this app declares, in route-match order — imported first,
+        like ``routers()`` does, so a headless caller reads the whole surface.
+        Empty for an app that ships no ``pages.py``. Raises
+        ``PageRouteError`` on a table a request could not resolve."""
+        from druks.ui.page import list_pages_for_app
+
+        cls.discover()
+        return list_pages_for_app(cls.name, cls.package)
+
+    @classmethod
+    def navigation_pages(cls) -> "list[PageRoute]":
+        """The pages ``navigation`` names, in the order it names them. The shell
+        shows one tab for each, labelled by the page."""
+        declared = {page.name: page for page in cls.pages()}
+        chosen = []
+        for name in cls.navigation:
+            page = declared.get(name)
+            if page and page.is_static and not page.parent:
+                chosen.append(page)
+                continue
+            raise PageRouteError(
+                f"app {cls.name!r} navigation names {name!r}. A navigation entry must be a "
+                f"static top-level page the shell can open with no parameters. This app "
+                f"declares {sorted(declared)}."
+            )
+        return chosen
 
     @classmethod
     def discover(cls) -> list[ModuleType]:
@@ -244,10 +281,10 @@ class App:
         contains is what ``druks init-db`` upgrades under
         ``alembic_version_<name>``."""
         package_dir = cls.package_dir()
-        if not package_dir:
-            return None
-        migrations = package_dir / "migrations"
-        return migrations if (migrations / "versions").is_dir() else None
+        if package_dir:
+            migrations = package_dir / "migrations"
+            return migrations if (migrations / "versions").is_dir() else None
+        return
 
     @classmethod
     def package_dir(cls) -> Path | None:
@@ -255,9 +292,9 @@ class App:
         assets (``migrations/``, ``dist/``) live. None when the package has no
         location (a namespace-less or frozen import)."""
         spec = importlib.util.find_spec(cls.package)
-        if not spec or not spec.submodule_search_locations:
-            return None
-        return Path(spec.submodule_search_locations[0])
+        if spec and spec.submodule_search_locations:
+            return Path(spec.submodule_search_locations[0])
+        return
 
     @classmethod
     def frontend_dist(cls) -> Path | None:
@@ -266,10 +303,10 @@ class App:
         is its marker. Inside the package, not the project root, so the same
         path resolves for a wheel and an editable install alike."""
         package_dir = cls.package_dir()
-        if not package_dir:
-            return None
-        dist = package_dir / "dist"
-        return dist if (dist / "entry.js").is_file() else None
+        if package_dir:
+            dist = package_dir / "dist"
+            return dist if (dist / "entry.js").is_file() else None
+        return
 
     @classmethod
     def get_routers(cls, modules: list[ModuleType]) -> "list[APIRouter]":
@@ -291,6 +328,20 @@ class App:
             for value in vars(module).values():
                 if isinstance(value, APIRouter) and id(value) not in seen:
                     seen.add(id(value))
+                    # Every path the router would mount, prefixed or not: a
+                    # reserved first segment anywhere in it takes a platform read.
+                    # Starlette route kinds differ, so read the path defensively.
+                    taken = {
+                        f"{value.prefix}{getattr(route, 'path', '')}".strip("/").partition("/")[0]
+                        for route in value.routes
+                    }
+                    reserved = sorted(taken & RESERVED_SEGMENTS)
+                    if reserved:
+                        raise AppRouteConflict(
+                            f"app {cls.name!r} mounts a router on {reserved}, and those "
+                            "segments serve every app's platform reads. Name the router for "
+                            "its own resource."
+                        )
                     declared.append(value)
         # The platform's routers are narrow — each confined to its own segment — so
         # matching them first costs an app nothing anywhere else and leaves it

--- a/backend/druks/apps/exceptions.py
+++ b/backend/druks/apps/exceptions.py
@@ -40,6 +40,12 @@ class AppImportError(AppLoadError):
     import — carries the original exception as its cause."""
 
 
+class AppRouteConflict(AppLoadError):
+    """An app mounts a router on a segment the platform serves for every app.
+    Raised when the routers are enumerated, so the conflict fails the load
+    instead of hiding one route behind the other."""
+
+
 class AppSubjectContractError(AppLoadError):
     """A declared subject fails the read-side contract: no ``list_summaries()``
     implementation, or it names the reserved ``transcripts`` segment."""

--- a/backend/druks/apps/loader.py
+++ b/backend/druks/apps/loader.py
@@ -97,7 +97,8 @@ def load_app(name: str) -> type[App]:
     an entry point that doesn't resolve to an ``App`` raises
     ``MalformedApp``; the app's own code raising on import raises
     ``AppImportError``; a declared subject that fails the read-side contract
-    raises ``AppSubjectContractError``."""
+    raises ``AppSubjectContractError``; a page table a request could not
+    resolve raises ``PageRouteError``."""
     app = _resolve(name)
     try:
         import_app_models(app)
@@ -106,6 +107,7 @@ def load_app(name: str) -> type[App]:
         raise AppImportError(f"app {name!r} failed to import: {error}") from error
     # Outside the try: a contract break is not an import error.
     app.subjects()
+    app.navigation_pages()
     return app
 
 
@@ -239,11 +241,12 @@ def mount(api: "FastAPI", app: type[App], modules: list["ModuleType"]) -> None:
 
 
 def load(api: "FastAPI") -> None:
-    """API boot: for each app — discover, validate subjects, mount."""
+    """API boot: for each app — discover, validate subjects and pages, mount."""
     # The table-prefix check runs here, not just in makemigrations — an author
     # who hand-writes migrations still can't boot with an unprefixed table.
     import_app_models()
     for app in iter_apps():
         modules = app.discover()
         app.subjects()
+        app.navigation_pages()
         mount(api, app, modules)

--- a/backend/druks/apps/registry.py
+++ b/backend/druks/apps/registry.py
@@ -5,10 +5,11 @@ from types import ModuleType
 from typing import Any
 
 # Leaf-module names that carry self-registering capabilities. ``autodiscover``
-# imports exactly these (``routes`` defines routers the loader mounts; the rest
-# fire registration as an import side effect). The set is the single source of
-# truth for what "a capability module" is named.
-_ROLES = frozenset({"webhooks", "subscribers", "workflows", "tasks", "routes", "services"})
+# imports exactly these (``routes`` defines routers the loader mounts, ``pages``
+# defines the app's screens; the rest fire registration as an import side
+# effect). The set is the single source of truth for what "a capability module"
+# is named.
+_ROLES = frozenset({"webhooks", "subscribers", "workflows", "tasks", "routes", "pages", "services"})
 
 
 class Registry:
@@ -62,6 +63,7 @@ def autodiscover(package: str) -> list[ModuleType]:
 
 
 webhooks = Registry("webhooks", key=lambda cls: f"{cls.__module__}.{cls.__qualname__}")
+pages = Registry("pages", key=lambda page_route: page_route.key)
 services = Registry("services", key=lambda cls: cls.slug)
 workflows = Registry("workflows", key=lambda cls: cls.kind)
 agents = Registry("agents", key=lambda agent: agent.id)

--- a/backend/druks/apps/routes.py
+++ b/backend/druks/apps/routes.py
@@ -16,7 +16,10 @@ async def list_apps() -> list[AppResponse]:
             builtin=app.builtin,
             subject_types=[subject.subject_type for subject in app.subjects()],
             has_frontend=bool(app.frontend_dist()),
-            navigation=app.navigation,
+            navigation=[
+                (f"/{app.name}{page.route}".rstrip("/"), page.label)
+                for page in app.navigation_pages()
+            ],
         )
         for app in iter_apps()
     ]

--- a/backend/druks/apps/schemas.py
+++ b/backend/druks/apps/schemas.py
@@ -8,5 +8,5 @@ class AppResponse(BaseResponse):
     builtin: bool
     subject_types: list[str]
     has_frontend: bool
-    # (url, name) pairs, straight from the app's declaration.
+    # (url, label) pairs, one for each page the app's navigation names.
     navigation: list[tuple[str, str]]

--- a/backend/druks/contrib/software_factory/app.py
+++ b/backend/druks/contrib/software_factory/app.py
@@ -58,11 +58,6 @@ class SoftwareFactory(App):
         "Turns a ticket into a pull request — it plans the change, builds it, and "
         "gates on you before shipping."
     )
-    navigation = [
-        ("/software_factory", "active"),
-        ("/software_factory/history", "history"),
-        ("/software_factory/projects", "projects"),
-    ]
 
     class Settings(AppSettings):
         tracker: Literal["none", "linear", "jira"] = Field(

--- a/backend/druks/ui/__init__.py
+++ b/backend/druks/ui/__init__.py
@@ -1,0 +1,4 @@
+from .page import page
+from .schemas import Page
+
+__all__ = ["Page", "page"]

--- a/backend/druks/ui/exceptions.py
+++ b/backend/druks/ui/exceptions.py
@@ -1,0 +1,5 @@
+class PageRouteError(Exception):
+    """An app's pages cannot make a route table. Raised at declaration for a
+    nested child, and at boot for a missing landing page, a repeated page name,
+    two routes a request cannot tell apart, a signature that does not match its
+    route, or a navigation entry that is not a static top-level page."""

--- a/backend/druks/ui/page.py
+++ b/backend/druks/ui/page.py
@@ -1,0 +1,178 @@
+import re
+from collections.abc import Awaitable, Callable
+from inspect import Parameter, signature
+from itertools import count
+
+from druks.apps.registry import pages
+
+from .exceptions import PageRouteError
+from .schemas import Page
+
+PageFunction = Callable[..., Awaitable[Page]]
+
+# A route parameter — ``{note_id}``, or the catch-all ``{rest:path}``.
+_PARAMETER = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)(:path)?\}")
+
+# The order the app declared its pages in, which sets tab order. A parent's
+# children all come from one ``pages.py``, and a module runs top to bottom, so
+# the count follows the source.
+_declared = count()
+
+# The parameter kinds FastAPI can fill by name. A positional-only or variadic
+# parameter would take the route value only by position, and the endpoint is
+# called with keywords.
+_CALLABLE_BY_NAME = frozenset({Parameter.POSITIONAL_OR_KEYWORD, Parameter.KEYWORD_ONLY})
+
+
+class PageRoute:
+    """One page an app declares: the route it answers, the function that
+    projects it, and the parent it hangs under."""
+
+    def __init__(
+        self,
+        path: str,
+        function: PageFunction,
+        *,
+        label: str = "",
+        parent: "PageRoute | None" = None,
+    ) -> None:
+        self.path = path
+        self.function = function
+        self.parent = parent
+        self.name = function.__name__
+        self.module = function.__module__
+        self.label = label or self.name.replace("_", " ")
+        self.order = next(_declared)
+
+    def child(self, path: str, *, label: str = "") -> Callable[[PageFunction], "PageRoute"]:
+        """Declare a page under this one, at ``path`` relative to this route."""
+        if self.parent:
+            raise PageRouteError(
+                f"page {self.name!r} is already a child of {self.parent.name!r}, and one "
+                f"child level is allowed. Declare {path!r} with @page instead."
+            )
+
+        def declare(function: PageFunction) -> PageRoute:
+            return pages.register(PageRoute(path, function, label=label, parent=self))
+
+        return declare
+
+    @property
+    def key(self) -> str:
+        """What the registry files this page under. Module, name, and route
+        together, so two pages that share a name both reach the boot check."""
+        return f"{self.module}.{self.name}.{self.route}"
+
+    @property
+    def children(self) -> list["PageRoute"]:
+        """The pages declared under this one, in the order the app declared them.
+        The static ones are this page's tabs."""
+        return sorted(
+            (page_route for page_route in pages.all() if page_route.parent is self),
+            key=lambda page_route: page_route.order,
+        )
+
+    @property
+    def route(self) -> str:
+        """The page's whole path — a child joins its parent's route."""
+        if self.parent:
+            return f"{self.parent.route.rstrip('/')}{self.path}"
+        return self.path
+
+    @property
+    def is_static(self) -> bool:
+        """Whether the page's own path segment carries no parameter. A static
+        child renders as a tab; a parameterized one is a detail page a Link reaches."""
+        return "{" not in self.path
+
+    def check(self, app_name: str) -> None:
+        """Everything this page decides on its own: its catch-all sits last, and
+        it takes one name-callable parameter for each parameter of its route. A
+        child inherits its parent's; an extra one comes from the child path."""
+        if any(":path}" in segment for segment in self.route.split("/")[:-1]):
+            raise PageRouteError(
+                f"app {app_name!r} routes {self.name!r} at {self.route!r}, and its catch-all "
+                "is not the last segment, so it would swallow every route under it. Put the "
+                "catch-all last."
+            )
+        route_parameters = {name for name, _ in _PARAMETER.findall(self.route)}
+        declared = signature(self.function).parameters
+        by_name = {
+            name for name, parameter in declared.items() if parameter.kind in _CALLABLE_BY_NAME
+        }
+        if set(declared) == route_parameters and by_name == route_parameters:
+            return
+        raise PageRouteError(
+            f"app {app_name!r} page {self.name!r} takes {sorted(declared)}, and its route "
+            f"{self.route!r} carries {sorted(route_parameters)}. Take one parameter for "
+            "each route parameter, each one callable by name."
+        )
+
+    @property
+    def match_key(self) -> tuple[tuple[int, str], ...]:
+        """Sort key that puts literal segments before parameters and catch-alls
+        at every depth, so a match never follows the order an app declared in."""
+        key: list[tuple[int, str]] = []
+        for segment in self.route.strip("/").split("/"):
+            if "{" not in segment:
+                key.append((0, segment))
+            elif ":path}" in segment:
+                key.append((2, ""))
+            else:
+                key.append((1, ""))
+        return tuple(key)
+
+
+def page(path: str, *, label: str = "") -> Callable[[PageFunction], PageRoute]:
+    """Declare a top-level page at ``path``. The label defaults to the function
+    name with its underscores as spaces."""
+
+    def declare(function: PageFunction) -> PageRoute:
+        return pages.register(PageRoute(path, function, label=label))
+
+    return declare
+
+
+def list_pages_for_app(app_name: str, package: str) -> list[PageRoute]:
+    """The pages ``package`` declares, in route-match order: literal segments
+    before parameters before catch-alls, at every depth. What an app declared
+    first never decides a match. Raises ``PageRouteError`` on a table a request
+    could not resolve."""
+    declared = [
+        page_route for page_route in pages.all() if page_route.module.startswith(f"{package}.")
+    ]
+    if not declared:
+        return []
+
+    landing = [page_route for page_route in declared if page_route.route == "/"]
+    if len(landing) != 1:
+        named = sorted(page_route.name for page_route in landing)
+        raise PageRouteError(
+            f"app {app_name!r} declares {len(landing)} pages at '/' ({named}). Declare "
+            "exactly one: it is the page the app opens on."
+        )
+
+    by_name: dict[str, PageRoute] = {}
+    by_shape: dict[str, PageRoute] = {}
+    for page_route in declared:
+        page_route.check(app_name)
+        clash = by_name.get(page_route.name)
+        if clash:
+            raise PageRouteError(
+                f"app {app_name!r} declares two pages named {page_route.name!r} "
+                f"({clash.module} and {page_route.module}). A Link and a navigation "
+                "entry address a page by name, so rename one."
+            )
+        by_name[page_route.name] = page_route
+        # Drop each parameter's name but keep the catch-all marker: a catch-all
+        # spans segments, so it is not the same shape as a plain parameter.
+        shape = _PARAMETER.sub(r"{\2}", page_route.route)
+        clash = by_shape.get(shape)
+        if clash:
+            raise PageRouteError(
+                f"app {app_name!r} routes {clash.route!r} and {page_route.route!r} to the "
+                "same shape, so no request could tell them apart. Give one a literal segment."
+            )
+        by_shape[shape] = page_route
+
+    return sorted(declared, key=lambda page_route: page_route.match_key)

--- a/backend/druks/ui/schemas.py
+++ b/backend/druks/ui/schemas.py
@@ -1,0 +1,9 @@
+from druks.schemas import BaseResponse
+
+
+class Page(BaseResponse):
+    """One screen, as a page function projects it. The shared dashboard
+    renders it."""
+
+    title: str
+    description: str = ""

--- a/backend/tests/druks-field_notes/druks_field_notes/app.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/app.py
@@ -31,7 +31,7 @@ class FieldNotes(App):
     name = "field_notes"
     icon = "notebook"
     description = "Turns a jotted observation into a one-line gist with an agent."
-    navigation = [("/field_notes", "notes")]
+    navigation = ["notes"]
 
     class Settings(AppSettings):
         # How many recent notes the board shows — an operator knob, so it lives here.

--- a/backend/tests/druks-field_notes/druks_field_notes/pages.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/pages.py
@@ -1,0 +1,26 @@
+from druks.ui import Page, page
+
+
+@page("/")
+async def notes():
+    return Page(title="Notes", description="Every note this install captured.")
+
+
+@notes.child("/recent")
+async def recent_notes():
+    return Page(title="Recent notes")
+
+
+@page("/notes/new")
+async def new_note():
+    return Page(title="Write a note")
+
+
+@page("/notes/{note_id}")
+async def note(note_id: int):
+    return Page(title=f"Note {note_id}")
+
+
+@note.child("/history")
+async def note_history(note_id: int):
+    return Page(title=f"Note {note_id} history")

--- a/backend/tests/test_app_roster.py
+++ b/backend/tests/test_app_roster.py
@@ -12,12 +12,10 @@ def test_roster_lists_installed_apps_with_subject_types(tmp_path: Path):
     assert software_factory["builtin"] is False
     assert "work_item" in software_factory["subjectTypes"]
     assert software_factory["hasFrontend"] is False
-    assert software_factory["navigation"] == [
-        ["/software_factory", "active"],
-        ["/software_factory/history", "history"],
-        ["/software_factory/projects", "projects"],
-    ]
+    # Software Factory's pages are React, so its tabs live in its frontend.
+    assert software_factory["navigation"] == []
     assert software_factory["icon"]
     field_notes = roster["field_notes"]
     assert field_notes["subjectTypes"] == ["note"]
+    # Derived from the landing page the app declares, labelled by that page.
     assert field_notes["navigation"] == [["/field_notes", "notes"]]

--- a/backend/tests/test_apps.py
+++ b/backend/tests/test_apps.py
@@ -194,7 +194,7 @@ def test_a_subject_cannot_take_the_transcripts_segment():
         def workflows(cls):
             return [SimpleNamespace(subject=Transcripts)]
 
-    with pytest.raises(AppSubjectContractError, match="agent-call reads"):
+    with pytest.raises(AppSubjectContractError, match="serves every app's platform reads"):
         Colliding.subjects()
 
 

--- a/backend/tests/test_author_surface.py
+++ b/backend/tests/test_author_surface.py
@@ -39,6 +39,7 @@ AUTHOR_SURFACE = {
     },
     "druks.db": {"Base", "StoredSubject", "db_session"},
     "druks.schemas": {"BaseResponse"},
+    "druks.ui": {"Page", "page"},
     "druks.signals": {"subscribe"},
     "druks.events": {"Event"},
     "druks.files": {"File", "FileField"},

--- a/backend/tests/test_ui_pages.py
+++ b/backend/tests/test_ui_pages.py
@@ -1,0 +1,272 @@
+from inspect import Parameter, Signature
+from types import ModuleType
+
+import pytest
+from druks.apps.exceptions import AppRouteConflict
+from druks.apps.loader import load_app
+from druks.ui import Page, page
+from druks.ui.exceptions import PageRouteError
+from druks.ui.page import PageRoute, list_pages_for_app
+from fastapi import APIRouter
+
+
+def declare(
+    package: str,
+    path: str,
+    name: str,
+    *parameters: str,
+    parent: PageRoute | None = None,
+    label: str = "",
+) -> PageRoute:
+    """One page in a make-believe app package, so a test can build a table the
+    loader would reject without shipping a package for each one."""
+
+    async def project():
+        return Page(title=name)
+
+    project.__name__ = name
+    project.__module__ = f"{package}.pages"
+    project.__signature__ = Signature(  # type: ignore[attr-defined]
+        [Parameter(parameter, Parameter.POSITIONAL_OR_KEYWORD) for parameter in parameters]
+    )
+    declaration = parent.child(path, label=label) if parent else page(path, label=label)
+    return declaration(project)
+
+
+def routes_for(package: str) -> list[str]:
+    return [declaration.route for declaration in list_pages_for_app(package, package)]
+
+
+def test_discovery_loads_the_pages_module():
+    app = load_app("field_notes")
+
+    assert [declaration.name for declaration in app.pages()] == [
+        "notes",
+        "new_note",
+        "note",
+        "note_history",
+        "recent_notes",
+    ]
+
+
+def test_child_route_joins_its_parent():
+    app = load_app("field_notes")
+    pages = {declaration.name: declaration for declaration in app.pages()}
+
+    assert pages["note_history"].route == "/notes/{note_id}/history"
+    assert pages["note_history"].parent is pages["note"]
+    # The landing page's route is "/", so its child does not double the slash.
+    assert pages["recent_notes"].route == "/recent"
+
+
+def test_a_static_child_is_a_tab_and_a_parameterized_page_is_not():
+    app = load_app("field_notes")
+    pages = {declaration.name: declaration for declaration in app.pages()}
+
+    assert pages["note_history"].is_static
+    assert pages["recent_notes"].is_static
+    assert not pages["note"].is_static
+
+
+def test_a_label_comes_from_the_page_name():
+    app = load_app("field_notes")
+    pages = {declaration.name: declaration for declaration in app.pages()}
+
+    assert pages["note_history"].label == "note history"
+
+
+def test_a_declared_label_wins():
+    assert declare("labelled", "/peers", "peers", label="Peer roster").label == "Peer roster"
+
+
+def test_literal_segments_match_before_parameters():
+    # Declared parameter first, so only the sort can put the literal ahead of it.
+    declare("precedence", "/", "overview")
+    declare("precedence", "/notes/{note_id}", "note", "note_id")
+    declare("precedence", "/notes/new", "new_note")
+
+    assert routes_for("precedence") == ["/", "/notes/new", "/notes/{note_id}"]
+
+
+def test_child_pages_follow_the_same_precedence():
+    declare("child_precedence", "/", "overview")
+    note = declare("child_precedence", "/notes/{note_id}", "note", "note_id")
+    declare("child_precedence", "/{section}", "section", "note_id", "section", parent=note)
+    declare("child_precedence", "/history", "note_history", "note_id", parent=note)
+
+    assert routes_for("child_precedence") == [
+        "/",
+        "/notes/{note_id}",
+        "/notes/{note_id}/history",
+        "/notes/{note_id}/{section}",
+    ]
+
+
+def test_a_catch_all_matches_last():
+    declare("catch_all", "/", "overview")
+    declare("catch_all", "/files/{rest:path}", "any_file", "rest")
+    declare("catch_all", "/files/{name}", "one_file", "name")
+    declare("catch_all", "/files/recent", "recent_files")
+
+    assert routes_for("catch_all") == [
+        "/",
+        "/files/recent",
+        "/files/{name}",
+        "/files/{rest:path}",
+    ]
+
+
+def test_a_child_declaration_can_live_in_another_module():
+    declare("cross_module", "/", "overview")
+    note = declare("cross_module", "/notes/{note_id}", "note", "note_id")
+
+    async def note_history(note_id: int):
+        return Page(title="History")
+
+    note_history.__module__ = "cross_module.more_pages"
+    child = note.child("/history")(note_history)
+
+    assert child.route == "/notes/{note_id}/history"
+    assert "/notes/{note_id}/history" in routes_for("cross_module")
+
+
+def test_a_child_of_a_child_fails_at_declaration():
+    note = declare("nested", "/notes/{note_id}", "note", "note_id")
+    history = declare("nested", "/history", "note_history", "note_id", parent=note)
+
+    with pytest.raises(PageRouteError, match="one child level is allowed"):
+        history.child("/deeper")
+
+
+def test_a_missing_landing_page_fails():
+    declare("no_landing", "/notes", "notes")
+
+    with pytest.raises(PageRouteError, match=r"declares 0 pages at '/'"):
+        list_pages_for_app("no_landing", "no_landing")
+
+
+def test_two_landing_pages_fail():
+    declare("two_landings", "/", "overview")
+    declare("two_landings", "/", "home")
+
+    with pytest.raises(PageRouteError, match=r"declares 2 pages at '/'"):
+        list_pages_for_app("two_landings", "two_landings")
+
+
+def test_equivalent_parameter_shapes_fail():
+    declare("same_shape", "/", "overview")
+    declare("same_shape", "/{note_id}", "note", "note_id")
+    declare("same_shape", "/{slug}", "note_by_slug", "slug")
+
+    with pytest.raises(PageRouteError, match="same shape"):
+        list_pages_for_app("same_shape", "same_shape")
+
+
+def test_a_repeated_page_name_fails():
+    declare("same_name", "/", "overview")
+    declare("same_name", "/notes", "notes")
+
+    async def notes():
+        return Page(title="Notes again")
+
+    notes.__module__ = "same_name.more_pages"
+    page("/archive")(notes)
+
+    with pytest.raises(PageRouteError, match="two pages named 'notes'"):
+        list_pages_for_app("same_name", "same_name")
+
+
+def test_a_child_must_take_its_parent_parameters():
+    declare("dropped_parameter", "/", "overview")
+    note = declare("dropped_parameter", "/notes/{note_id}", "note", "note_id")
+    declare("dropped_parameter", "/history", "note_history", parent=note)
+
+    with pytest.raises(PageRouteError, match=r"takes \[\], and its route"):
+        list_pages_for_app("dropped_parameter", "dropped_parameter")
+
+
+def test_an_extra_parameter_must_come_from_the_route():
+    declare("extra_parameter", "/", "overview")
+    declare("extra_parameter", "/notes", "notes", "note_id")
+
+    with pytest.raises(PageRouteError, match="one parameter for each route parameter"):
+        list_pages_for_app("extra_parameter", "extra_parameter")
+
+
+def test_navigation_resolves_page_labels():
+    app = load_app("field_notes")
+
+    assert [(declaration.name, declaration.label) for declaration in app.navigation_pages()] == [
+        ("notes", "notes")
+    ]
+
+
+@pytest.mark.parametrize("named", ["missing", "note", "note_history"])
+def test_navigation_takes_only_a_static_top_level_page(monkeypatch, named):
+    app = load_app("field_notes")
+    monkeypatch.setattr(app, "navigation", [named])
+
+    with pytest.raises(PageRouteError, match="static top-level page"):
+        app.navigation_pages()
+
+
+@pytest.mark.parametrize("prefix, path", [("/pages", "/one"), ("", "/pages/hidden")])
+def test_a_router_cannot_take_the_pages_segment(prefix, path):
+    app = load_app("field_notes")
+    module = ModuleType("druks_field_notes.routes")
+    module.router = APIRouter(prefix=prefix)
+    module.router.get(path)(lambda: None)
+
+    with pytest.raises(AppRouteConflict, match="serve every app's platform reads"):
+        app.get_routers([module])
+
+
+def test_two_pages_in_one_module_with_one_name_fail():
+    declare("one_module_twice", "/", "overview")
+    declare("one_module_twice", "/first", "notes")
+    declare("one_module_twice", "/second", "notes")
+
+    with pytest.raises(PageRouteError, match="two pages named 'notes'"):
+        list_pages_for_app("one_module_twice", "one_module_twice")
+
+
+def test_static_children_keep_declaration_order():
+    declare("tab_order", "/", "overview")
+    notes = declare("tab_order", "/notes", "notes")
+    declare("tab_order", "/z-last", "last_tab", parent=notes)
+    declare("tab_order", "/a-first", "first_tab", parent=notes)
+
+    assert [child.name for child in notes.children] == ["last_tab", "first_tab"]
+
+
+def test_a_positional_only_parameter_fails():
+    declare("positional_only", "/", "overview")
+
+    async def note(note_id, /):
+        return Page(title="Note")
+
+    note.__module__ = "positional_only.pages"
+    page("/notes/{note_id}")(note)
+
+    with pytest.raises(PageRouteError, match="callable by name"):
+        list_pages_for_app("positional_only", "positional_only")
+
+
+def test_a_catch_all_must_be_the_last_segment():
+    declare("late_catch_all", "/", "overview")
+    files = declare("late_catch_all", "/files/{rest:path}", "any_file", "rest")
+    declare("late_catch_all", "/metadata", "file_metadata", "rest", parent=files)
+
+    with pytest.raises(PageRouteError, match="catch-all is not the last segment"):
+        list_pages_for_app("late_catch_all", "late_catch_all")
+
+
+def test_two_children_of_different_parents_with_one_name_fail():
+    declare("shared_child_name", "/", "overview")
+    note = declare("shared_child_name", "/notes/{note_id}", "note", "note_id")
+    peer = declare("shared_child_name", "/peers/{peer_id}", "peer", "peer_id")
+    declare("shared_child_name", "/history", "history", "note_id", parent=note)
+    declare("shared_child_name", "/history", "history", "peer_id", parent=peer)
+
+    with pytest.raises(PageRouteError, match="two pages named 'history'"):
+        list_pages_for_app("shared_child_name", "shared_child_name")

--- a/docs/druks-ui.md
+++ b/docs/druks-ui.md
@@ -122,6 +122,11 @@ cause.
 - A child declaration can live in another module.
 - A child inherits every parameter of its parent route.
 - An extra child parameter must come from the relative child path.
+- A page function takes one parameter for each parameter of its route, and no
+  others. Each one must be callable by name, so a positional-only or variadic
+  parameter is a boot error.
+- A catch-all is the last segment of its route. A catch-all anywhere else would
+  swallow every route under it, so it is a boot error.
 - A static child is a tab. The parent is the first tab.
 - A parameterized child is not a tab. A `Link` reaches it.
 - A parameterized detail page shows a link back to its parent.

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -67,6 +67,7 @@ package modules:
 | `contracts.py` | `AgentOutput` contracts |
 | `schemas.py` | HTTP responses and subject summaries |
 | `routes.py` | FastAPI routers |
+| `pages.py` | `@page` declarations that return `Page` objects |
 | `subscribers.py` | signal reactions |
 | `webhooks.py` | Optional authenticated provider deliveries |
 | `services.py` | Optional `Service` declarations for appliance credentials at external providers |
@@ -74,8 +75,8 @@ package modules:
 | `dist/` | optional built frontend module, mounted inside the shell (served under `/app/<name>`) |
 
 Druks recursively discovers leaf modules named `workflows`, `tasks`, `routes`,
-`subscribers`, `webhooks`, and `services`. A capability hidden in `workflow.py` is not
-discovered. Ordinary names such as `policy.py` and `workspace.py` have no import
+`pages`, `subscribers`, `webhooks`, and `services`. A capability hidden in
+`workflow.py` is not discovered. Ordinary names such as `policy.py` and `workspace.py` have no import
 side effect unless a discovered module imports them.
 
 ## Declare the app
@@ -772,9 +773,11 @@ Two spellings run through druks, and which one a segment wears says who owns it:
 
 Thus, `/api/review/pull_request` is the subject board for review runs.
 `/api/review/reviews` is the resource that your POST creates. The platform
-matches `<subject_type>` and `transcripts` before your routers. A custom router
-cannot take a platform read, including through a catch-all. Name the router for
-its resource to prevent a conflict.
+matches `<subject_type>`, `transcripts`, and `pages` before your routers. A
+custom router cannot take a platform read, including through a catch-all.
+`transcripts` and `pages` are reserved: a subject type or a router prefix that
+takes one fails the load. Name the router for its resource to prevent a
+conflict.
 
 ## Declare a service
 
@@ -1143,11 +1146,63 @@ DBOS system tables through DBOS database migrations. It does not reset or drop a
 schema. It rolls back each test write through `druks_db`. `druks_redis`
 runs `FLUSHDB` on the test index.
 
-## Frontends
+## Declare pages
 
-An app declares its screens in Python and ships no JavaScript. The
-[Druks UI contract](druks-ui.md) holds the page declarations, the block,
-value, and field catalog, actions, and liveness.
+An app declares its screens in Python and ships no JavaScript. Pages live in
+`pages.py`:
+
+```python
+from druks.ui import Page, page
+
+
+@page("/")
+async def reports():
+    return Page(title="Reports", description="Every sweep this install ran.")
+
+
+@page("/peers/{peer_id}")
+async def peer(peer_id: int):
+    return Page(title=f"Peer {peer_id}")
+
+
+@peer.child("/history")
+async def peer_history(peer_id: int):
+    return Page(title=f"Peer {peer_id} history")
+```
+
+`@page` declares a top-level page. `@parent.child` declares a page under it,
+one level deep. A page function takes one parameter for each parameter of its
+route, so a child inherits its parent's. It needs no return annotation.
+
+Exactly one page declares `/`. That page is the one the app opens on. A static
+child renders as a tab on its parent. A parameterized child is a detail page a
+`Link` reaches.
+
+The page name is the function name. The page label is that name with its
+underscores as spaces, and `label=` overrides it.
+
+`App.pages()` enumerates the pages in route-match order: literal segments
+before parameters, at every depth. Declaration order never decides a match.
+
+`navigation` names the pages the appbar shows as subnav tabs, in order. Each
+one must be a static top-level page. The tab wears the page's label, so an app
+never spells a label twice:
+
+```python
+class NightWatch(App):
+    name = "night_watch"
+    navigation = ["reports"]
+```
+
+Druks checks the whole table at boot. A missing landing page, a repeated page
+name, a nested child, two routes a request could not tell apart, a signature
+that does not match its route, or a navigation entry that is not a static
+top-level page fails the load, with the app name and the exact cause.
+
+The [Druks UI contract](druks-ui.md) holds the block, value, and field catalog,
+actions, and liveness.
+
+## Frontends
 
 An installed app is visible in the dashboard without a custom UI. The shell
 reads the installed roster from `/api/apps`. It gives each app an entry in the
@@ -1158,18 +1213,11 @@ summary fields form the board row.
 No additional declaration is necessary.
 The shell derives the switcher label from `name` (underscores become spaces).
 
-The app declares chrome contributions as data. `navigation` on the app class
-adds appbar subnav tabs as `(url, name)` pairs. The shell shows these tabs for
-generic pages and shipped frontends. The active tab has the URL that is the
-longest prefix of the current location:
+An app that needs full control of its interface ships a frontend instead. Its
+pages are its own JavaScript, so it declares its own tabs there and leaves
+`App.navigation` empty.
 
-```python
-class NightWatch(App):
-    name = "night_watch"
-    navigation = [("/night_watch", "reports")]
-```
-
-To add custom pages, ship a frontend. It is an ES module that the shell mounts
+The frontend is an ES module that the shell mounts
 inside its own document, below the chrome. The scaffold ships a placeholder
 `druks_night_watch/dist/entry.js`. Set the frontend build output to that `dist/`
 directory. The contract uses `shellApi: 1`:
@@ -1212,6 +1260,7 @@ Import from concern namespaces, not from `druks.durable` or internal modules:
 | `druks.sandbox` | `Sandbox` |
 | `druks.db` | `Base`, `StoredSubject`, `db_session` |
 | `druks.schemas` | `BaseResponse` |
+| `druks.ui` | `Page`, `page` |
 | `druks.signals` | `subscribe` |
 | `druks.events` | `Event` |
 | `druks.files` | `File`, `FileField` |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -152,9 +152,10 @@ function AppShell() {
 
   const home = app ? appHome(app) : '/'
   const accentColor = app ? accent[app] : undefined
-  // The subnav tabs the app declared on its backend class, off the roster —
-  // the one nav channel, for bundled and installed apps alike.
-  const navigation = rosterQuery.data?.find((entry) => entry.name === app)?.navigation
+  // The subnav tabs: an app that owns its own pages in JavaScript declares
+  // them in its registry entry, and a Python-page app gets them from the
+  // roster, resolved from its declared pages.
+  const navigation = ui?.navigation ?? rosterQuery.data?.find((entry) => entry.name === app)?.navigation
 
   return (
     <>

--- a/frontend/src/apps/registry.tsx
+++ b/frontend/src/apps/registry.tsx
@@ -2,11 +2,12 @@ import type { ReactNode } from 'react'
 
 // The client-side app-UI registry: how an app contributes frontend.
 // An app calls ``registerAppUI`` once at import time with the routes
-// its pages live at; the shell mounts them. Subnav tabs are not part of this —
-// every app declares those on its backend class, and the shell renders them
-// from the roster. An app that registers nothing still gets feed, settings,
-// and usage from the shell for free — those are platform surfaces, not
-// per-app contributions.
+// its pages live at; the shell mounts them. An app whose pages are its own
+// JavaScript declares its subnav tabs here too, because only it knows those
+// URLs; an app whose pages are Python declarations gets its tabs from the
+// roster. An app that registers nothing still gets feed, settings, and usage
+// from the shell for free — those are platform surfaces, not per-app
+// contributions.
 
 // One route an app mounts. ``path`` is a wouter pattern under the router base
 // (e.g. ``/software_factory`` or ``/software_factory/work-items/:slug``); ``render`` receives the matched
@@ -22,6 +23,10 @@ export interface AppUI {
   // The path the brand + dropdown land on (defaults to ``/<name>``).
   home?: string
   routes: AppRoute[]
+  // Subnav tabs as (url, label) pairs, for an app whose pages are its own
+  // JavaScript. A Python-page app leaves this off and declares
+  // ``App.navigation`` on its backend class instead.
+  navigation?: [string, string][]
   // Where a feed row about one of this app's subjects navigates. The shell knows
   // an app has subjects, never where its pages put them.
   subjectPath?: (subject: { type: string; id: string }) => string | undefined

--- a/frontend/src/apps/software_factory/ui.tsx
+++ b/frontend/src/apps/software_factory/ui.tsx
@@ -9,12 +9,17 @@ import { WorkItemPage } from './WorkItemPage'
 import { WorkItemsPage } from './WorkItemsPage'
 
 // Software Factory contributes its UI through the same registry any app uses — its pages
-// are not the app's spine, they're one app's routes. The subnav tabs come from
-// the app's backend declaration; feed, settings, and usage it gets for free.
+// are not the app's spine, they're one app's routes. Its pages are React, so it
+// declares its own tabs; feed, settings, and usage it gets for free.
 registerAppUI({
   name: SOFTWARE_FACTORY,
   home: `/${SOFTWARE_FACTORY}`,
   systemStrip: true,
+  navigation: [
+    [`/${SOFTWARE_FACTORY}`, 'active'],
+    [`/${SOFTWARE_FACTORY}/history`, 'history'],
+    [`/${SOFTWARE_FACTORY}/projects`, 'projects'],
+  ],
   // Software Factory's other subject, a project repo, has no page of its own — a row about one
   // stays unclickable rather than landing on the work item that shares its id.
   subjectPath: ({ type, id }) => (type === 'work_item' ? `/${SOFTWARE_FACTORY}/work-items/${id}` : undefined),


### PR DESCRIPTION
ENG-900

Adds `druks.ui`, the surface an app uses to declare its screens in Python.

## What it does

An app declares pages in `pages.py`, which app discovery imports beside
`routes.py`:

```python
from druks.ui import Page, page


@page("/")
async def notes():
    return Page(title="Notes")


@page("/notes/{note_id}")
async def note(note_id: int):
    return Page(title=f"Note {note_id}")


@note.child("/history")
async def note_history(note_id: int):
    return Page(title="History")
```

A page function needs no return annotation. The route names `Page` as its
response model, so writing it again on every function says nothing.

`App.pages()` imports the module and returns the route table in match order:
literal segments before parameters before catch-alls, at every depth. What an
app declares first never decides what a request matches.

The load fails with the app name and the exact cause on:

- no landing page, or more than one
- a repeated page name
- a child of a child
- two routes a request could not tell apart, such as `/{id}` and `/{slug}`
- a catch-all that is not the last segment
- a signature that does not match its route, or a parameter FastAPI cannot
  fill by name
- a navigation entry that is not a static top-level page

Pages register through the same `Registry` as webhooks, services, workflows,
and agents, and `pages` joins the capability modules discovery walks. Two
pages that claim one key raise there, like every other capability.

`pages` also joins `transcripts` as a reserved segment under `/api/<app>`.
Neither a subject type nor an app router can take it.

`App.navigation` now names pages. The roster derives each tab's url and label
from the page it names, so an app never spells a label twice. An app whose
pages are its own JavaScript declares its tabs in its frontend registration,
which is where Software Factory's now live.

## How it is verified

`backend/tests/test_ui_pages.py` covers route composition, parameter
inheritance, precedence at top level and under a child, catch-all ordering,
tab order, cross-module children, and every boot error above. The proof app
declares five pages, so the suite exercises real discovery.

Gates run: `uv run ruff check backend`, `uv run ruff format --check backend`,
`npm --prefix frontend run lint`, `npm --prefix frontend test` (119 tests
pass), `npm --prefix frontend run build`. `uv run pytest backend/` did not run:
this machine has no Postgres or Redis. The 22 page tests were run directly
instead, and all pass.
