### PR TITLE
Rename BaseResponse to Schema

### DIFF
--- a/backend/druks/accounts/schemas.py
+++ b/backend/druks/accounts/schemas.py
@@ -2,17 +2,17 @@ from datetime import datetime
 
 from pydantic import ConfigDict, Field
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 
-class AccountResponse(BaseResponse):
+class AccountResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     id: str
     username: str
 
 
-class IdentityResponse(BaseResponse):
+class IdentityResponse(Schema):
     # What /api/auth/me answers: how this deployment authenticates, who the
     # request resolved to (null in the none/zero setup state), and whether that
     # identity still needs its first harness connection.
@@ -21,7 +21,7 @@ class IdentityResponse(BaseResponse):
     onboarding_required: bool
 
 
-class PatResponse(BaseResponse):
+class PatResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     id: str

--- a/backend/druks/api/schemas.py
+++ b/backend/druks/api/schemas.py
@@ -4,7 +4,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from druks.durable.enums import RunState
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 
 class ResumeRequest(BaseModel):
@@ -18,16 +18,16 @@ class ResumeRequest(BaseModel):
     note: str = ""
 
 
-class CancelRunResponse(BaseResponse):
+class CancelRunResponse(Schema):
     run: str
     result: Literal["cancelled", "already_cancelled"]
 
 
-class RetryRunResponse(BaseResponse):
+class RetryRunResponse(Schema):
     run: str
 
 
-class OpenWorkflowResponse(BaseResponse):
+class OpenWorkflowResponse(Schema):
     app: str
     state: RunState
     run: str = Field(description="What get_gate, cancel_run, and retry_run take.")
@@ -38,18 +38,18 @@ class OpenWorkflowResponse(BaseResponse):
     created_at: datetime
 
 
-class OpenSubjectResponse(BaseResponse):
+class OpenSubjectResponse(Schema):
     subject_type: str
     subject_id: str
     subject_label: str
     workflows: list[OpenWorkflowResponse]
 
 
-class OpenSubjectsResponse(BaseResponse):
+class OpenSubjectsResponse(Schema):
     subjects: list[OpenSubjectResponse]
 
 
-class ArtifactContent(BaseResponse):
+class ArtifactContent(Schema):
     # A call's renderable output, served to the in-app review so it can show the
     # plan (or other markdown) beside its controls.
     kind: str
@@ -57,18 +57,18 @@ class ArtifactContent(BaseResponse):
     content: str
 
 
-class WebhookSource(BaseResponse):
+class WebhookSource(Schema):
     source: str
     last_at: datetime | None = None
 
 
-class WebhookFreshness(BaseResponse):
+class WebhookFreshness(Schema):
     # One entry per monitored webhook source, with its newest delivery timestamp;
     # the strip labels a tile per source.
     sources: list[WebhookSource] = Field(default_factory=list)
 
 
-class DashboardHealth(BaseResponse):
+class DashboardHealth(Schema):
     web: Literal["ok", "degraded"]
     webhook_freshness: WebhookFreshness
     spend_today_usd: float | None

--- a/backend/druks/apps/schemas.py
+++ b/backend/druks/apps/schemas.py
@@ -1,7 +1,7 @@
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 
-class PageEntry(BaseResponse):
+class PageEntry(Schema):
     name: str
     label: str
     path: str
@@ -9,13 +9,13 @@ class PageEntry(BaseResponse):
     order: int
 
 
-class Operation(BaseResponse):
+class Operation(Schema):
     id: str
     method: str
     path: str
 
 
-class AppResponse(BaseResponse):
+class AppResponse(Schema):
     name: str
     icon: str
     description: str

--- a/backend/druks/browser/schemas.py
+++ b/backend/druks/browser/schemas.py
@@ -3,10 +3,10 @@ from datetime import datetime
 from pydantic import ConfigDict
 
 from druks.browser.enums import BrowserSessionPayloadFormat, BrowserSessionStatus
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 
-class BrowserSessionResponse(BaseResponse):
+class BrowserSessionResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     name: str

--- a/backend/druks/contrib/software_factory/schemas.py
+++ b/backend/druks/contrib/software_factory/schemas.py
@@ -3,7 +3,7 @@ from typing import Any, Literal
 
 from pydantic import AliasPath, BaseModel, ConfigDict, Field, computed_field
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 from druks.workflows import SubjectSummary
 
 # GitHub's verdict on a PR, verbatim.
