### PR TITLE
Stop reading a subject with no run as scheduled

### DIFF
--- a/backend/druks/durable/reads.py
+++ b/backend/druks/durable/reads.py
@@ -133,7 +133,8 @@ async def _timeline(runs: list[Run]) -> list[RunResponse]:
 async def _status(driving_run: Run | None) -> SubjectStatus:
     # Facts only: the app's UI renders its copy from them.
     if not driving_run:
-        return SubjectStatus(state=RunState.SCHEDULED)
+        # No run drives it, so it wears no run's state.
+        return SubjectStatus()
     # A parked run is always the active one (ACTIVE_STATES), so the
     # driving run alone decides parked-ness.
     parked = driving_run.state == RunState.PARKED.value

--- a/backend/druks/durable/schemas.py
+++ b/backend/druks/durable/schemas.py
@@ -148,10 +148,10 @@ class SubjectSummary(Schema):
 
 class SubjectStatus(Schema):
     # The subject's lifecycle status for the dashboard lane — derived by the read
-    # side, never stored; ``state`` is the canonical RunState aggregated across
-    # the subject's runs. Everything else is a fact the app's UI renders
-    # its own copy from; the platform ships no prose.
-    state: RunState
+    # side, never stored; ``state`` is the state of the run driving the subject,
+    # and None when no run drives it. Everything else is a fact the app's UI
+    # renders its own copy from; the platform ships no prose.
+    state: RunState | None = None
     # The driving run's id — identity, so an app page can name it in a block
     # (GateControls) without reaching for the platform's own read side.
     run: str | None = None
@@ -161,11 +161,10 @@ class SubjectStatus(Schema):
     # A parked run's gate identity — the app's UI maps it to its own
     # words; the ask's content rides the timeline's ``input_request``.
     gate: str | None = None
