### PR TITLE
An app page answers when you act on it

### DIFF
--- a/frontend/src/druksui/AppPage.test.tsx
+++ b/frontend/src/druksui/AppPage.test.tsx
@@ -168,8 +168,8 @@ describe('the parent link', () => {
   it('takes a parameterized detail page back to its longest declared prefix', async () => {
     renderAt('/field_notes/notes/7', 'note', { title: 'Note 7', description: '', blocks: [], follows: null })
 
-    await waitFor(() => expect(screen.getByText('← notes')).toBeTruthy())
-    expect(screen.getByText('← notes').getAttribute('href')).toBe('/field_notes')
+    await waitFor(() => expect(screen.getByRole('link', { name: 'notes' })).toBeTruthy())
+    expect(screen.getByRole('link', { name: 'notes' }).getAttribute('href')).toBe('/field_notes')
   })
 
   it('takes a parameterized child back to the page it was declared under', async () => {
@@ -180,8 +180,10 @@ describe('the parent link', () => {
       follows: null,
     })
 
-    await waitFor(() => expect(screen.getByText('← note')).toBeTruthy())
-    expect(screen.getByText('← note').getAttribute('href')).toBe('/field_notes/notes/7')
+    await waitFor(() => expect(screen.getByRole('link', { name: 'note' })).toBeTruthy())
+    expect(screen.getByRole('link', { name: 'note' }).getAttribute('href')).toBe(
+      '/field_notes/notes/7',
+    )
     // A detail page is not one of its parent's tabs, so it shows none.
     expect(container.querySelector('.dui-tabs')).toBeNull()
   })

--- a/frontend/src/druksui/AppPage.tsx
+++ b/frontend/src/druksui/AppPage.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useRef, type ReactNode } from 'react'
 import { Link as RouteLink, useLocation } from 'wouter'
 
 import { api } from '../api/client'
-import type { Follows, PageSnapshot } from '../api/types'
+import type { Follows, PageEntry, PageSnapshot } from '../api/types'
 import { EmptyState } from '../components/EmptyState'
 import { Page } from '../components/Page'
 import { AppSurface } from './AppSurface'
@@ -68,18 +68,6 @@ export function AppPage({ app, page }: { app: string; page: string }) {
     [snapshot.data],
   )
 
-  if (snapshot.isLoading) {
-    return (
-      <Page className="dui-page">
-        <EmptyState glyph="…" msg="loading" />
-      </Page>
-    )
-  }
-  if (snapshot.isError || !snapshot.data) {
-    const detail = snapshot.error instanceof Error ? snapshot.error.message : ''
-    return appError(app, detail, () => snapshot.refetch())
-  }
-
   const current = pages.find((entry) => entry.name === page)
   const root = pages.find((entry) => entry.name === current?.parent) ?? current
   // A page shows its family's tabs only when it is one of them. A
@@ -87,6 +75,33 @@ export function AppPage({ app, page }: { app: string; page: string }) {
   const family = root ? tabsFor(pages, root) : []
   const tabs = family.some((tab) => tab.name === page) ? family : []
   const parent = current && isDetail(pages, current) ? parentOf(pages, current) : undefined
+  const chrome = { app, page, location, parent, root, tabs }
+
+  if (snapshot.isLoading) {
+    const waiting = `loading ${app.replaceAll('_', ' ')}`
+    // The breadcrumb and the tabs come from the roster, which is already warm,
+    // so the page keeps its frame while the body arrives. A cold deeplink has
+    // no roster yet and waits bare.
+    if (!pages.length) {
+      return (
+        <Page className="dui-page">
+          <EmptyState glyph="…" msg={waiting} />
+        </Page>
+      )
+    }
+    return (
+      <Page className="dui-page">
+        {/* The title is the app's to compute, so it is held rather than
+            guessed: a page label would show the wrong words first. */}
+        <PageChrome {...chrome} title="…" />
+        <EmptyState glyph="…" msg={waiting} />
+      </Page>
+    )
+  }
+  if (snapshot.isError || !snapshot.data) {
+    const detail = snapshot.error instanceof Error ? snapshot.error.message : ''
+    return appError(app, detail, () => snapshot.refetch())
+  }
 
   return (
     <AppSurface
@@ -107,33 +122,65 @@ export function AppPage({ app, page }: { app: string; page: string }) {
       ))}
       <PagesContext.Provider value={{ app, pages, operations }}>
         <Page className="dui-page">
-          {parent && (
-            <RouteLink href={hrefUnder(location, parent)} className="breadcrumb dui-parent">
-              ← {parent.label}
-            </RouteLink>
-          )}
-          <h1 className="dui-title">{snapshot.data.title}</h1>
-          {snapshot.data.description && (
-            <p className="dui-description dim">{snapshot.data.description}</p>
-          )}
-          {tabs.length > 0 && root && (
-            <nav className="dui-tabs" aria-label={`${app} page tabs`}>
-              {tabs.map((tab) => (
-                <RouteLink
-                  key={tab.name}
-                  href={hrefUnder(location, root) + tab.path.slice(root.path.length)}
-                  className={`dui-tab mono ${tab.name === page ? 'dui-tab-active' : ''}`}
-                  aria-current={tab.name === page ? 'page' : undefined}
-                >
-                  {tab.label}
-                </RouteLink>
-              ))}
-            </nav>
-          )}
+          <PageChrome
+            {...chrome}
+            title={snapshot.data.title}
+            description={snapshot.data.description}
+          />
           <Blocks blocks={snapshot.data.blocks} />
         </Page>
       </PagesContext.Provider>
     </AppSurface>
+  )
+}
+
+// The frame a page wears whether or not its body has arrived: where it sits,
+// what it is called, and the tabs beside it.
+function PageChrome({
+  app,
+  page,
+  location,
+  parent,
+  root,
+  tabs,
+  title,
+  description,
+}: {
+  app: string
+  page: string
+  location: string
+  parent?: PageEntry
+  root?: PageEntry
+  tabs: PageEntry[]
+  title: ReactNode
+  description?: string
+}) {
+  return (
+    <>
+      {parent && (
+        <RouteLink href={hrefUnder(location, parent)} className="breadcrumb dui-parent">
+          {/* The arrow points; it is not part of the link's name. */}
+          <span aria-hidden="true">← </span>
+          {parent.label}
+        </RouteLink>
+      )}
+      <h1 className="dui-title">{title}</h1>
+      {description && <p className="dui-description dim">{description}</p>}
+      {tabs.length > 0 && root && (
+        <nav className="dui-tabs" aria-label={`${app} page tabs`}>
+          {tabs.map((tab) => (
+            <RouteLink
+              key={tab.name}
+              href={hrefUnder(location, root) + tab.path.slice(root.path.length)}
+              className={`dui-tab mono ${tab.name === page ? 'dui-tab-active' : ''}`}
+              aria-current={tab.name === page ? 'page' : undefined}
+            >
+              {tab.label}
+            </RouteLink>
+          ))}
+        </nav>
+      )}
+    </>
   )
 }
 

