### PR TITLE
Cut the Harness ABC to two abstract methods

### DIFF
--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -33,6 +33,7 @@ from .datastructures import (
     ParsedMetric,
     ParsedModels,
     ParsedUsage,
+    ProviderRequest,
     RotationResult,
     SandboxSettings,
 )
@@ -74,8 +75,6 @@ class Harness(ABC):
     # Suggested models for the settings picker and the ``default_model`` seed.
     models: ClassVar[tuple[str, ...]]
     default_model: ClassVar[str]
-    # The provider's model-list endpoint the picker refresh fetches.
-    model_discovery_url: ClassVar[str]
     # This CLI's terminal-error vocabulary: phrase → the failure it names, the
     # first phrase found in a death's text winning in declaration order; no
     # match stays a bare, never-retried HarnessError. The terminal event has no
@@ -276,17 +275,17 @@ class Harness(ABC):
         )
 
     @classmethod
-    @abstractmethod
     def authorize_url(cls, *, verifier: str, challenge: str) -> tuple[str, str]:
         """Build this provider's PKCE authorize URL; return (url, state), where
         ``state`` is what the provider echoes back so connect_complete can
         verify the round-trip."""
+        raise NotImplementedError
 
     @classmethod
-    @abstractmethod
     async def exchange(cls, *, code: str, verifier: str) -> tuple[dict, str | None]:
         """Exchange the authorization code for tokens; return (credential-file
         payload, provider-reported account email)."""
+        raise NotImplementedError
 
     @classmethod
     def load_token(cls, connection: HarnessConnection, *, now: datetime | None = None) -> Token:
@@ -301,10 +300,10 @@ class Harness(ABC):
         return token
 
     @classmethod
-    @abstractmethod
     def _token_from_credentials(cls, data: dict) -> Token:
         """Extract the token object from the parsed credential file;
         raise ``OAuthTokenError('no_token')`` if absent."""
