### PR TITLE
web declares readiness in compose

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -103,6 +103,21 @@ services:
         "--port",
         "8001",
       ]
+    # Ready means the API answers, not that the process exists. Then
+    # `up -d --wait` returns only when the stack serves, and a check that
+    # probes through the edge right after cannot race the bind.
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8001/api/system/health', timeout=2)",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 30s
 
   drukbox:
     <<: *drukbox


### PR DESCRIPTION
Postgres and redis have healthchecks, and the janitor/gateway explicitly disable theirs — but `web`, the service the whole stack fronts, declared none. `up -d --wait` therefore returned at process start, while uvicorn was still importing the app; a doctor probe through the edge right after raced the bind and reported a 502 from a healthy deployment (observed on every first-deploy-after-image-change).

The check probes the existing `/api/system/health` on loopback with the same python-urllib pattern the drukbox images use; `start_period: 30s` covers app import on slow boxes. With it, `--wait` means what operators assume it means.

🤖 Generated with [Claude Code](https://claude.com/claude-code)