### PR TITLE
Let a page read a browser session status

### DIFF
--- a/backend/druks/browser/__init__.py
+++ b/backend/druks/browser/__init__.py
@@ -1,5 +1,6 @@
 from druks.browser import subscribers  # noqa: F401  (connects the signal reaction)
+from druks.browser.enums import BrowserSessionStatus
 from druks.browser.exceptions import BrowserSessionSignedOutError
 from druks.browser.sessions import BrowserSession
 
-__all__ = ["BrowserSession", "BrowserSessionSignedOutError"]
+__all__ = ["BrowserSession", "BrowserSessionSignedOutError", "BrowserSessionStatus"]

--- a/backend/druks/browser/sessions.py
+++ b/backend/druks/browser/sessions.py
@@ -70,6 +70,14 @@ class BrowserSession:
             return BrowserSessionStatus.ANONYMOUS
         return BrowserSessionStatus.NEEDS_LOGIN
 
+    async def get_status(self) -> BrowserSessionStatus:
+        """Where the login stands: READY to borrow, STALE after a run found it
+        signed out, NEEDS_LOGIN before the first sign-in."""
+        row = await StoredBrowserSession.get_for_name(self.name)
+        if row:
+            return BrowserSessionStatus(row.status)
+        return self.initial_status
+
     @asynccontextmanager
     async def cdp(self):
         """A browser carrying the session's login (blank for an anonymous

--- a/backend/tests/test_author_surface.py
+++ b/backend/tests/test_author_surface.py
@@ -6,7 +6,7 @@ import pytest
 # exact names it exports. Pattern A — no root facade; druks stays thin.
 AUTHOR_SURFACE = {
     "druks.apps": {"App", "AppSettings", "Secret"},
-    "druks.browser": {"BrowserSession", "BrowserSessionSignedOutError"},
+    "druks.browser": {"BrowserSession", "BrowserSessionSignedOutError", "BrowserSessionStatus"},
     "druks.services": {
         "OauthClient",
         "OauthExchangeError",

--- a/backend/tests/test_browser_borrow.py
+++ b/backend/tests/test_browser_borrow.py
@@ -122,6 +122,23 @@ def test_declaration_carries_the_app_namespace(night_watch):
     assert night_watch.docs.name == "night_watch.docs"
 
 
+async def test_status_reads_the_row_and_writes_nothing(druks_db, night_watch):
+    """A page reads where the login stands: the declaration's own status while
+    no row exists, then the row's."""
+    assert await night_watch.docs.get_status() == BrowserSessionStatus.NEEDS_LOGIN
+    assert await night_watch.status_page.get_status() == BrowserSessionStatus.ANONYMOUS
+    assert not await StoredBrowserSession.list_all()
+
+    row = await StoredBrowserSession.get_or_create(
+        name=night_watch.docs.name,
+        payload_format=BrowserSessionPayloadFormat.PROFILE_DIR,
+        site=night_watch.docs.site,
+    )
+    await row.mark_stale()
+
+    assert await night_watch.docs.get_status() == BrowserSessionStatus.STALE
+
+
 async def test_borrow_yields_a_tunneled_cdp_url(borrow, night_watch):
     browser, redis = borrow
     await stored_session(night_watch.docs)


### PR DESCRIPTION
An app page must be able to tell an operator that a browser login went stale, because that is the failure which stops a run. The only way to reach the status was `get_or_create_row()`, which writes a row. A read page must not write.

`BrowserSession.get_status()` reads the stored row, and answers with the declaration's own status while no row exists. `BrowserSessionStatus` joins the `druks.browser` author surface, so a page can name the states it renders:

```python
status = await NightWatch.docs.get_status()
if status is BrowserSessionStatus.STALE:
    blocks.append(ui.Callout("The login stopped working. Sign in again.", tone="warning"))
```

The HTTP route and its response are untouched.