@@ -21,7 +21,7 @@ class ProjectRepoSummary(SubjectSummary):
     created_at: datetime
 
 
-class ProjectSummary(BaseResponse):
+class ProjectSummary(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
@@ -31,7 +31,7 @@ class ProjectSummary(BaseResponse):
     repos: list[ProjectRepoSummary] = Field(default_factory=list)
 
 
-class ProjectsResponse(BaseResponse):
+class ProjectsResponse(Schema):
     projects: list[ProjectSummary]
 
 
@@ -44,16 +44,16 @@ class AddProjectRepoRequest(BaseModel):
     purpose: str | None = None
 
 
-class GitHubRepoSummary(BaseResponse):
+class GitHubRepoSummary(Schema):
     full_name: str
     description: str | None = None
 
 
-class GitHubReposResponse(BaseResponse):
+class GitHubReposResponse(Schema):
     repos: list[GitHubRepoSummary]
 
 
-class Links(BaseResponse):
+class Links(Schema):
     repo: str
     pr: str | None = None
     ticket: str | None = None
@@ -87,7 +87,7 @@ class WorkItemSummary(SubjectSummary):
         return Links(repo=f"https://github.com/{self.repo}", pr=pr, ticket=self.ticket_url)
 
 
-class DashboardItem(BaseResponse):
+class DashboardItem(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     source_id: int | str = Field(validation_alias="id")
@@ -110,5 +110,5 @@ class DashboardItem(BaseResponse):
         return f"code:{self.source_id}"
 
 
-class WorkItemsHistoryResponse(BaseResponse):
+class WorkItemsHistoryResponse(Schema):
     items: list[DashboardItem]

--- a/backend/druks/durable/live.py
+++ b/backend/druks/durable/live.py
@@ -23,7 +23,7 @@ def keepalive_comment() -> str:
 
 def serialize_model_event(event_type: str, model: BaseModel) -> str:
     """Serialize a typed model as a named SSE event — the streaming twin of returning a
-    BaseResponse. Push events with this instead of hand-writing model_dump(by_alias)."""
+    Schema. Push events with this instead of hand-writing model_dump(by_alias)."""
     return serialize_event(event_type, model.model_dump(by_alias=True, mode="json"))
 
 

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -11,7 +11,7 @@ from pydantic import (
     computed_field,
 )
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 from .enums import AgentCallStatus, RunState
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from .models import Run
 
 
-class TokenUsage(BaseResponse):
+class TokenUsage(Schema):
     input_tokens: int
     output_tokens: int
     cached_input_tokens: int = 0
@@ -33,7 +33,7 @@ def get_display_label(kind: str) -> str:
     return kind.rsplit(".", 1)[-1].replace("_", " ").capitalize()
 
 
-class AgentCallResponse(BaseResponse):
+class AgentCallResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     id: str
@@ -56,13 +56,13 @@ class AgentCallResponse(BaseResponse):
         return get_display_label(self.agent)
 
 
-class ArtifactFile(BaseResponse):
+class ArtifactFile(Schema):
     name: str
     size_bytes: int
     updated_at: datetime
 
 
-class ArtifactDescriptor(BaseResponse):
+class ArtifactDescriptor(Schema):
     # A call's renderable output (a plan's markdown), rendered by kind — distinct
     # from the raw files. ``name`` is its file in the call dir, downloadable from
     # the transcript files route like any other.
@@ -71,7 +71,7 @@ class ArtifactDescriptor(BaseResponse):
     name: str
 
 
-class AgentCallFiles(BaseResponse):
+class AgentCallFiles(Schema):
     # A call's on-disk artifacts by role (prompt / response / stdout / stderr /
     # metadata / manifest). Each carries its file name; the client composes the
     # download URL from the transcript route it fetched this listing from.
@@ -87,7 +87,7 @@ class AgentCallFiles(BaseResponse):
     artifact: ArtifactDescriptor | None = None
 
 
-class RunResponse(BaseResponse):
+class RunResponse(Schema):
     id: str
     # The durable kind ("software_factory.build"); ``label`` is its display name ("Build").
     kind: str
@@ -136,7 +136,7 @@ SubjectId = Annotated[str, BeforeValidator(str)]
 SubjectLabel = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
-class SubjectSummary(BaseResponse):
+class SubjectSummary(Schema):
     # The base an app's subject header subclasses; ``id`` keys the subject's
     # status, timeline and detail URL, and ``from_attributes`` builds the header
     # straight off the subject.
@@ -146,7 +146,7 @@ class SubjectSummary(BaseResponse):
     label: SubjectLabel
 
 
-class SubjectStatus(BaseResponse):
+class SubjectStatus(Schema):
     # The subject's lifecycle status for the dashboard lane — derived by the read
     # side, never stored; ``state`` is the canonical RunState aggregated across
     # the subject's runs. Everything else is a fact the app's UI renders
@@ -187,23 +187,23 @@ class SubjectStatus(BaseResponse):
         return self.state == RunState.FAILED
 
 
-class SubjectRow(BaseResponse):
+class SubjectRow(Schema):
     summary: SerializeAsAny[SubjectSummary]
     status: SubjectStatus
 
 
-class SubjectList(BaseResponse):
+class SubjectList(Schema):
     rows: list[SubjectRow] = Field(default_factory=list)
 
 
-class SubjectActivity(BaseResponse):
+class SubjectActivity(Schema):
     # The running sub-phase the timeline can't show ("Provisioning sandbox VM…"), supplied
     # by the app; ``kind`` groups it for display ("infra" | "agent").
     label: str
     kind: str
 
 
-class SubjectResponse(BaseResponse):
+class SubjectResponse(Schema):
     summary: SerializeAsAny[SubjectSummary]
     status: SubjectStatus
     # The subject's runs, oldest first, each with its agent calls — the timeline.
@@ -211,7 +211,7 @@ class SubjectResponse(BaseResponse):
     activity: SubjectActivity | None = None
 
 
-class TranscriptChunk(BaseResponse):
+class TranscriptChunk(Schema):
     call_id: str
     stream: Literal["stdout", "stderr"]
     offset: int
@@ -220,7 +220,7 @@ class TranscriptChunk(BaseResponse):
     text: str
 
 
-class TextSlice(BaseResponse):
+class TextSlice(Schema):
     # One bounded UTF-8-safe cut of an on-disk text file; offsets are byte
     # positions, has_earlier marks content before this slice.
     offset: int

--- a/backend/druks/events/feed.py
+++ b/backend/druks/events/feed.py
@@ -2,10 +2,10 @@ from datetime import datetime
 
 from pydantic import AliasPath, ConfigDict, Field, computed_field
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 
-class FeedItem(BaseResponse):
+class FeedItem(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     # The event's monotonic log position (its pk) — the feed's ordering and
@@ -28,7 +28,7 @@ class FeedItem(BaseResponse):
         return f"event:{self.seq}"
 
 
-class FeedResponse(BaseResponse):
+class FeedResponse(Schema):
     items: list[FeedItem]
     # Event sequence cursor for the next (older) page; None at the tail.
     next_cursor: str | None = None

--- a/backend/druks/mcp/gateway/schemas.py
+++ b/backend/druks/mcp/gateway/schemas.py
@@ -5,18 +5,18 @@ from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 from druks.durable.schemas import AgentCallResponse
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 from druks.usage.schemas import UsageHistoryPoint
 
 
-class ArtifactContent(BaseResponse):
+class ArtifactContent(Schema):
     call_id: str
     kind: str
     title: str
     content: str
 
 
-class GateResponse(BaseResponse):
+class GateResponse(Schema):
     # parked_at is the park identity answer_gate must echo back.
     run: str
     gate: str
@@ -25,7 +25,7 @@ class GateResponse(BaseResponse):
     artifact: ArtifactContent | None = None
 
 
-class GateAnswerResponse(BaseResponse):
+class GateAnswerResponse(Schema):
     run: str
     parked_at: datetime
     result: Literal["answered", "already_answered"]
@@ -48,7 +48,7 @@ class AnswerGateRequest(BaseModel):
     note: str = Field(default="", description="The optional note to submit with this answer.")
 
 
-class AgentCallDetailResponse(BaseResponse):
+class AgentCallDetailResponse(Schema):
     run: str
     call: AgentCallResponse
     transcript: str
@@ -56,7 +56,7 @@ class AgentCallDetailResponse(BaseResponse):
     artifact: ArtifactContent | None = None
 
 
-class AgentHarnessUsage(BaseResponse):
+class AgentHarnessUsage(Schema):
     # *_history: percent-left trend samples, oldest first.
     name: str
     is_connected: bool = False
@@ -71,7 +71,7 @@ class AgentHarnessUsage(BaseResponse):
     week_history: list[UsageHistoryPoint] = Field(default_factory=list)
 
 
-class AgentUsageResponse(BaseResponse):
+class AgentUsageResponse(Schema):
     day: str
     timezone: str
     spend_today_usd: float

--- a/backend/druks/mcp/schemas.py
+++ b/backend/druks/mcp/schemas.py
@@ -2,12 +2,12 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, StringConstraints
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 NonBlank = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
-class McpServerResponse(BaseResponse):
+class McpServerResponse(Schema):
     # A pure projection of one account's ``McpServer.get_resolved()`` item — the dict's
     # ``token`` is not a field here, so the secret can't serialize (and it
     # arrives as a Secret, redacted even if it did).
@@ -24,13 +24,13 @@ class McpServerResponse(BaseResponse):
     has_token: bool
 
 
-class ConnectMcpServerResponse(BaseResponse):
+class ConnectMcpServerResponse(Schema):
     # The consent URL the operator's browser opens; the grant lands via the
     # callback, never through this response.
     authorization_url: str
 
 
-class McpRegistryCandidateResponse(BaseResponse):
+class McpRegistryCandidateResponse(Schema):
     name: str
     registry_name: str
     description: str

--- a/backend/druks/notifications/schemas.py
+++ b/backend/druks/notifications/schemas.py
@@ -4,10 +4,10 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, computed_field
 
 from druks.notifications.models import DestinationKind
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 
-class DestinationResponse(BaseResponse):
+class DestinationResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     id: str
@@ -33,7 +33,7 @@ class CreateDestinationRequest(BaseModel):
     url: SecretStr
 
 
-class NotificationResponse(BaseResponse):
+class NotificationResponse(Schema):
     # Serializes exactly the fields declared here — the correlation token (the
     # respond capability) is deliberately not among them.
     model_config = ConfigDict(from_attributes=True)

--- a/backend/druks/scaffolding/app_template/package/schemas.py-tpl
+++ b/backend/druks/scaffolding/app_template/package/schemas.py-tpl
@@ -1,5 +1,5 @@
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
-# HTTP request/response models for this app's routes. Response models subclass
-# ``BaseResponse`` (snake_case fields serialize to camelCase for the frontend);
-# request bodies are plain ``pydantic.BaseModel``.
+# HTTP request and response models for this app's routes. A response subclasses
+# ``Schema``, whose snake_case fields serialize as camelCase; a request body is
+# a plain ``pydantic.BaseModel``.

--- a/backend/druks/schemas.py
+++ b/backend/druks/schemas.py
@@ -2,11 +2,10 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 
-class BaseResponse(BaseModel):
-    # Read-side response base: snake_case fields serialize to camelCase for the
-    # frontend, so a shape doesn't hand-write serialization_alias on every field.
-    # Output-only — request bodies use alias= for input and don't inherit this.
+class Schema(BaseModel):
+    # What the API answers with. Output only: a request body takes alias= for
+    # input and does not inherit this.
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
 
-__all__ = ["BaseResponse"]
+__all__ = ["Schema"]

--- a/backend/druks/services/schemas.py
+++ b/backend/druks/services/schemas.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import ConfigDict
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 if TYPE_CHECKING:
     from druks.services.base import Service
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 # The settings-form field vocabulary (label/help/type), minus everything a
 # write-only paste form has no use for (values, defaults, overrides).
-class ServiceFieldSpec(BaseResponse):
+class ServiceFieldSpec(Schema):
     name: str
     label: str
     help: str
@@ -20,7 +20,7 @@ class ServiceFieldSpec(BaseResponse):
     multiline: bool
 
 
-class ConnectionResponse(BaseResponse):
+class ConnectionResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     id: str
@@ -32,7 +32,7 @@ class ConnectionResponse(BaseResponse):
     revoked_reason: str
 
 
-class ServiceResponse(BaseResponse):
+class ServiceResponse(Schema):
     # Connection state and identity facts only — never a stored secret.
     slug: str
     title: str

--- a/backend/druks/skills/schemas.py
+++ b/backend/druks/skills/schemas.py
@@ -2,10 +2,10 @@ from datetime import datetime
 
 from pydantic import ConfigDict
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 
-class SkillResponse(BaseResponse):
+class SkillResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     name: str
@@ -14,7 +14,7 @@ class SkillResponse(BaseResponse):
     updated_at: datetime
 
 
-class CollectionResponse(BaseResponse):
+class CollectionResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     id: str

--- a/backend/druks/ui/blocks.py
+++ b/backend/druks/ui/blocks.py
@@ -12,7 +12,7 @@ from pydantic import (
     model_validator,
 )
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 from .fields import Field as FormField
 
@@ -32,7 +32,7 @@ def _subject_identity(value):
     return {"subject_type": identity["type"], "subject_id": str(identity["id"])}
 
 
-class Follows(BaseResponse):
+class Follows(Schema):
     """The subject a page or a named region watches."""
 
     subject_type: str
@@ -42,7 +42,7 @@ class Follows(BaseResponse):
 Watched = Annotated[Follows | None, BeforeValidator(_subject_identity)]
 
 
-class PageBlock(BaseResponse):
+class PageBlock(Schema):
     """What every block shares. ``block`` names its kind on the wire, and
     ``check_placement`` is how a block refuses a spot it cannot work in."""
 
@@ -244,7 +244,7 @@ class GateControls(PageBlock):
         )
 
 
-class TextValue(BaseResponse):
+class TextValue(Schema):
     """Words. ``link`` is how a table cell, a fact, or a list item reaches
     another page."""
 
@@ -256,7 +256,7 @@ class TextValue(BaseResponse):
     link: Link | None = None
 
 
-class NumberValue(BaseResponse):
+class NumberValue(Schema):
     value: Literal["number"] = "number"
     number: float = Field(allow_inf_nan=False)
     unit: str = ""
@@ -265,7 +265,7 @@ class NumberValue(BaseResponse):
         super().__init__(number=number, **data)
 
 
-class StatusValue(BaseResponse):
+class StatusValue(Schema):
     """Where something stands. The app writes the word; the tone selects the
     presentation."""
 
@@ -277,7 +277,7 @@ class StatusValue(BaseResponse):
         super().__init__(label=label, **data)
 
 
-class TimeValue(BaseResponse):
+class TimeValue(Schema):
     value: Literal["time"] = "time"
     when: AwareDatetime
 
@@ -288,7 +288,7 @@ class TimeValue(BaseResponse):
 Value = Annotated[TextValue | NumberValue | StatusValue | TimeValue, Discriminator("value")]
 
 
-class TimelineItem(BaseResponse):
+class TimelineItem(Schema):
     # Aware, so items from different sources order against each other.
     when: AwareDatetime
     title: str
@@ -316,7 +316,7 @@ class Timeline(PageBlock):
         super().__init__(items=items, **data)
 
 
-class ProgressStep(BaseResponse):
+class ProgressStep(Schema):
     label: str
     status: StatusValue
 
@@ -360,7 +360,7 @@ class Image(PageBlock):
     caption: str = ""
 
 
-class FileSummary(BaseResponse):
+class FileSummary(Schema):
     """One file, as the shell shows it. The download is derived from the id, so
     a file always travels through the platform's own route and its identity
     gate."""
@@ -390,7 +390,7 @@ class Files(PageBlock):
         super().__init__(files=files, **data)
 
 
-class ChartSeries(BaseResponse):
+class ChartSeries(Schema):
     label: str
     points: list[Annotated[float, Field(allow_inf_nan=False)]]
 
@@ -427,7 +427,7 @@ class ImageGallery(PageBlock):
         super().__init__(images=images, **data)
 
 
-class Metric(BaseResponse):
+class Metric(Schema):
     label: str
     value: Value
     description: str = ""
@@ -445,7 +445,7 @@ class Metrics(PageBlock):
         super().__init__(metrics=metrics, **data)
 
 
-class Fact(BaseResponse):
+class Fact(Schema):
     label: str
     value: Value
 
@@ -464,7 +464,7 @@ class Facts(PageBlock):
         super().__init__(facts=facts, **data)
 
 
-class TableColumn(BaseResponse):
+class TableColumn(Schema):
     label: str
     align: Literal["start", "end"] = "start"
 
@@ -472,7 +472,7 @@ class TableColumn(BaseResponse):
         super().__init__(label=label, **data)
 
 
-class TableRow(BaseResponse):
+class TableRow(Schema):
     cells: list[Value] = Field(default_factory=list)
 
     def __init__(self, cells=(), **data):

--- a/backend/druks/ui/fields.py
+++ b/backend/druks/ui/fields.py
@@ -2,10 +2,10 @@ from typing import Annotated, Literal
 
 from pydantic import Discriminator
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 
-class Option(BaseResponse):
+class Option(Schema):
     value: str
     label: str
 
@@ -13,7 +13,7 @@ class Option(BaseResponse):
         super().__init__(label=label, **data)
 
 
-class TextField(BaseResponse):
+class TextField(Schema):
     field: Literal["text"] = "text"
     name: str
     label: str
@@ -23,7 +23,7 @@ class TextField(BaseResponse):
     is_required: bool = False
 
 
-class TextAreaField(BaseResponse):
+class TextAreaField(Schema):
     field: Literal["text_area"] = "text_area"
     name: str
     label: str
@@ -34,7 +34,7 @@ class TextAreaField(BaseResponse):
     rows: int = 4
 
 
-class NumberField(BaseResponse):
+class NumberField(Schema):
     field: Literal["number"] = "number"
     name: str
     label: str
@@ -46,7 +46,7 @@ class NumberField(BaseResponse):
     is_required: bool = False
 
 
-class SelectField(BaseResponse):
+class SelectField(Schema):
     field: Literal["select"] = "select"
     name: str
     label: str
@@ -56,7 +56,7 @@ class SelectField(BaseResponse):
     is_required: bool = False
 
 
-class MultiSelectField(BaseResponse):
+class MultiSelectField(Schema):
     field: Literal["multi_select"] = "multi_select"
     name: str
     label: str
@@ -66,7 +66,7 @@ class MultiSelectField(BaseResponse):
     is_required: bool = False
 
 
-class RadioField(BaseResponse):
+class RadioField(Schema):
     field: Literal["radio"] = "radio"
     name: str
     label: str
@@ -76,7 +76,7 @@ class RadioField(BaseResponse):
     is_required: bool = False
 
 
-class CheckboxField(BaseResponse):
+class CheckboxField(Schema):
     field: Literal["checkbox"] = "checkbox"
     name: str
     label: str

--- a/backend/druks/ui/schemas.py
+++ b/backend/druks/ui/schemas.py
@@ -2,12 +2,12 @@ from collections.abc import Iterable
 
 from pydantic import Field, model_validator
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 from .blocks import Action, Block, Watched
 
 
-class Page(BaseResponse):
+class Page(Schema):
     """One screen, as a page function projects it. The shared dashboard renders
     it, and rereads it on every snapshot of what ``follows`` watches."""
 

--- a/backend/druks/usage/schemas.py
+++ b/backend/druks/usage/schemas.py
@@ -2,10 +2,10 @@ from datetime import datetime
 
 from pydantic import Field
 
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 
-class UsageMetricSummary(BaseResponse):
+class UsageMetricSummary(Schema):
     percent_left: int | None = None
     resets_at: datetime | None = None
     # Set when this window meters one model separately from the rest,
@@ -13,7 +13,7 @@ class UsageMetricSummary(BaseResponse):
     model: str | None = None
 
 
-class UsageHarnessSummary(BaseResponse):
+class UsageHarnessSummary(Schema):
     # A registered harness name (get_harnesses()) — the UI keys panels,
     # colors, and legends off it.
     name: str
@@ -50,22 +50,22 @@ class UsageHarnessSummary(BaseResponse):
     raw_output: str | None = None
 
 
-class UsageResponse(BaseResponse):
+class UsageResponse(Schema):
     # One summary per registered harness, in registry order.
     harnesses: list[UsageHarnessSummary]
 
 
-class UsageHistoryPoint(BaseResponse):
+class UsageHistoryPoint(Schema):
     t: datetime
     pct: int
 
 
-class UsageWindowHistory(BaseResponse):
+class UsageWindowHistory(Schema):
     model: str | None = None
     points: list[UsageHistoryPoint] = Field(default_factory=list)
 
 
-class UsageHarnessHistory(BaseResponse):
+class UsageHarnessHistory(Schema):
     name: str
     # Percent-left samples, oldest first. ``five_hour`` covers the last
     # ~6h (one full 5h window plus headroom); ``weeks`` covers the last
@@ -75,11 +75,11 @@ class UsageHarnessHistory(BaseResponse):
     weeks: list[UsageWindowHistory] = Field(default_factory=list)
 
 
-class UsageHistoryResponse(BaseResponse):
+class UsageHistoryResponse(Schema):
     harnesses: list[UsageHarnessHistory]
 
 
-class UsageHarnessToday(BaseResponse):
+class UsageHarnessToday(Schema):
     name: str
     spend_usd: float
     tokens: int
@@ -88,7 +88,7 @@ class UsageHarnessToday(BaseResponse):
     hours: list[float]
 
 
-class UsageTodayResponse(BaseResponse):
+class UsageTodayResponse(Schema):
     # Local day the aggregates cover — same boundary as the sys-strip's
     # spend-today figure (operator timezone, finished_at attribution).
     day: str

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -11,7 +11,7 @@ from druks.apps.settings import (
     field_section,
     field_visibility,
 )
-from druks.schemas import BaseResponse
+from druks.schemas import Schema
 
 if TYPE_CHECKING:
     from druks.accounts.models import Account
@@ -19,12 +19,12 @@ if TYPE_CHECKING:
     from druks.user_settings.models import HarnessSettings
 
 
-class AllowedModel(BaseResponse):
+class AllowedModel(Schema):
     id: str
     label: str
 
 
-class HarnessResponse(BaseResponse):
+class HarnessResponse(Schema):
     name: str
     provider: str
     model: str
@@ -73,7 +73,7 @@ class HarnessUpdate(BaseModel):
     timeout: int | None = None
 
 
-class UserSettingsResponse(BaseResponse):
+class UserSettingsResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     timezone: str
@@ -89,7 +89,7 @@ class UpdateUserSettingsRequest(BaseModel):
     )
 
 
-class AgentSettingResponse(BaseResponse):
+class AgentSettingResponse(Schema):
     name: str
     description: str
     model: str
@@ -102,7 +102,7 @@ class AgentSettingResponse(BaseResponse):
     timeout_source: Literal["agent", "declared", "harness"]
 
 
-class SettingsFieldResponse(BaseResponse):
+class SettingsFieldResponse(Schema):
     name: str
     # Human label + one-line help, from the field's ``Field(title=, description=)``.
     label: str
@@ -153,12 +153,12 @@ class SettingsFieldResponse(BaseResponse):
         )
 
 
-class WorkflowSettingsResponse(BaseResponse):
+class WorkflowSettingsResponse(Schema):
     kind: str
     fields: list[SettingsFieldResponse]
 
 
-class AppSettingsResponse(BaseResponse):
+class AppSettingsResponse(Schema):
     name: str
     description: str
     # A Lucide icon name the frontend renders (falls back to a default if unknown).
@@ -173,7 +173,7 @@ class AppSettingsResponse(BaseResponse):
     settings: list[SettingsFieldResponse]
 
 
-class AppsSettingsResponse(BaseResponse):
+class AppsSettingsResponse(Schema):
     allowed_efforts: list[str]
     apps: list[AppSettingsResponse]
 

--- a/backend/tests/test_author_surface.py
+++ b/backend/tests/test_author_surface.py
@@ -38,7 +38,7 @@ AUTHOR_SURFACE = {
         "task",
     },
     "druks.db": {"Base", "StoredSubject", "db_session"},
-    "druks.schemas": {"BaseResponse"},
+    "druks.schemas": {"Schema"},
     "druks.ui": {
         "Action",
         "Block",

--- a/docs/druks-ui.md
+++ b/docs/druks-ui.md
@@ -478,7 +478,7 @@ rules hold for every one of them.
 the discriminator.
 
 **Wire names are camelCase.** `alternative_text` serializes as
-`alternativeText`. `BaseResponse` does that for every model here.
+`alternativeText`. `Schema` does that for every model here.
 
 **Druks coerces author input to the wire type.** Three fields take a friendlier
 input than they store:

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -731,8 +731,8 @@ Druks scopes autogeneration to the table prefix and writes the version to
 `alembic_version_night_watch`. Query through `druks.db.db_session()` inside an
 HTTP request, durable step, or other platform-bound session.
 
-HTTP response models subclass `druks.schemas.BaseResponse`, whose snake_case
-fields serialize as camelCase. Request models are ordinary Pydantic models.
+HTTP response models subclass `druks.schemas.Schema`, whose snake_case fields
+serialize as camelCase. Request models are ordinary Pydantic models.
 Druks mounts each router from a discovered `routes.py` below the app namespace.
 It tags the router with the app name. A router declares only the prefix of its
 resource:
@@ -1376,7 +1376,7 @@ Import from concern namespaces, not from `druks.durable` or internal modules:
 | `druks.workflows` | `Workflow`, `Gate`, `step`, run/agent response types, lifecycle enums and workflow errors |
 | `druks.sandbox` | `Sandbox` |
 | `druks.db` | `Base`, `StoredSubject`, `db_session` |
-| `druks.schemas` | `BaseResponse` |
+| `druks.schemas` | `Schema` |
 | `druks.ui` | `Action`, `Block`, `Callout`, `Card`, `Chart`, `ChartSeries`, `CheckboxField`, `Columns`, `Divider`, `EmptyState`, `Fact`, `Facts`, `Field`, `FileSummary`, `Files`, `Follows`, `Form`, `GateControls`, `Image`, `ImageGallery`, `Link`, `List`, `Markdown`, `Metric`, `Metrics`, `MultiSelectField`, `NumberField`, `NumberValue`, `Option`, `Page`, `Progress`, `ProgressStep`, `RadioField`, `Section`, `SelectField`, `Stack`, `StatusValue`, `Table`, `TableColumn`, `TableRow`, `Text`, `TextAreaField`, `TextField`, `TextValue`, `TimeValue`, `Timeline`, `TimelineItem`, `Value`, `page` |
 | `druks.signals` | `subscribe` |
 | `druks.events` | `Event` |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -54,8 +54,8 @@ supplies one shared React instance. See the app-author guide.
 
 Shared requests use `src/api/client.ts`. The event feed and transcript
 components consume server-sent events. Standard HTTP queries supply the initial
-state. Keep API field names aligned with the camelCase `BaseResponse` output
-from the backend.
+state. Keep API field names aligned with the camelCase `Schema` output from the
+backend.
 
 If a backend response contract changes, update the TypeScript type, consumer,
 and focused frontend test in the same change. The `types:openapi` script is


### PR DESCRIPTION
Renames `druks.schemas.BaseResponse` to `druks.schemas.Schema`.

```python
from druks.schemas import Schema


class Operation(Schema):
    id: str
    method: str
    path: str
```

## Why

The class carries two lines of outbound-wire config — `alias_generator=to_camel`
and `populate_by_name=True` — and nothing about responses. Of the 74 classes
that inherit it, many are nested components rather than responses:
`UsageHistoryPoint`, `DashboardItem`, `FeedItem`, `ServiceFieldSpec`,
`AllowedModel`, `ArtifactFile`, `TextSlice`, `TokenUsage`, `Links`, `PageEntry`,
`Option`, `TableRow`.

It is also a published author name. `druks.schemas` exports it and the author
guide lists it, so an app writing its own nested wire shape was told to inherit
something called "Response".

`Schema` is the word already in use here and elsewhere: the file is
`schemas.py`, the OpenAPI document these classes become calls them schemas, and
Django Ninja names the same pydantic base the same way.

## What changed

The class, its `__all__`, every import and subclass across `accounts`, `api`,
`apps`, `browser`, `contrib/software_factory`, `durable`, `events`, `mcp`,
`notifications`, `services`, `skills`, `ui`, `usage`, and `user_settings`, the
author-surface test, the author guide, the UI contract, the frontend README, and
the app scaffold template.

No behavior changes. The config is untouched, and every wire shape serializes
exactly as before.

## How it is verified

`uv run ruff check backend` and `uv run ruff format --check backend` pass on 374
files. The author-surface test passes for all 13 namespaces, `druks.schemas`
included. The UI suites — pages, actions, run blocks, data blocks — pass
directly: 48 tests. Wire output confirmed unchanged, `alternativeText` and
friends still camelCase. No `BaseResponse` remains anywhere in the tree,
including `*-tpl` templates. CI runs the full suite.
