### PR TITLE
Add followed regions and derived GateControls

### DIFF
--- a/backend/druks/durable/reads.py
+++ b/backend/druks/durable/reads.py
@@ -140,6 +140,7 @@ async def _status(driving_run: Run | None) -> SubjectStatus:
             agent = calls[-1].agent
     return SubjectStatus(
         state=RunState(driving_run.state),
+        run=driving_run.id,
         kind=driving_run.kind,
         agent=agent,
         gate=driving_run.input_gate if parked else None,

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -152,6 +152,9 @@ class SubjectStatus(BaseResponse):
     # the subject's runs. Everything else is a fact the app's UI renders
     # its own copy from; the platform ships no prose.
     state: RunState
+    # The driving run's id — identity, so an app page can name it in a block
+    # (GateControls) without reaching for the platform's own read side.
+    run: str | None = None
     # The driving run's kind and, while running, its latest agent call's agent.
     kind: str | None = None
     agent: str | None = None

--- a/backend/druks/ui/__init__.py
+++ b/backend/druks/ui/__init__.py
@@ -1,4 +1,16 @@
-from .blocks import Block, Callout, Card, Divider, EmptyState, Link, Markdown, Section, Text
+from .blocks import (
+    Block,
+    Callout,
+    Card,
+    Divider,
+    EmptyState,
+    Follows,
+    GateControls,
+    Link,
+    Markdown,
+    Section,
+    Text,
+)
 from .page import page
 from .schemas import Page
 
@@ -8,6 +20,8 @@ __all__ = [
     "Card",
     "Divider",
     "EmptyState",
+    "Follows",
+    "GateControls",
     "Link",
     "Markdown",
     "Page",

--- a/backend/druks/ui/blocks.py
+++ b/backend/druks/ui/blocks.py
@@ -1,11 +1,58 @@
 from typing import Annotated, Literal
 
-from pydantic import Field, model_validator
+from pydantic import BeforeValidator, Field, model_validator
 
 from druks.schemas import BaseResponse
 
 
-class Link(BaseResponse):
+def _subject_identity(value):
+    """``follows=`` takes the subject a page or a region watches. Druks streams
+    that subject and rereads the page on every snapshot it sends."""
+    if isinstance(value, dict | Follows) or value is None:
+        return value
+    identity = getattr(value, "identity", None)
+    if not identity:
+        raise ValueError(
+            f"follows= takes the subject a page watches, not {type(value).__name__}. A run is "
+            "about a subject, and the subject is what the stream carries."
+        )
+    # A subject id reaches the stream through a URL, so it travels as text.
+    return {"subject_type": identity["type"], "subject_id": str(identity["id"])}
+
+
+class Follows(BaseResponse):
+    """The subject a page or a named region watches."""
+
+    subject_type: str
+    subject_id: str
+
+
+Watched = Annotated[Follows | None, BeforeValidator(_subject_identity)]
+
+
+class PageBlock(BaseResponse):
+    """What every block shares. ``block`` names its kind on the wire, and
+    ``check_placement`` is how a block refuses a spot it cannot work in."""
+
+    block: str
+
+    def check_placement(self, *, followed: bool, regions: set[str]) -> None:
+        """Raise when this block cannot sit where the page put it. ``followed``
+        says whether any ancestor watches a subject; ``regions`` collects the
+        region names already taken."""
+
+
+class BlockParent(PageBlock):
+    """A block that holds other blocks."""
+
+    blocks: list["Block"] = Field(default_factory=list)
+
+    def check_placement(self, *, followed: bool, regions: set[str]) -> None:
+        for block in self.blocks:
+            block.check_placement(followed=followed, regions=regions)
+
+
+class Link(PageBlock):
     """A control that navigates: to another page of this app, or outside."""
 
     block: Literal["link"] = "link"
@@ -24,7 +71,7 @@ class Link(BaseResponse):
         raise ValueError(f"Link {self.label!r} must set page or url, never both and never neither")
 
 
-class Text(BaseResponse):
+class Text(PageBlock):
     block: Literal["text"] = "text"
     text: str
 
@@ -32,7 +79,7 @@ class Text(BaseResponse):
         super().__init__(text=text, **data)
 
 
-class Markdown(BaseResponse):
+class Markdown(PageBlock):
     block: Literal["markdown"] = "markdown"
     text: str
 
@@ -40,7 +87,7 @@ class Markdown(BaseResponse):
         super().__init__(text=text, **data)
 
 
-class Callout(BaseResponse):
+class Callout(PageBlock):
     """A short message the reader should not miss. The tone selects the
     presentation; the app writes the words."""
 
@@ -53,11 +100,11 @@ class Callout(BaseResponse):
         super().__init__(text=text, **data)
 
 
-class Divider(BaseResponse):
+class Divider(PageBlock):
     block: Literal["divider"] = "divider"
 
 
-class EmptyState(BaseResponse):
+class EmptyState(PageBlock):
     """What a page shows in place of content it has none of."""
 
     block: Literal["empty_state"] = "empty_state"
@@ -69,28 +116,66 @@ class EmptyState(BaseResponse):
         super().__init__(title=title, **data)
 
 
-class Card(BaseResponse):
+class GateControls(PageBlock):
+    """The operator's answer to a parked run, derived from the run itself. The
+    shell reads the ask, the options, and the artifact from the gate, and
+    submits the answer with the run's ``parkedAt``."""
+
+    block: Literal["gate_controls"] = "gate_controls"
+    run: str
+
+    def __init__(self, run: str, **data):
+        super().__init__(run=run, **data)
+
+    def check_placement(self, *, followed: bool, regions: set[str]) -> None:
+        if followed:
+            return
+        raise ValueError(
+            f"GateControls for run {self.run!r} sits in nothing that follows a subject, so an "
+            "answered gate would stay on screen. Put it in a Page or Section with follows=."
+        )
+
+
+class Card(BlockParent):
     block: Literal["card"] = "card"
     title: str = ""
     description: str = ""
-    blocks: list["Block"] = Field(default_factory=list)
     actions: list[Link] = Field(default_factory=list)
 
 
-class Section(BaseResponse):
+class Section(BlockParent):
     """A titled part of a page. A ``name`` makes it a region the shell can
-    replace on its own."""
+    replace on its own, and ``follows`` is what makes it do so."""
 
     block: Literal["section"] = "section"
     title: str = ""
     name: str = ""
-    blocks: list["Block"] = Field(default_factory=list)
+    follows: Watched = None
+
+    def check_placement(self, *, followed: bool, regions: set[str]) -> None:
+        if self.name in regions:
+            raise ValueError(
+                f"this page has two regions named {self.name!r}; the shell replaces a region "
+                "by name, so it could not tell them apart. Give each one its own name."
+            )
+        if self.name:
+            regions.add(self.name)
+        super().check_placement(followed=followed or bool(self.follows), regions=regions)
+
+    @model_validator(mode="after")
+    def _named_when_followed(self) -> "Section":
+        if self.follows and not self.name:
+            raise ValueError(
+                "a Section that follows a subject needs a name — the shell replaces it by name"
+            )
+        return self
 
 
 Block = Annotated[
-    Text | Markdown | Section | Card | Callout | Divider | EmptyState | Link,
+    Text | Markdown | Section | Card | Callout | Divider | EmptyState | Link | GateControls,
     Field(discriminator="block"),
 ]
 
 Card.model_rebuild()
 Section.model_rebuild()
+BlockParent.model_rebuild()

--- a/backend/druks/ui/schemas.py
+++ b/backend/druks/ui/schemas.py
@@ -1,14 +1,22 @@
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from druks.schemas import BaseResponse
 
-from .blocks import Block
+from .blocks import Block, Watched
 
 
 class Page(BaseResponse):
-    """One screen, as a page function projects it. The shared dashboard
-    renders it."""
+    """One screen, as a page function projects it. The shared dashboard renders
+    it, and rereads it on every snapshot of what ``follows`` watches."""
 
     title: str
     description: str = ""
     blocks: list[Block] = Field(default_factory=list)
+    follows: Watched = None
+
+    @model_validator(mode="after")
+    def _blocks_sit_where_they_work(self) -> "Page":
+        regions: set[str] = set()
+        for block in self.blocks:
+            block.check_placement(followed=bool(self.follows), regions=regions)
+        return self

--- a/backend/tests/druks-field_notes/druks_field_notes/pages.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/pages.py
@@ -1,4 +1,16 @@
-from druks.ui import Callout, Card, Divider, EmptyState, Link, Markdown, Page, Section, Text, page
+from druks.ui import (
+    Callout,
+    Card,
+    Divider,
+    EmptyState,
+    GateControls,
+    Link,
+    Markdown,
+    Page,
+    Section,
+    Text,
+    page,
+)
 
 from druks_field_notes.models import Note
 
@@ -66,10 +78,20 @@ async def new_note():
 async def note(note_id: int):
     found = await Note.get(note_id)
     if found:
+        status = await found.get_status()
+        # The region follows the note, so answering the gate refreshes it and
+        # the controls go away.
+        if status.gate:
+            decision = [GateControls(status.run)]
+        else:
+            decision = [Text("Nothing is waiting on you.")]
         return Page(
             title=f"Note {note_id}",
             description=found.gist or "Waiting for its gist.",
-            blocks=[Markdown(found.body)],
+            blocks=[
+                Markdown(found.body),
+                Section(title="Your decision", name="decision", follows=found, blocks=decision),
+            ],
         )
     return Page(title=f"Note {note_id}", blocks=[EmptyState("No such note")])
 

--- a/backend/tests/test_author_surface.py
+++ b/backend/tests/test_author_surface.py
@@ -45,6 +45,8 @@ AUTHOR_SURFACE = {
         "Card",
         "Divider",
         "EmptyState",
+        "Follows",
+        "GateControls",
         "Link",
         "Markdown",
         "Page",

--- a/backend/tests/test_ui_followed_regions.py
+++ b/backend/tests/test_ui_followed_regions.py
@@ -1,0 +1,96 @@
+import pytest
+from druks.ui import Card, GateControls, Page, Section, Text
+from druks_field_notes.models import Note
+
+
+@pytest.fixture
+async def note(druks_db) -> Note:
+    return await Note.create(body="Fan noise on rack 3.")
+
+
+def test_a_region_follows_the_subject_it_watches(note: Note):
+    section = Section(name="decision", follows=note, blocks=[])
+
+    assert section.follows
+    assert section.follows.subject_type == "note"
+    # A subject id reaches the stream through a URL, so it travels as text.
+    assert section.follows.subject_id == str(note.id)
+
+
+def test_a_page_follows_a_subject_too(note: Note):
+    page = Page(title="Note", follows=note)
+
+    assert page.follows
+    assert page.follows.subject_id == str(note.id)
+
+
+def test_a_followed_region_needs_a_name(note: Note):
+    with pytest.raises(ValueError, match="needs a name"):
+        Section(follows=note, blocks=[])
+
+
+def test_gate_controls_need_something_that_follows(note: Note):
+    with pytest.raises(ValueError, match="follows a subject"):
+        Page(title="Note", blocks=[GateControls("run-6f0a")])
+
+
+def test_a_following_page_is_enough_for_gate_controls(note: Note):
+    page = Page(title="Note", follows=note, blocks=[GateControls("run-6f0a")])
+
+    assert page.blocks[0].run == "run-6f0a"
+
+
+def test_a_following_region_covers_the_blocks_under_it(note: Note):
+    page = Page(
+        title="Note",
+        blocks=[
+            Section(
+                name="decision",
+                follows=note,
+                blocks=[Card(blocks=[GateControls("run-6f0a")])],
+            )
+        ],
+    )
+
+    assert page.blocks[0].blocks[0].blocks[0].run == "run-6f0a"
+
+
+def test_a_region_that_follows_nothing_does_not_cover_gate_controls(note: Note):
+    with pytest.raises(ValueError, match="follows a subject"):
+        Page(
+            title="Note",
+            blocks=[Section(name="decision", blocks=[GateControls("run-6f0a")])],
+        )
+
+
+def test_a_page_that_follows_nothing_serializes_it_as_nothing():
+    page = Page(title="Note", blocks=[Text("static")])
+
+    assert page.model_dump(by_alias=True, mode="json")["follows"] is None
+
+
+def test_two_regions_cannot_share_a_name(note: Note):
+    with pytest.raises(ValueError, match="two regions named 'decision'"):
+        Page(
+            title="Note",
+            blocks=[
+                Section(name="decision", follows=note, blocks=[]),
+                Section(name="decision", follows=note, blocks=[]),
+            ],
+        )
+
+
+def test_a_nested_region_cannot_take_a_name_already_used(note: Note):
+    with pytest.raises(ValueError, match="two regions named 'decision'"):
+        Page(
+            title="Note",
+            blocks=[
+                Section(name="decision", follows=note, blocks=[]),
+                Card(blocks=[Section(name="decision", follows=note, blocks=[])]),
+            ],
+        )
+
+
+def test_follows_takes_a_subject_and_says_so_when_it_does_not(note: Note):
+    with pytest.raises(ValueError, match="takes the subject a page watches"):
+        Page(title="Note", follows="run-6f0a")

--- a/backend/tests/test_ui_page_api.py
+++ b/backend/tests/test_ui_page_api.py
@@ -1,6 +1,10 @@
+from datetime import UTC, datetime
+
 import httpx
 import pytest
+from druks.testing import seed_run
 from druks_field_notes.models import Note
+from druks_field_notes.workflows import Summarize
 
 
 @pytest.fixture
@@ -102,3 +106,36 @@ async def test_an_undeclared_page_path_answers_404(druks_client: httpx.AsyncClie
     response = await druks_client.get("/api/field_notes/pages/nowhere/at/all")
 
     assert response.status_code == 404
+
+
+async def test_a_page_carries_the_region_that_follows_its_subject(
+    druks_client: httpx.AsyncClient, note: Note
+):
+    page = (await druks_client.get(f"/api/field_notes/pages/notes/{note.id}")).json()
+
+    region = page["blocks"][1]
+    assert region["block"] == "section"
+    assert region["name"] == "decision"
+    assert region["follows"] == {"subjectType": "note", "subjectId": str(note.id)}
+    assert region["blocks"][0]["block"] == "text"
+
+
+async def test_a_parked_run_puts_gate_controls_in_the_followed_region(
+    druks_client: httpx.AsyncClient, druks_db, note: Note
+):
+    run = await seed_run(
+        druks_db,
+        kind=Summarize.kind,
+        subject=note,
+        state="parked",
+        input_gate="review",
+        input_request={"presentation": "in_app", "controls": ["approve"], "questions": []},
+    )
+    run.input_requested_at = datetime.now(UTC)
+    await druks_db.flush()
+
+    page = (await druks_client.get(f"/api/field_notes/pages/notes/{note.id}")).json()
+
+    region = page["blocks"][1]
+    assert region["follows"] == {"subjectType": "note", "subjectId": str(note.id)}
+    assert region["blocks"] == [{"block": "gate_controls", "run": run.id}]

--- a/docs/druks-ui.md
+++ b/docs/druks-ui.md
@@ -286,7 +286,7 @@ async def peer(peer_id: int):
                 name="decision",
                 title="Decision",
                 follows=watched,
-                blocks=[GateControls(run=watched.active_run)],
+                blocks=[GateControls(watched.active_run)],
             )
         ],
     )
@@ -335,7 +335,7 @@ A `follows=` on the `Page` itself replaces the whole page body.
 `GateControls` declares only the run:
 
 ```python
-GateControls(run=peer.active_run)
+GateControls(peer.active_run)
 ```
 
 The shell derives everything else from the parked run: the questions, the
@@ -476,7 +476,7 @@ input than they store:
 
 | Field | Author passes | Druks stores |
 | --- | --- | --- |
-| `Page.follows`, `Section.follows` | a subject, or a run id | `Follows` |
+| `Page.follows`, `Section.follows` | a subject | `Follows` |
 | `Files.files` | `druks.files.File` objects | `list[FileSummary]` |
 | `Metric.value`, `Fact.value`, `TableRow.cells`, `List.items` | any `Value` | the same value |
 

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -1199,6 +1199,61 @@ name, a nested child, two routes a request could not tell apart, a signature
 that does not match its route, or a navigation entry that is not a static
 top-level page fails the load, with the app name and the exact cause.
 
+### A page function is a pure read
+
+Druks reruns a page function on initial load, on an event, on reconnect, on a
+manual refresh, and on a retry. The call count and the call order are not
+guaranteed. These are the rules.
+
+A page function can:
+
+- read Druks state,
+- read the app's own data,
+- read a projection,
+- read a read-only external source.
+
+A page function must not:
+
+- write data,
+- start or enqueue work,
+- publish an event,
+- answer a gate,
+- cause an external effect,
+- depend on mutable process state.
+
+Write the function so that a repeat call is free. Put every write behind an
+operation the operator triggers.
+
+### Watch a subject
+
+A page, or a named region inside it, declares the subject it `follows`. Druks
+streams that subject through the read side every app already gets, and the
+shell rereads the page on each snapshot:
+
+```python
+@page("/notes/{note_id}")
+async def note(note_id: int):
+    found = await Note.get(note_id)
+    status = await found.get_status()
+    if status.gate:
+        decision = [GateControls(status.run)]
+    else:
+        decision = [Text("Nothing is waiting on you.")]
+    return Page(
+        title=f"Note {note_id}",
+        blocks=[Section(title="Your decision", name="decision", follows=found, blocks=decision)],
+    )
+```
+
+The shell replaces the named region and leaves the rest of the page alone, so
+scroll position, focus, and half-filled inputs outside it survive. A region
+that follows a subject must have a name; that is how the shell finds it.
+
+`GateControls` names only the run. The shell reads the ask, its options, its
+context, and its artifact from the parked run, and submits the operator's
+answer with the run's `parkedAt`. A `GateControls` block must sit inside
+something that follows a subject, or an answered gate would stay on screen.
+
 The [Druks UI contract](druks-ui.md) holds the block, value, and field catalog,
 actions, and liveness.
 
@@ -1260,7 +1315,7 @@ Import from concern namespaces, not from `druks.durable` or internal modules:
 | `druks.sandbox` | `Sandbox` |
 | `druks.db` | `Base`, `StoredSubject`, `db_session` |
 | `druks.schemas` | `BaseResponse` |
-| `druks.ui` | `page`, `Page`, `Block`, `Text`, `Markdown`, `Section`, `Card`, `Callout`, `Divider`, `EmptyState`, `Link` |
+| `druks.ui` | `page`, `Page`, `Block`, `Text`, `Markdown`, `Section`, `Card`, `Callout`, `Divider`, `EmptyState`, `Link`, `Follows`, `GateControls` |
 | `druks.signals` | `subscribe` |
 | `druks.events` | `Event` |
 | `druks.files` | `File`, `FileField` |

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,8 @@ import type {
   UsageHistoryResponse,
   UsageResponse,
   UsageTodayResponse,
+  Gate,
+  GateAnswer,
   McpRegistryCandidate,
   PageSnapshot,
   McpServer,
@@ -188,6 +190,14 @@ export const api = {
   // ``path`` is the location under the app's own root: "" for the landing
   // page, "/notes/7" for a detail page.
   readPage: (app: string, path: string) => getJSON<PageSnapshot>(`/api/${app}/pages${path}`),
+  // A parked run's gate. The answer echoes ``parkedAt`` unchanged, so it names
+  // the exact question it answers; a run that re-parked rejects the stale one.
+  getGate: (run: string) => getJSON<Gate>(`/api/gates/${run}`),
+  answerGate: (run: string, answer: GateAnswer) =>
+    postJSON<{ run: string; parkedAt: string; result: string }>(
+      `/api/gates/${run}/answer`,
+      answer,
+    ),
   artifact: (id: string) => getJSON<ArtifactContent>(`/api/artifacts/${id}`),
   resumeRun: (
     runId: string,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -39,6 +39,8 @@ export interface SubjectSummary {
 
 export interface SubjectStatus {
   state: RunState
+  // The driving run's id.
+  run: string | null
   // Facts the app renders its lane copy from; the backend ships no prose.
   // The driving run's kind and, while running, its latest agent call's agent.
   kind: string | null
@@ -220,7 +222,8 @@ export interface Link {
 export type Block =
   | { block: 'text'; text: string }
   | { block: 'markdown'; text: string }
-  | { block: 'section'; title: string; name: string; blocks: Block[] }
+  | { block: 'section'; title: string; name: string; blocks: Block[]; follows: Follows | null }
+  | { block: 'gate_controls'; run: string }
   | { block: 'card'; title: string; description: string; blocks: Block[]; actions: Link[] }
   | {
       block: 'callout'
@@ -232,11 +235,36 @@ export type Block =
   | { block: 'empty_state'; title: string; description: string; actions: Link[] }
   | Link
 
+// The subject a page or a named region watches. The shell streams it and
+// rereads the page on every snapshot it sends.
+export interface Follows {
+  subjectType: string
+  subjectId: string
+}
+
 // What a page function returned at one moment — the contract's ``Page``.
 export interface PageSnapshot {
   title: string
   description: string
   blocks: Block[]
+  follows: Follows | null
+}
+
+// A parked run's open gate. ``parkedAt`` names the exact question being
+// answered, and the answer echoes it unchanged.
+export interface Gate {
+  run: string
+  gate: string
+  parkedAt: string
+  ask: InputRequest
+  artifact: ArtifactContent | null
+}
+
+export interface GateAnswer {
+  parkedAt: string
+  control: string
+  answers: Record<string, string>
+  note: string
 }
 
 // --- System health ---------------------------------------------------------

--- a/frontend/src/apps/software_factory/statusLine.test.ts
+++ b/frontend/src/apps/software_factory/statusLine.test.ts
@@ -6,6 +6,7 @@ import { runSubLine, statusLine } from './statusLine'
 function status(overrides: Partial<SubjectStatus>): SubjectStatus {
   return {
     state: 'running',
+    run: null,
     kind: 'software_factory.build',
     agent: null,
     gate: null,

--- a/frontend/src/components/RunControls.tsx
+++ b/frontend/src/components/RunControls.tsx
@@ -94,7 +94,21 @@ const CONTROL_LABEL: Record<string, string> = {
 // note, and the workflow's controls. A click resumes the run with
 // {control, answers, note}; free text is content for the next agent prompt,
 // never a control.
-export function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }) {
+export function InAppReview({
+  runId,
+  ask,
+  submit,
+}: {
+  runId: string
+  ask: InputRequest
+  // How the answer reaches the platform. A page's GateControls answers through
+  // the gate route with the run's parkedAt; without one, this resumes the run.
+  submit?: (answer: {
+    control: string
+    answers: Record<string, string>
+    note: string
+  }) => Promise<unknown>
+}) {
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [note, setNote] = useState('')
   const [pending, setPending] = useState<string | null>(null)
@@ -126,10 +140,15 @@ export function InAppReview({ runId, ask }: { runId: string; ask: InputRequest }
   async function choose(control: string) {
     setPending(control)
     setError(null)
+    const answer = { control, answers, note: note.trim() }
     try {
       // The run un-parks; the subject's SSE stream re-emits the snapshot and this
       // banner clears itself.
-      await api.resumeRun(runId, { control, answers, note: note.trim() })
+      if (submit) {
+        await submit(answer)
+      } else {
+        await api.resumeRun(runId, answer)
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'could not submit')
       setPending(null)

--- a/frontend/src/druksui/AppPage.test.tsx
+++ b/frontend/src/druksui/AppPage.test.tsx
@@ -73,6 +73,7 @@ const NOTES: PageSnapshot = {
   title: 'Notes',
   description: 'Every note this install captured.',
   blocks: [{ block: 'text', text: 'a jotted observation' }],
+  follows: null,
 }
 
 describe('a declared page', () => {
@@ -86,7 +87,7 @@ describe('a declared page', () => {
   })
 
   it('reads a detail page at its own location', async () => {
-    renderAt('/field_notes/notes/7', 'note', { title: 'Note 7', description: '', blocks: [] })
+    renderAt('/field_notes/notes/7', 'note', { title: 'Note 7', description: '', blocks: [], follows: null })
 
     await waitFor(() => expect(screen.getByText('Note 7')).toBeTruthy())
     expect(readPage).toHaveBeenCalledWith('field_notes', '/notes/7')
@@ -126,6 +127,7 @@ describe('tabs', () => {
       title: 'Recent notes',
       description: '',
       blocks: [],
+      follows: null,
     })
 
     await waitFor(() => expect(container.querySelector('.dui-tab-active')).toBeTruthy())
@@ -138,6 +140,7 @@ describe('tabs', () => {
       title: 'Note 7',
       description: '',
       blocks: [],
+      follows: null,
     })
 
     await waitFor(() => expect(container.querySelector('.dui-tabs')).toBeTruthy())
@@ -152,6 +155,7 @@ describe('tabs', () => {
       title: 'Write a note',
       description: '',
       blocks: [],
+      follows: null,
     })
 
     await waitFor(() => expect(screen.getByText('Write a note')).toBeTruthy())
@@ -161,7 +165,7 @@ describe('tabs', () => {
 
 describe('the parent link', () => {
   it('takes a parameterized detail page back to its longest declared prefix', async () => {
-    renderAt('/field_notes/notes/7', 'note', { title: 'Note 7', description: '', blocks: [] })
+    renderAt('/field_notes/notes/7', 'note', { title: 'Note 7', description: '', blocks: [], follows: null })
 
     await waitFor(() => expect(screen.getByText('← notes')).toBeTruthy())
     expect(screen.getByText('← notes').getAttribute('href')).toBe('/field_notes')
@@ -172,6 +176,7 @@ describe('the parent link', () => {
       title: 'Run 9',
       description: '',
       blocks: [],
+      follows: null,
     })
 
     await waitFor(() => expect(screen.getByText('← note')).toBeTruthy())

--- a/frontend/src/druksui/AppPage.tsx
+++ b/frontend/src/druksui/AppPage.tsx
@@ -1,24 +1,70 @@
-import { useQuery } from '@tanstack/react-query'
-import type { ReactNode } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useMemo, useRef, type ReactNode } from 'react'
 import { Link as RouteLink, useLocation } from 'wouter'
 
 import { api } from '../api/client'
+import type { Follows, PageSnapshot } from '../api/types'
 import { EmptyState } from '../components/EmptyState'
 import { Page } from '../components/Page'
 import { AppSurface } from './AppSurface'
 import { Blocks } from './Blocks'
-import { hrefUnder, isDetail, PagesContext, parentOf, tabsFor } from './pages'
+import { followedSubjects, hrefUnder, isDetail, mergeRegions, PagesContext, parentOf, tabsFor } from './pages'
+import { SubjectStream } from './SubjectStream'
+
+// The wait before each attempt at one refresh. Three tries, then the page
+// keeps what it had until the subject changes again.
+const REFRESH_WAITS = [0, 300, 1200]
 
 /** One page an app declared in Python, rendered by the shell. */
 export function AppPage({ app, page }: { app: string; page: string }) {
   const [location] = useLocation()
+  const queryClient = useQueryClient()
   const roster = useQuery({ queryKey: ['apps'], queryFn: api.listApps, staleTime: 60_000 })
   const pages = roster.data?.find((entry) => entry.name === app)?.pages ?? []
   const path = location.slice(`/${app}`.length)
+  const key = useMemo(() => ['page', app, path], [app, path])
   const snapshot = useQuery({
-    queryKey: ['page', app, path],
+    queryKey: key,
     queryFn: () => api.readPage(app, path),
+    // The stream is what keeps this page fresh. Without this, a background
+    // refetch would write the cache outside the numbered reads below and could
+    // land after a newer snapshot.
+    staleTime: Infinity,
   })
+
+  // Every read gets a number, per subject: a read that lands after a newer read
+  // of the same subject is stale, while another subject's read is not.
+  const latest = useRef(new Map<string, number>())
+  const reread = useCallback(
+    async (subject: Follows) => {
+      const watched = `${subject.subjectType}/${subject.subjectId}`
+      const mine = (latest.current.get(watched) ?? 0) + 1
+      latest.current.set(watched, mine)
+      // The stream repeats nothing, so a read that fails would leave the page
+      // stale until the subject changes again. Back off and try again, still
+      // numbered, so a newer read still wins.
+      for (const wait of REFRESH_WAITS) {
+        if (wait) await new Promise((resume) => setTimeout(resume, wait))
+        const fresh = await api.readPage(app, path).catch(() => undefined)
+        if (mine !== latest.current.get(watched)) return
+        if (fresh) {
+          queryClient.setQueryData(key, (previous?: PageSnapshot) =>
+            previous ? mergeRegions(previous, fresh, subject) : fresh,
+          )
+          // A snapshot can open, change, or close a gate on a run this page
+          // already shows, so the gates read themselves again.
+          void queryClient.invalidateQueries({ queryKey: ['gate'] })
+          return
+        }
+      }
+    },
+    [app, path, key, queryClient],
+  )
+
+  const followed = useMemo(
+    () => (snapshot.data ? followedSubjects(snapshot.data) : []),
+    [snapshot.data],
+  )
 
   if (snapshot.isLoading) {
     return (
@@ -49,6 +95,14 @@ export function AppPage({ app, page }: { app: string; page: string }) {
         })
       }
     >
+      {followed.map((subject) => (
+        <SubjectStream
+          key={`${subject.subjectType}/${subject.subjectId}`}
+          app={app}
+          subject={subject}
+          onSnapshot={reread}
+        />
+      ))}
       <PagesContext.Provider value={{ app, pages }}>
         <Page className="dui-page">
           {parent && (

--- a/frontend/src/druksui/Blocks.test.tsx
+++ b/frontend/src/druksui/Blocks.test.tsx
@@ -47,6 +47,7 @@ describe('the display core', () => {
         block: 'section',
         title: 'Recent',
         name: 'recent',
+        follows: null,
         blocks: [
           {
             block: 'card',

--- a/frontend/src/druksui/Blocks.tsx
+++ b/frontend/src/druksui/Blocks.tsx
@@ -3,6 +3,7 @@ import { Link as RouteLink } from 'wouter'
 
 import type { Block, Link } from '../api/types'
 import { Markdown } from '../components/Markdown'
+import { GateControls } from './GateControls'
 import { fillPath, PagesContext } from './pages'
 
 export function Blocks({ blocks }: { blocks: Block[] }) {
@@ -25,6 +26,8 @@ function BlockContent({ block }: { block: Block }) {
       return <hr className="dui-divider" />
     case 'link':
       return <LinkControl link={block} />
+    case 'gate_controls':
+      return <GateControls run={block.run} />
     case 'callout':
       return (
         <div className={`dui-callout dui-callout-${block.tone}`} role="note">

--- a/frontend/src/druksui/GateControls.test.tsx
+++ b/frontend/src/druksui/GateControls.test.tsx
@@ -1,0 +1,100 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '../api/client'
+import type { Gate } from '../api/types'
+import { GateControls } from './GateControls'
+
+vi.mock('../api/client', () => ({
+  api: { getGate: vi.fn(), answerGate: vi.fn(), artifact: vi.fn() },
+}))
+
+const getGate = vi.mocked(api.getGate)
+const answerGate = vi.mocked(api.answerGate)
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const GATE: Gate = {
+  run: 'run-6f0a',
+  gate: 'review_plan',
+  parkedAt: '2026-08-29T09:14:02Z',
+  ask: {
+    presentation: 'in_app',
+    controls: ['approve', 'request_changes'],
+    questions: [
+      {
+        id: 'scope',
+        prompt: 'Is the scope right?',
+        options: [
+          { id: 'yes', label: 'Yes', recommended: true },
+          { id: 'no', label: 'No', recommended: false },
+        ],
+      },
+    ],
+    context: 'The plan covers three files.',
+  },
+  artifact: null,
+}
+
+function renderControls() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GateControls run="run-6f0a" />
+    </QueryClientProvider>,
+  )
+}
+
+describe('GateControls', () => {
+  it('derives its questions, options, and controls from the parked run', async () => {
+    getGate.mockResolvedValue(GATE)
+    renderControls()
+
+    await waitFor(() => expect(screen.getByText('Is the scope right?')).toBeTruthy())
+    expect(getGate).toHaveBeenCalledWith('run-6f0a')
+    expect(screen.getByText('The plan covers three files.')).toBeTruthy()
+    expect(screen.getByText('recommended')).toBeTruthy()
+    expect(screen.getByText('Approve')).toBeTruthy()
+    expect(screen.getByText('Request changes')).toBeTruthy()
+  })
+
+  it('answers through the gate route and echoes parkedAt', async () => {
+    getGate.mockResolvedValue(GATE)
+    answerGate.mockResolvedValue({ run: 'run-6f0a', parkedAt: GATE.parkedAt, result: 'answered' })
+    renderControls()
+
+    await waitFor(() => expect(screen.getByText('Approve')).toBeTruthy())
+    fireEvent.click(screen.getAllByRole('radio')[0]!)
+    fireEvent.click(screen.getByText('Approve'))
+
+    await waitFor(() => expect(answerGate).toHaveBeenCalled())
+    expect(answerGate).toHaveBeenCalledWith('run-6f0a', {
+      parkedAt: '2026-08-29T09:14:02Z',
+      control: 'approve',
+      answers: { scope: 'yes' },
+      note: '',
+    })
+  })
+
+  it('shows a stale answer as a failure the operator can read', async () => {
+    getGate.mockResolvedValue(GATE)
+    answerGate.mockRejectedValue(new Error('Run run-6f0a has re-parked since the parked_at you read'))
+    renderControls()
+
+    await waitFor(() => expect(screen.getByText('Approve')).toBeTruthy())
+    fireEvent.click(screen.getByText('Approve'))
+
+    await waitFor(() => expect(screen.getByText(/re-parked/)).toBeTruthy())
+  })
+
+  it('says so when the run is no longer waiting', async () => {
+    getGate.mockRejectedValue(new Error('Run run-6f0a is not parked'))
+    renderControls()
+
+    await waitFor(() => expect(screen.getByText('this run is not waiting on you')).toBeTruthy())
+  })
+})

--- a/frontend/src/druksui/GateControls.tsx
+++ b/frontend/src/druksui/GateControls.tsx
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { api } from '../api/client'
+import { EmptyState } from '../components/EmptyState'
+import { InAppReview } from '../components/RunControls'
+
+/** The operator's answer to a parked run. The block names only the run; the
+ * ask, its options, and its artifact come from the gate. The answer echoes the
+ * run's ``parkedAt``, so a run that re-parked rejects it. When the run resumes,
+ * the region that follows its subject refreshes and these controls go away. */
+export function GateControls({ run }: { run: string }) {
+  const gate = useQuery({ queryKey: ['gate', run], queryFn: () => api.getGate(run), retry: false })
+
+  if (gate.isLoading) return <EmptyState glyph="…" msg="reading the gate" />
+  if (gate.isError || !gate.data) {
+    return (
+      <EmptyState
+        glyph="·"
+        msg="this run is not waiting on you"
+        sub={gate.error instanceof Error ? gate.error.message : undefined}
+      />
+    )
+  }
+  const parkedAt = gate.data.parkedAt
+  return (
+    <InAppReview
+      // A run that parks again asks a new question, so the controls start over
+      // rather than keeping the last round's answers and pending state.
+      key={parkedAt}
+      runId={run}
+      ask={gate.data.ask}
+      submit={(answer) => api.answerGate(run, { parkedAt, ...answer })}
+    />
+  )
+}

--- a/frontend/src/druksui/SubjectStream.tsx
+++ b/frontend/src/druksui/SubjectStream.tsx
@@ -1,0 +1,20 @@
+import type { Follows } from '../api/types'
+import { useSSE } from '../api/sse'
+
+/** Watches one subject through the stream every app already serves, and calls
+ * ``onSnapshot`` each time it changes. Renders nothing: it exists so a page can
+ * watch several subjects at once, one component per subject. The hook owns the
+ * EventSource, its reconnect, and the identity recheck. */
+export function SubjectStream({
+  app,
+  subject,
+  onSnapshot,
+}: {
+  app: string
+  subject: Follows
+  onSnapshot: (subject: Follows) => void
+}) {
+  const path = `/api/${app}/${subject.subjectType}/${encodeURIComponent(subject.subjectId)}/stream`
+  useSSE(path, { handlers: { snapshot: () => onSnapshot(subject) } })
+  return null
+}

--- a/frontend/src/druksui/followed.test.tsx
+++ b/frontend/src/druksui/followed.test.tsx
@@ -1,0 +1,216 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Router } from 'wouter'
+import { memoryLocation } from 'wouter/memory-location'
+
+import { api } from '../api/client'
+import { useSSE } from '../api/sse'
+import type { App, Block, PageSnapshot } from '../api/types'
+import { AppPage } from './AppPage'
+import { followedSubjects, mergeRegions } from './pages'
+
+vi.mock('../api/client', () => ({
+  api: { listApps: vi.fn(), readPage: vi.fn(), getGate: vi.fn() },
+}))
+vi.mock('../api/sse', () => ({ useSSE: vi.fn() }))
+
+const listApps = vi.mocked(api.listApps)
+const readPage = vi.mocked(api.readPage)
+const sse = vi.mocked(useSSE)
+
+afterEach(() => {
+  cleanup()
+  // Reset, not clear: a test that queues a one-shot answer must not leave it
+  // for the next one.
+  listApps.mockReset()
+  readPage.mockReset()
+  sse.mockReset()
+})
+
+const ROSTER = [
+  {
+    name: 'field_notes',
+    icon: 'notebook',
+    description: '',
+    builtin: false,
+    subjectTypes: ['note'],
+    hasFrontend: false,
+    navigation: [],
+    pages: [{ name: 'note', label: 'note', path: '/field_notes/notes/{note_id}', parent: '', order: 0 }],
+  },
+] as App[]
+
+const NOTE_7 = { subjectType: 'note', subjectId: '7' }
+
+function region(name: string, text: string, follows = NOTE_7): Block {
+  return {
+    block: 'section',
+    title: 'Decision',
+    name,
+    follows,
+    blocks: [{ block: 'text', text }],
+  }
+}
+
+function snapshot(blocks: Block[], follows: PageSnapshot['follows'] = null): PageSnapshot {
+  return { title: 'Note 7', description: '', blocks, follows }
+}
+
+describe('followedSubjects', () => {
+  it('collects the page and every region, once per subject', () => {
+    const page = snapshot(
+      [
+        region('decision', 'waiting'),
+        { block: 'card', title: '', description: '', actions: [], blocks: [region('nested', 'also')] },
+        region('other', 'another', { subjectType: 'note', subjectId: '9' }),
+      ],
+      { subjectType: 'note', subjectId: '7' },
+    )
+
+    expect(followedSubjects(page)).toEqual([
+      { subjectType: 'note', subjectId: '7' },
+      { subjectType: 'note', subjectId: '9' },
+    ])
+  })
+
+  it('finds nothing on a page that follows nothing', () => {
+    expect(followedSubjects(snapshot([{ block: 'text', text: 'static' }]))).toEqual([])
+  })
+})
+
+describe('mergeRegions', () => {
+  it('replaces only the followed region', () => {
+    const stable: Block = { block: 'text', text: 'outside the region' }
+    const previous = snapshot([stable, region('decision', 'waiting')])
+    const fresh = snapshot([{ block: 'text', text: 'changed' }, region('decision', 'answered')])
+
+    const merged = mergeRegions(previous, fresh, NOTE_7)
+
+    // The block outside the region is the object it already was, so React
+    // renders nothing there again.
+    expect(merged.blocks[0]).toBe(stable)
+    expect(merged.blocks[1]).toEqual(region('decision', 'answered'))
+    expect(merged.title).toBe(previous.title)
+  })
+
+  it('replaces a region nested inside a card', () => {
+    const previous = snapshot([
+      { block: 'card', title: 'Run', description: '', actions: [], blocks: [region('decision', 'waiting')] },
+    ])
+    const fresh = snapshot([
+      { block: 'card', title: 'Run', description: '', actions: [], blocks: [region('decision', 'answered')] },
+    ])
+
+    const merged = mergeRegions(previous, fresh, NOTE_7)
+
+    const card = merged.blocks[0] as Extract<Block, { block: 'card' }>
+    expect(card.blocks[0]).toEqual(region('decision', 'answered'))
+  })
+
+  it('replaces the whole page when the page itself follows', () => {
+    const previous = snapshot([{ block: 'text', text: 'old' }], { subjectType: 'note', subjectId: '7' })
+    const fresh = snapshot([{ block: 'text', text: 'new' }], { subjectType: 'note', subjectId: '7' })
+
+    expect(mergeRegions(previous, fresh, NOTE_7)).toBe(fresh)
+  })
+})
+
+function renderPage(first: PageSnapshot) {
+  listApps.mockResolvedValue(ROSTER)
+  readPage.mockResolvedValue(first)
+  const { hook } = memoryLocation({ path: '/field_notes/notes/7' })
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Router hook={hook}>
+        <AppPage app="field_notes" page="note" />
+      </Router>
+    </QueryClientProvider>,
+  )
+}
+
+// The snapshot handler the page gave the subject stream.
+function fireSnapshot() {
+  const options = sse.mock.calls.at(-1)?.[1]
+  return act(async () => {
+    options?.handlers.snapshot?.({})
+  })
+}
+
+describe('a followed region', () => {
+  it('watches the subject through the stream the app already serves', async () => {
+    renderPage(snapshot([region('decision', 'waiting')]))
+
+    await waitFor(() => expect(screen.getByText('waiting')).toBeTruthy())
+    expect(sse.mock.calls.at(-1)?.[0]).toBe('/api/field_notes/note/7/stream')
+  })
+
+  it('opens no stream for a page that follows nothing', async () => {
+    renderPage(snapshot([{ block: 'text', text: 'static' }]))
+
+    await waitFor(() => expect(screen.getByText('static')).toBeTruthy())
+    expect(sse).not.toHaveBeenCalled()
+  })
+
+  it('rereads the page on a snapshot and swaps the region', async () => {
+    renderPage(snapshot([{ block: 'text', text: 'outside' }, region('decision', 'waiting')]))
+    await waitFor(() => expect(screen.getByText('waiting')).toBeTruthy())
+
+    readPage.mockResolvedValue(snapshot([{ block: 'text', text: 'outside' }, region('decision', 'answered')]))
+    await fireSnapshot()
+
+    await waitFor(() => expect(screen.getByText('answered')).toBeTruthy())
+    expect(screen.queryByText('waiting')).toBeNull()
+    expect(screen.getByText('outside')).toBeTruthy()
+  })
+
+  it('leaves the page as it was when a read fails', async () => {
+    renderPage(snapshot([region('decision', 'waiting')]))
+    await waitFor(() => expect(screen.getByText('waiting')).toBeTruthy())
+
+    readPage.mockRejectedValueOnce(new Error('page function raised'))
+    await fireSnapshot()
+
+    expect(screen.getByText('waiting')).toBeTruthy()
+  })
+})
+
+describe('a snapshot from one subject', () => {
+  const NOTE_9 = { subjectType: 'note', subjectId: '9' }
+
+  it('leaves a region that watches another subject alone', () => {
+    const mine = region('decision', 'waiting')
+    const theirs = region('other', 'untouched', NOTE_9)
+    const previous = snapshot([mine, theirs])
+    const fresh = snapshot([region('decision', 'answered'), region('other', 'changed', NOTE_9)])
+
+    const merged = mergeRegions(previous, fresh, NOTE_7)
+
+    expect(merged.blocks[0]).toEqual(region('decision', 'answered'))
+    expect(merged.blocks[1]).toBe(theirs)
+  })
+
+  it('leaves the page alone when the page watches another subject', () => {
+    const previous = snapshot([{ block: 'text', text: 'old' }], NOTE_9)
+    const fresh = snapshot([{ block: 'text', text: 'new' }], NOTE_9)
+
+    expect(mergeRegions(previous, fresh, NOTE_7)).toBe(previous)
+  })
+})
+
+describe('a page that changed shape', () => {
+  it('is taken whole when a region is gone', () => {
+    const previous = snapshot([region('decision', 'waiting'), region('other', 'also')])
+    const fresh = snapshot([region('decision', 'answered')])
+
+    expect(mergeRegions(previous, fresh, NOTE_7)).toBe(fresh)
+  })
+
+  it('is taken whole when a region was renamed', () => {
+    const previous = snapshot([region('decision', 'waiting')])
+    const fresh = snapshot([region('verdict', 'answered')])
+
+    expect(mergeRegions(previous, fresh, NOTE_7)).toBe(fresh)
+  })
+})

--- a/frontend/src/druksui/pages.ts
+++ b/frontend/src/druksui/pages.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react'
 
-import type { PageEntry } from '../api/types'
+import type { Block, Follows, PageEntry, PageSnapshot } from '../api/types'
 
 // Which app's pages a block tree belongs to. A Link carries a page name, and
 // only this table turns that name into a URL — so the renderer reads it here
@@ -59,4 +59,91 @@ export function parentOf(pages: PageEntry[], current: PageEntry): PageEntry | un
  * depth, so the parameters already in the URL come along. */
 export function hrefUnder(location: string, ancestor: PageEntry): string {
   return location.split('/').slice(0, ancestor.path.split('/').length).join('/')
+}
+
+/** Every subject this snapshot watches: the page's own, and each named
+ * region's. One entry per subject, so a page that follows the same subject
+ * twice opens one stream. */
+export function followedSubjects(snapshot: PageSnapshot): Follows[] {
+  const found = new Map<string, Follows>()
+  const take = (follows: Follows | null) => {
+    if (follows) found.set(`${follows.subjectType}/${follows.subjectId}`, follows)
+  }
+  take(snapshot.follows)
+  for (const region of regionsIn(snapshot.blocks)) take(region.follows)
+  return [...found.values()]
+}
+
+/** Take the regions that watch ``subject`` from ``fresh`` and put them in place
+ * of the ones ``previous`` holds. Everything else stays the object it already
+ * was, so nothing else re-renders. A page that watches ``subject`` itself is
+ * replaced whole. */
+export function mergeRegions(
+  previous: PageSnapshot,
+  fresh: PageSnapshot,
+  subject: Follows,
+): PageSnapshot {
+  if (watches(previous.follows, subject)) return fresh
+  const standing = regionsIn(previous.blocks).filter((region) => watches(region.follows, subject))
+  if (standing.length === 0) return previous
+  const replacements = new Map(
+    regionsIn(fresh.blocks)
+      .filter((region) => watches(region.follows, subject))
+      .map((region) => [region.name, region]),
+  )
+  // A page that dropped or renamed one of these regions is a different page, so
+  // nothing is left to merge into: take the new one whole.
+  if (standing.length !== replacements.size) return fresh
+  if (standing.some((region) => !replacements.has(region.name))) return fresh
+  return { ...previous, blocks: replaceRegions(previous.blocks, replacements) }
+}
+
+function watches(follows: Follows | null, subject: Follows): boolean {
+  return (
+    !!follows &&
+    follows.subjectType === subject.subjectType &&
+    follows.subjectId === subject.subjectId
+  )
+}
+
+type Region = Extract<Block, { block: 'section' }>
+
+// A page snapshot is data an app produced, and this runs in the component body
+// where no error boundary can catch a throw. A shape that is not a block list
+// simply holds no regions; the renderer is where the app hears about it.
+function regionsIn(blocks: Block[]): Region[] {
+  if (!Array.isArray(blocks)) return []
+  const found: Region[] = []
+  for (const block of blocks) {
+    if (block.block === 'section') {
+      if (block.follows) found.push(block)
+      found.push(...regionsIn(block.blocks))
+    } else if (block.block === 'card') {
+      found.push(...regionsIn(block.blocks))
+    }
+  }
+  return found
+}
+
+function replaceRegions(blocks: Block[], replacements: Map<string, Region>): Block[] {
+  if (!Array.isArray(blocks)) return blocks
+  let changed = false
+  const next = blocks.map((block): Block => {
+    if (block.block === 'section') {
+      const fresh = replacements.get(block.name)
+      if (fresh) {
+        changed = true
+        return fresh
+      }
+    }
+    if (block.block !== 'section' && block.block !== 'card') return block
+    const inner = replaceRegions(block.blocks, replacements)
+    // Nothing under this block moved, so hand back the block itself: React
+    // sees the same object and renders none of it again.
+    if (inner === block.blocks) return block
+    changed = true
+    return { ...block, blocks: inner }
+  })
+  if (changed) return next
+  return blocks
 }

--- a/frontend/src/druksui/reads.test.tsx
+++ b/frontend/src/druksui/reads.test.tsx
@@ -1,0 +1,142 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Router } from 'wouter'
+import { memoryLocation } from 'wouter/memory-location'
+
+import { api } from '../api/client'
+import { useSSE } from '../api/sse'
+import type { App, Block, PageSnapshot } from '../api/types'
+import { AppPage } from './AppPage'
+
+vi.mock('../api/client', () => ({
+  api: { listApps: vi.fn(), readPage: vi.fn(), getGate: vi.fn() },
+}))
+vi.mock('../api/sse', () => ({ useSSE: vi.fn() }))
+
+const listApps = vi.mocked(api.listApps)
+const readPage = vi.mocked(api.readPage)
+const sse = vi.mocked(useSSE)
+
+afterEach(() => {
+  cleanup()
+  // Reset, not clear: a test that queues a one-shot answer must not leave it
+  // for the next one.
+  listApps.mockReset()
+  readPage.mockReset()
+  sse.mockReset()
+})
+
+const ROSTER = [
+  {
+    name: 'field_notes',
+    icon: 'notebook',
+    description: '',
+    builtin: false,
+    subjectTypes: ['note'],
+    hasFrontend: false,
+    navigation: [],
+    pages: [{ name: 'note', label: 'note', path: '/field_notes/notes/{note_id}', parent: '', order: 0 }],
+  },
+] as App[]
+
+const NOTE_7 = { subjectType: 'note', subjectId: '7' }
+
+function region(name: string, text: string, follows = NOTE_7): Block {
+  return {
+    block: 'section',
+    title: 'Decision',
+    name,
+    follows,
+    blocks: [{ block: 'text', text }],
+  }
+}
+
+function snapshot(blocks: Block[], follows: PageSnapshot['follows'] = null): PageSnapshot {
+  return { title: 'Note 7', description: '', blocks, follows }
+}
+
+function renderPage(first: PageSnapshot) {
+  listApps.mockResolvedValue(ROSTER)
+  readPage.mockResolvedValue(first)
+  const { hook } = memoryLocation({ path: '/field_notes/notes/7' })
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Router hook={hook}>
+        <AppPage app="field_notes" page="note" />
+      </Router>
+    </QueryClientProvider>,
+  )
+}
+
+// The snapshot handler the page gave one subject's stream. ``start`` leaves the
+// read running: an act() promise held open across another act() leaves React's
+// own queue in a state the next render cannot recover from.
+function start(which = 0) {
+  sse.mock.calls[which]?.[1].handlers.snapshot?.({})
+}
+
+function fireSnapshot(which = 0) {
+  return act(async () => {
+    start(which)
+  })
+}
+
+describe('a read that is still in flight', () => {
+  it('drops a read that lands after a newer one', async () => {
+    renderPage(snapshot([region('decision', 'first')]))
+    await waitFor(() => expect(screen.getByText('first')).toBeTruthy())
+
+    let releaseSlow: (value: PageSnapshot) => void = () => {}
+    readPage.mockReturnValueOnce(
+      new Promise<PageSnapshot>((resolve) => {
+        releaseSlow = resolve
+      }),
+    )
+    start()
+
+    readPage.mockResolvedValueOnce(snapshot([region('decision', 'newest')]))
+    await fireSnapshot()
+    await waitFor(() => expect(screen.getByText('newest')).toBeTruthy())
+
+    // The older read finishes last and must not put its answer on screen.
+    await act(async () => {
+      releaseSlow(snapshot([region('decision', 'stale')]))
+    })
+
+    expect(screen.getByText('newest')).toBeTruthy()
+    expect(screen.queryByText('stale')).toBeNull()
+  })
+
+  it('keeps each subject on its own read number', async () => {
+    const NOTE_9 = { subjectType: 'note', subjectId: '9' }
+    renderPage(snapshot([region('decision', 'first'), region('other', 'nine', NOTE_9)]))
+    await waitFor(() => expect(screen.getByText('first')).toBeTruthy())
+
+    // The read for note 7 starts first and finishes last; note 9's read in
+    // between must not discard it.
+    let releaseSeven: (value: PageSnapshot) => void = () => {}
+    readPage.mockReturnValueOnce(
+      new Promise<PageSnapshot>((resolve) => {
+        releaseSeven = resolve
+      }),
+    )
+    start(0)
+
+    readPage.mockResolvedValueOnce(
+      snapshot([region('decision', 'first'), region('other', 'nine answered', NOTE_9)]),
+    )
+    await fireSnapshot(1)
+    await waitFor(() => expect(screen.getByText('nine answered')).toBeTruthy())
+
+    await act(async () => {
+      releaseSeven(
+        snapshot([region('decision', 'seven answered'), region('other', 'nine', NOTE_9)]),
+      )
+    })
+
+    await waitFor(() => expect(screen.getByText('seven answered')).toBeTruthy())
+    expect(screen.getByText('nine answered')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
ENG-902

The vertical slice that proves the product: a durable run parks, a followed
region shows the controls, an operator answers, the run resumes, and the region
clears itself. The app writes no JavaScript.

```python
if status.gate:
    decision = [GateControls(status.run)]
else:
    decision = [Text("Nothing is waiting on you.")]

return Page(
    title=f"Note {note_id}",
    blocks=[Section(title="Your decision", name="decision", follows=found, blocks=decision)],
)
```

## Followed regions

A `Page` or a named `Section` declares the subject it `follows`. Druks fills
the subject identity from what the app passes, and the shell streams that
subject through the per-subject read side every app already has. There is no
second streaming system.

On a snapshot the shell rereads the page, takes the regions that watch the
subject that sent it, and puts them in place of the old ones. Everything else
stays the object it already was, so nothing outside re-renders and scroll,
focus, and half-filled inputs survive. A page that dropped or renamed one of
those regions is taken whole instead.

Every read is numbered per subject. A read that lands after a newer read of the
same subject is dropped; another subject's read is not. A failed read backs off
and tries again, still numbered, so the page never sits on a snapshot it should
have replaced.

## GateControls

`GateControls` names only the run, so it takes it positionally. The shell reads
the ask, its options, its context, and its artifact from
`GET /api/gates/{run}`, and submits the answer to
`POST /api/gates/{run}/answer` with the run's `parkedAt`, through the signed-in
dashboard session. It never uses the resume route. A run that parked again asks
a new question, so the controls start over rather than keeping the last round's
answers.

`InAppReview` grew a `submit` parameter, so the gate door and the subject page
share one presentation.

## What fails loudly

- A `GateControls` block in nothing that follows a subject: an answered gate
  would stay on screen.
- A `Section` that follows a subject with no name: the shell replaces a region
  by name.
- Two regions on one page with the same name.
- A `follows=` that is not a subject.

`SubjectStatus` now carries its driving run's id, so a page function can name
the run without reaching into the platform's read side. A parked run always has
one, so a page reads `status.gate` alone to decide.

## How it is verified

`backend/tests/test_ui_followed_regions.py` covers the subject identity, every
rejection above, and nesting. `backend/tests/test_ui_page_api.py` reads the
proof app's note page and asserts the region, its `follows`, and the controls a
parked run puts in it.

`frontend/src/druksui/followed.test.tsx` covers subject collection, region
replacement, object identity outside the region, a snapshot from another
subject, and a failed read. `reads.test.tsx` covers the two in-flight races:
an older read landing last, and one subject's read outliving another's.
`GateControls.test.tsx` covers the derived ask, the echoed `parkedAt`, a stale
answer, and a run that is no longer waiting.

Gates run: `uv run ruff check backend`, `uv run ruff format --check backend`,
`npm --prefix frontend run lint`, `npm --prefix frontend test` (159 tests
pass), `npm --prefix frontend run build`. `uv run pytest backend/` did not run:
this machine has no Postgres or Redis. The new backend tests that need no
database were run directly, and all pass.
