### PR TITLE
Give every field one place to say what they share

### DIFF
--- a/backend/druks/ui/fields.py
+++ b/backend/druks/ui/fields.py
@@ -13,102 +13,79 @@ class Option(Schema):
         super().__init__(label=label, **data)
 
 
-class TextField(Schema):
+class PageField(Schema):
+    """What every field shares. ``field`` names its kind on the wire, and
+    ``name`` is the key the shell sends the operator's answer under."""
+
+    field: str
+    name: str
+    label: str
+    help_text: str = ""
+    is_required: bool = False
+    # ``value`` is not here on purpose. An upload and a secret have none, and a
+    # field with nowhere to hold one cannot send a stored secret to the browser.
+
+
+class TextField(PageField):
     field: Literal["text"] = "text"
-    name: str
-    label: str
     value: str = ""
     placeholder: str = ""
-    help_text: str = ""
-    is_required: bool = False
 
 
-class TextAreaField(Schema):
+class TextAreaField(PageField):
     field: Literal["text_area"] = "text_area"
-    name: str
-    label: str
     value: str = ""
     placeholder: str = ""
-    help_text: str = ""
-    is_required: bool = False
     rows: int = 4
 
 
-class NumberField(Schema):
+class NumberField(PageField):
     field: Literal["number"] = "number"
-    name: str
-    label: str
     value: float | None = None
     minimum: float | None = None
     maximum: float | None = None
     step: float | None = None
-    help_text: str = ""
-    is_required: bool = False
 
 
-class SelectField(Schema):
+class SelectField(PageField):
     field: Literal["select"] = "select"
-    name: str
-    label: str
     options: list[Option] = []
     value: str = ""
-    help_text: str = ""
-    is_required: bool = False
 
 
-class MultiSelectField(Schema):
+class MultiSelectField(PageField):
     field: Literal["multi_select"] = "multi_select"
-    name: str
-    label: str
     options: list[Option] = []
     value: list[str] = []
-    help_text: str = ""
-    is_required: bool = False
 
 
-class RadioField(Schema):
+class RadioField(PageField):
     field: Literal["radio"] = "radio"
-    name: str
-    label: str
     options: list[Option] = []
     value: str = ""
-    help_text: str = ""
-    is_required: bool = False
 
 
-class CheckboxField(Schema):
+class CheckboxField(PageField):
     field: Literal["checkbox"] = "checkbox"
-    name: str
-    label: str
     value: bool = False
-    help_text: str = ""
-    is_required: bool = False
 
 
-class UploadField(Schema):
+class UploadField(PageField):
     """One file the operator picks. The shell stores it through the platform and
     submits its id, so the operation takes a plain string."""
 
     field: Literal["upload"] = "upload"
-    name: str
-    label: str
     # Straight into the file dialog's own filter, in its own syntax:
     # "image/*", ".csv,.tsv". It narrows what the operator sees. It is not a
     # promise about the bytes.
     accept: str = ""
-    help_text: str = ""
-    is_required: bool = False
 
 
-class SecretField(Schema):
+class SecretField(PageField):
     """One secret the operator hands over: a token, a key. It has no ``value``,
     so a page cannot send a stored secret back to the browser."""
 
     field: Literal["secret"] = "secret"
-    name: str
-    label: str
-    help_text: str = ""
-    is_required: bool = False
 
 
 Field = Annotated[

--- a/backend/druks/ui/fields.py
+++ b/backend/druks/ui/fields.py
@@ -22,8 +22,8 @@ class PageField(Schema):
     label: str
     help_text: str = ""
     is_required: bool = False
-    # ``value`` is not here on purpose. An upload and a secret have none, and a
-    # field with nowhere to hold one cannot send a stored secret to the browser.
+    # No ``value`` here: an upload and a secret have none, and a field with
+    # nowhere to hold one cannot send a stored secret to the browser.
 
 
 class TextField(PageField):

--- a/backend/tests/test_ui_actions.py
+++ b/backend/tests/test_ui_actions.py
@@ -13,6 +13,7 @@ from druks.ui import (
     Section,
     TextField,
 )
+from druks.ui.fields import PageField
 
 OPERATIONS = {
     "write_note": Operation(id="write_note", method="POST", path="/api/field_notes/notes"),
@@ -94,6 +95,12 @@ def test_a_secret_field_declares_no_value():
             "isRequired": False,
         }
     ]
