### PR TITLE
Onboarding and docs stop naming two harnesses

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,7 +58,7 @@ the error.
 ## 5. Hand back to the operator
 
 Report that the installation succeeded. Tell the operator to open
-<http://127.0.0.1:8001>. Connect Claude and Codex under **Settings → Harnesses**.
+<http://127.0.0.1:8001>. Connect a harness under **Settings → Harnesses**.
 Agent runs do not start with a disconnected harness. Then connect the GitHub
 App that Druks uses. Run `docker compose exec web druks doctor --sandbox` to
 prove the full sandbox path with a real container.

--- a/backend/druks/harnesses/routes.py
+++ b/backend/druks/harnesses/routes.py
@@ -10,11 +10,19 @@ from druks.database import db_session
 from druks.harnesses.base import Harness
 from druks.harnesses.exceptions import ConnectError
 from druks.harnesses.models import HarnessConnection
-from druks.harnesses.registry import get_harness
+from druks.harnesses.registry import get_harness, get_harnesses
+from druks.harnesses.schemas import HarnessSummary
 from druks.user_settings.models import HarnessSettings, UserSettings
 from druks.user_settings.schemas import HarnessResponse
 
 router = APIRouter(prefix="/api/harnesses", tags=["harnesses"])
+
+
+@router.get("", response_model=list[HarnessSummary], response_model_by_alias=True)
+async def list_harnesses(
+    _account: Account | None = Depends(current_session_or_setup),
+) -> list[HarnessSummary]:
+    return [HarnessSummary.model_validate(harness) for harness in get_harnesses()]
 
 
 def _resolve_harness(name: str) -> type[Harness]:

--- a/backend/druks/harnesses/schemas.py
+++ b/backend/druks/harnesses/schemas.py
@@ -1,0 +1,16 @@
+from pydantic import ConfigDict, field_validator
+
+from druks.schemas import Schema
+
+
+class HarnessSummary(Schema):
+    model_config = ConfigDict(from_attributes=True)
+
+    name: str
+    # A frozenset on the class; sorted so the wire is deterministic.
+    login_kinds: list[str]
+
+    @field_validator("login_kinds", mode="after")
+    @classmethod
+    def _sorted(cls, kinds: list[str]) -> list[str]:
+        return sorted(kinds)

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -5,13 +5,17 @@ from druks.accounts.dependencies import (
     current_session_account,
     current_session_or_setup,
 )
+from druks.accounts.models import Account
 from druks.api.server import app