-    # The stop reason of the run driving ``state`` — set only when that run is
-    # terminal-failed (an active or finished subject carries none). Lets a board
-    # render "why" inline without reaching into the timeline. ``reason`` is its
-    # machine-readable classification (``gate_timeout``): an unanswered gate,
-    # not a crash.
+    # The driving run's message: a crash's error, or the reason the operator typed
+    # at cancel. It is a message, not a state — read ``state`` to tell failed from
+    # cancelled from orphaned. ``reason`` is its machine-readable classification
+    # (``gate_timeout``): an unanswered gate, not a crash.
     failure: str | None = None
     reason: str | None = None
     # When druks last picked this subject up, and whose work it is. A subject with

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -275,8 +275,8 @@ async def test_list_returns_every_subject_with_status(client: TestClient, druks_
     rows = {row["summary"]["id"]: row for row in body["rows"]}
     assert rows["1"]["summary"]["title"] == "First"
     assert rows["1"]["status"]["state"] == "running"
-    # "2" has no runs yet — it still lists, defaulting to scheduled.
-    assert rows["2"]["status"]["state"] == "scheduled"
+    # "2" has no runs yet — it still lists, and carries no state.
+    assert rows["2"]["status"]["state"] is None
 
 
 async def test_the_board_and_its_stream_hand_the_caller_to_list_summaries(druks_db):

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -620,6 +620,11 @@ if status.is_parked:
 question it stopped on. While a run is active, `await repository.get_phase()`
 returns the step it is on.
 
+A subject that Druks did not run has no state: `status.state` is None, and so
+is `status.run`. `get_status(workflow=NightWatch)` narrows the read to one
+workflow's runs. It answers the same way when the subject has no run of that
+kind.
+
 ## Record events and react to signals
 
 Record an event through the app. Druks stamps its ownership:

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -19,7 +19,7 @@
 // app keys its board/detail on its own subject summary; SubjectRow and
 // SubjectResponse are generic over that summary (a WorkItemSummary for build).
 
-// The platform's canonical lifecycle states, aggregated across a subject's runs.
+// The platform's canonical lifecycle states, each one a run's own.
 export type RunState =
   | 'scheduled'
   | 'running'
@@ -38,7 +38,8 @@ export interface SubjectSummary {
 }
 
 export interface SubjectStatus {
-  state: RunState
+  // Null when no run drives the subject: druks has not run it.
+  state: RunState | null
   // The driving run's id.
   run: string | null
   // Facts the app renders its lane copy from; the backend ships no prose.

--- a/frontend/src/apps/software_factory/WorkItemPage.tsx
+++ b/frontend/src/apps/software_factory/WorkItemPage.tsx
@@ -134,7 +134,9 @@ const STATE_CLS: Record<RunState, string> = {
 // tone comes from the lifecycle state. Live (a dot animates) while a run is active.
 function statusView(status: SubjectStatus, resolution: PRResolution | null): Status {
   const live = status.state === 'running' || status.state === 'parked'
-  return { cls: STATE_CLS[status.state], label: statusLine(status, resolution), live }
+  // Nothing has run yet — the pill rests, in the same tone as a cancelled row.
+  const cls = status.state ? STATE_CLS[status.state] : 'cancelled'
+  return { cls, label: statusLine(status, resolution), live }
 }
 
 const fmtTok = (n: number) => (n > 0 ? formatTokenCount(n) : '0')

--- a/frontend/src/components/StatusGlyph.tsx
+++ b/frontend/src/components/StatusGlyph.tsx
@@ -1,8 +1,8 @@
-import { STATES } from '../lib/states'
+import { NO_RUN, STATES } from '../lib/states'
 import type { RunState } from '../api/types'
 
 interface Props {
-  state: RunState
+  state: RunState | null
   size?: number
 }
 
@@ -10,8 +10,8 @@ interface Props {
 const PULSING: RunState[] = ['scheduled', 'running', 'parked']
 
 export function StatusGlyph({ state, size = 10 }: Props) {
-  const style = STATES[state]
-  const pulse = PULSING.includes(state)
+  const style = state ? STATES[state] : NO_RUN
+  const pulse = state ? PULSING.includes(state) : false
   return (
     <span
       className={`glyph${pulse ? ' glyph-pulse' : ''}`}

--- a/frontend/src/lib/states.ts
+++ b/frontend/src/lib/states.ts
@@ -15,3 +15,10 @@ export const STATES: Record<RunState, StateStyle> = {
   cancelled: { color: 'var(--outcome-abandoned)', glyph: '◯', label: 'cancelled' },
   orphaned: { color: 'var(--bucket-dead)', glyph: '⚠', label: 'orphaned' },
 }
+
+// What a subject with no run wears: it holds none of the states above.
+export const NO_RUN: StateStyle = {
+  color: 'var(--text-faint)',
+  glyph: '◌',
+  label: 'never run',
+}

--- a/frontend/src/pages/AppHomePage.tsx
+++ b/frontend/src/pages/AppHomePage.tsx
@@ -83,5 +83,5 @@ function statusText(row: SubjectRow): string {
   const { state, gate, failure } = row.status
   if (state === 'parked' && gate) return `parked · ${gate.replaceAll('_', ' ')}`
   if (state === 'failed' && failure) return `failed · ${failure.slice(0, 60)}`
-  return state
+  return state ?? 'never run'
 }


### PR DESCRIPTION
A subject Druks never ran came back as `state="scheduled"` with `run=None`, so it was indistinguishable from a queued one. Every reader that lists the working states counted a never-touched row as work in flight. In this repo that is four of them: the review board says "Reviewing" over a pull request Druks never read, build's board counts the row as in flight, and the shared status glyph pulses it.

`SubjectStatus.state` reads `never` now — a `RunState` member that belongs to none of the groupings, because no run ever carries it. Every reader that names the states it means gets the right answer with no other change.

The `failure` comment was wrong in the same place, and it taught the wrong reading. It claimed failure is set only for a terminal-failed run. `Run.cancel(failure=…)` writes it too, and the cancel route requires a reason, so `if status.failure` fires on a cancelled run and stays silent on an orphaned one. The comment now says what the field is: a message, not a state. Read `state` to tell failed from cancelled from orphaned.

Apps read the new value on their next Druks bump. A Python app that buckets states by name keeps working; a TypeScript app with an exhaustive `Record<RunState, …>` map fails to compile until it names `never`, which is the intended loud break. This repo has two such maps and both are updated here.
