### PR TITLE
Retry an invalid agent payload once

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from dbos import DBOS, StepOptions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from druks.apps.registry import agents
 from druks.database import db_session
@@ -17,7 +17,7 @@ from druks.durable.engine import _step_engine, step_session
 from druks.durable.exceptions import WorkflowError
 from druks.durable.models import AgentCall, Artifact
 from druks.files.datastructures import File
-from druks.harnesses.exceptions import HarnessError, Retry
+from druks.harnesses.exceptions import HarnessError, HarnessInvalidOutputError, Retry
 from druks.harnesses.models import HarnessConnection
 from druks.harnesses.registry import get_harness_for_model
 from druks.prompts import render_prompt
@@ -327,10 +327,16 @@ class Agent:
                     raise result.error
                 try:
                     workspace_files: list[File] = []
-                    output = self.contract.model_validate(
-                        result.output,
-                        context={"workspace_files": workspace_files},
-                    )
+                    try:
+                        output = self.contract.model_validate(
+                            result.output,
+                            context={"workspace_files": workspace_files},
+                        )
+                    except ValidationError as error:
+                        raise HarnessInvalidOutputError(
+                            f"agent {self.id!r} returned a payload that fails "
+                            f"{self.contract.__name__}: {error}"
+                        ) from error
                     if workspace_files:
                         await runner.save_files(
                             workspace_files,

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -115,7 +115,7 @@ class Harness(ABC):
     @classmethod
     def check_returncode(cls, result: HarnessRunResult) -> None:
         if result.returncode != 0:
-            detail = _terminal_detail(result.stdout)
+            detail = _terminal_detail(result)
             message = f"{cls.name} exited with {result.returncode}.{detail}"
             lowered = detail.lower()
             for marker, error in cls.failure_markers.items():
@@ -685,11 +685,13 @@ async def post_token(url: str, body: dict, *, form: bool) -> dict:
         raise exceptions.ConnectError("The provider returned an unreadable response.") from exc
 
 
-def _terminal_detail(stdout: bytes) -> str:
+def _terminal_detail(result: HarnessRunResult) -> str:
     """The CLI's terminal error ("You've hit your session limit · resets
     5:10pm") rides the stream's last result event; without it the persisted
-    failure is a bare exit code and the operator has to dig transcripts."""
-    for line in reversed(stdout.splitlines()[-20:]):
+    failure is a bare exit code and the operator has to dig transcripts.
+    A CLI that died before emitting events leaves its reason on stderr,
+    so the last non-empty line stands in."""
+    for line in reversed(result.stdout.splitlines()[-20:]):
         try:
             event = json.loads(line)
         except ValueError:
@@ -706,4 +708,7 @@ def _terminal_detail(stdout: bytes) -> str:
             error = error.get("message")
         if isinstance(error, str) and error:
             return f" {error[:300]}"
+    for line in reversed(result.stderr.decode("utf-8", errors="replace").splitlines()):
+        if detail := line.strip():
+            return f" {detail[:300]}"
     return ""

--- a/backend/druks/harnesses/exceptions.py
+++ b/backend/druks/harnesses/exceptions.py
@@ -51,6 +51,9 @@ class HarnessAuthError(HarnessError):
 
 class HarnessInvalidOutputError(HarnessError):
     code = "invalid_output"
+    retry = Retry.TRANSIENT
+    # Immediate: nothing throttled us, so waiting buys nothing.
+    retry_delays = (0,)
 
 
 class HarnessSandboxError(HarnessError):

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -483,6 +483,27 @@ async def test_body_level_first_byte_retries_immediately_then_reraises(
     assert all(call.status == "failed" for call in calls)
 
 
+async def test_body_level_invalid_output_retries_once_then_reraises(
+    druks_db, tmp_path, monkeypatch, current_run, _inline_agent_steps
+):
+    from druks.harnesses.exceptions import HarnessInvalidOutputError
+
+    sandbox = _patch_runtime(monkeypatch, tmp_path, {"unexpected": True})
+    _patch_ephemeral(monkeypatch, sandbox)
+    current_run._reap_run = AsyncMock()
+    _, sleep = _inline_agent_steps
+
+    with pytest.raises(HarnessInvalidOutputError):
+        await DUMMY_AGENT()
+
+    assert sandbox.run_agent.await_count == 2
+    sleep.assert_awaited_once_with(0.0)
+    current_run._reap_run.assert_not_awaited()
+    calls = await AgentCall.list_for_run("wf-9")
+    assert len(calls) == 2
+    assert all(call.status == "failed" for call in calls)
+
+
 def _async_scrape(make):
     async def latest_for(_cls, _harness, _account_id):
         return make()

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -391,6 +391,22 @@ def test_check_returncode_stays_bare_without_a_terminal_event():
     assert excinfo.value.retry is Retry.NEVER
 
 
+def test_check_returncode_falls_back_to_the_last_non_empty_stderr_line():
+    result = HarnessRunResult(
+        returncode=2, stdout=b"not json\n", stderr=b"first detail\n\nlast detail\n"
+    )
+    with pytest.raises(HarnessError, match="last detail"):
+        ClaudeHarness.check_returncode(result)
+
+
+def test_check_returncode_classifies_the_stderr_detail():
+    result = HarnessRunResult(
+        returncode=1, stdout=b"not json\n", stderr=b"request failed\nrate limit exceeded\n"
+    )
+    with pytest.raises(HarnessRateLimitError):
+        ClaudeHarness.check_returncode(result)
+
+
 def _claude_result_event(text: str) -> bytes:
     payload = {"type": "result", "subtype": "success", "is_error": True, "result": text}
     return json.dumps(payload).encode() + b"\n"


### PR DESCRIPTION
An agent payload that fails its contract now retries once instead of dying terminal, and a harness death that only wrote to stderr is now classified.

- `HarnessInvalidOutputError` is transient with one immediate retry. A retry is one whole fresh invocation of the same rendered prompt.
- `Agent._run` re-raises a pydantic `ValidationError` from contract validation as `HarnessInvalidOutputError`. Before, a shape slip was not a `HarnessError`, so it never retried.
- `_terminal_detail` takes the whole `HarnessRunResult` and falls back to the last non-empty stderr line when stdout has no terminal event, so `failure_markers` can classify a stderr-only death. Unclassified, a rate limit read as permanent and never retried.

Tests cover the retry path (typed error, exactly two invocations, zero delay) and the stderr fallback (the detail lands in the message; a marker on stderr picks the typed error).

DRU-360