### PR TITLE
Per-harness command, first-byte window, doctor probe

### DIFF
--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -281,18 +281,17 @@ async def _drukbox_doctor(settings: Settings):
         await api.aclose()
 
 
-async def check_sandbox_e2e(settings: Settings) -> CheckResult:
-    """Provision a real VM and exercise the two dial paths builds use:
-    the acquire-time connection and a reattach from a GET-built record.
-    Costs one VM-minute — opt-in via ``druks doctor --sandbox``, never
-    part of the default check set."""
+async def check_sandbox_e2e(settings: Settings) -> CheckResult | list[CheckResult]:
+    """Provision a real VM, exercise the acquire and reattach dial paths, and
+    probe each registered harness CLI's presence on the image. Costs one
+    VM-minute — opt-in via ``druks doctor --sandbox``, never part of the
+    default check set."""
     if not settings.sandbox.service_url:
         return CheckResult(name="sandbox_e2e", ok=True, detail="not configured")
     try:
-        detail = await _sandbox_e2e()
+        return await _sandbox_e2e()
     except Exception as error:  # noqa: BLE001 — doctor reports, never raises
         return CheckResult(name="sandbox_e2e", ok=False, detail=f"{error}")
-    return CheckResult(name="sandbox_e2e", ok=True, detail=detail)
 
 
 async def check_declared_sandboxes(settings: Settings) -> CheckResult | list[CheckResult]:
