### PR TITLE
Name a file's source instead of pointing at it

### DIFF
--- a/backend/druks/database.py
+++ b/backend/druks/database.py
@@ -63,8 +63,16 @@ def make_app_migration(app_name: str, message: str, database_url: str) -> None:
     for table in Base.metadata.tables.values():
         if table.name.startswith(app.table_prefix):
             table.to_metadata(scoped)
-    files_table = Base.metadata.tables["files"].to_metadata(scoped)
-    files_table.info[_MIGRATION_SUPPORT_ONLY] = True
+    # FileField points at the platform files table, and that table points at
+    # others. They all ride along so every foreign key resolves; include_object
+    # keeps each of them out of the app's own diff.
+    supporting = [Base.metadata.tables["files"]]
+    for table in supporting:
+        for key in table.foreign_key_constraints:
+            if key.referred_table not in supporting:
+                supporting.append(key.referred_table)
+    for table in supporting:
+        table.to_metadata(scoped).info[_MIGRATION_SUPPORT_ONLY] = True
 
     config = Config(str(_ALEMBIC_INI))
     config.set_main_option("version_locations", str(migrations_dir / "versions"))

--- a/backend/druks/files/datastructures.py
+++ b/backend/druks/files/datastructures.py
@@ -41,7 +41,7 @@ class File:
         content_type: str,
         content: bytes,
         app: str,
-        origin_id: str,
+        uploaded_by: str,
     ) -> "File":
         if len(content) > MAX_FILE_BYTES:
             raise FileTooLargeError(f"{name} is {len(content)} bytes; the cap is {MAX_FILE_BYTES}")
@@ -58,8 +58,7 @@ class File:
                 content_type=content_type,
                 sha256=digest.hexdigest(),
                 app=app,
-                origin_type="user_upload",
-                origin_id=origin_id,
+                uploaded_by=uploaded_by,
             )
             db_session().add(record)
             await db_session().flush()

--- a/backend/druks/files/models.py
+++ b/backend/druks/files/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import BigInteger, CheckConstraint, Index, String
+from sqlalchemy import BigInteger, CheckConstraint, ForeignKey, Index, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from druks.core.models import Uuid7Pk
@@ -10,8 +10,10 @@ from druks.models import Base
 class FileRecord(Base, Uuid7Pk):
     __tablename__ = "files"
     __table_args__ = (
+        # A file comes from one place. It can outlive that place: a trimmed run
+        # takes its calls with it, and the file stays without a source.
         CheckConstraint(
-            "origin_type IN ('agent_call', 'user_upload')", name="files_origin_type_check"
+            "num_nonnulls(uploaded_by, agent_call_id) <= 1", name="files_one_source_check"
         ),
         Index("files_deleted_at_idx", "deleted_at"),
     )
@@ -21,7 +23,11 @@ class FileRecord(Base, Uuid7Pk):
     content_type: Mapped[str] = mapped_column(String)
     sha256: Mapped[str] = mapped_column(String(64))
     app: Mapped[str] = mapped_column(String)
-    origin_type: Mapped[str] = mapped_column(String)
-    origin_id: Mapped[str] = mapped_column(String)
+    uploaded_by: Mapped[str | None] = mapped_column(
+        ForeignKey("accounts.id", ondelete="RESTRICT"), default=None
+    )
+    agent_call_id: Mapped[str | None] = mapped_column(
+        ForeignKey("agent_calls.id", ondelete="SET NULL"), default=None
+    )
     created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
     deleted_at: Mapped[datetime | None] = mapped_column(default=None)

--- a/backend/druks/workspaces.py
+++ b/backend/druks/workspaces.py
@@ -118,8 +118,7 @@ class Workspace:
             content_type=mimetypes.guess_type(name)[0] or "application/octet-stream",
             sha256=sha256,
             app=app,
-            origin_type="agent_call",
-            origin_id=agent_call_id,
+            agent_call_id=agent_call_id,
         )
         return record, temp
 

