### PR TITLE
Store and read the connection kind

### DIFF
--- a/backend/druks/core/tasks.py
+++ b/backend/druks/core/tasks.py
@@ -40,7 +40,11 @@ async def refresh_models() -> None:
 
 async def _refresh() -> dict[str, object]:
     by_name = {harness.name: harness for harness in get_harnesses()}
-    connections = [c for c in await HarnessConnection.list_all() if c.harness in by_name]
+    connections = [
+        connection
+        for connection in await HarnessConnection.list_all()
+        if connection.supports_refresh and connection.harness in by_name
+    ]
 
     # A refresh 401s a VM mid-call holding the old token, so a due rotation
     # runs only while its connection is idle — busy defers to the next tick;

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -65,6 +65,7 @@ _WEEKLY_WINDOWS = TypeAdapter(tuple[ParsedMetric, ...])
 
 class Harness(ABC):
     name: str
+    login_kinds: ClassVar[frozenset[str]] = frozenset({"subscription"})
     # Harness identity + shipped config, the seed source for the per-harness
     # ``HarnessSettings`` row the operator then tunes. Subclasses set provider,
     # models and default_model; effort/timeout default to the shipped values.

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -96,6 +96,7 @@ class HarnessConnection(Base, Uuid7Pk):
         payload: dict,
         expires_at: datetime | None,
         provider_email: str,
+        kind: str = "subscription",
     ) -> "HarnessConnection":
         """Upsert ``account``'s connection for this harness — update its
         existing row or create one."""
@@ -104,11 +105,20 @@ class HarnessConnection(Base, Uuid7Pk):
         if not row:
             row = cls(harness=harness, account_id=account.id)
             session.add(row)
+        row.kind = kind
         row.payload = payload
         row.provider_email = provider_email
         row.expires_at = expires_at
         await session.flush()
         return row
+
+    @property
+    def supports_refresh(self) -> bool:
+        return self.kind == "subscription"
+
+    @property
+    def is_metered(self) -> bool:
+        return self.kind == "subscription"
 
     async def update_payload(self, payload: dict, *, expires_at: datetime | None) -> None:
         # Whole-value reassignment is the write path: the encrypted column

--- a/backend/druks/usage/routes.py
+++ b/backend/druks/usage/routes.py
@@ -71,7 +71,7 @@ async def refresh_usage(account: Account = Depends(current_account)) -> None:
         connection = await HarnessConnection.get_for_account(harness.name, account.id)
         row = await UsageScrape.latest_for(harness.name, account.id)
         age = _age_seconds(row.scraped_at, now=now) if row else None
-        if connection and (age is None or age >= _REFRESH_FLOOR_SECONDS):
+        if connection and connection.is_metered and (age is None or age >= _REFRESH_FLOOR_SECONDS):
             await harness.poll_usage(connection)
 
 

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -35,6 +35,7 @@ class HarnessResponse(Schema):
     # The requesting account's own connection; false until this account connects.
     connected: bool
     kind: str | None
+    login_kinds: list[str]
     account: str | None
     # The email the provider reported at connect — display, never authority.
     provider_email: str | None
@@ -60,6 +61,7 @@ class HarnessResponse(Schema):
             allowed_models=settings.allowed_models,
             connected=connected,
             kind=connection.kind if connection else None,
+            login_kinds=sorted(settings.harness.login_kinds),
             account=account.username if connection else None,
             provider_email=connection.provider_email if connection else None,
             expires_at=connection.expires_at if connection else None,

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from druks.contrib.review.app import Review
 from druks.contrib.software_factory.app import SoftwareFactory
 from druks.database import db_session
+from druks.harnesses.claude import ClaudeHarness
 from druks.testing import configure_app_for_test, make_settings
 from druks.user_settings.models import SettingsOverride
 from fastapi.testclient import TestClient