@@ -342,8 +341,9 @@ async def check_declared_sandboxes(settings: Settings) -> CheckResult | list[Che
     return results
 
 
-async def _sandbox_e2e() -> str:
+async def _sandbox_e2e() -> list[CheckResult]:
     start = time.monotonic()
+    binary_results: list[CheckResult] = []
     # acquire rolls its own host back on failure; once it yields, we own
     # the release.
     async with sandbox_client.acquire() as sandbox:
@@ -351,17 +351,39 @@ async def _sandbox_e2e() -> str:
         try:
             await _doctor_exec(sandbox)
             provision_seconds = time.monotonic() - start
-
+            for harness in get_harnesses():
+                result = await sandbox.exec(
+                    ["sh", "-c", f"command -v {harness.command}"],
+                    timeout=30.0,
+                )
+                if result.ok:
+                    binary_detail = result.stdout.strip() or f"{harness.command} found"
+                else:
+                    binary_detail = result.stderr.strip() or f"{harness.command} not found"
+                binary_results.append(
+                    CheckResult(
+                        name=f"sandbox_binary:{harness.name}",
+                        ok=result.ok,
+                        detail=binary_detail,
+                    )
+                )
             reattach_start = time.monotonic()
             async with sandbox_client.attach(host_id=host_id) as reattached:
                 await _doctor_exec(reattached)
             reattach_seconds = time.monotonic() - reattach_start
         finally:
             await sandbox_client.release(host_id=host_id)
-    return (
-        f"provision+dial {provision_seconds:.0f}s · "
-        f"reattach {reattach_seconds:.1f}s · host {host_id}"
-    )
+    return [
+        CheckResult(
+            name="sandbox_e2e",
+            ok=True,
+            detail=(
+                f"provision+dial {provision_seconds:.0f}s · "
+                f"reattach {reattach_seconds:.1f}s · host {host_id}"
+            ),
+        ),
+        *binary_results,
+    ]
 
 
 async def _doctor_exec(sandbox) -> None:
@@ -545,7 +567,8 @@ async def run_checks(settings: Settings, *, sandbox: bool = False) -> list[Check
             outcome = await outcome
         results.extend(outcome if isinstance(outcome, list) else [outcome])
     if sandbox:
-        results.append(await check_sandbox_e2e(settings))
+        outcome = await check_sandbox_e2e(settings)
+        results.extend(outcome if isinstance(outcome, list) else [outcome])
     return results
 
 

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -66,6 +66,7 @@ _WEEKLY_WINDOWS = TypeAdapter(tuple[ParsedMetric, ...])
 
 class Harness(ABC):
     name: str
+    command: ClassVar[str]
     login_kinds: ClassVar[frozenset[str]] = frozenset({"subscription"})
     credentials_path: ClassVar[str]
     # Harness identity + shipped config, the seed source for the per-harness
@@ -82,6 +83,9 @@ class Harness(ABC):
     failure_markers: ClassVar[dict[str, type[exceptions.HarnessError]]] = {}
     default_effort: ClassVar[str] = "high"
     default_timeout: ClassVar[int] = 1800
+    # Claude's slowest measured cold start is under 60 seconds. This margin
+    # covers slow MCP loads, token refresh, and prompt assembly.
+    first_byte_seconds: ClassVar[int | None] = 90
     # Per-CLI OAuth refresh config (set by subclasses).
     REFRESH_MARGIN: timedelta
     _TOKEN_URL: str

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -49,24 +49,6 @@ _ARTIFACT_FILENAMES = ("stdout.jsonl", "stderr.log", "exit_code", "pid")
 STDOUT_BUFFER_LIMIT = 50 * 1024 * 1024
 STDERR_BUFFER_LIMIT = 10 * 1024 * 1024
 
-# Maximum window between exec start and the first output byte before we
-# consider the run wedged and kill it. Anthropic's Claude CLI streams its
-# first ``stream-json`` event within a couple of seconds normally; the
-# worst legitimate cold-start we've measured is well under 60s. 90s gives
-# a comfortable margin for slow MCP loads + auth refresh + long-prompt
-# assembly while still recovering the operation budget fast when the CLI
-# silently wedges.
-#
-# Pre-LLM wedges (Claude Code's ``--add-dir <cwd>`` event-loop hang,
-# upstream HTTP stalls that the CLI doesn't surface as errors) all share
-# the symptom "process alive, zero output bytes, forever." The full
-# per-operation timeout is in the tens of minutes, so without this guard
-# a wedged run blocks a worker slot for far longer than necessary. Pair
-# with ``--debug-file`` on the CLI side to get post-mortem context on
-# what the wedge was doing.
-FIRST_BYTE_KILL_SECONDS_DEFAULT = 90
-
-
 _CONNECT_TIMEOUT_SECONDS = 30.0
 _KEEPALIVE_INTERVAL_SECONDS = 15.0
 
@@ -361,6 +343,7 @@ class Host:
             run_id=run_id,
             artifact_dir=artifact_dir,
             timeout=timeout,
+            first_byte_kill_seconds=harness.first_byte_seconds,
         )
         return harness.parse(result, artifact_dir=artifact_dir, run_id=run_id)
 
@@ -371,7 +354,7 @@ class Host:
         run_id: str,
         artifact_dir: Path,
         timeout: int,
-        first_byte_kill_seconds: int | None = FIRST_BYTE_KILL_SECONDS_DEFAULT,
+        first_byte_kill_seconds: int | None = None,
     ) -> HarnessRunResult:
         """Execute a built invocation on this VM: tee stdout/stderr to the
         artifact dir, enforce the first-byte and overall timeouts, record

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -416,34 +416,47 @@ def test_print_results_fails_on_a_genuine_fault_alongside_pending(capsys) -> Non
     assert "1 pending" in captured.out
 
 
-def _fake_sandbox_client(monkeypatch, *, reattach_fails=False):
+def _fake_sandbox_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    reattach_fails: bool = False,
+    missing_command: str | None = None,
+) -> list[object]:
     """Async-context-manager stubs mirroring acquire/attach/release."""
-    import contextlib
-
-    class _FakeExec:
-        ok = True
-        stderr = ""
 
     class _FakeSandbox:
         id = "host-doc"
 
-        async def exec(self, argv, timeout):
-            return _FakeExec()
+        def __init__(self, connection: str) -> None:
+            self.connection = connection
 
-    calls = []
+        async def exec(self, argv: list[str], timeout: float) -> SimpleNamespace:
+            calls.append((self.connection, argv, timeout))
+            command_missing = missing_command is not None and argv == [
+                "sh",
+                "-c",
+                f"command -v {missing_command}",
+            ]
+            return SimpleNamespace(
+                ok=not command_missing,
+                stdout="" if command_missing else "/usr/bin/tool\n",
+                stderr="missing\n" if command_missing else "",
+            )
+
+    calls: list[object] = []
 
     class _FakeClient:
-        @contextlib.asynccontextmanager
+        @asynccontextmanager
         async def acquire(self):
             calls.append("acquire")
-            yield _FakeSandbox()
+            yield _FakeSandbox("acquire")
 
-        @contextlib.asynccontextmanager
+        @asynccontextmanager
         async def attach(self, *, host_id):
             calls.append(f"attach:{host_id}")
             if reattach_fails:
                 raise TimeoutError("dial timed out")
-            yield _FakeSandbox()
+            yield _FakeSandbox("reattach")
 
         async def release(self, *, host_id):
             calls.append(f"release:{host_id}")
@@ -461,15 +474,42 @@ async def test_sandbox_e2e_not_configured_is_ok(tmp_path: Path) -> None:
     assert result.detail == "not configured"
 
 
-async def test_sandbox_e2e_exercises_dial_and_reattach(tmp_path: Path, monkeypatch) -> None:
+async def test_sandbox_e2e_exercises_dial_and_reattach(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     calls = _fake_sandbox_client(monkeypatch)
     settings = make_settings(tmp_path, sandbox={"service_url": "http://127.0.0.1:8780"})
 
-    result = await doctor.check_sandbox_e2e(settings)
+    results = await doctor.check_sandbox_e2e(settings)
 
-    assert result.ok
-    assert "reattach" in result.detail
-    assert calls == ["acquire", "attach:host-doc", "release:host-doc"]
+    assert [result.name for result in results] == [
+        "sandbox_e2e",
+        "sandbox_binary:claude",
+        "sandbox_binary:codex",
+    ]
+    assert all(result.ok for result in results)
+    assert calls == [
+        "acquire",
+        ("acquire", ["echo", "doctor"], 30.0),
+        ("acquire", ["sh", "-c", "command -v claude"], 30.0),
+        ("acquire", ["sh", "-c", "command -v codex"], 30.0),
+        "attach:host-doc",
+        ("reattach", ["echo", "doctor"], 30.0),
+        "release:host-doc",
+    ]
+
+
+async def test_sandbox_e2e_reports_a_missing_harness_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = _fake_sandbox_client(monkeypatch, missing_command="codex")
+    settings = make_settings(tmp_path, sandbox={"service_url": "http://127.0.0.1:8780"})
+
+    results = await doctor.check_sandbox_e2e(settings)
+
+    assert _named(results, "sandbox_binary:claude").ok
+    assert not _named(results, "sandbox_binary:codex").ok
+    assert ("acquire", ["sh", "-c", "command -v codex"], 30.0) in calls
 
 
 async def test_sandbox_e2e_failure_names_the_phase_and_releases(

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -318,13 +318,18 @@ async def test_run_prompt_builds_executes_and_parses(
     the harness never sees the live sandbox, only ``ssh_username``."""
     run = _FakeRun(stdout_chunks=[b"streamed\n"], exit_code=0)
     sandbox = _fake_sandbox(run)