--- a/backend/migrations/versions/b4c7e1a8d052_name_a_files_source.py
+++ b/backend/migrations/versions/b4c7e1a8d052_name_a_files_source.py
@@ -1,0 +1,76 @@
+"""Name a file's source.
+
+Revision ID: b4c7e1a8d052
+Revises: c1e8b4a9f2d7
+Create Date: 2026-08-31
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b4c7e1a8d052"
+down_revision: str | Sequence[str] | None = "c1e8b4a9f2d7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("files", sa.Column("uploaded_by", sa.String(), nullable=True))
+    op.add_column("files", sa.Column("agent_call_id", sa.String(), nullable=True))
+    # origin_id carried no foreign key, so some rows name a source that is gone.
+    # Those keep the source they already had: none.
+    op.execute(
+        """
+        UPDATE files SET agent_call_id = origin_id
+        WHERE origin_type = 'agent_call'
+          AND origin_id IN (SELECT id FROM agent_calls)
+        """
+    )
+    op.execute(
+        """
+        UPDATE files SET uploaded_by = origin_id
+        WHERE origin_type = 'user_upload'
+          AND origin_id IN (SELECT id FROM accounts)
+        """
+    )
+    op.create_foreign_key(
+        "files_uploaded_by_fkey", "files", "accounts", ["uploaded_by"], ["id"], ondelete="RESTRICT"
+    )
+    op.create_foreign_key(
+        "files_agent_call_id_fkey",
+        "files",
+        "agent_calls",
+        ["agent_call_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.drop_constraint("files_origin_type_check", "files")
+    op.create_check_constraint(
+        "files_one_source_check", "files", "num_nonnulls(uploaded_by, agent_call_id) <= 1"
+    )
+    op.drop_column("files", "origin_type")
+    op.drop_column("files", "origin_id")
+
+
+def downgrade() -> None:
+    op.add_column("files", sa.Column("origin_type", sa.String(), nullable=True))
+    op.add_column("files", sa.Column("origin_id", sa.String(), nullable=True))
+    op.execute(
+        """
+        UPDATE files SET
+            origin_type = CASE WHEN agent_call_id IS NULL THEN 'user_upload' ELSE 'agent_call' END,
+            origin_id = coalesce(agent_call_id, uploaded_by, '')
+        """
+    )
+    op.alter_column("files", "origin_type", nullable=False)
+    op.alter_column("files", "origin_id", nullable=False)
+    op.drop_constraint("files_one_source_check", "files")
+    op.create_check_constraint(
+        "files_origin_type_check", "files", "origin_type IN ('agent_call', 'user_upload')"
+    )
+    op.drop_constraint("files_agent_call_id_fkey", "files", type_="foreignkey")
+    op.drop_constraint("files_uploaded_by_fkey", "files", type_="foreignkey")
+    op.drop_column("files", "agent_call_id")
+    op.drop_column("files", "uploaded_by")

--- a/backend/tests/test_api_files.py
+++ b/backend/tests/test_api_files.py
@@ -21,8 +21,7 @@ async def _seed_file(druks_db, *, name: str, content_type: str, content: bytes) 
         content_type=content_type,
         sha256=hashlib.sha256(content).hexdigest(),
         app="field_notes",
-        origin_type="agent_call",
-        origin_id="call-1",
+        uploaded_by="system",
     )
     druks_db.add(record)
     await druks_db.flush()

--- a/backend/tests/test_app_migrations.py
+++ b/backend/tests/test_app_migrations.py
@@ -5,7 +5,6 @@ from alembic import command
 from alembic.config import Config
 from druks.database import make_app_migration
 from druks.files import File, FileField
-from druks.files.models import FileRecord
 from druks.models import Base
 from druks.testing import TEST_DATABASE_URL
 from sqlalchemy import Column, Integer, MetaData, String, Table, create_engine
@@ -80,7 +79,7 @@ def test_app_upgrade_runs_through_platform_env_with_its_own_version_table(tmp_pa
     try:
         command.upgrade(_config(versions, version_table="alembic_version_ext"), "head")
         with engine.connect() as conn:
-            assert conn.exec_driver_sql("SELECT to_regclass('ext_probe')").scalar() is not None
+            assert conn.exec_driver_sql("SELECT to_regclass('ext_probe')").scalar()
             assert (
                 conn.exec_driver_sql("SELECT version_num FROM alembic_version_ext").scalar()
                 == "ext0001"
@@ -129,7 +128,9 @@ def test_app_autogenerate_scopes_to_the_app_metadata(tmp_path):
         engine.dispose()
 
 
-def test_file_field_autogenerates_and_upgrades_with_the_platform_foreign_key(tmp_path, monkeypatch):
+def test_file_field_autogenerates_and_upgrades_with_the_platform_foreign_key(
+    _druks_schema, tmp_path, monkeypatch
+):
     """An app migration renders FileField as a String FK without owning the files table."""
     engine = create_engine(TEST_DATABASE_URL, isolation_level="AUTOCOMMIT")
     package_dir = tmp_path / "migration_probe"
@@ -145,7 +146,6 @@ def test_file_field_autogenerates_and_upgrades_with_the_platform_foreign_key(tmp
         connection.exec_driver_sql(
             "DROP TABLE IF EXISTS migration_probe_files, alembic_version_migration_probe"
         )
-        FileRecord.__table__.create(connection, checkfirst=True)
         connection.commit()
     try:
         make_app_migration(
@@ -158,7 +158,9 @@ def test_file_field_autogenerates_and_upgrades_with_the_platform_foreign_key(tmp
         assert "create_table('migration_probe_files'" in body
         assert "sa.String()" in body
         assert "sa.ForeignKeyConstraint(['image'], ['files.id']" in body
-        assert "create_table('files'" not in body
+        # Only the app's own table: files and everything it names ride along to
+        # resolve foreign keys, and nothing more.
+        assert body.count("create_table(") == 1
 
         command.upgrade(
             _config(

--- a/backend/tests/test_files.py
+++ b/backend/tests/test_files.py
@@ -3,15 +3,19 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from druks.accounts.models import Account
 from druks.agents import AgentOutput
+from druks.durable import AgentCall
 from druks.files import File, FileField
 from druks.files.exceptions import FileTooLargeError, FileUnavailableError
 from druks.files.models import FileRecord
 from druks.files.storage import LocalFileStorage, reap_deleted_file_bytes
 from druks.models import Base
 from druks.sandbox.exceptions import SandboxDownloadError
+from druks.testing import seed_call, seed_run
 from druks.workspaces import Workspace
 from sqlalchemy import Integer, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped, mapped_column
 
 
@@ -31,7 +35,13 @@ class FileReference(Base):
     image: Mapped[File] = FileField()
 
 
-async def _hydrate_file(tmp_path, monkeypatch, *, name="home.png", content=b"image") -> File:
+async def _survey_call(session) -> AgentCall:
+    return await seed_call(session, await seed_run(session, kind="survey"), agent="survey")
+
+
+async def _hydrate_file(
+    session, tmp_path, monkeypatch, *, name="home.png", content=b"image"
+) -> File:
     monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
     workspace_files: list[File] = []
     output = SurveyOutput.model_validate(
@@ -44,16 +54,17 @@ async def _hydrate_file(tmp_path, monkeypatch, *, name="home.png", content=b"ima
         local.write_bytes(content)
 
     host.download = AsyncMock(side_effect=download)
+    call = await _survey_call(session)
     await Workspace(host=host).save_files(
         workspace_files,
         app="field_notes",
-        agent_call_id="call-1",
+        agent_call_id=call.id,
     )
     return output.shots[0].image
 
 
-async def test_create_stores_a_user_upload(druks_db, tmp_path, monkeypatch):
-    """File.create stores bytes and a user_upload record and returns a live handle."""
+async def test_create_stores_an_upload_against_its_account(druks_db, tmp_path, monkeypatch):
+    """File.create stores bytes against the account that sent them."""
     monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
 
     file = await File.create(
@@ -61,7 +72,7 @@ async def test_create_stores_a_user_upload(druks_db, tmp_path, monkeypatch):
         content_type="image/jpeg",
         content=b"jpeg bytes",
         app="site_builder",
-        origin_id="site-1",
+        uploaded_by="system",
     )
 
     record = await druks_db.get(FileRecord, file.id)
@@ -71,9 +82,11 @@ async def test_create_stores_a_user_upload(druks_db, tmp_path, monkeypatch):
         "image/jpeg",
         f"/api/files/{file.id}",
     )
-    assert record.app == "site_builder"
-    assert record.origin_type == "user_upload"
-    assert record.origin_id == "site-1"
+    assert (record.app, record.uploaded_by, record.agent_call_id) == (
+        "site_builder",
+        "system",
+        None,
+    )
     assert record.sha256 == hashlib.sha256(b"jpeg bytes").hexdigest()
     assert await file.open() == b"jpeg bytes"
 
@@ -88,7 +101,7 @@ async def test_create_refuses_an_oversized_upload(monkeypatch):
             content_type="image/jpeg",
             content=b"jpeg bytes",
             app="site_builder",
-            origin_id="site-1",
+            uploaded_by="system",
         )
 
 
@@ -100,7 +113,7 @@ async def test_uploaded_file_delete_and_reap(druks_db, tmp_path, monkeypatch):
         content_type="image/jpeg",
         content=b"jpeg bytes",
         app="site_builder",
-        origin_id="site-1",
+        uploaded_by="system",
     )
     await file.delete()
     record = await druks_db.get(FileRecord, file.id)
@@ -123,7 +136,7 @@ def test_file_contract_is_a_strict_nested_workspace_path():
 
 async def test_hydration_pulls_and_stores_a_nested_file(druks_db, tmp_path, monkeypatch):
     """Hydration stores immutable bytes and stamps the handle and provenance."""
-    file = await _hydrate_file(tmp_path, monkeypatch, content=b"png bytes")
+    file = await _hydrate_file(druks_db, tmp_path, monkeypatch, content=b"png bytes")
 
     record = await druks_db.get(FileRecord, file.id)
     assert (file.name, file.size, file.content_type, file.url) == (
@@ -133,10 +146,44 @@ async def test_hydration_pulls_and_stores_a_nested_file(druks_db, tmp_path, monk
         f"/api/files/{file.id}",
     )
     assert record.app == "field_notes"
-    assert record.origin_type == "agent_call"
-    assert record.origin_id == "call-1"
+    assert await druks_db.get(AgentCall, record.agent_call_id)
+    assert not record.uploaded_by
     assert record.sha256 == hashlib.sha256(b"png bytes").hexdigest()
     assert await file.open() == b"png bytes"
+
+
+async def test_a_deleted_agent_call_leaves_its_file_without_a_source(
+    druks_db, tmp_path, monkeypatch
+):
+    """A file outlives the call that made it, and stops naming it."""
+    file = await _hydrate_file(druks_db, tmp_path, monkeypatch)
+    record = await druks_db.get(FileRecord, file.id)
+
+    await druks_db.delete(await druks_db.get(AgentCall, record.agent_call_id))
+    await druks_db.flush()
+    await druks_db.refresh(record)
+
+    assert not record.agent_call_id
+    assert await file.open() == b"image"
+
+
+async def test_an_upload_holds_its_uploader(druks_db, tmp_path, monkeypatch):
+    """An upload holds its uploader, so the account cannot leave without it."""
+    monkeypatch.setenv("DRUKS_DATA_DIR", str(tmp_path))
+    account = Account(username="shopkeeper@example.com")
+    druks_db.add(account)
+    await druks_db.flush()
+    await File.create(
+        name="shopfront.jpg",
+        content_type="image/jpeg",
+        content=b"jpeg bytes",
+        app="site_builder",
+        uploaded_by=account.id,
+    )
+
+    await druks_db.delete(account)
+    with pytest.raises(IntegrityError):
+        await druks_db.flush()
 
 
 async def test_hydration_leaves_no_canonical_bytes_when_a_later_pull_fails(
@@ -164,11 +211,12 @@ async def test_hydration_leaves_no_canonical_bytes_when_a_later_pull_fails(
 
     host.download = AsyncMock(side_effect=download)
 
+    call = await _survey_call(druks_db)
     with pytest.raises(SandboxDownloadError, match="missing"):
         await Workspace(host=host).save_files(
             workspace_files,
             app="field_notes",
-            agent_call_id="call-1",
+            agent_call_id=call.id,
         )
 
     files_dir = tmp_path / "files"
@@ -177,7 +225,7 @@ async def test_hydration_leaves_no_canonical_bytes_when_a_later_pull_fails(
 
 async def test_prepared_context_uploads_into_the_call_directory(druks_db, tmp_path, monkeypatch):
     """A hydrated handle becomes a path inside the call's own directory."""
