### PR TITLE
Each agent gets its input, not the conversation

### DIFF
--- a/backend/druks/contrib/software_factory/journal.py
+++ b/backend/druks/contrib/software_factory/journal.py
@@ -57,6 +57,20 @@ class BuildJournal(Journal):
         return
 
     @property
+    def revision_request(self) -> str | None:
+        # The newest triage's instructions drive exactly one implement round.
+        # An evaluation recorded after that triage means the round already ran —
+        # the evaluator's findings are the current request, not these.
+        triage = self.latest(TriageOutput)
+        if (
+            triage
+            and triage.implementation_instructions
+            and not self.filter(EvaluationOutput, after=triage)
+        ):
+            return triage.implementation_instructions
+        return
+
+    @property
     def human_feedback(self) -> list[dict[str, Any]]:
         # Every request_changes reply, in order, with the triage that digested it.
         # The newest reply has no triage yet while its own triage agent renders

--- a/backend/druks/contrib/software_factory/templates/build/_contract.md
+++ b/backend/druks/contrib/software_factory/templates/build/_contract.md
@@ -48,25 +48,3 @@
 {% endif %}
 {% endfor %}
 {% endif %}
-{% if build.journal.human_feedback %}
-## Human feedback
-
-{% for fb in build.journal.human_feedback %}
-### {{ fb.reviewer }}{% if not fb.triage %} — PENDING, not yet triaged{% endif %}
-
-{{ fb.body }}
-
-{% if fb.triage %}
-**Triage decision ({{ fb.triage.action }}):** {{ fb.triage.body }}
-
-{% if fb.triage.question %}
-**Question:** {{ fb.triage.question }}
-
-{% endif %}
-{% if fb.triage.implementation_instructions %}
-**Implementation instructions:** {{ fb.triage.implementation_instructions }}
-
-{% endif %}
-{% endif %}
-{% endfor %}
-{% endif %}

--- a/backend/druks/contrib/software_factory/templates/build/implement.md
+++ b/backend/druks/contrib/software_factory/templates/build/implement.md
@@ -38,9 +38,14 @@ acceptance criterion — nothing more, nothing less.
 {% include "software_factory/build/_contract.md" %}
 {% include "software_factory/build/_related_repos.md" %}
 {% include "software_factory/build/_skills.md" %}
-When the checkout has `.druks/review/checklist.md`, read it before you write: it is the repo's standing rules for code and prose, and the reviewer holds your diff to it.
+{% if build.journal.revision_request %}
+## Revision request
 
-Implement the approved plan (rendered above as **Current plan**) on the work branch (see "Delivering your work" below). If the **Human feedback** section above has entries, the newest entry's implementation instructions are the current revision request; earlier entries are history that prior revisions already addressed. Before pushing, you may run the repo's configured test, lint, or typecheck command narrowed to the files your diff touches — self-checking your own work, nothing more. Never run the full verification profile, and never adjudicate it: the evaluator owns that verdict, and a failure you cannot attribute to your own diff is environment noise to report, not a gate to chase. Do not run ad hoc install, build, or smoke commands beyond that unless the plan explicitly requires changing those commands or generated outputs. Never leave dependency lockfile, generated, or cache changes unless they are part of the requested implementation. Return structured evidence for every acceptance criterion, every check you ran or intentionally did not run, changed files, and known risks. If a check was not run, include status not_run and a reason.
+{{ build.journal.revision_request }}
+
+{% endif %}When the checkout has `.druks/review/checklist.md`, read it before you write: it is the repo's standing rules for code and prose, and the reviewer holds your diff to it.
+
+Implement the approved plan (rendered above as **Current plan**) on the work branch (see "Delivering your work" below). When a **Revision request** section is rendered above, implement it on top of the plan — it is the reviewer's feedback, already triaged into instructions. Before pushing, you may run the repo's configured test, lint, or typecheck command narrowed to the files your diff touches — self-checking your own work, nothing more. Never run the full verification profile, and never adjudicate it: the evaluator owns that verdict, and a failure you cannot attribute to your own diff is environment noise to report, not a gate to chase. Do not run ad hoc install, build, or smoke commands beyond that unless the plan explicitly requires changing those commands or generated outputs. Never leave dependency lockfile, generated, or cache changes unless they are part of the requested implementation. Return structured evidence for every acceptance criterion, every check you ran or intentionally did not run, changed files, and known risks. If a check was not run, include status not_run and a reason.
 
 ## Delivering your work
 

--- a/backend/druks/contrib/software_factory/templates/build/revise_contract.md
+++ b/backend/druks/contrib/software_factory/templates/build/revise_contract.md
@@ -25,7 +25,23 @@ everything the original plan got right.
 {% include "software_factory/build/_contract.md" %}
 {% include "software_factory/build/_related_repos.md" %}
 {% include "software_factory/build/_skills.md" %}