@@ -32,6 +33,20 @@ def test_get_harnesses_lists_seeded_defaults(tmp_path: Path):
     assert "claude-sonnet-4-6" in claude_model_ids
     assert harnesses["codex"]["provider"] == "openai"
     assert (harnesses["codex"]["effort"], harnesses["codex"]["timeout"]) == ("high", 1800)
+
+
+def test_harness_response_carries_sorted_login_kinds(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        ClaudeHarness,
+        "login_kinds",
+        frozenset({"subscription", "api_key"}),
+    )
+
+    with _build_client(tmp_path) as client:
+        harnesses = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}
+
+    assert harnesses["claude"]["loginKinds"] == ["api_key", "subscription"]
+    assert harnesses["codex"]["loginKinds"] == ["subscription"]
 
 
 def test_harness_response_carries_connection_state(tmp_path: Path):

--- a/backend/tests/test_api_usage.py
+++ b/backend/tests/test_api_usage.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -351,6 +352,23 @@ async def test_refresh_scrapes_only_the_viewers_connections(client, druks_db, mo
     assert client.post("/api/usage/refresh").status_code == 200
     assert fetched == [viewer.account_id]
     assert (await UsageScrape.latest_for("claude", viewer.account_id)).five_hour_percent_left == 50
+
+
+async def test_refresh_skips_a_non_metered_connection(client, druks_db, monkeypatch) -> None:
+    account = await Account.get_or_create("op@example.com")
+    await HarnessConnection.connect(
+        harness="claude",
+        account=account,
+        payload={"apiKey": "key"},
+        expires_at=None,
+        provider_email="op@example.com",
+        kind="api_key",
+    )
+    poll_usage = AsyncMock()
+    monkeypatch.setattr(ClaudeHarness, "poll_usage", poll_usage)
+
+    assert client.post("/api/usage/refresh").status_code == 200
+    poll_usage.assert_not_awaited()
 
 
 async def test_refresh_floors_repeat_scrapes(client, druks_db, monkeypatch) -> None:

--- a/backend/tests/test_gate.py
+++ b/backend/tests/test_gate.py
@@ -11,6 +11,8 @@ from druks.sandbox import gate
 @pytest.fixture(autouse=True)
 def _fast_poll(monkeypatch):
     monkeypatch.setattr(gate, "_POLL", 0.01)
+    _FakeHarness.rotated_connection_ids = []
+    _FakeConnections.refresh_capable_connection_ids = {"login-1", "login-2"}
 
 
 async def test_use_registers_for_the_span_and_unregisters():
@@ -61,6 +63,7 @@ class _FakeHarness:
     name = "fake"
     due_connection_ids: set[str] = set()
     urgent_connection_ids: set[str] = set()
+    rotated_connection_ids: list[str] = []
 
     @classmethod
     def needs_refresh(cls, login):
@@ -72,20 +75,30 @@ class _FakeHarness:
 
     @classmethod
     async def rotate_token(cls, connection_id):
+        cls.rotated_connection_ids.append(connection_id)
         return RotationResult(cls.name, "refreshed", connection_id=connection_id)
 
 
 class _FakeConnection:
     harness = "fake"
 
-    def __init__(self, connection_id: str) -> None:
+    def __init__(self, connection_id: str, *, supports_refresh: bool) -> None:
         self.id = connection_id
+        self.supports_refresh = supports_refresh
 
 
 class _FakeConnections:
-    @staticmethod
-    async def list_all():
-        return [_FakeConnection("login-1"), _FakeConnection("login-2")]
+    refresh_capable_connection_ids = {"login-1", "login-2"}
+
+    @classmethod
+    async def list_all(cls):
+        return [
+            _FakeConnection(
+                connection_id,
+                supports_refresh=connection_id in cls.refresh_capable_connection_ids,
+            )
+            for connection_id in ("login-1", "login-2")
+        ]
 
 
 def _fake_shut(shut: list[str], *, idle: bool):
@@ -111,6 +124,22 @@ async def test_refresh_shuts_only_the_due_logins(monkeypatch):
     # no-ops inside rotate_token itself).
     assert shut == ["login-2"]
     assert [r["action"] for r in result["results"]] == ["refreshed", "refreshed"]
+
+
+async def test_refresh_skips_a_connection_that_does_not_refresh(monkeypatch):
+    shut: list[str] = []
+    monkeypatch.setattr(harness_workflows, "get_harnesses", lambda: (_FakeHarness,))
+    monkeypatch.setattr(harness_workflows, "HarnessConnection", _FakeConnections)
+    monkeypatch.setattr(harness_workflows.gate, "shut", _fake_shut(shut, idle=True))
+    _FakeHarness.due_connection_ids = {"login-1", "login-2"}
+    _FakeHarness.urgent_connection_ids = set()
+    _FakeConnections.refresh_capable_connection_ids = {"login-1"}
+
+    result = await harness_workflows._refresh()
+
+    assert shut == ["login-1"]
+    assert _FakeHarness.rotated_connection_ids == ["login-1"]
+    assert [row["connection_id"] for row in result["results"]] == ["login-1"]
 
 
 async def test_refresh_defers_a_busy_login(monkeypatch):

--- a/backend/tests/test_harness_login_persistence.py
+++ b/backend/tests/test_harness_login_persistence.py
@@ -61,7 +61,7 @@ async def _committed(engine, work):
         await session.close()
 
 
-async def _connect(payload: dict) -> str:
+async def _connect(payload: dict, *, kind: str = "subscription") -> str:
     from druks.accounts.models import Account
     from druks.user_settings.models import UserSettings
 
@@ -75,8 +75,44 @@ async def _connect(payload: dict) -> str:
         payload=payload,
         expires_at=None,
         provider_email="op@example.com",
+        kind=kind,
     )
     return row.id