+from druks.harnesses.claude import ClaudeHarness
+from druks.harnesses.registry import get_harnesses
 from fastapi.routing import APIRoute, _IncludedRouter
 
 # Every /api path allowed to skip the identity gate; additions are deliberate.
 EXEMPT_API_PATHS = {
     "/api/system/health",
     "/api/auth/me",
+    "/api/harnesses",
     "/api/harnesses/{name}/connection/start",
     "/api/harnesses/{name}/connection/complete",
     "/api/{path:path}",  # the JSON-404 catch-all
@@ -45,9 +49,10 @@ DUAL_GATED_API_PATHS = {
     "/api/oauth/connections/{connection_id}",
 }
 
-# The connection flow must answer during none/zero setup, before any account
-# exists.
+# Harness discovery and connection must answer during none/zero setup, before
+# any account exists.
 SETUP_CAPABLE_API_PATHS = {
+    "/api/harnesses",
     "/api/harnesses/{name}/connection/start",
     "/api/harnesses/{name}/connection/complete",
 }
@@ -114,7 +119,7 @@ def test_identity_bootstrap_is_the_only_setup_tolerant_read(api_routes):
             assert not _gated_by(route, current_account_or_setup), route.path
 
 
-def test_connection_setup_uses_only_the_session_or_setup_resolver(api_routes):
+def test_harness_setup_uses_only_the_session_or_setup_resolver(api_routes):
     listed = [route for route in api_routes if route.path in SETUP_CAPABLE_API_PATHS]
     assert {route.path for route in listed} == SETUP_CAPABLE_API_PATHS
     for route in listed:
@@ -123,6 +128,34 @@ def test_connection_setup_uses_only_the_session_or_setup_resolver(api_routes):
     for route in api_routes:
         if route.path not in SETUP_CAPABLE_API_PATHS:
             assert not _gated_by(route, current_session_or_setup), route.path
+
+
+async def test_harness_list_answers_before_an_account_exists(
+    druks_client,
+    monkeypatch,
+):
+    assert not await Account.list_non_system()
+    monkeypatch.setattr(
+        ClaudeHarness,
+        "login_kinds",
+        frozenset({"subscription", "api_key"}),
+    )
+
+    response = await druks_client.get("/api/harnesses")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["name"] for item in body] == [harness.name for harness in get_harnesses()]
+    by_name = {item["name"]: item for item in body}
+    assert by_name["claude"] == {
+        "name": "claude",
+        "loginKinds": ["api_key", "subscription"],
+    }
+    assert by_name["codex"] == {
+        "name": "codex",
+        "loginKinds": ["subscription"],
+    }
+    assert not await Account.list_non_system()
 
 
 def test_capability_management_is_session_only(api_routes):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -27,6 +27,7 @@ import type {
   PageSnapshot,
   McpServer,
   Service,
+  SetupHarness,
   Skill,
   SkillCollection,
   UserSettings,
@@ -264,6 +265,7 @@ export const api = {
   harnesses: () => getJSON<Harness[]>('/api/settings/harnesses'),
   updateHarness: (name: string, body: UpdateHarnessRequest) =>
     patchJSON<Harness>(`/api/settings/harnesses/${encodeURIComponent(name)}`, body),
+  setupHarnesses: () => getJSON<SetupHarness[]>('/api/harnesses'),
   // The harness connection flow — the capability connect (and, during setup,
   // what creates the operator account).
   startHarnessConnect: (name: string) =>

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -502,6 +502,11 @@ export interface Harness {
   expiresAt: string | null
 }
 
+export interface SetupHarness {
+  name: string
+  loginKinds: string[]
+}
+
 export interface Account {
   id: string
   username: string
@@ -605,7 +610,7 @@ export interface AgentSetting {
   description: string
   model: string
   source: ModelSource
-  /** The declared family-token default (codex / claude) the model resolves to. */
+  /** The declared family-token default the model resolves to. */
   default: string
   effort: string
   effortSource: EffortSource
@@ -708,8 +713,7 @@ export interface UsageMetric {
 }
 
 export interface UsageHarnessSummary {
-  // A registered harness name ("claude", "codex", …) — panels, colors,
-  // and legends key off it.
+  // Panels, colors, and legends key off the registered harness name.
   name: string
   available: boolean
   /** The requesting account has its own connection; false renders a connect action. */
@@ -718,8 +722,7 @@ export interface UsageHarnessSummary {
   planTier: string | null
   fiveHour: UsageMetric | null
   weeks: UsageMetric[]
-  // Unmetered plan (e.g. Codex business). The window metrics are
-  // synthesized permanently-full buckets — render "unmetered" plus
+  // An unmetered plan has permanently-full window metrics. Render "unmetered" plus
   // actual consumption instead of a quota bar that never moves.
   unlimited: boolean
   scrapedAt: string | null

--- a/frontend/src/components/IdentityBootstrap.test.tsx
+++ b/frontend/src/components/IdentityBootstrap.test.tsx
@@ -83,6 +83,10 @@ describe('IdentityBootstrap', () => {
     let me = identity({ account: null, onboardingRequired: true })
     stubRoutes({
       '/api/auth/me': () => ({ status: 200, body: me }),
+      '/api/harnesses': () => ({
+        status: 200,
+        body: [{ name: 'claude', loginKinds: ['subscription'] }],
+      }),
       '/api/harnesses/claude/connection/start': () => ({
         status: 200,
         body: { authorizeUrl: 'https://x/auth', connectionId: 'C1' },

--- a/frontend/src/components/Onboarding.test.tsx
+++ b/frontend/src/components/Onboarding.test.tsx
@@ -1,7 +1,13 @@
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { SetupHarness } from '../api/types'
 import { Onboarding } from './Onboarding'
+
+const REGISTERED_HARNESSES: SetupHarness[] = [
+  { name: 'claude', loginKinds: ['subscription'] },
+  { name: 'codex', loginKinds: ['subscription'] },
+]
 
 afterEach(() => {
   cleanup()
@@ -14,9 +20,25 @@ async function flush() {
   })
 }
 
+function harnessListResponse(harnesses: SetupHarness[]) {
+  return new Response(JSON.stringify(harnesses), { status: 200 })
+}
+
+function stubHarnessList(harnesses = REGISTERED_HARNESSES) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request) => {
+      expect(String(url)).toBe('/api/harnesses')
+      return harnessListResponse(harnesses)
+    }),
+  )
+}
+
 describe('Onboarding', () => {
-  it('frames the door as finishing setup, never as signing in', () => {
+  it('frames the door as finishing setup, never as signing in', async () => {
+    stubHarnessList()
     render(<Onboarding onConnected={() => undefined} />)
+    await screen.findByText('Connect Claude')
     expect(screen.getByText('Connect a harness to finish setup')).toBeTruthy()
     expect(screen.queryByText(/sign in/i)).toBeNull()
   })
@@ -25,7 +47,9 @@ describe('Onboarding', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async (url: string | URL | Request) => {
-        expect(String(url)).toBe('/api/harnesses/codex/connection/start')
+        const path = String(url)
+        if (path === '/api/harnesses') return harnessListResponse(REGISTERED_HARNESSES)
+        expect(path).toBe('/api/harnesses/codex/connection/start')
         return new Response(
           JSON.stringify({ authorizeUrl: 'https://x/auth', connectionId: 'C1' }),
           { status: 200 },
@@ -34,7 +58,7 @@ describe('Onboarding', () => {
     )
 
     render(<Onboarding onConnected={() => undefined} />)
-    fireEvent.click(screen.getByText('Connect Codex'))
+    fireEvent.click(await screen.findByText('Connect Codex'))
     await flush()
 
     // The challenge panel replaces both cards, not just its own.
@@ -43,6 +67,18 @@ describe('Onboarding', () => {
 
     fireEvent.click(screen.getByText('Cancel'))
     expect(screen.queryByText('Open the authorization page')).toBeNull()
-    expect(screen.getByText('Connect Claude')).toBeTruthy()
+    expect(await screen.findByText('Connect Claude')).toBeTruthy()
+  })
+
+  it('renders one card for each harness returned by setup', async () => {
+    stubHarnessList([
+      ...REGISTERED_HARNESSES,
+      { name: 'opencode', loginKinds: ['subscription'] },
+    ])
+
+    render(<Onboarding onConnected={() => undefined} />)
+
+    await screen.findByText('Connect Opencode')
+    expect(screen.getAllByRole('button')).toHaveLength(3)
   })
 })

--- a/frontend/src/components/Onboarding.tsx
+++ b/frontend/src/components/Onboarding.tsx
@@ -1,8 +1,10 @@
-import type { CSSProperties } from 'react'
+import { useCallback, useEffect, useState, type CSSProperties } from 'react'
 
 import { ConnectSteps, useHarnessConnect } from './HarnessConnectFlow'
+import { api } from '../api/client'
 import { harnessColors } from '../lib/harnessColors'
-import type { Account } from '../api/types'
+import { harnessLabel } from '../lib/harnessDisplay'
+import type { Account, SetupHarness } from '../api/types'
 
 type OnboardingEntry = {
   title: string
@@ -15,16 +17,32 @@ type OnboardingEntry = {
 // are — druks just needs its first harness connection. Works before any
 // account exists (fresh none mode) and for a newly enrolled header identity.
 export function Onboarding({ onConnected }: { onConnected: (account: Account) => void }) {
-  const codex = useHarnessConnect('codex', onConnected)
-  const claude = useHarnessConnect('claude', onConnected)
-  // Accent slots follow registry enrolment order (claude, codex) so each
-  // harness keeps the colour it has everywhere in the app.
-  const color = harnessColors(['claude', 'codex'])
-  const entries: OnboardingEntry[] = [
-    { title: 'Codex', mark: 'Cx', fam: color.codex!, flow: codex },
-    { title: 'Claude', mark: 'Cl', fam: color.claude!, flow: claude },
-  ]
-  const active = entries.find((e) => e.flow.busy || e.flow.challenge)
+  const [harnesses, setHarnesses] = useState<SetupHarness[]>([])
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [activeHarness, setActiveHarness] = useState<string | null>(null)
+
+  useEffect(() => {
+    let ignore = false
+    api.setupHarnesses().then(
+      (registered) => {
+        if (!ignore) setHarnesses(registered)
+      },
+      (error: unknown) => {
+        if (!ignore) setLoadError(error instanceof Error ? error.message : String(error))
+      },
+    )
+    return () => {
+      ignore = true
+    }
+  }, [])
+
+  const setHarnessActive = useCallback((name: string, active: boolean) => {
+    setActiveHarness((current) => {
+      if (active) return name
+      return current === name ? null : current
+    })
+  }, [])
+  const color = harnessColors(harnesses.map((harness) => harness.name))
 
   return (
     <div className="landing">
@@ -40,15 +58,51 @@ export function Onboarding({ onConnected }: { onConnected: (account: Account) =>
           </p>
         </div>
         <div className="landing-stage">
-          {active ? (
-            <ConnectPanel entry={active} />
+          {loadError ? (
+            <OnboardingError message={loadError} />
           ) : (
-            entries.map((entry) => <HarnessCard key={entry.title} entry={entry} />)
+            harnesses.map((harness) => (
+              <HarnessEntry
+                key={harness.name}
+                harness={harness}
+                fam={color[harness.name]!}
+                activeHarness={activeHarness}
+                onActive={setHarnessActive}
+                onConnected={onConnected}
+              />
+            ))
           )}
         </div>
       </div>
     </div>
   )
+}
+
+function HarnessEntry({
+  harness,
+  fam,
+  activeHarness,
+  onActive,
+  onConnected,
+}: {
+  harness: SetupHarness
+  fam: string
+  activeHarness: string | null
+  onActive: (name: string, active: boolean) => void
+  onConnected: (account: Account) => void
+}) {
+  const flow = useHarnessConnect(harness.name, onConnected)
+  const active = flow.busy || Boolean(flow.challenge)
+
+  useEffect(() => {
+    onActive(harness.name, active)
+  }, [active, harness.name, onActive])
+
+  if (activeHarness && activeHarness !== harness.name) return null
+
+  const title = harnessLabel(harness.name)
+  const entry = { title, mark: title.slice(0, 2), fam, flow }
+  return active ? <ConnectPanel entry={entry} /> : <HarnessCard entry={entry} />
 }
 
 function HarnessCard({ entry }: { entry: OnboardingEntry }) {

--- a/frontend/src/components/UsagePanel.tsx
+++ b/frontend/src/components/UsagePanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, type CSSProperties } from 'react'
 
 import { harnessColors } from '../lib/harnessColors'
+import { harnessLabel } from '../lib/harnessDisplay'
 import { usageTone, type UsageTone } from '../lib/usageHealth'
 import { useUsage, useUsageHistory, useUsageToday } from '../lib/useUsage'
 import type {
@@ -154,7 +155,7 @@ function ExhaustionAlert({ harnesses }: { harnesses: UsageHarnessSummary[] }) {
   const resetSeconds = secondsUntil(exhausted.resetsAt, now)
   const title = exhausted.model
     ? `${exhausted.model} ${exhausted.windowLabel} limit reached`
-    : `${capitalize(exhausted.harness)} ${exhausted.windowLabel} limit reached`
+    : `${harnessLabel(exhausted.harness)} ${exhausted.windowLabel} limit reached`
 
   return (
     <div className="us-alert" role="alert">
@@ -172,14 +173,14 @@ function ExhaustionAlert({ harnesses }: { harnesses: UsageHarnessSummary[] }) {
           {exhausted.model ? (
             <span>
               New {exhausted.harness} runs on {exhausted.model} will fail until the window resets.{' '}
-              <b>{capitalize(exhausted.harness)} still has capacity for other models.</b>
+              <b>{harnessLabel(exhausted.harness)} still has capacity for other models.</b>
             </span>
           ) : (
             <>
               New {exhausted.harness} runs will fail until the window resets.{' '}
               {alternative ? (
                 <span>
-                  <b>{capitalize(alternative.name)} has capacity</b> — route new work there to keep
+                  <b>{harnessLabel(alternative.name)} has capacity</b> — route new work there to keep
                   builds moving.
                 </span>
               ) : (
@@ -800,10 +801,6 @@ function currentHourIn(timeZone: string): number {
   } catch {
     return new Date().getUTCHours()
   }
-}
-
-function capitalize(s: string): string {
-  return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 function describeIdle(usage: UsageHarnessSummary): string {

--- a/frontend/src/lib/harnessDisplay.ts
+++ b/frontend/src/lib/harnessDisplay.ts
@@ -1,0 +1,2 @@
+export const harnessLabel = (name: string): string =>
+  name.charAt(0).toUpperCase() + name.slice(1)

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -579,11 +579,10 @@ button { background: none; border: none; color: inherit; cursor: pointer; font: 
   background: var(--bg);
 }
 
-/* Structured rendering of Claude's --output-format stream-json
- * transcript. Each row is one event from Claude's NDJSON stream;
- * the goal is for an operator scanning the pane to read what Claude
- * is doing without parsing JSON. Raw lines (non-JSON, e.g. Codex
- * transcripts or stderr leakage) still flow through legibly.
+/* Structured rendering of a harness stream transcript. Each row is one
+ * event; the goal is for an operator scanning the pane to read what the
+ * harness is doing without parsing JSON. Raw lines and stderr leakage
+ * still flow through legibly.
  */
 .stream-transcript {
   flex: 1; overflow: auto;
@@ -1428,11 +1427,11 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 /* ---------------------------------------------------------------------------
  * Usage pill (appbar) + Usage panel (dashboard)
  *
- * Pill: two adjacent mini-pills (c / x for claude / codex). Color tier
+ * Pill: one mini-pill per registered harness. Color tier
  * matches the bar tier in the panel so the eye learns one mapping:
  * green = plenty left, amber = mind it, red = imminent reset trip.
  *
- * Panel: two columns (one per CLI), each with stacked horizontal bars.
+ * Panel: one column per harness, each with stacked horizontal bars.
  * Bar tier same as pill tier. Stale snapshots get a warning row above
  * the bars; parse failures hide the bars and surface a disclosure of
  * the raw /status output so the operator can update the regex without
@@ -1506,8 +1505,7 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
   box-shadow: 0 0 6px color-mix(in oklch, var(--bucket-dead) 50%, transparent);
 }
 
-/* Usage page (from the Claude Design handoff — Usage.html).
- * Rate-limit windows with burn rate + trend, spend/token totals by
+/* Usage page with rate-limit windows, burn rate, trend, and totals by
  * provider. The raw-output disclosure (.usage-raw, below) is shared
  * with the old panel vocabulary. */
 
@@ -1595,7 +1593,7 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 
 /* provider grid */
 .us-grid {
-  display: grid; grid-template-columns: 1fr 1fr; gap: 16px;
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px;
   margin-bottom: 24px;
 }
 .us-prov {
@@ -1845,7 +1843,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .us-hours-axis { display: flex; justify-content: space-between; font-size: 9px; color: var(--text-faint); letter-spacing: 0.04em; }
 
 @media (max-width: 920px) {
-  .us-grid { grid-template-columns: 1fr; }
   .us-today { grid-template-columns: 1fr; }
   .us-alert { flex-wrap: wrap; }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -238,9 +238,9 @@ Stack is up. Verify with:
   docker compose ps
   docker compose exec web druks doctor
 
-Then finish in the dashboard: Settings → Harnesses. Connect
-Claude and Codex (agent runs refuse to start on a harness that
-isn't connected) and connect the GitHub App druks acts as.
+Then finish in the dashboard. Connect a harness under
+Settings → Harnesses. Agent runs refuse to start on a harness
+that is not connected. Connect the GitHub App that druks uses.
 MSG
 
   if [ "$PROVIDER" = "docker" ]; then


### PR DESCRIPTION
Setup named claude and codex by hand. A third harness now appears there by registering, not by edits.

- GET `/api/harnesses` (setup-scoped, `current_session_or_setup`) lists the registered harnesses with `loginKinds`; `HarnessSummary` is the minimal wire shape.
- Onboarding maps the endpoint: one connect card per harness, a per-harness component owning its connect flow, accent colors from wire order. The hand-written cards and the `harnessColors(['claude','codex'])` literal are gone. Title/mark derive from the name via `harnessLabel` (extracted from UsagePanel's capitalize, now shared).
- `.us-grid` is `repeat(auto-fit, minmax(320px, 1fr))`; the mobile override is gone. The FE wire files and stylesheet carry zero harness names.
- INSTALL.md and install.sh say "connect a harness under Settings → Harnesses".

Frontend: 242/242 vitest, tsc clean. Backend suite not run locally (test DB down) — CI gates it.

DRU-366