+        raise NotImplementedError
 
     @classmethod
     async def rotate_token(
@@ -418,20 +417,20 @@ class Harness(ABC):
         return token.expires_at - now <= cls.REFRESH_MARGIN
 
     @classmethod
-    @abstractmethod
     def _refresh_state(cls, data: dict) -> tuple[str | None, datetime | None]:
         """Return (refresh_token, current_expiry) from the credential file."""
+        raise NotImplementedError
 
     @classmethod
-    @abstractmethod
     def _grant_body(cls, refresh_token: str) -> dict:
         """The JSON body for this CLI's refresh grant."""
+        raise NotImplementedError
 
     @classmethod
-    @abstractmethod
     def _apply_refresh(cls, data: dict, grant: dict, now: datetime) -> datetime | None:
         """Merge the grant response into ``data`` in place; return the new
         expiry. Raise ``ValueError`` if the response is unusable."""
+        raise NotImplementedError
 
     @classmethod
     async def fetch_usage(
@@ -443,13 +442,14 @@ class Harness(ABC):
         '0 metrics'."""
         try:
             token = cls.load_token(connection, now=now)
+            request = cls._usage_request(token)
         except exceptions.OAuthTokenError as exc:
             return ParsedUsage(ok=False, error=exc.tag)
-
-        url, headers = cls._usage_request(token)
+        except NotImplementedError:
+            return ParsedUsage(ok=False, error="unsupported")
         try:
             async with httpx.AsyncClient(timeout=_USAGE_TIMEOUT_SECONDS) as client:
-                response = await client.get(url, headers=headers)
+                response = await client.get(request.url, headers=request.headers)
         except httpx.TimeoutException:
             return ParsedUsage(ok=False, error="timeout")
         except httpx.HTTPError as exc:
@@ -514,14 +514,14 @@ class Harness(ABC):
         }
 
     @classmethod
-    @abstractmethod
-    def _usage_request(cls, token: Token) -> tuple[str, dict]:
-        """Return (url, headers) for the usage endpoint."""
+    def _usage_request(cls, token: Token) -> ProviderRequest:
+        """The authenticated request for the usage endpoint."""
+        raise NotImplementedError
 
     @classmethod
-    @abstractmethod
     def _parse_usage(cls, raw: str) -> ParsedUsage:
         """Map the usage endpoint's JSON body into :class:`ParsedUsage`."""
+        return ParsedUsage(ok=False, error="unsupported")
 
     @classmethod
     async def fetch_models(cls, connection: HarnessConnection) -> ParsedModels:
@@ -531,13 +531,14 @@ class Harness(ABC):
         only ever advances, it is never wiped by a bad fetch."""
         try:
             token = cls.load_token(connection)
+            request = cls._model_discovery_request(token)
         except exceptions.OAuthTokenError as exc:
             return ParsedModels(ok=False, error=exc.tag)
-
-        headers = cls.get_model_discovery_headers(token)
+        except NotImplementedError:
+            return ParsedModels(ok=False, error="unsupported")
         try:
             async with httpx.AsyncClient(timeout=_USAGE_TIMEOUT_SECONDS) as client:
-                response = await client.get(cls.model_discovery_url, headers=headers)
+                response = await client.get(request.url, headers=request.headers)
         except httpx.TimeoutException:
             return ParsedModels(ok=False, error="timeout")
         except httpx.HTTPError as exc:
@@ -556,15 +557,15 @@ class Harness(ABC):
         return ParsedModels(ok=False, error=tag)
 
     @classmethod
-    @abstractmethod
-    def get_model_discovery_headers(cls, token: Token) -> dict:
-        """Auth headers for the model-discovery endpoint."""
+    def _model_discovery_request(cls, token: Token) -> ProviderRequest:
+        """The authenticated request for the model-discovery endpoint."""
+        raise NotImplementedError
 
     @classmethod
-    @abstractmethod
     def _parse_models(cls, raw: str) -> ParsedModels:
         """Map the model-list endpoint's JSON body into :class:`ParsedModels`.
         A payload offering nothing is a tagged error, never an ok-empty."""
+        return ParsedModels(ok=False, error="unsupported")
 
 
 def _utc_now() -> datetime:

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -21,7 +21,14 @@ from . import exceptions
 from .artifacts import call_dir, write_cost
 from .base import Harness, parse_epoch_expiry, post_token
 from .constants import CLAUDE_DISALLOWED_TOOLS
-from .datastructures import OAuthToken, ParsedMetric, ParsedModels, ParsedUsage, SandboxSettings
+from .datastructures import (
+    OAuthToken,
+    ParsedMetric,
+    ParsedModels,
+    ParsedUsage,
+    ProviderRequest,
+    SandboxSettings,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +47,6 @@ class ClaudeHarness(Harness):
     provider = "anthropic"
     models = ("claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5")
     default_model = "claude-opus-4-7"
-    model_discovery_url = "https://api.anthropic.com/v1/models?limit=100"
     command = "claude"
     credentials_path = ".claude/.credentials.json"
 
@@ -301,17 +307,17 @@ class ClaudeHarness(Harness):
         return parse_epoch_expiry(block.get("expiresAt"))
 
     @classmethod
-    def _usage_request(cls, token: OAuthToken) -> tuple[str, dict]:
-        headers = {
-            "Authorization": f"Bearer {token.access_token}",
-            "anthropic-beta": _OAUTH_BETA,
-            "anthropic-version": _ANTHROPIC_VERSION,
-            "User-Agent": _CLAUDE_CODE_USER_AGENT,
-        }
-        return _USAGE_URL, headers
+    def _usage_request(cls, token: OAuthToken) -> ProviderRequest:
+        return ProviderRequest(_USAGE_URL, cls._oauth_headers(token))
 
     @classmethod
-    def get_model_discovery_headers(cls, token: OAuthToken) -> dict:
+    def _model_discovery_request(cls, token: OAuthToken) -> ProviderRequest:
+        return ProviderRequest(
+            "https://api.anthropic.com/v1/models?limit=100", cls._oauth_headers(token)
+        )
+
+    @classmethod
+    def _oauth_headers(cls, token: OAuthToken) -> dict:
         return {
             "Authorization": f"Bearer {token.access_token}",
             "anthropic-beta": _OAUTH_BETA,

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -22,7 +22,7 @@ from druks.skills.models import Skill
 
 from .artifacts import write_cost
 from .base import Harness, jwt_claims, jwt_expiry, post_token
-from .datastructures import CodexToken, ParsedMetric, ParsedModels, ParsedUsage
+from .datastructures import CodexToken, ParsedMetric, ParsedModels, ParsedUsage, ProviderRequest
 from .exceptions import (
     HarnessAuthError,
     HarnessError,
@@ -284,11 +284,6 @@ class CodexHarness(Harness):
     provider = "openai"
     models = ("gpt-5.5",)
     default_model = "gpt-5.5"
-    # ``client_version`` is required and lower-bounds the list (the server
-    # returns models with ``minimal_client_version <= client_version``); the
-    # high constant asks for the full catalog, and the empty-list guard
-    # catches it if the server ever starts rejecting unknown versions.
-    model_discovery_url = "https://chatgpt.com/backend-api/codex/models?client_version=99.99.99"
     command = "codex"
     credentials_path = ".codex/auth.json"
 
@@ -402,17 +397,22 @@ class CodexHarness(Harness):
         return jwt_expiry(access)
 
     @classmethod
-    def _usage_request(cls, token: CodexToken) -> tuple[str, dict]:
-        headers = {
-            "Authorization": f"Bearer {token.access_token}",
-            "User-Agent": _CODEX_USER_AGENT,
-        }
-        if token.account_id:
-            headers["ChatGPT-Account-Id"] = token.account_id
-        return _CODEX_USAGE_URL, headers
+    def _usage_request(cls, token: CodexToken) -> ProviderRequest:
+        return ProviderRequest(_CODEX_USAGE_URL, cls._chatgpt_headers(token))
 
     @classmethod
-    def get_model_discovery_headers(cls, token: CodexToken) -> dict:
+    def _model_discovery_request(cls, token: CodexToken) -> ProviderRequest:
+        # ``client_version`` is required and lower-bounds the list (the server
+        # returns models with ``minimal_client_version <= client_version``); the
+        # high constant asks for the full catalog, and the empty-list guard
+        # catches it if the server ever starts rejecting unknown versions.
+        return ProviderRequest(
+            "https://chatgpt.com/backend-api/codex/models?client_version=99.99.99",
+            cls._chatgpt_headers(token),
+        )
+
+    @classmethod
+    def _chatgpt_headers(cls, token: CodexToken) -> dict:
         headers = {
             "Authorization": f"Bearer {token.access_token}",
             "User-Agent": _CODEX_USER_AGENT,

--- a/backend/druks/harnesses/datastructures.py
+++ b/backend/druks/harnesses/datastructures.py
@@ -73,6 +73,14 @@ class ParsedMetric:
 
 
 @dataclass(frozen=True)
+class ProviderRequest:
+    """One authenticated GET the platform makes to the provider."""
+
+    url: str
+    headers: dict
+
+
+@dataclass(frozen=True)
 class ParsedUsage:
     ok: bool
     error: str | None = None

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -2,6 +2,7 @@ import base64
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 
 import druks.redis
 import httpx
@@ -11,7 +12,13 @@ from druks.accounts.models import Account
 from druks.harnesses import base as hbase
 from druks.harnesses.claude import ClaudeHarness, _get_credentials
 from druks.harnesses.codex import CodexHarness
-from druks.harnesses.datastructures import SandboxSettings
+from druks.harnesses.datastructures import (
+    AgentInvocation,
+    HarnessRunResult,
+    ParsedModels,
+    ParsedUsage,
+    SandboxSettings,
+)
 from druks.harnesses.exceptions import HarnessNotConnectedError, OAuthTokenError
 from druks.harnesses.models import HarnessConnection
 from druks.user_settings.models import UserSettings
@@ -421,6 +428,62 @@ async def test_codex_fetch_usage_success(monkeypatch, druks_db):
     assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acc-7"
 
 
+async def test_claude_fetch_models_success(monkeypatch, druks_db):
+    # fetch_models reads the wall clock (no ``now=`` seam), so the token's
+    # expiry must be real-future, not _NOW-relative.
+    connection = await _seed_claude(access="tok", expires_at=datetime.now(UTC) + timedelta(hours=2))
+    body = {"data": [{"id": "claude-fable-5", "display_name": "Claude Fable 5"}]}
+    calls = _mock_get(monkeypatch, _resp(200, body))
+
+    parsed = await ClaudeHarness.fetch_models(connection)
+
+    assert parsed == ParsedModels(
+        ok=True,
+        models=({"id": "claude-fable-5", "label": "Claude Fable 5"},),
+        raw=json.dumps(body),
+    )
+    assert calls[0]["url"] == "https://api.anthropic.com/v1/models?limit=100"
+    assert calls[0]["headers"]["Authorization"] == "Bearer tok"
+
+
+async def test_codex_fetch_models_success(monkeypatch, druks_db):
+    connection = await _seed_codex(
+        account_id="acc-7",
+        access=_jwt(int((datetime.now(UTC) + timedelta(days=9)).timestamp())),
+    )
+    body = {
+        "models": [
+            {
+                "slug": "gpt-5.6-sol",
+                "display_name": "GPT-5.6-Sol",
+                "visibility": "list",
+                "supported_reasoning_levels": [{"effort": "high"}],
+                "minimal_client_version": "0.144.0",
+            }
+        ]
+    }
+    calls = _mock_get(monkeypatch, _resp(200, body))
+
+    parsed = await CodexHarness.fetch_models(connection)
+
+    assert parsed == ParsedModels(
+        ok=True,
+        models=(
+            {
+                "id": "gpt-5.6-sol",
+                "label": "GPT-5.6-Sol",
+                "efforts": ["high"],
+                "minimal_client_version": "0.144.0",
+            },
+        ),
+        raw=json.dumps(body),
+    )
+    assert calls[0]["url"] == (
+        "https://chatgpt.com/backend-api/codex/models?client_version=99.99.99"
+    )
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acc-7"
+
+
 async def test_render_credentials_file_serializes_stored_payload(druks_db):
     connection = await _seed_claude(access="tok", refresh="R0")
     rendered = await ClaudeHarness.render_credentials_file(connection.id)
@@ -560,3 +623,31 @@ async def test_render_credentials_file_for_a_deleted_connection_raises(druks_db)
     # fall through to another account's payload.
     with pytest.raises(HarnessNotConnectedError, match="removed"):
         await ClaudeHarness.render_credentials_file(gone_id)
+
+
+async def test_minimal_harness_reports_unsupported_optional_endpoints(monkeypatch):
+    class MinimalHarness(hbase.Harness):
+        name = "minimal"
+
+        async def build_invocation(self, **kwargs: object) -> AgentInvocation:
+            raise AssertionError("not called")
+
+        def parse(
+            self,
+            result: HarnessRunResult,
+            *,
+            artifact_dir: Path,
+            run_id: str,
+        ) -> object:
+            return {}
+
+    harness = MinimalHarness(model="minimal", fast_mode=False, effort=None)
+    connection = SimpleNamespace(payload={})
+    calls = _mock_get(monkeypatch, _resp(200, {}))
+
+    usage = await harness.fetch_usage(connection)
+    models = await harness.fetch_models(connection)
+
+    assert usage == ParsedUsage(ok=False, error="unsupported")
+    assert models == ParsedModels(ok=False, error="unsupported")
+    assert calls == []


### PR DESCRIPTION
`Harness` declared twelve abstract methods, so a harness with no subscription OAuth, no quota endpoint, or no model-discovery endpoint could not subclass it without stubs. Only `build_invocation` and `parse` stay abstract.

- The six OAuth-only hooks (`authorize_url`, `exchange`, `_token_from_credentials`, `_refresh_state`, `_grant_body`, `_apply_refresh`) raise `NotImplementedError` — never reached for a connection that does not support refresh.
- `fetch_usage` / `fetch_models` report `ok=False, error="unsupported"` when the harness declares no endpoint, without an HTTP request; the usage surface already renders less UI for `ok=False`. No capability flags, no tiers.
- `model_discovery_url` + `get_model_discovery_headers` collapse into `_model_discovery_request(token) -> ProviderRequest`, symmetric with `_usage_request` — the discovery URL is kind-dependent, so a ClassVar cannot carry it. `ProviderRequest` is a small frozen dataclass (url, headers), so neither method returns a loose tuple.

A subclass defining only `build_invocation` and `parse` instantiates and runs (pinned by test); claude/codex behavior unchanged.

DRU-363