### PR TITLE
Drop get_timeline from the subject surface

### DIFF
--- a/backend/druks/durable/datastructures.py
+++ b/backend/druks/durable/datastructures.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Self
 from druks.models import snake_name
 
 if TYPE_CHECKING:
-    from druks.durable.schemas import RunResponse, SubjectStatus, SubjectSummary
+    from druks.durable.schemas import SubjectStatus, SubjectSummary
     from druks.workflows import Workflow
 
 
@@ -68,12 +68,6 @@ class Subject:
         from druks.durable.reads import get_subject_status
 
         return await get_subject_status(self.subject_type, self.id, workflow=workflow)
-
-    async def get_timeline(self) -> "list[RunResponse]":
-        """Every run about this subject, oldest first, each with its agent calls."""
-        from druks.durable.reads import list_subject_timeline
-
-        return await list_subject_timeline(self.subject_type, self.id)
 
     async def get_phase(self) -> str | None:
         """The step it is on right now ("provisioning_vm"), while something is running."""

--- a/backend/druks/models.py
+++ b/backend/druks/models.py
@@ -11,7 +11,7 @@ from sqlalchemy.types import TypeDecorator
 from druks.core.utils.time import ensure_utc
 
 if TYPE_CHECKING:
-    from druks.durable.schemas import RunResponse, SubjectStatus, SubjectSummary
+    from druks.durable.schemas import SubjectStatus, SubjectSummary
     from druks.workflows import Workflow
 
 _CAMEL_BOUNDARY = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
@@ -109,11 +109,6 @@ class StoredSubject(Base):
         from druks.durable.reads import get_subject_status
 
         return await get_subject_status(self.subject_type, str(self.id), workflow=workflow)
-
-    async def get_timeline(self) -> "list[RunResponse]":
-        from druks.durable.reads import list_subject_timeline
-
-        return await list_subject_timeline(self.subject_type, str(self.id))
 
     async def get_phase(self) -> str | None:
         from druks.durable.reads import get_subject_phase

--- a/backend/tests/software_factory/test_api_work_items.py
+++ b/backend/tests/software_factory/test_api_work_items.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 from druks.contrib.software_factory.models import WorkItem
+from druks.durable.reads import list_subject_timeline
 from druks.testing import asgi_client, seed_call
 from fastapi.testclient import TestClient
 
@@ -141,7 +142,7 @@ async def test_pending_gate_surfaces_input_request_on_the_run(druks_db):
     await seed_call(druks_db, run, "generate_plan")
     await seed_call(druks_db, run, "review_plan")
 
-    (entry,) = await item.get_timeline()
+    (entry,) = await list_subject_timeline(item.subject_type, str(item.id))
     assert entry.input_request == {"next_action": "approve_plan", "label": "Approve plan"}
     assert entry.state == "parked"
     assert [call.agent for call in entry.agent_calls] == ["generate_plan", "review_plan"]
@@ -153,7 +154,7 @@ async def test_detail_surfaces_running_run_before_its_first_call(druks_db):
     item = await make_test_work_item(repo="ClawHaven/acme-app", title="x")
     await seed_build_run(druks_db, work_item_id=item.id, state="running")
 
-    (entry,) = await item.get_timeline()
+    (entry,) = await list_subject_timeline(item.subject_type, str(item.id))
     assert entry.state == "running"
     assert entry.agent_calls == []  # surfaces even with no call yet
 
@@ -223,7 +224,7 @@ async def test_repeated_runs_on_one_subject_each_surface_separately(druks_db):
     for _ in range(3):
         await seed_build_run(druks_db, work_item_id=item.id, state="finished")
 
-    entries = await item.get_timeline()
+    entries = await list_subject_timeline(item.subject_type, str(item.id))
     assert [entry.kind for entry in entries] == ["software_factory.build"] * 3
     assert len({entry.id for entry in entries}) == 3
 
@@ -237,7 +238,7 @@ async def test_timeline_shows_every_build_attempt(druks_db):
     await seed_call(druks_db, run1, "generate_plan", status="failed", last_error="boom")
     await seed_call(druks_db, run2, "generate_plan", status="failed")
 
-    entries = await item.get_timeline()
+    entries = await list_subject_timeline(item.subject_type, str(item.id))
     assert len(entries) == 2
     assert all(e.agent_calls[0].agent == "generate_plan" for e in entries)
     assert any(e.failure == "boom" for e in entries)


### PR DESCRIPTION
Removes `get_timeline()` from `Subject` and `StoredSubject`.

It was the one author door to raw run rows, and after the Druks UI arc nothing
uses it: an app page never assembles the platform's run history, because the
subject's own platform page renders it and `Link(subject=)` points there.

The platform read side keeps `list_subject_timeline` — the subject API route
serves it, and the software_factory suite now asserts through it directly.

Verified with `uv run ruff check backend` and `uv run ruff format --check
backend`; both subject classes confirmed clean of the method. The full suite
runs in CI.