+
+
+def test_the_shared_base_has_no_value_to_hand_out():
+    """An upload and a secret have none. A value on the base would give every
+    secret field somewhere to carry a stored secret back to the browser."""
+    assert "value" not in PageField.model_fields
 
 
 def test_a_form_sends_each_value_once():

--- a/docs/druks-ui.md
+++ b/docs/druks-ui.md
@@ -484,10 +484,10 @@ hold one directly. `Card.actions` and `EmptyState.actions` hold either one.
 Each listing below gives every field a model carries and the JSON it sends.
 Four rules hold for every one of them.
 
-**A listing is the whole shape, not the class body.** Several models share a
-base — every block a discriminator and a place, every field a name and a label
-— and a listing shows what the model carries rather than which class declared
-it. The bases are internal, so nothing here names one.
+**A listing is the whole shape, not the class body.** Some models share a base:
+every field carries a name and a label, and a section, a card and a column all
+carry blocks. A listing shows what the model carries, whichever class declares
+it. A sample fixes the keys and their values, never their order.
 
 **A discriminator carries its own literal as its default.** `Text.block` is
 `Literal["text"] = "text"`. The author writes `Text("…")` and never passes

--- a/docs/druks-ui.md
+++ b/docs/druks-ui.md
@@ -481,8 +481,13 @@ hold one directly. `Card.actions` and `EmptyState.actions` hold either one.
 
 ## How to read the model listings
 
-Each listing below gives the exact Python fields and the exact JSON. Three
-rules hold for every one of them.
+Each listing below gives every field a model carries and the JSON it sends.
+Four rules hold for every one of them.
+
+**A listing is the whole shape, not the class body.** Several models share a
+base — every block a discriminator and a place, every field a name and a label
+— and a listing shows what the model carries rather than which class declared
+it. The bases are internal, so nothing here names one.
 
 **A discriminator carries its own literal as its default.** `Text.block` is
 `Literal["text"] = "text"`. The author writes `Text("…")` and never passes


### PR DESCRIPTION
ENG-918

Nine field classes each wrote out `field`, `name`, `label`, `help_text` and
`is_required`. Nothing checked that a tenth would. `UploadField` and
`SecretField` carry the four because whoever wrote them copied a neighbour, and
a field that shipped without `help_text` would break the shell with nothing to
catch it.

```python
class PageField(Schema):
    """What every field shares. ``field`` names its kind on the wire, and
    ``name`` is the key the shell sends the operator's answer under."""

    field: str
    name: str
    label: str
    help_text: str = ""
    is_required: bool = False


class SecretField(PageField):
    field: Literal["secret"] = "secret"
```

`PageField` is not exported. An app never builds one, so `druks.ui.__all__`,
the author-surface test and the import table are untouched.

## Why it looks like this

`blocks.py` already does the same job. `PageBlock` is an unexported base
declaring a bare `block: str` that twenty-four blocks narrow to a `Literal`, and
the `Block` union consumes them through a `Discriminator` from the same file
that consumes the `Field` union. This is that, for fields.

The base declares `field: str` for one reason: it keeps the discriminator first
on the wire. Left off the base, `field` sinks behind four inherited keys in
every payload, and the key that says what you are looking at stops leading the
object.

`value` is deliberately not on the base, and a comment says so. It looks like a
fifth shared key, and it is the obvious thing to hoist next. Hoisting it would
put a `value` on `SecretField` and break the guarantee that a page cannot send a
stored secret back to the browser.

## The docs

The field reference keeps showing every key a field carries, including the
inherited ones. `Section` and `Card` already inherit `blocks` from the
unexported `BlockParent`, and the reference already flattens that into their
listings, so this was always the convention. It is now written down, as a fourth
rule under "How to read the model listings".

## How it is verified

Against artifacts captured before the change: every field's JSON keys **and
values** are identical, and `field` is still the first key of all nine. The
`Field` union still resolves by discriminator, still rejects an unknown tag, and
still accepts camelCase input. The generated JSON Schema is unchanged — same
`$defs`, same properties, same `required` for every field, and no `PageField` in
it. Only the order of a field's own extra keys moved, from between `label` and
`helpText` to after `isRequired`.

`ruff check backend`, `ruff format --check backend`, `pytest backend`
(1487 passed), `npm run lint`, `npm test` (237 passed) and `npm run build`
all pass.
