### PR TITLE
Let a declared page read every row's status in one query

### DIFF
--- a/backend/druks/durable/datastructures.py
+++ b/backend/druks/durable/datastructures.py
@@ -69,6 +69,14 @@ class Subject:
 
         return await get_subject_status(self.subject_type, self.id, workflow=workflow)
 
+    @classmethod
+    async def get_statuses(cls, subject_ids: Sequence[str]) -> "dict[str, SubjectStatus]":
+        """Where a whole board stands, keyed by subject id — one read for the whole
+        board, so a page listing subjects does not ask once per row."""
+        from druks.durable.reads import get_subject_statuses
+
+        return await get_subject_statuses(cls.subject_type, list(subject_ids))
+
     async def get_phase(self) -> str | None:
         """The step it is on right now ("provisioning_vm"), while something is running."""
         from druks.durable.reads import get_subject_phase

--- a/backend/druks/models.py
+++ b/backend/druks/models.py
@@ -110,6 +110,16 @@ class StoredSubject(Base):
 
         return await get_subject_status(self.subject_type, str(self.id), workflow=workflow)
 
+    @classmethod
+    async def get_statuses(cls, subject_ids: Sequence[str | int]) -> "dict[str, SubjectStatus]":
+        """Where a whole board stands, keyed by subject id — one read for the whole
+        board, so a page listing rows does not ask once per row."""
+        from druks.durable.reads import get_subject_statuses
+
+        return await get_subject_statuses(
+            cls.subject_type, [str(subject_id) for subject_id in subject_ids]
+        )
+
     async def get_phase(self) -> str | None:
         from druks.durable.reads import get_subject_phase
 

--- a/backend/tests/test_generic_subjects.py
+++ b/backend/tests/test_generic_subjects.py
@@ -267,6 +267,25 @@ async def test_the_board_status_read_answers_for_every_id_it_is_given(druks_db):
     assert statuses["2"].run is None
 
 
+async def test_a_page_reads_a_whole_board_through_the_subject_class(druks_db):
+    # What a declared page calls to fill a list of rows: the read the platform's
+    # own board makes, reached without importing the durable read side.
+    live = await _seed_run(druks_db, subject_id="1", state="running")
+    parked = await _seed_run(
+        druks_db, subject_type="ticket", subject_id="owner/repo#7", state="parked"
+    )
+
+    # A stored subject keys its rows by integer and answers by the id its summary
+    # carries; an identity-only subject is asked with the id it already is.
+    stored = await Thing.get_statuses([1, 2])
+    tickets = await Ticket.get_statuses(["owner/repo#7", "owner/repo#9"])
+
+    assert stored["1"].run == live.id
+    assert stored["2"].run is None
+    assert tickets["owner/repo#7"].run == parked.id
+    assert tickets["owner/repo#9"].run is None
+
+
 async def test_list_returns_every_subject_with_status(client: TestClient, druks_db):
     live = await _seed_run(druks_db, subject_id="1", state="running")
     await _seed_call(druks_db, live, agent="implement", status="running")

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -625,6 +625,17 @@ is `status.run`. `get_status(workflow=NightWatch)` narrows the read to one
 workflow's runs. It answers the same way when the subject has no run of that
 kind.
 
+A page that lists subjects reads them all at once instead. `get_statuses()`
+takes the ids and returns one status per id, in a single read:
+
+```python
+summaries = await Repository.list_summaries(account_id)
+statuses = await Repository.get_statuses([summary.id for summary in summaries])
+```
+
+This is the read the platform's own board uses, so a declared page listing
+fifty rows costs one query rather than fifty.
+
 ## Record events and react to signals
 
 Record an event through the app. Druks stamps its ownership:


### PR DESCRIPTION
A page that lists subjects had to read them one at a time.

`get_subject_statuses` reads a whole board in one query, but it lives in
`druks.durable`, and the author guide tells an app to import from concern
namespaces only. So the platform's own generic board got the batched read and
a declared page did not: it called `get_status()` once per row, and apps
capped their lists to stay cheap.

`Subject` and `StoredSubject` now carry `get_statuses()`:

```python
summaries = await Repository.list_summaries(account_id)
statuses = await Repository.get_statuses([summary.id for summary in summaries])
```

It wraps the same read the generic board makes, the way `get_status()` wraps
the single one. `StoredSubject` casts its integer key to the string id a
summary carries, which is what `get_status()` already does.

`get_status()` stays. The two are different queries: the single read is
`ORDER BY created_at DESC LIMIT 1` and takes `workflow=` to narrow to one
workflow's runs; the batched read is a `row_number()` window over the
subject partition and eager-loads every row's agent calls. A detail page
should not pay a partition scan to ask about one subject.

## How it is verified

`test_a_page_reads_a_whole_board_through_the_subject_class` seeds a running
stored row and a parked identity-only subject, then asks each class for a set
of ids that includes one it has no run for. Both answer for every id they were
given, and the id with no run comes back with no run rather than missing.

`uv run ruff check backend` and `uv run ruff format --check backend` pass.
CI runs the suite; this machine has no Postgres or Redis.