-The human reviewer's feedback contradicts the current acceptance criteria. Revise the plan and acceptance criteria to incorporate the feedback while preserving the original issue intent. The latest triaged human feedback is in the **Human feedback** section above; the current acceptance criteria are in the **Acceptance criteria** section above. Return the full revised plan markdown, the complete updated acceptance criteria list, and concise implementation instructions describing what changed so the implementer knows what to redo.
+{% if build.journal.human_feedback %}
+{% set fb = build.journal.human_feedback | last %}
+## Rejecting review
+
+### {{ fb.reviewer }}
+
+{{ fb.body }}
+
+{% if fb.triage %}
+**Triage decision ({{ fb.triage.action }}):** {{ fb.triage.body }}
+
+{% if fb.triage.implementation_instructions %}
+**What must change:** {{ fb.triage.implementation_instructions }}
+
+{% endif %}
+{% endif %}
+{% endif %}The human reviewer's feedback contradicts the current acceptance criteria. Revise the plan and acceptance criteria to incorporate the feedback while preserving the original issue intent. The rejecting review is rendered above under **Rejecting review**; the current acceptance criteria are in the **Acceptance criteria** section above. Return the full revised plan markdown, the complete updated acceptance criteria list, and concise implementation instructions describing what changed so the implementer knows what to redo.
 
 # Update the PR description
 

--- a/backend/druks/contrib/software_factory/templates/build/triage_human_feedback.md
+++ b/backend/druks/contrib/software_factory/templates/build/triage_human_feedback.md
@@ -22,6 +22,28 @@ without ambiguity.
 {% include "software_factory/build/_contract.md" %}
 {% include "software_factory/build/_related_repos.md" %}
 {% include "software_factory/build/_skills.md" %}
+{% if build.journal.human_feedback %}
+## Human feedback
+
+{% for fb in build.journal.human_feedback %}
+### {{ fb.reviewer }}{% if not fb.triage %} — PENDING, not yet triaged{% endif %}
+
+{{ fb.body }}
+
+{% if fb.triage %}
+**Triage decision ({{ fb.triage.action }}):** {{ fb.triage.body }}
+
+{% if fb.triage.question %}
+**Question:** {{ fb.triage.question }}
+
+{% endif %}
+{% if fb.triage.implementation_instructions %}
+**Implementation instructions:** {{ fb.triage.implementation_instructions }}
+
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 Triage the entry marked PENDING in the **Human feedback** section above — the reviewer's own words, not yet digested. Earlier entries are history that prior rounds already triaged; read them for context, never as the target. Decide whether the feedback requires code changes, is incorrect or already addressed, needs a follow-up question, or means the PR should be closed/cancelled. Do not edit files. Use action `no_change` when no code change is needed and explain why in body. Use `change_required` only for actionable implementation work and put precise instructions for the implementer in implementation_instructions. Use `contract_change_required` when the feedback contradicts or invalidates one or more acceptance criteria — for example the human rejects a design choice that the criteria explicitly required. In that case put revised instructions in implementation_instructions explaining what changed. Use `question` when human input is needed before acting and put the exact question in question. Use `close` only when the correct action is to stop the PR.
 ## Post your triage outcome on the PR — REQUIRED (GitHub MCP)
 

--- a/backend/tests/software_factory/test_build_journal.py
+++ b/backend/tests/software_factory/test_build_journal.py
@@ -1,10 +1,11 @@
 from druks.contrib.software_factory.contracts import (
+    EvaluationOutput,
     ImplementationOutput,
     PlanData,
     ReviewWork,
     TriageOutput,
 )
-from druks.contrib.software_factory.enums import HumanFeedbackAction
+from druks.contrib.software_factory.enums import EvaluationVerdict, HumanFeedbackAction
 from druks.contrib.software_factory.journal import BuildJournal
 
 
@@ -36,6 +37,17 @@ def _implementation(
             "workspace_path": "/repo",
             "workspace_retention": None,
         }
+    )
+
+
+def _evaluation() -> EvaluationOutput:
+    return EvaluationOutput(
+        verdict=EvaluationVerdict.FAIL,
+        body="",
+        review_notes="",
+        findings=[],
+        checks=[],
+        acceptance_results=[],
     )
 
 
@@ -72,6 +84,18 @@ def test_assignee_scan_falls_through_unresolved_revisions():
     )
     assert journal.assignee_github_login == "bob"
     assert _journal(PlanData()).assignee_github_login is None
+
+
+def test_revision_request_is_the_newest_triage_until_an_evaluation_supersedes_it():
+    triage = TriageOutput(
+        action=HumanFeedbackAction.CHANGE_REQUIRED,
+        body="rename the flag",
+        question="",
+        implementation_instructions="rename X to Y",
+    )
+    assert _journal(triage).revision_request == "rename X to Y"
+    assert _journal(triage, _evaluation()).revision_request is None
+    assert _journal().revision_request is None
 
 
 def test_human_feedback_lists_every_reply_and_marks_the_untriaged_one_pending():


### PR DESCRIPTION
The Human feedback thread rendered in every agent prompt, because it lived in the shared `_contract.md` partial. The planner, the implementer, and the evaluator all read the reviewer's words and the triage digests, in every round. Only one agent is the addressee of that thread: triage.

Now each agent gets its own input:

- **Triage** renders the thread — history plus the pending raw review it must digest. Unchanged content, new home: the block moved from `_contract.md` into `triage_human_feedback.md`.
- **The implementer** gets a `## Revision request` section: the newest triage's implementation instructions, nothing else. A new `BuildJournal.revision_request` projection returns them only until an evaluation supersedes them, so an evaluator-fail round never re-serves instructions a prior round already applied.
- **The contract mediator** gets a `## Rejecting review` section: the newest entry only — the reviewer's words and the triage decision that invalidated the contract.
- **The planner and the evaluator** get nothing. The evaluator keeps its own round history; the reviewer's feedback was never its input.

Every non-triage prompt gets smaller, and prompt content is re-billed per turn.
