### PR TITLE
A status is its word and its tone, and the contract page says so

### DIFF
--- a/backend/druks/ui/blocks.py
+++ b/backend/druks/ui/blocks.py
@@ -293,12 +293,11 @@ class NumberValue(Schema):
 
 class StatusValue(Schema):
     """Where something stands. The app writes the word; the tone selects the
-    presentation, and a ``state`` still moves where a ``verdict`` has settled."""
+    presentation."""
 
     value: Literal["status"] = "status"
     label: str
     tone: Literal["neutral", "active", "success", "warning", "danger"] = "neutral"
-    kind: Literal["state", "verdict"] = "state"
 
     def __init__(self, label: str, **data):
         super().__init__(label=label, **data)

--- a/backend/tests/test_ui_run_blocks.py
+++ b/backend/tests/test_ui_run_blocks.py
@@ -41,7 +41,7 @@ def test_a_timeline_item_carries_its_stamp_and_status():
                 "when": "2026-08-29T09:14:02Z",
                 "title": "Run started",
                 "description": "",
-                "status": {"value": "status", "label": "active", "tone": "active", "kind": "state"},
+                "status": {"value": "status", "label": "active", "tone": "active"},
             }
         ],
     }
@@ -60,7 +60,7 @@ def test_progress_carries_its_three_shapes():
     assert staged["steps"] == [
         {
             "label": "plan",
-            "status": {"value": "status", "label": "done", "tone": "neutral", "kind": "state"},
+            "status": {"value": "status", "label": "done", "tone": "neutral"},
         }
     ]
 

--- a/docs/druks-ui.md
+++ b/docs/druks-ui.md
@@ -48,8 +48,8 @@ It exports exactly these names:
 ```text
 page                                       declaration
 Page  Follows                              the snapshot
-Text  Markdown  Section  Card  Callout     display and layout blocks
-Divider  EmptyState  Stack  Columns
+Text  Markdown  Quote  Section  Card       display and layout blocks
+Callout  Divider  EmptyState  Stack  Columns
 Link  Action  Form                         controls
 Timeline  TimelineItem  Progress           run and artifact blocks
 ProgressStep  Image  Files
@@ -503,8 +503,8 @@ input than they store:
 
 ```python
 Block = Annotated[
-    Text | Markdown | Section | Card | Callout | Divider | EmptyState | Link
-    | Action | Form | Timeline | Progress | Image | Files
+    Text | Markdown | Quote | Section | Card | Callout | Divider | EmptyState
+    | Link | Action | Form | Timeline | Progress | Image | Files
     | GateControls | Chart | ImageGallery | Metrics | Facts | Table | List
     | Stack | Columns,
     Discriminator("block"),
@@ -574,6 +574,22 @@ class Markdown:
 ```
 
 The shell renders the markdown. It strips raw HTML.
+
+### Quote
+
+```python
+class Quote:
+    block: Literal["quote"] = "quote"
+    text: str
+```
+
+```json
+{"block": "quote", "text": "No access to that repository.\nFalling back."}
+```
+
+Someone else's words, kept as they arrived — a message, a reply, an answer.
+Line breaks survive, and nothing is read as markup. `Text` closes the breaks
+up into a paragraph, and `Markdown` would rewrite the text.
 
 ### Section
 
@@ -1039,6 +1055,7 @@ class TableColumn:
 
 class TableRow:
     cells: list[Value] = []
+    detail: str = ""
 
 
 class Table:
@@ -1070,6 +1087,11 @@ Every row must have one cell for each column. With no rows the shell shows
 `empty_text`, and nothing of its own. A wide table scrolls inside its own
 container, on a narrow screen as well: a stacked row would lose the header each
 cell belongs to.
+
+A row's `detail` is the sentence it has no room for — the failure behind a
+status, the reason behind a verdict. The shell keeps it folded and the reader
+opens it, so twenty rows that stopped for one reason do not cost twenty page
+loads to find that out. It is text, not blocks.
 
 ### List
 
@@ -1130,14 +1152,17 @@ Every value carries a `value` discriminator. A value renders the same way in
 class TextValue:
     value: Literal["text"] = "text"
     text: str
+    description: str = ""
     link: Link | None = None
 ```
 
 ```json
-{"value": "text", "text": "peer-7", "link": null}
+{"value": "text", "text": "peer-7", "description": "the fastest peer", "link": null}
 ```
 
 `link` is how a table cell, a fact, or a list item reaches another page.
+`description` says what the thing is, on a quieter second line under what it
+is called, so a name needs no column of its own to explain it.
 
 ### NumberValue
 
@@ -1146,11 +1171,15 @@ class NumberValue:
     value: Literal["number"] = "number"
     number: float
     unit: str = ""
+    tone: Literal["neutral", "active", "success", "warning", "danger"] = "neutral"
 ```
 
 ```json
-{"value": "number", "number": 40.0, "unit": "ms"}
+{"value": "number", "number": 40.0, "unit": "ms", "tone": "neutral"}
 ```
+
+A `tone` colours a count that is itself the warning — how many need attention.
+A figure that is only a figure stays `neutral`.
 
 ### StatusValue
 
@@ -1166,7 +1195,8 @@ class StatusValue:
 ```
 
 The app writes the word. The tone selects the presentation. The contract has
-no type named `Status`.
+no type named `Status`. `active` reads as work in flight, so a settled fact
+takes another tone.
 
 ### TimeValue
 
@@ -1431,8 +1461,9 @@ needs it:
 
 ## Not in V1
 
-V1 has no `Tabs` block, no accordion, no expandable table row, no modal, no
-inline reveal form, and no general client-state API.
+V1 has no `Tabs` block, no accordion, no modal, no inline reveal form, and no
+general client-state API. A table row folds its `detail` away, and that is the
+whole of it: the app declares the sentence, the shell owns whether it is open.
 
 Static child pages already give tabs, and the URL holds the current one. An
 app that needs a control the contract does not have ships an ESM frontend.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -227,7 +227,6 @@ export interface StatusValue {
   value: 'status'
   label: string
   tone: 'neutral' | 'active' | 'success' | 'warning' | 'danger'
-  kind: 'state' | 'verdict'
 }
 
 export interface TimelineItem {

--- a/frontend/src/druksui/DataBlocks.test.tsx
+++ b/frontend/src/druksui/DataBlocks.test.tsx
@@ -26,7 +26,7 @@ function renderBlocks(blocks: Block[]) {
 
 const TEXT: Value = { value: 'text', text: 'peer-7', description: '', link: null }
 const NUMBER: Value = { value: 'number', number: 1234, unit: 'ms', tone: 'neutral' }
-const STATUS: Value = { value: 'status', label: 'parked', tone: 'warning', kind: 'state' }
+const STATUS: Value = { value: 'status', label: 'parked', tone: 'warning' }
 const TIME: Value = { value: 'time', when: '2026-08-29T09:14:02Z' }
 
 describe('values', () => {
@@ -187,21 +187,6 @@ describe('values', () => {
     expect(container.querySelector('.dui-number-danger')).toBeTruthy()
   })
 
-  it('tells a verdict apart from a state', () => {
-    const { container } = renderBlocks([
-      {
-        block: 'facts',
-        title: '',
-        facts: [
-          { label: 'Run', value: { value: 'status', label: 'scouting', tone: 'active', kind: 'state' } },
-          { label: 'Parity', value: { value: 'status', label: 'yes', tone: 'success', kind: 'verdict' } },
-        ],
-      },
-    ])
-
-    expect(container.querySelector('.dui-status-state')).toBeTruthy()
-    expect(container.querySelector('.dui-status-verdict')).toBeTruthy()
-  })
 })
 
 describe('Table', () => {

--- a/frontend/src/druksui/RunBlocks.test.tsx
+++ b/frontend/src/druksui/RunBlocks.test.tsx
@@ -20,8 +20,8 @@ function renderBlocks(blocks: Block[]) {
   )
 }
 
-const ACTIVE = { value: 'status', label: 'active', tone: 'active', kind: 'state' } as const
-const DONE = { value: 'status', label: 'done', tone: 'success', kind: 'state' } as const
+const ACTIVE = { value: 'status', label: 'active', tone: 'active' } as const
+const DONE = { value: 'status', label: 'done', tone: 'success' } as const
 
 describe('Timeline', () => {
   it('shows the items in the order Druks ordered them', () => {

--- a/frontend/src/druksui/RunBlocks.tsx
+++ b/frontend/src/druksui/RunBlocks.tsx
@@ -6,11 +6,7 @@ import { RelTime } from '../components/RelTime'
 // How much of one call a page block reads. A page can hold several.
 
 export function Status({ status }: { status: StatusValue }) {
-  return (
-    <span className={`dui-status dui-status-${status.tone} dui-status-${status.kind}`}>
-      {status.label}
-    </span>
-  )
+  return <span className={`dui-status dui-status-${status.tone}`}>{status.label}</span>
 }
 
 export function Timeline({ title, items }: { title: string; items: TimelineItem[] }) {

--- a/frontend/src/druksui/catalog.json
+++ b/frontend/src/druksui/catalog.json
@@ -59,8 +59,7 @@
           "status": {
             "value": "status",
             "label": "running",
-            "tone": "active",
-            "kind": "state"
+            "tone": "active"
           }
         }
       ]
@@ -83,8 +82,7 @@
           "status": {
             "value": "status",
             "label": "running",
-            "tone": "active",
-            "kind": "state"
+            "tone": "active"
           }
         }
       ]
@@ -175,8 +173,7 @@
           "value": {
             "value": "status",
             "label": "running",
-            "tone": "active",
-            "kind": "state"
+            "tone": "active"
           }
         },
         {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2691,11 +2691,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .dui-number-warning { color: var(--decision-request-revision); }
 .dui-number-danger { color: var(--outcome-failed); }
 
-/* The settled judgement is the filled pill; a state that still moves is drawn
-   in outline. */
-.dui-status-state { background: none; }
-.dui-status-verdict { font-weight: 600; }
-
 .dui-quote { font-size: 13.5px; line-height: 1.6; color: var(--text-mid); max-width: 68ch;
   white-space: pre-wrap; margin: 0; padding-left: 12px; border-left: 2px solid var(--border); }
 


### PR DESCRIPTION
Follow-up to #368: `StatusValue.kind` comes out, and the contract page catches up.

**`kind` was a second knob for a job the word and the tone already do.** The contract page's own line is "The app writes the word. The tone selects the presentation." A `kind` adds a second presentation selector and asks every author to answer "has this settled?" on every status, forever, when the label answers it.

The case I made for it in #368 was that one column holds both a state and a verdict. Across all three first-party apps there are 15 `StatusValue` call sites, and that is true at exactly one — `inbox-manager`'s thread column, where a disposition and `untriaged` both happen to pick `tone="neutral"`. Different words, and two things sharing a tone is a reason to change one of the tones. In `peer-tracker`'s parity table, the other adopter, every cell is `kind="verdict"`: a constant for the whole column, set once, never varying, rendering nothing differently for being there.

It also had a cost that was not incidental to it. `kind` had to default to something, and anything a default paints stops being a default — which is how every pill in every app flattened to an outline on the bump. Fixing which side carried the paint would have worked, but it was fixing the symptom of a field that should not have to paint anything.

`.dui-status` is untouched, so every pill renders as it did before #368.

**The contract page never learned about #368 at all.** `docs/druks-ui.md` documented `TextValue`, `NumberValue` and `TableRow` without their new fields, had no `Quote` section, and listed `Quote` in neither the `Block` union nor the import map. It also promised V1 has "no expandable table row", which `TableRow.detail` had already made untrue — that line now says what is true: the app declares the sentence, the shell owns whether it is open. Every documented model is checked field-for-field against the real one, and the union against `typing.get_args`.

The other four fields stay. Each of them changes what a page can say — `description` collapses a column, `detail` saves a page load per row, `Quote` fixes four call sites that lose their line breaks today, and `NumberValue.tone` is the same knob every other value type already had. `kind` was the one that only changed how something looked.

Two lines in druks-apps adopted `kind=` and want dropping: `inbox-manager/druks_inbox_manager/pages.py` and `peer-tracker/druks_peer_tracker/pages.py`. Because `Schema` ignores extras they will not break, they will silently do nothing — worth removing in the same pass that bumps the floor.

`ruff`, `eslint`, 224 frontend tests and `vite build` pass.