--- a/frontend/src/druksui/DataBlocks.test.tsx
+++ b/frontend/src/druksui/DataBlocks.test.tsx
@@ -208,7 +208,9 @@ describe('Table', () => {
       'Peer',
       'Answers',
     ])
-    expect(container.querySelectorAll('td')[1]?.getAttribute('data-align')).toBe('end')
+    // The first cell names its row, so a reader hears which row a value is in.
+    expect(screen.getAllByRole('rowheader').map((one) => one.textContent)).toEqual(['peer-7'])
+    expect(container.querySelectorAll('td')[0]?.getAttribute('data-align')).toBe('end')
   })
 })
 

--- a/frontend/src/druksui/DataBlocks.tsx
+++ b/frontend/src/druksui/DataBlocks.tsx
@@ -223,7 +223,7 @@ export function Chart({
 export function ImageGallery({ title, images }: { title: string; images: ImageBlock[] }) {
   return (
     <div className="dui-gallery">
-      {title && <div className="dui-block-title">{title}</div>}
+      {title && <h3 className="dui-block-title">{title}</h3>}
       <ul className="dui-gallery-grid">
         {images.map((image) => (
           <li key={image.url}>
@@ -246,7 +246,7 @@ export function ImageGallery({ title, images }: { title: string; images: ImageBl
 export function Metrics({ title, metrics }: { title: string; metrics: Metric[] }) {
   return (
     <div className="dui-metrics">
-      {title && <div className="dui-block-title">{title}</div>}
+      {title && <h3 className="dui-block-title">{title}</h3>}
       <dl className="dui-metric-row">
         {metrics.map((metric) => (
           <div key={metric.label} className="dui-metric">
@@ -265,7 +265,7 @@ export function Metrics({ title, metrics }: { title: string; metrics: Metric[] }
 export function Facts({ title, facts }: { title: string; facts: Fact[] }) {
   return (
     <div className="dui-facts">
-      {title && <div className="dui-block-title">{title}</div>}
+      {title && <h3 className="dui-block-title">{title}</h3>}
       <dl className="dui-fact-list">
         {facts.map((fact) => (
           <div key={fact.label} className="dui-fact">
@@ -294,7 +294,7 @@ export function Table({
   if (rows.length === 0) {
     return (
       <div className="dui-table-block">
-        {title && <div className="dui-block-title">{title}</div>}
+        {title && <h3 className="dui-block-title">{title}</h3>}
         <div className="dui-table-empty dim">{emptyText}</div>
       </div>
     )
@@ -318,17 +318,20 @@ export function Table({
           <tbody>
             {rows.map((row, index) => (
               <tr key={index}>
-                {row.cells.map((cell, place) => (
-                  // The column label doubles as the row's label on a narrow
-                  // screen, where each row stacks as label and value.
-                  <td
-                    key={place}
-                    data-align={columns[place]?.align}
-                    data-label={columns[place]?.label}
-                  >
-                    <Datum value={cell} />
-                  </td>
-                ))}
+                {row.cells.map((cell, place) =>
+                  // The first cell names its row, the way the column header
+                  // names its column, so a reader hears which row a value
+                  // belongs to.
+                  place === 0 ? (
+                    <th key={place} scope="row" data-align={columns[place]?.align}>
+                      <Datum value={cell} />
+                    </th>
+                  ) : (
+                    <td key={place} data-align={columns[place]?.align}>
+                      <Datum value={cell} />
+                    </td>
+                  ),
+                )}
               </tr>
             ))}
           </tbody>
@@ -341,7 +344,7 @@ export function Table({
 export function List({ title, items }: { title: string; items: Value[] }) {
   return (
     <div className="dui-list-block">
-      {title && <div className="dui-block-title">{title}</div>}
+      {title && <h3 className="dui-block-title">{title}</h3>}
       <ul className="dui-list">
         {items.map((item, index) => (
           <li key={index}>

--- a/frontend/src/druksui/Fields.tsx
+++ b/frontend/src/druksui/Fields.tsx
@@ -20,26 +20,52 @@ export function Fields({
   const form = useId()
   return (
     <>
-      {fields.map((field) => (
-        <div key={field.name} className="dui-field">
-          <label className="dui-field-label" htmlFor={`${form}${field.name}`}>
+      {fields.map((field) => {
+        const id = `${form}${field.name}`
+        const help = field.helpText ? `${id}-help` : ''
+        const error = errors[field.name] ? `${id}-error` : ''
+        const describedBy = [help, error].filter(Boolean).join(' ') || undefined
+        // Radio and multi-select are a group of inputs rather than one, so the
+        // label names the group instead of pointing at an id no element has.
+        const isGroup = field.field === 'radio' || field.field === 'multi_select'
+        const name = (
+          <>
             {field.label}
             {field.isRequired && <span className="dui-field-required"> *</span>}
-          </label>
-          <Input
-            field={field}
-            id={`${form}${field.name}`}
-            value={values[field.name]}
-            onChange={onChange}
-          />
-          {field.helpText && <div className="dui-field-help dim">{field.helpText}</div>}
-          {errors[field.name] && (
-            <div className="dui-field-error" role="alert">
-              {errors[field.name]}
-            </div>
-          )}
-        </div>
-      ))}
+          </>
+        )
+        return (
+          <div key={field.name} className="dui-field">
+            {isGroup ? (
+              <div className="dui-field-label" id={`${id}-label`}>
+                {name}
+              </div>
+            ) : (
+              <label className="dui-field-label" htmlFor={id}>
+                {name}
+              </label>
+            )}
+            <Input
+              field={field}
+              id={id}
+              value={values[field.name]}
+              onChange={onChange}
+              describedBy={describedBy}
+              isInvalid={Boolean(errors[field.name])}
+            />
+            {field.helpText && (
+              <div className="dui-field-help dim" id={help}>
+                {field.helpText}
+              </div>
+            )}
+            {errors[field.name] && (
+              <div className="dui-field-error" role="alert" id={error}>
+                {errors[field.name]}
+              </div>
+            )}
+          </div>
+        )
+      })}
     </>
   )
 }
@@ -49,11 +75,15 @@ function Input({
   id,
   value,
   onChange,
+  describedBy,
+  isInvalid,
 }: {
   field: Field
   id: string
   value: unknown
   onChange: (name: string, value: unknown) => void
+  describedBy?: string
+  isInvalid: boolean
 }) {
   const shared = {
     id,
@@ -62,8 +92,12 @@ function Input({
     // is keyed by the field's own name, not by this one.
     name: id,
     required: field.isRequired,
-    'aria-invalid': undefined,
+    'aria-describedby': describedBy,
+    'aria-invalid': isInvalid || undefined,
   }
+  // A group is described and labelled as a whole; invalidity belongs to an
+  // input, not to the box around several.
+  const group = { 'aria-labelledby': `${id}-label`, 'aria-describedby': describedBy }
   switch (field.field) {
     case 'text':
       return (
@@ -120,7 +154,7 @@ function Input({
       )
     case 'multi_select':
       return (
-        <div className="dui-choices" role="group" aria-label={field.label}>
+        <div className="dui-choices" role="group" {...group}>
           {field.options.map((option) => {
             const chosen = Array.isArray(value) ? (value as string[]) : []
             return (
@@ -147,7 +181,7 @@ function Input({
       )
     case 'radio':
       return (
-        <div className="dui-choices" role="radiogroup" aria-label={field.label}>
+        <div className="dui-choices" role="radiogroup" {...group}>
           {field.options.map((option) => (
             <label key={option.value} className="dui-choice">
               <input

--- a/frontend/src/druksui/Form.test.tsx
+++ b/frontend/src/druksui/Form.test.tsx
@@ -216,13 +216,17 @@ describe('submitting a form', () => {
     )
     renderBlocks([form([BODY], action({ refresh: 'none' }))])
 
-    fireEvent.click(screen.getByText('Save'))
-    await waitFor(() => expect(screen.getByText('working…')).toBeTruthy())
-    fireEvent.click(screen.getByText('working…'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' }).getAttribute('aria-busy')).toBe('true'),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     expect(callOperation).toHaveBeenCalledTimes(1)
     release()
-    await waitFor(() => expect(screen.getByText('Save')).toBeTruthy())
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' }).getAttribute('aria-busy')).toBe('false'),
+    )
   })
 
   it('puts a server validation error on the field it belongs to', async () => {
@@ -316,7 +320,6 @@ describe('what an action does next', () => {
   })
 
   it('asks first when the action says to, and sends nothing on a refusal', async () => {
-    vi.stubGlobal('confirm', vi.fn().mockReturnValue(false))
     renderBlocks([
       {
         block: 'card',
@@ -327,10 +330,31 @@ describe('what an action does next', () => {
       },
     ])
 
-    fireEvent.click(screen.getByText('Clear the gist'))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear the gist' }))
 
-    expect(window.confirm).toHaveBeenCalledWith('Clear it?')
+    // The question is asked in the page, and going back sends nothing.
+    expect(screen.getByText('Clear it?')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
     expect(callOperation).not.toHaveBeenCalled()
+    expect(screen.queryByText('Clear it?')).toBeNull()
+  })
+
+  it('sends once the operator answers the question in the page', async () => {
+    renderBlocks([
+      {
+        block: 'card',
+        title: '',
+        description: '',
+        blocks: [],
+        actions: [action({ label: 'Clear the gist', confirm: 'Clear it?', tone: 'danger' })],
+      },
+    ])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear the gist' }))
+    // The question replaces the control, so answering it presses the same name.
+    fireEvent.click(screen.getByRole('button', { name: 'Clear the gist' }))
+
+    await waitFor(() => expect(callOperation).toHaveBeenCalledTimes(1))
   })
 
   it('leaves the browser to navigate somewhere outside the app', async () => {
@@ -416,7 +440,7 @@ describe('what an action does next', () => {
     await waitFor(() => expect(screen.getByText(/saved, but the page did not refresh/)).toBeTruthy())
     // One write happened, and the control cannot make a second.
     expect(callOperation).toHaveBeenCalledTimes(1)
-    expect(screen.getByText('working…')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Clear' }).getAttribute('aria-busy')).toBe('true')
   })
 
   it('shows a danger action as one', () => {

--- a/frontend/src/druksui/Form.tsx
+++ b/frontend/src/druksui/Form.tsx
@@ -3,6 +3,7 @@ import { useContext, useState } from 'react'
 import { useLocation } from 'wouter'
 
 import { ApiError, api } from '../api/client'
+import { useFlashNote } from '../lib/useFlashNote'
 import type { Action, Field, Operation, PageEntry } from '../api/types'
 import type { PageSnapshot } from '../api/types'
 import { Fields } from './Fields'
@@ -37,6 +38,7 @@ export function Form({
   const run = useAction(
     action,
     fields.map((one) => one.name),
+    () => setValues(Object.fromEntries(fields.map(startingValue))),
   )
 
   return (
@@ -47,7 +49,7 @@ export function Form({
         void run.call(values)
       }}
     >
-      {title && <div className="dui-block-title">{title}</div>}
+      {title && <h3 className="dui-block-title">{title}</h3>}
       {description && <p className="dui-form-desc dim">{description}</p>}
       <Fields
         fields={fields}
@@ -61,14 +63,22 @@ export function Form({
         </div>
       )}
       <div className="dui-form-submit">
-        <button
-          type="submit"
-          className={`dui-action dui-action-${action.tone}`}
-          disabled={run.pending}
-        >
-          {run.pending ? 'working…' : action.label}
-        </button>
+        {run.confirming ? (
+          <Confirm action={action} run={run} />
+        ) : (
+          <button
+            type="submit"
+            className={`dui-action dui-action-${action.tone}`}
+            disabled={run.pending}
+            aria-busy={run.pending}
+          >
+            {action.label}
+          </button>
+        )}
       </div>
+      <p className="dui-action-note" role="status">
+        {run.note}
+      </p>
     </form>
   )
 }
@@ -87,29 +97,62 @@ export function ActionButton({ action }: { action: Action }) {
   }
   return (
     <>
-      <button
-        type="button"
-        className={`dui-action dui-action-${action.tone}`}
-        disabled={run.pending}
-        onClick={() => void run.call({})}
-      >
-        {run.pending ? 'working…' : action.label}
-      </button>
+      {run.confirming ? (
+        <Confirm action={action} run={run} />
+      ) : (
+        <button
+          type="button"
+          className={`dui-action dui-action-${action.tone}`}
+          disabled={run.pending}
+          aria-busy={run.pending}
+          onClick={() => void run.call({})}
+        >
+          {action.label}
+        </button>
+      )}
       {run.problem && (
         <span className="dui-form-error" role="alert">
           {run.problem}
         </span>
       )}
+      <span className="dui-action-note" role="status">
+        {run.note}
+      </span>
     </>
+  )
+}
+
+// An action that asks first asks in the page, in the page's own type and
+// colour. The browser's own dialog is the one thing an author cannot restyle.
+function Confirm({ action, run }: { action: Action; run: ReturnType<typeof useAction> }) {
+  return (
+    <span className="dui-confirm">
+      <span className="dui-confirm-ask">{action.confirm}</span>
+      <button
+        type="button"
+        className={`dui-action dui-action-${action.tone}`}
+        disabled={run.pending}
+        aria-busy={run.pending}
+        onClick={() => void run.confirm()}
+      >
+        {action.label}
+      </button>
+      <button type="button" className="dui-action" disabled={run.pending} onClick={run.back}>
+        Back
+      </button>
+    </span>
   )
 }
 
 // Everything an action does once someone presses it: ask first when it says to,
 // send the one payload, keep a second press out while it runs, and then stay,
 // refresh, or navigate.
-function useAction(action: Action, fieldNames: string[] = []) {
+function useAction(action: Action, fieldNames: string[] = [], clear?: () => void) {
   const [pending, setPending] = useState(false)
   const [problem, setProblem] = useState('')
+  const [note, setNote] = useFlashNote<string>()
+  // The payload an action is holding while it asks; null when it is not asking.
+  const [asked, setAsked] = useState<Payload | null>(null)
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({})
   const { app, pages, operations } = useContext(PagesContext)
   const region = useContext(RegionContext)
@@ -119,7 +162,21 @@ function useAction(action: Action, fieldNames: string[] = []) {
 
   async function call(values: Payload) {
     if (pending) return
-    if (action.confirm && !window.confirm(action.confirm)) return
+    if (action.confirm) {
+      setAsked(values)
+      return
+    }
+    await perform(values)
+  }
+
+  async function confirm() {
+    if (pending) return
+    const values = asked ?? {}
+    setAsked(null)
+    await perform(values)
+  }
+
+  async function perform(values: Payload) {
     const target = operations.find((one) => one.id === action.operation)
     if (!target) {
       setProblem(`this app declares no operation named ${action.operation}`)
@@ -156,6 +213,8 @@ function useAction(action: Action, fieldNames: string[] = []) {
     // twice.
     try {
       await finish()
+      clear?.()
+      setNote(`${action.label} — done`)
       setPending(false)
     } catch (error) {
       setProblem(`saved, but the page did not refresh: ${message(error)}`)
@@ -207,7 +266,7 @@ function useAction(action: Action, fieldNames: string[] = []) {
     await queryClient.invalidateQueries({ queryKey: ['gate'] })
   }
 
-  return { pending, problem, fieldErrors, call }
+  return { pending, problem, note, fieldErrors, call, confirm, back: () => setAsked(null), confirming: asked !== null }
 }
 
 // The operation's path parameters come out of the payload; everything left is

--- a/frontend/src/druksui/RunBlocks.tsx
+++ b/frontend/src/druksui/RunBlocks.tsx
@@ -15,7 +15,7 @@ export function Timeline({ title, items }: { title: string; items: TimelineItem[
   const ordered = items
   return (
     <div className="dui-timeline">
-      {title && <div className="dui-block-title">{title}</div>}
+      {title && <h3 className="dui-block-title">{title}</h3>}
       <ol className="dui-timeline-items">
         {ordered.map((item, index) => (
           <li key={index} className="dui-timeline-item">
@@ -114,7 +114,7 @@ export function Image({
 export function Files({ title, files }: { title: string; files: FileSummary[] }) {
   return (
     <div className="dui-files">
-      {title && <div className="dui-block-title">{title}</div>}
+      {title && <h3 className="dui-block-title">{title}</h3>}
       <ul className="dui-file-list">
         {files.map((file) => (
           <li key={file.id} className="dui-file">

--- a/frontend/src/druksui/accessibility.test.tsx
+++ b/frontend/src/druksui/accessibility.test.tsx
@@ -12,7 +12,7 @@ import { PagesContext } from './pages'
 
 vi.mock('../components/RunTranscript', () => ({ RunTranscript: () => <pre /> }))
 vi.mock('../api/client', () => ({
-  api: { getGate: vi.fn(), answerGate: vi.fn(), artifact: vi.fn() },
+  api: { getGate: vi.fn(), answerGate: vi.fn(), artifact: vi.fn(), callOperation: vi.fn(), readPage: vi.fn() },
 }))
 
 afterEach(cleanup)
@@ -45,7 +45,7 @@ vi.mocked(api.getGate).mockResolvedValue({
   artifact: null,
 })
 
-function renderCatalog() {
+function renderBlocks(blocks: Block[]) {
   const { hook } = memoryLocation({ path: '/field_notes' })
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
@@ -54,11 +54,15 @@ function renderCatalog() {
         <PagesContext.Provider
           value={{ app: 'field_notes', pages: PAGES, operations: OPERATIONS }}
         >
-          <Blocks blocks={CATALOG} />
+          <Blocks blocks={blocks} />
         </PagesContext.Provider>
       </Router>
     </QueryClientProvider>,
   )
+}
+
+function renderCatalog() {
+  return renderBlocks(CATALOG)
 }
 
 describe('every V1 renderer', () => {
@@ -171,5 +175,77 @@ describe('every V1 renderer', () => {
     renderCatalog()
 
     expect(screen.getAllByRole('columnheader').map((one) => one.textContent)).toContain('Note')
+  })
+
+  it('names every row as well as every column', () => {
+    renderCatalog()
+
+    // A value read on its own says which column it is in and which row.
+    expect(screen.getAllByRole('rowheader').length).toBeGreaterThan(0)
+  })
+
+  it('points a field at its own help, and marks the one that failed', () => {
+    renderBlocks([
+            {
+              block: 'form',
+              title: '',
+              description: '',
+              fields: [
+                {
+                  field: 'text',
+                  name: 'repo',
+                  label: 'Repository',
+                  value: '',
+                  isRequired: true,
+                  helpText: 'owner/name',
+                  placeholder: '',
+                },
+              ],
+              action: {
+                block: 'action',
+                label: 'Track',
+                operation: 'write_note',
+                tone: 'primary',
+                confirm: '',
+                refresh: 'page',
+                link: null,
+                arguments: {},
+              },
+            },
+          ])
+
+    const input = screen.getByLabelText(/Repository/)
+    const help = screen.getByText('owner/name')
+    expect(input.getAttribute('aria-describedby')).toBe(help.getAttribute('id'))
+    expect(input.getAttribute('aria-invalid')).toBeNull()
+  })
+
+  it('says so when an action has happened', async () => {
+    vi.mocked(api.callOperation).mockResolvedValue(undefined)
+    renderBlocks([
+            {
+              block: 'card',
+              title: '',
+              description: '',
+              blocks: [],
+              actions: [
+                {
+                  block: 'action',
+                  label: 'Rescout peer',
+                  operation: 'write_note',
+                  tone: 'primary',
+                  confirm: '',
+                  refresh: 'none',
+                  link: null,
+                  arguments: {},
+                },
+              ],
+            },
+          ])
+
+    screen.getByRole('button', { name: 'Rescout peer' }).click()
+
+    // Success is announced; before this a reader heard nothing at all.
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Rescout peer'))
   })
 })

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2668,6 +2668,14 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .dui-choice { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; }
 .dui-form-submit { margin-top: 16px; }
 
+/* An action that asks does it in the page. */
+.dui-confirm { display: inline-flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+.dui-confirm-ask { font-size: 12.5px; color: var(--text-mid); }
+/* What an action says once it has happened; it clears itself. */
+.dui-action-note { font-size: 12.5px; color: var(--outcome-merged); margin: 0; }
+.dui-action-note:empty { display: none; }
+.dui-action[aria-busy='true'] { opacity: 0.7; cursor: progress; }
+
 .dui-action { padding: 7px 14px; border: 1px solid var(--border-loud); border-radius: 6px; background: var(--surface-2); color: var(--text-mid); font-size: 12.5px; font-family: inherit; }
 .dui-action:hover:not(:disabled) { color: var(--text); border-color: var(--text-faint); }
 .dui-action:disabled { opacity: 0.5; }


### PR DESCRIPTION
Stacked on #364; the row-header change needs that PR's `thead`/`tbody` split or every first cell renders as a 10px uppercase micro-label.

**Acting on a page said nothing.** `useAction` wrote a message only in its catch arms, so a successful press rendered nothing at all and a screen-reader operator heard silence. An app cannot supply its own acknowledgement either — a page function cannot tell a refresh-after-press from a plain read. Success is now announced in a polite live region, worded from the action's own label and cleared by `useFlashNote`, which core already ships.

**A pressed control lost its name.** `working…` replaced the label, so the button a reader had just found became a different button. The label stays and `aria-busy` carries the state, matching what `SettingsModal` already does.

**A form that worked kept its contents.** Values reset only when the field *shape* changed, so the typed text sat there under a form that had already submitted. On a real page that is a duplicate: `adopt_product` has no uniqueness check and dispatches a scout, so a second Enter makes a second product and a second run.

**A destructive action asked through `window.confirm`** — an unthemed OS dialog, on the one confirmation an author cannot opt out of. It now asks inline, replacing the control with the question and an answer/Back pair, copying `CancelRun`'s existing pattern. Same author API, no new field.

**Fields were unwired.** Help had no id, `aria-invalid` was hardcoded `undefined` directly above a `role="alert"` that also had no id, and `aria-describedby` appeared nowhere in the frontend. Fixed, including the pre-existing bug where a radio or multi-select label pointed `htmlFor` at an id no element has — those groups are now labelled as groups.

**Rows had no headers.** Every body cell was a `<td>`, so a value read on its own carried its column but not its row; the chart's own fallback table already did this correctly. The first cell is now `<th scope="row">`. The dead `data-label` attribute goes with it — nothing reads it, and the stylesheet's own comment rejects the stacking it was for.

**Also:** block titles render as `<h3>` rather than divs styled like the `<h2>` beside them; the breadcrumb's arrow is `aria-hidden` so the link is named by its destination; and a loading page keeps its breadcrumb and tab strip, which are roster-derived and already warm, holding only the title — a cold deeplink with no roster still waits bare.

Four test files updated where they asserted the old behaviour, plus three new cases: the in-page confirm, row headers, and the two accessibility additions. `eslint`, 217 tests, and `vite build` pass.