-    file = await _hydrate_file(tmp_path, monkeypatch)
+    file = await _hydrate_file(druks_db, tmp_path, monkeypatch)
     host = MagicMock(ssh_username="root")
     host.upload_file = AsyncMock()
 
@@ -192,7 +240,7 @@ async def test_prepared_context_uploads_into_the_call_directory(druks_db, tmp_pa
 
 async def test_prepare_context_refuses_a_deleted_file(druks_db, tmp_path, monkeypatch):
     """A deleted handle never uploads bytes into the next agent call."""
-    file = await _hydrate_file(tmp_path, monkeypatch)
+    file = await _hydrate_file(druks_db, tmp_path, monkeypatch)
     await file.delete()
     host = MagicMock(ssh_username="root")
     host.upload_file = AsyncMock()
@@ -205,7 +253,7 @@ async def test_prepare_context_refuses_a_deleted_file(druks_db, tmp_path, monkey
 
 async def test_file_field_round_trip_loads_metadata_with_the_row(druks_db, tmp_path, monkeypatch):
     """FileField persists a real FK and projects complete handle metadata on load."""
-    file = await _hydrate_file(tmp_path, monkeypatch, content=b"1234")
+    file = await _hydrate_file(druks_db, tmp_path, monkeypatch, content=b"1234")
     reference = FileReference(image=file)
     druks_db.add(reference)
     await druks_db.flush()
@@ -228,7 +276,7 @@ async def test_file_field_round_trip_loads_metadata_with_the_row(druks_db, tmp_p
 
 async def test_delete_and_reaper_leave_the_tombstone(druks_db, tmp_path, monkeypatch):
     """The reaper removes bytes while the soft-deleted row and app FK remain."""
-    file = await _hydrate_file(tmp_path, monkeypatch)
+    file = await _hydrate_file(druks_db, tmp_path, monkeypatch)
     reference = FileReference(image=file)
     druks_db.add(reference)
     await druks_db.flush()


### PR DESCRIPTION
ENG-909

A file comes from an account or from an agent call. The table now says so.

## What changed

`files` recorded where a row came from as `origin_type`, a checked enum of
`agent_call` and `user_upload`, plus `origin_id`, a free-text column with no
foreign key. Two columns replace both:

| Column | Points at | On delete |
| --- | --- | --- |
| `uploaded_by` | `accounts.id` | `RESTRICT` |
| `agent_call_id` | `agent_calls.id` | `SET NULL` |

A check constraint keeps a row from claiming both.

The polymorphic pair cost integrity and bought nothing. The set of sources is
closed and the platform owns both members, so no app ever adds a third. And
because `origin_id` carried no foreign key, a row could name an agent call
that no longer existed — the migration finds those and gives them the source
they already had, which is none.

`SET NULL` rather than `CASCADE`: an app row points at `files.id` with
`ON DELETE RESTRICT`, so cascading from a deleted agent call would raise a
foreign key error for every file an app has stored. A trimmed run takes its
calls with it and the file stays, without a source. That is why the constraint
reads `<= 1` and not `= 1`: a file is created with exactly one source and can
lose it later.

`File.create` takes `uploaded_by` in place of `origin_id`, and the agent path
writes `agent_call_id`.

## An app's migrations

An app that stores a file gets `files` copied into its migration scope so
`FileField`'s foreign key resolves. `files` now points at two more tables, so
those ride along too, found by following the foreign keys rather than by name.
Every one of them is marked support-only, so the app's own diff still proposes
exactly one table: its own.

## How it is verified

The suite passes: 1479 tests before, 1480 after. Two new ones cover the delete
rules — a deleted agent call leaves its file behind with no source, and an
account that uploaded a file cannot be deleted.

The migration was run against a database seeded at the previous revision with
three rows: a file naming a live agent call, a file naming a call that never
existed, and an upload naming an account. After the upgrade the first two land
as expected and the upload keeps its account. Downgrade and upgrade again
preserve both real sources. Deleting the call cleared the file's source;
deleting the account was refused by name.
