### PR TITLE
Render nothing for a collection with nothing in it

### DIFF
--- a/frontend/src/druksui/Blocks.tsx
+++ b/frontend/src/druksui/Blocks.tsx
@@ -87,12 +87,14 @@ function BlockContent({ block }: { block: Block }) {
     case 'list':
       return <List title={block.title} items={block.items} />
     case 'stack':
+      if (!block.blocks.length) return null
       return (
         <div className={`dui-stack dui-stack-${block.gap}`}>
           <Blocks blocks={block.blocks} />
         </div>
       )
     case 'columns':
+      if (!block.blocks.length) return null
       return (
         <div className="dui-columns">
           {block.blocks.map((column, index) => (

--- a/frontend/src/druksui/DataBlocks.test.tsx
+++ b/frontend/src/druksui/DataBlocks.test.tsx
@@ -205,7 +205,7 @@ describe('Table', () => {
     expect(screen.queryByRole('table')).toBeNull()
   })
 
-  it('says nothing of its own when the app said nothing', () => {
+  it('renders nothing at all when the app said nothing', () => {
     const { container } = renderBlocks([
       {
         block: 'table',
@@ -216,7 +216,9 @@ describe('Table', () => {
       },
     ])
 
-    expect(container.querySelector('.dui-table-empty')?.textContent).toBe('')
+    // A heading over an empty box is worse than no block.
+    expect(container.querySelector('.dui-table-block')).toBeNull()
+    expect(screen.queryByText('Peers')).toBeNull()
   })
 
   it('names the table itself, so a reader can tell it from another', () => {
@@ -277,6 +279,21 @@ describe('Table', () => {
     expect(screen.queryByText(/no access/)).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'More' }))
     expect(screen.getByText(/no access/)).toBeTruthy()
+  })
+})
+
+describe('a collection with nothing in it', () => {
+  it('renders nothing rather than a heading over a void', () => {
+    const { container } = renderBlocks([
+      { block: 'list', title: 'Peers', items: [] },
+      { block: 'facts', title: 'About', facts: [] },
+      { block: 'metrics', title: 'Today', metrics: [] },
+      { block: 'image_gallery', title: 'Shots', images: [] },
+      { block: 'columns', blocks: [] },
+      { block: 'stack', gap: 'small', blocks: [] },
+    ])
+
+    expect(container.textContent).toBe('')
   })
 })
 

--- a/frontend/src/druksui/DataBlocks.tsx
+++ b/frontend/src/druksui/DataBlocks.tsx
@@ -237,6 +237,7 @@ export function Chart({
 }
 
 export function ImageGallery({ title, images }: { title: string; images: ImageBlock[] }) {
+  if (!images.length) return null
   return (
     <div className="dui-gallery">
       {title && <h3 className="dui-block-title">{title}</h3>}
@@ -260,6 +261,7 @@ export function ImageGallery({ title, images }: { title: string; images: ImageBl
 }
 
 export function Metrics({ title, metrics }: { title: string; metrics: Metric[] }) {
+  if (!metrics.length) return null
   return (
     <div className="dui-metrics">
       {title && <h3 className="dui-block-title">{title}</h3>}
@@ -279,6 +281,7 @@ export function Metrics({ title, metrics }: { title: string; metrics: Metric[] }
 }
 
 export function Facts({ title, facts }: { title: string; facts: Fact[] }) {
+  if (!facts.length) return null
   return (
     <div className="dui-facts">
       {title && <h3 className="dui-block-title">{title}</h3>}
@@ -308,6 +311,9 @@ export function Table({
   emptyText: string
 }) {
   if (rows.length === 0) {
+    // Nothing to show and nothing to say about it: a heading over an empty box
+    // is worse than no block at all.
+    if (!emptyText) return null
     return (
       <div className="dui-table-block">
         {title && <h3 className="dui-block-title">{title}</h3>}
@@ -380,6 +386,7 @@ function Row({ row, columns }: { row: TableRow; columns: TableColumn[] }) {
 }
 
 export function List({ title, items }: { title: string; items: Value[] }) {
+  if (!items.length) return null
   return (
     <div className="dui-list-block">
       {title && <h3 className="dui-block-title">{title}</h3>}

--- a/frontend/src/druksui/RunBlocks.tsx
+++ b/frontend/src/druksui/RunBlocks.tsx
@@ -10,6 +10,7 @@ export function Status({ status }: { status: StatusValue }) {
 }
 
 export function Timeline({ title, items }: { title: string; items: TimelineItem[] }) {
+  if (!items.length) return null
   // Already oldest first: Druks orders the items where their stamps keep full
   // precision.
   const ordered = items
@@ -112,6 +113,7 @@ export function Image({
 }
 
 export function Files({ title, files }: { title: string; files: FileSummary[] }) {
+  if (!files.length) return null
   return (
     <div className="dui-files">
       {title && <h3 className="dui-block-title">{title}</h3>}


### PR DESCRIPTION
A block holding an empty collection drew its heading over a void.

An empty `Files` printed its title above an empty list. An empty `Columns`
rendered a bare invisible div. The gallery had to write a paragraph of prose
beside an empty `Files` to explain what the reader was looking at.

`List`, `Facts`, `Metrics`, `ImageGallery`, `Timeline`, `Files`, `Columns` and
`Stack` now render nothing when they hold nothing. `Table` already had
`empty_text` for the case where an app wants to say something; with no rows and
nothing to say, it renders nothing too.

An app that wants words, or a way forward, keeps `Table.empty_text` and
`ui.EmptyState`.

## How it is verified

`npm test` 237 to 238. The new case renders all six collection blocks empty in
one page and asserts the page has no text at all. One existing test changed:
`Table` with no rows and no `empty_text` used to assert an empty box, and now
asserts no block.

`npm run lint` and `npm run build` pass.