+
+
+async def test_connect_stores_the_default_kind(engine):
+    async def connect():
+        return await _connect({"claudeAiOauth": {"accessToken": "token"}})
+
+    connection_id = await _committed(engine, connect)
+
+    async def read_back():
+        row = await HarnessConnection.get(connection_id)
+        return row.kind, row.supports_refresh, row.is_metered
+
+    assert await _committed(engine, read_back) == ("subscription", True, True)
+
+
+async def test_reconnect_overwrites_the_kind(engine):
+    async def connect_subscription():
+        return await _connect({"claudeAiOauth": {"accessToken": "subscription"}})
+
+    connection_id = await _committed(engine, connect_subscription)
+
+    async def connect_api_key():
+        return await _connect(
+            {"claudeAiOauth": {"accessToken": "api-key"}},
+            kind="api_key",
+        )
+
+    reconnected_id = await _committed(engine, connect_api_key)
+
+    async def read_back():
+        row = await HarnessConnection.get(connection_id)
+        return row.kind, row.supports_refresh, row.is_metered
+
+    assert reconnected_id == connection_id
+    assert await _committed(engine, read_back) == ("api_key", False, False)
 
 
 async def test_rotation_persists_new_payload_across_sessions(engine):


### PR DESCRIPTION
`HarnessConnection.kind` was declared and echoed on the wire but never written or read. This makes it a real fact so an API-key connection can exist.

- `connect()` takes and stores `kind` on every upsert; `supports_refresh` and `is_metered` read it (both `kind == "subscription"`).
- A connection that does not support refresh never enters the token-refresh loop, so it never logs `no_refresh_token`. A non-metered one never enters the usage poll.
- `Harness.login_kinds` declares what connect doors a harness offers (default `{"subscription"}`); `HarnessResponse` echoes it sorted, beside `kind`.

`kind` stays out of `connect_start`/`connect_complete` — PKCE state does not apply to a pasted key. The `(harness, account_id)` unique constraint is unchanged.

DRU-361