### PR TITLE
One credential slot for the sandbox push

### DIFF
--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -66,6 +66,7 @@ _WEEKLY_WINDOWS = TypeAdapter(tuple[ParsedMetric, ...])
 class Harness(ABC):
     name: str
     login_kinds: ClassVar[frozenset[str]] = frozenset({"subscription"})
+    credentials_path: ClassVar[str]
     # Harness identity + shipped config, the seed source for the per-harness
     # ``HarnessSettings`` row the operator then tunes. Subclasses set provider,
     # models and default_model; effort/timeout default to the shipped values.

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -42,6 +42,7 @@ class ClaudeHarness(Harness):
     default_model = "claude-opus-4-7"
     model_discovery_url = "https://api.anthropic.com/v1/models?limit=100"
     command = "claude"
+    credentials_path = ".claude/.credentials.json"
 
     # OAuth refresh config (consumed by the Harness templates).
     REFRESH_MARGIN = timedelta(hours=2)
@@ -140,7 +141,7 @@ class ClaudeHarness(Harness):
             name="claude",
             args=("sh", "-c", wrapper),
             stdin=prompt.encode("utf-8"),
-            credentials=await _claude_credentials(
+            credentials=await _get_credentials(
                 self.sandbox,
                 github_token=github_token,
                 include_plugins=include_plugins,
@@ -404,7 +405,7 @@ def _parse_iso(value: object) -> datetime | None:
     return ensure_utc(parsed)
 
 
-async def _claude_credentials(
+async def _get_credentials(
     sandbox: SandboxSettings,
     *,
     github_token: str | None,
@@ -426,16 +427,16 @@ async def _claude_credentials(
     and the skills tree are kept either way; those aren't plugins.
     """
     config_dir = sandbox.claude_config_dir
-    files: tuple[tuple[Path, str], ...] = ()
+    config_files: tuple[tuple[Path, str], ...] = ()
     dirs: tuple[tuple[Path, str], ...] = ()
     if config_dir:
-        files = (
+        config_files = (
             (config_dir.parent / ".claude.json", ".claude.json"),
             (config_dir / "settings.json", ".claude/settings.json"),
             (config_dir / "CLAUDE.md", ".claude/CLAUDE.md"),
         )
         if include_plugins:
-            files += (
+            config_files += (
                 (
                     config_dir / "plugins" / "installed_plugins.json",
                     ".claude/plugins/installed_plugins.json",
@@ -455,9 +456,14 @@ async def _claude_credentials(
     if skills_src:
         dirs += ((skills_src, ".claude/skills"),)
     return Credentials(
-        claude_credentials=await ClaudeHarness.render_credentials_file(connection_id),
+        files=(
+            (
+                ClaudeHarness.credentials_path,
+                await ClaudeHarness.render_credentials_file(connection_id),
+            ),
+        ),
         github_token=github_token,
-        extra_config_files=files,
+        extra_config_files=config_files,
         extra_config_dirs=dirs,
         extra_dir_excludes={".claude/skills": await Skill.delivery_excludes(skills)},
     )

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -290,6 +290,7 @@ class CodexHarness(Harness):
     # catches it if the server ever starts rejecting unknown versions.
     model_discovery_url = "https://chatgpt.com/backend-api/codex/models?client_version=99.99.99"
     command = "codex"
+    credentials_path = ".codex/auth.json"
 
     # The CLI's terminal {"type":"error"} event carries prose, not status
     # shapes: stream drops after its internal retries, usage windows, 429s.
@@ -606,7 +607,7 @@ class CodexHarness(Harness):
             name=self.name,
             args=tuple(cmd),
             stdin=_with_final_message_note(prompt).encode("utf-8"),
-            credentials=await self._codex_credentials(
+            credentials=await self._get_credentials(
                 github_token=github_token,
                 skills=skills,
                 connection_id=connection_id,
@@ -684,7 +685,7 @@ class CodexHarness(Harness):
         args = (*args, "--json")
         return args
 
-    async def _codex_credentials(
+    async def _get_credentials(
         self,
         *,
         github_token: str | None,
@@ -695,9 +696,9 @@ class CodexHarness(Harness):
         # isn't connected); the local config dir only adds config carry on top.
         assert self.sandbox is not None  # callers guard
         config_dir = self.sandbox.codex_config_dir
-        files: tuple[tuple[Path, str], ...] = ()
+        config_files: tuple[tuple[Path, str], ...] = ()
         if config_dir:
-            files = (
+            config_files = (
                 (config_dir / "config.toml", ".codex/config.toml"),
                 (config_dir / ".credentials.json", ".codex/.credentials.json"),
                 (config_dir / "AGENTS.md", ".codex/AGENTS.md"),
@@ -710,9 +711,9 @@ class CodexHarness(Harness):
         if skills_src:
             dirs = ((skills_src, ".codex/skills"),)
         return Credentials(
-            codex_credentials=await self.render_credentials_file(connection_id),
+            files=((self.credentials_path, await self.render_credentials_file(connection_id)),),
             github_token=github_token,
-            extra_config_files=files,
+            extra_config_files=config_files,
             extra_config_dirs=dirs,
             extra_dir_excludes={".codex/skills": await Skill.delivery_excludes(skills)},
         )

--- a/backend/druks/sandbox/credentials.py
+++ b/backend/druks/sandbox/credentials.py
@@ -1,12 +1,7 @@
 from typing import TYPE_CHECKING
 
 from .datastructures import Credentials
-from .layout import (
-    get_claude_credentials_remote,
-    get_codex_auth_remote,
-    get_github_token_remote_path,
-    get_remote_home,
-)
+from .layout import get_github_token_remote_path, get_remote_home
 
 if TYPE_CHECKING:
     from .host import Host
@@ -31,29 +26,24 @@ DEFAULT_DIR_EXCLUDES: tuple[str, ...] = (
 )
 
 
-async def push(host: "Host", creds: Credentials) -> None:
-    if creds.claude_credentials:
+async def push(host: "Host", credentials: Credentials) -> None:
+    home = get_remote_home(host.ssh_username)
+    for remote_path_suffix, rendered_content in credentials.files:
         await host.write_secret(
-            secret=creds.claude_credentials,
-            remote=get_claude_credentials_remote(host.ssh_username),
+            secret=rendered_content,
+            remote=f"{home}/{remote_path_suffix}",
         )
-    if creds.codex_credentials:
-        await host.write_secret(
-            secret=creds.codex_credentials,
-            remote=get_codex_auth_remote(host.ssh_username),
-        )
-    if creds.github_token is not None:
+    if credentials.github_token:
         # TODO: This token expires in ~60 min and is not refreshed, so a run
         # outliving it 401s on late git pushes. The in-VM credential helper
         # should mint on demand from a druks token-broker endpoint, retiring
         # this static file.
         await host.write_secret(
-            secret=creds.github_token,
+            secret=credentials.github_token,
             remote=get_github_token_remote_path(host.ssh_username),
         )
 
-    home = get_remote_home(host.ssh_username)
-    for local, dest_suffix in creds.extra_config_files:
+    for local, dest_suffix in credentials.extra_config_files:
         # Optional — a dev box may not have config.toml etc., and a Docker bind
         # mount whose host file never existed leaves a directory at the path.
         # Push real files only; missing config isn't fatal (the CLIs mint their
@@ -61,11 +51,11 @@ async def push(host: "Host", creds: Credentials) -> None:
         if not local.is_file():
             continue
         await host.upload_file(local=local, remote=f"{home}/{dest_suffix}")
-    for local, dest_suffix in creds.extra_config_dirs:
+    for local, dest_suffix in credentials.extra_config_dirs:
         if not local.is_dir():
             continue
         await host.upload_dir(
             local=local,
             remote=f"{home}/{dest_suffix}",
-            excludes=DEFAULT_DIR_EXCLUDES + creds.extra_dir_excludes.get(dest_suffix, ()),
+            excludes=DEFAULT_DIR_EXCLUDES + credentials.extra_dir_excludes.get(dest_suffix, ()),
         )

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -159,13 +159,8 @@ class RequiredMcpServer:
 
 @dataclass(frozen=True)
 class Credentials:
-    # The credential-file JSON each CLI reads, synthesized from the DB row at
-    # push time (``Harness.render_credentials_file()``, which raises when that
-    # harness isn't connected); None when this bundle doesn't carry that CLI —
-    # a claude bundle ships no codex credential and vice versa. Written into
-    # the VM as a secret, never a host-file copy.
-    claude_credentials: str | None = None
-    codex_credentials: str | None = None
+    # Home-relative paths and rendered content for files written as VM secrets.
+    files: tuple[tuple[str, str], ...] = ()
     github_token: str | None = None
     # Extra config files to carry into the VM, as
     # ``(local_path, home_relative_dest)`` pairs. This is how the

--- a/backend/druks/sandbox/layout.py
+++ b/backend/druks/sandbox/layout.py
@@ -1,38 +1,11 @@
-# The in-VM filesystem layout: where credentials, the helper script, and the
-# workspace live on a sandbox host, all derived from the SSH user's home so
+# The in-VM filesystem layout: where the helper script and workspace live on a
+# sandbox host, all derived from the SSH user's home so
 # non-root users (e.g. ``exedev`` on the standard exuntu image) can ``mkdir``
 # and own every subdir.
-
-# In-VM credential destinations, RELATIVE to the agent user's home.
-# These must match the exact files the Linux CLIs read on startup —
-# getting them wrong silently falls back to unauthenticated (or a
-# login prompt that hangs a headless run):
-#
-#   - Claude Code (Linux) reads its OAuth credentials from the HIDDEN
-#     file ``~/.claude/.credentials.json`` (note the leading dot).
-#     macOS uses the login Keychain instead, but Druks runs on Linux.
-#   - Codex CLI reads ``~/.codex/auth.json`` (NOT ``credentials.json``).
-#
-# The agent process resolves ``$HOME`` from whichever user SSHes into
-# the VM (``SandboxSettings.ssh_username`` / ``DRUKS_SANDBOX_SSH_USERNAME``).
-# On the exuntu image that's ``exedev`` (→ /home/exedev), not root, so
-# destinations are computed per-user via :func:`get_remote_home` rather
-# than hardcoded. The credential content is synthesized from the DB row
-# (``Harness.render_credentials_file()``) and written there as a secret.
-CLAUDE_CRED_HOME_SUFFIX = ".claude/.credentials.json"
-CODEX_AUTH_HOME_SUFFIX = ".codex/auth.json"
 
 
 def get_remote_home(ssh_username: str) -> str:
     return "/root" if ssh_username == "root" else f"/home/{ssh_username}"
-
-
-def get_claude_credentials_remote(ssh_username: str) -> str:
-    return f"{get_remote_home(ssh_username)}/{CLAUDE_CRED_HOME_SUFFIX}"
-
-
-def get_codex_auth_remote(ssh_username: str) -> str:
-    return f"{get_remote_home(ssh_username)}/{CODEX_AUTH_HOME_SUFFIX}"
 
 
 def get_helper_script_path(ssh_username: str) -> str:

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -9,7 +9,7 @@ import pytest
 from conftest import connect_harness
 from druks.accounts.models import Account
 from druks.harnesses import base as hbase
-from druks.harnesses.claude import ClaudeHarness, _claude_credentials
+from druks.harnesses.claude import ClaudeHarness, _get_credentials
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.datastructures import SandboxSettings
 from druks.harnesses.exceptions import HarnessNotConnectedError, OAuthTokenError
@@ -443,9 +443,10 @@ async def test_claude_builder_puts_db_credentials_on_the_bundle(druks_db):
         claude_config_dir=Path("/home/agent/.claude"),
         codex_config_dir=Path("/home/agent/.codex"),
     )
-    bundle = await _claude_credentials(sandbox, github_token=None)
-    assert json.loads(bundle.claude_credentials)["claudeAiOauth"]["accessToken"] == "live"
-    assert bundle.codex_credentials is None
+    bundle = await _get_credentials(sandbox, github_token=None)
+    [(credential_path, rendered_content)] = bundle.files
+    assert credential_path == ".claude/.credentials.json"
+    assert json.loads(rendered_content)["claudeAiOauth"]["accessToken"] == "live"
 
 
 async def test_credentials_builders_carry_global_instructions(druks_db):
@@ -462,20 +463,24 @@ async def test_credentials_builders_carry_global_instructions(druks_db):
         codex_config_dir=codex_config_dir,
     )
 
-    claude_credentials = await _claude_credentials(sandbox, github_token=None)
-    codex_credentials = await CodexHarness(
+    claude_bundle = await _get_credentials(sandbox, github_token=None)
+    codex_bundle = await CodexHarness(
         model=CodexHarness.default_model,
         fast_mode=False,
         effort=None,
         sandbox=sandbox,
-    )._codex_credentials(github_token=None)
+    )._get_credentials(github_token=None)
 
-    assert (claude_config_dir / "CLAUDE.md", ".claude/CLAUDE.md") in (
-        claude_credentials.extra_config_files
-    )
-    assert (codex_config_dir / "AGENTS.md", ".codex/AGENTS.md") in (
-        codex_credentials.extra_config_files
-    )
+    assert claude_bundle.files[0][0] == ".claude/.credentials.json"
+    assert codex_bundle.files[0][0] == ".codex/auth.json"
+    assert (
+        claude_config_dir / "CLAUDE.md",
+        ".claude/CLAUDE.md",
+    ) in claude_bundle.extra_config_files
+    assert (
+        codex_config_dir / "AGENTS.md",
+        ".codex/AGENTS.md",
+    ) in codex_bundle.extra_config_files
 
 
 async def test_no_config_dir_ships_credential_only(druks_db):
@@ -491,8 +496,9 @@ async def test_no_config_dir_ships_credential_only(druks_db):
         claude_config_dir=None,
         codex_config_dir=None,
     )
-    bundle = await _claude_credentials(sandbox, github_token="gh")
-    assert json.loads(bundle.claude_credentials)["claudeAiOauth"]["accessToken"] == "live"
+    bundle = await _get_credentials(sandbox, github_token="gh")
+    [(_, rendered_content)] = bundle.files
+    assert json.loads(rendered_content)["claudeAiOauth"]["accessToken"] == "live"
     assert bundle.extra_config_files == ()
     assert bundle.extra_config_dirs == ()
     assert bundle.github_token == "gh"
@@ -508,7 +514,7 @@ async def test_claude_builder_raises_when_not_connected(druks_db):
         codex_config_dir=None,
     )
     with pytest.raises(HarnessNotConnectedError, match="claude is not connected"):
-        await _claude_credentials(sandbox, github_token=None)
+        await _get_credentials(sandbox, github_token=None)
 
 
 async def test_lookup_prefers_the_accounts_own_connection(druks_db):

--- a/backend/tests/test_sandbox_lifecycle.py
+++ b/backend/tests/test_sandbox_lifecycle.py
@@ -161,18 +161,16 @@ def _record(
 # orchestration that drives them.
 
 
-async def test_push_skips_none_fields():
+async def test_push_writes_one_credential_file():
     sandbox = _FakeSandbox()
 
     await creds_module.push(
         sandbox,  # type: ignore[arg-type]
-        Credentials(claude_credentials="{}"),
+        Credentials(files=((".claude/.credentials.json", "{}"),)),
     )
 
-    # Only the Claude credential, written as a secret. Codex + GitHub skipped,
-    # and credentials never travel by SFTP.
     assert sandbox.uploads == []
-    assert sandbox.secrets == [("{}", layout.get_claude_credentials_remote(sandbox.ssh_username))]
+    assert sandbox.secrets == [("{}", "/root/.claude/.credentials.json")]
 
 
 async def test_push_writes_all_three_when_supplied():
@@ -181,17 +179,18 @@ async def test_push_writes_all_three_when_supplied():
     await creds_module.push(
         sandbox,  # type: ignore[arg-type]
         Credentials(
-            claude_credentials='{"claude": 1}',
-            codex_credentials='{"codex": 1}',
+            files=(
+                (".claude/.credentials.json", '{"claude": 1}'),
+                (".codex/auth.json", '{"codex": 1}'),
+            ),
             github_token="gho_xxx",
         ),
     )
 
-    # All three are synthesized content written via write_secret — no SFTP.
     assert sandbox.uploads == []
     assert set(sandbox.secrets) == {
-        ('{"claude": 1}', layout.get_claude_credentials_remote(sandbox.ssh_username)),
-        ('{"codex": 1}', layout.get_codex_auth_remote(sandbox.ssh_username)),
+        ('{"claude": 1}', "/root/.claude/.credentials.json"),
+        ('{"codex": 1}', "/root/.codex/auth.json"),
         ("gho_xxx", layout.get_github_token_remote_path(sandbox.ssh_username)),
     }
 


### PR DESCRIPTION
`druks.sandbox` no longer knows which CLI runs. `Credentials.claude_credentials` / `codex_credentials` collapse into one `files: tuple[tuple[str, str], ...]` slot (home-relative path, rendered content).

- Each harness declares its own `credentials_path` (`.claude/.credentials.json`, `.codex/auth.json`) and its `_get_credentials` builder passes the pair; `push()` is one write loop.
- The CLI-specific constants and getters in `sandbox/layout.py` are gone. Net-negative diff.
- A third harness adds a credential file without touching `druks.sandbox`; an env-var credential declares nothing here and rides `build_invocation`.

Tests pin the exact VM paths written, so the push writes the same two files to the same places as before.

DRU-362