-    # run_prompt delegates to self._exec — bind the real one onto the stub.
-    sandbox._exec = lambda *args, **kwargs: Host._exec(sandbox, *args, **kwargs)
     seen: dict[str, Any] = {}
+
+    async def execute(*args: Any, **kwargs: Any) -> HarnessRunResult:
+        seen["exec"] = kwargs
+        return await Host._exec(sandbox, *args, **kwargs)
+
+    sandbox._exec = execute
 
     class _FakeHarness:
         name = "claude"
         model = "claude-opus-4-8"
+        first_byte_seconds = 17
         # The real manifest method on the stubbed build/parse seam, so the
         # test exercises what run_prompt actually writes.
         get_manifest = Harness.get_manifest
@@ -356,6 +361,7 @@ async def test_run_prompt_builds_executes_and_parses(
     # The harness planned from values, not the live sandbox.
     assert seen["build"]["ssh_username"] == "root"
     assert seen["build"]["extra_env"] == {"GITHUB_MCP_TOKEN": "ghs_x"}
+    assert seen["exec"]["first_byte_kill_seconds"] == 17
     # The prompt was persisted to the artifact dir before exec.
     assert (ctx.artifact_dir / "call-7" / "prompt.md").read_text() == "do the thing"
     # The capability manifest was written alongside it, keyed to the same call.


### PR DESCRIPTION
Three per-harness facts lived as globals or were missing.

- `command: ClassVar[str]` is declared on `Harness` (claude and codex already assign it).
- The 90-second first-byte killer moves from a `host.py` module constant to `Harness.first_byte_seconds: ClassVar[int | None]`, threaded through `run_prompt` into `_exec` — a server-sidecar harness can carry its own window without touching `host.py`.
- The opt-in sandbox e2e doctor check now also probes `command -v <harness.command>` per registered harness on the acquired VM, one `CheckResult` row each (`sandbox_binary:<name>`). A CLI missing from the image fails doctor, not a live run.

Stacked on #387.

DRU-364