### PR TITLE
API-key connect route and paste field

### DIFF
--- a/backend/druks/core/tasks.py
+++ b/backend/druks/core/tasks.py
@@ -34,7 +34,7 @@ async def refresh_models() -> None:
         if not connections:
             continue
         preferred = [c for c in connections if c.account_id == fallback_id]
-        settings = await HarnessSettings.require(harness.name)
+        settings = await HarnessSettings.get_registered(harness.name)
         await settings.refresh_models((preferred or connections)[0])
 
 

--- a/backend/druks/harnesses/routes.py
+++ b/backend/druks/harnesses/routes.py
@@ -98,12 +98,48 @@ async def complete_connection(
         # Fresh picker right after connect; fetch failures are tagged inside.
         # The single-use flow is already spent, so trouble here — including a
         # database that vanished under the refresh — only logs.
-        await (await HarnessSettings.require(harness.name)).refresh_models(connection)
+        settings = await HarnessSettings.get_registered(harness.name)
+        await settings.refresh_models(connection)
     except Exception:
         logging.getLogger(__name__).exception("Model refresh after connect failed")
         with suppress(Exception):
             await db_session().rollback()
     return response
+
+
+@router.post(
+    "/{name}/connection",
+    response_model=HarnessResponse,
+    response_model_by_alias=True,
+)
+async def connect_harness_key(
+    name: str,
+    account: Account = Depends(current_session_account),
+    key: str = Body(..., embed=True),
+) -> HarnessResponse:
+    harness = _resolve_harness(name)
+    if "api_key" not in harness.login_kinds:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Harness {harness.name!r} does not accept API keys.",
+        )
+    key = key.strip()
+
+    if not key:
+        raise HTTPException(
+            status_code=422,
+            detail="The API key is empty. Paste a key.",
+        )
+    connection = await HarnessConnection.connect(
+        harness=harness.name,
+        account=account,
+        payload={"apiKey": key},
+        expires_at=None,
+        provider_email=account.username,
+        kind="api_key",
+    )
+    settings = await HarnessSettings.get_registered(harness.name)
+    return HarnessResponse.from_row(settings, connection, account)
 
 
 @router.delete("/{name}/connection", response_model=HarnessResponse, response_model_by_alias=True)
@@ -115,4 +151,5 @@ async def disconnect_harness(
     if connection:
         # Only the requesting account's own connection — never another's.
         await connection.delete()
-    return HarnessResponse.from_row(await HarnessSettings.require(harness.name), None, account)
+    settings = await HarnessSettings.get_registered(harness.name)
+    return HarnessResponse.from_row(settings, None, account)

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -236,7 +236,7 @@ class Host:
         settings = load_settings()
         # Effort/timeout fall back to the model's harness defaults.
         harness_class = await get_harness_for_model(model)
-        harness_settings = await HarnessSettings.require(harness_class.name)
+        harness_settings = await HarnessSettings.get_registered(harness_class.name)
         effort = effort or harness_settings.effort
         timeout = timeout if timeout is not None else harness_settings.timeout
         harness = harness_class(

--- a/backend/druks/user_settings/models.py
+++ b/backend/druks/user_settings/models.py
@@ -96,7 +96,7 @@ class HarnessSettings(Base):
         return await db_session().get(cls, name)
 
     @classmethod
-    async def require(cls, name: str) -> "HarnessSettings":
+    async def get_registered(cls, name: str) -> "HarnessSettings":
         # The resolution paths (effort/timeout, the harness factory) only pass a
         # ``get_harness_for_model`` name, which is always registered and so always
         # seeded — a miss means ``seed_harnesses`` didn't run before serving.
@@ -196,7 +196,7 @@ class SettingsOverride(Base):
             return ResolvedEffort(override, "agent")
         if declared is not None:
             return ResolvedEffort(declared, "declared")
-        return ResolvedEffort((await HarnessSettings.require(harness)).effort, "harness")
+        return ResolvedEffort((await HarnessSettings.get_registered(harness)).effort, "harness")
 
     @classmethod
     async def set_agent_effort(cls, name: str, value: str | None) -> None:
@@ -209,7 +209,7 @@ class SettingsOverride(Base):
             return ResolvedTimeout(override, "agent")
         if declared is not None:
             return ResolvedTimeout(declared, "declared")
-        return ResolvedTimeout((await HarnessSettings.require(harness)).timeout, "harness")
+        return ResolvedTimeout((await HarnessSettings.get_registered(harness)).timeout, "harness")
 
     @classmethod
     async def set_agent_timeout(cls, name: str, value: int | None) -> None:

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -31,6 +31,7 @@ SESSION_ONLY_API_ROUTES = {
     ("GET", "/api/auth/personal-tokens"),
     ("POST", "/api/auth/personal-tokens"),
     ("DELETE", "/api/auth/personal-tokens/{pat_id}"),
+    ("POST", "/api/harnesses/{name}/connection"),
     ("DELETE", "/api/harnesses/{name}/connection"),
     ("PATCH", "/api/settings/apps"),
     ("POST", "/api/services/{slug}"),

--- a/backend/tests/test_harness_model_routing.py
+++ b/backend/tests/test_harness_model_routing.py
@@ -16,7 +16,7 @@ async def test_shipped_tuple_fallback_routes_shipped_models(druks_db):
 
 
 async def test_fetched_list_routes_provider_models(druks_db):
-    (await HarnessSettings.require("claude")).models_fetched = [
+    (await HarnessSettings.get_registered("claude")).models_fetched = [
         {"id": "claude-fable-5", "label": "Claude Fable 5"}
     ]
     await druks_db.flush()
@@ -53,7 +53,7 @@ async def test_settings_reject_model_missing_from_lists_returns_422(druks_db):
 )
 async def test_settings_reject_invalid_model_returns_422(druks_db, model, detail):
     account = await Account.get_or_create("op@example.com")
-    settings = await HarnessSettings.require("claude")
+    settings = await HarnessSettings.get_registered("claude")
     original_model = settings.model
 
     with pytest.raises(HTTPException) as error:

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -215,6 +215,77 @@ async def test_none_zero_setup_flow_creates_the_operator(tmp_path, monkeypatch, 
     assert await HarnessConnection.get_for_account("claude", account.id)
 
 
+async def test_api_key_connect_stores_the_operator_identity(tmp_path, monkeypatch, druks_db):
+    monkeypatch.setattr(
+        ClaudeHarness,
+        "login_kinds",
+        frozenset({"subscription", "api_key"}),
+    )
+
+    with _header_client(tmp_path) as client:
+        response = client.post(
+            "/api/harnesses/claude/connection",
+            json={"key": "  api-key-value  "},
+            headers={HEADER: "operator@example.com"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["kind"] == "api_key"
+    assert "api-key-value" not in response.text
+    account = await Account.get_for_username("operator@example.com")
+    connection = await HarnessConnection.get_for_account("claude", account.id)
+    assert connection.kind == "api_key"
+    assert connection.payload == {"apiKey": "api-key-value"}
+    assert connection.provider_email == account.username
+    assert not connection.expires_at
+
+
+async def test_api_key_connect_requires_a_declared_kind(tmp_path, druks_db):
+    with _header_client(tmp_path) as client:
+        response = client.post(
+            "/api/harnesses/claude/connection",
+            json={"key": "api-key-value"},
+            headers={HEADER: "operator@example.com"},
+        )
+
+    assert response.status_code == 422
+
+
+async def test_api_key_connect_rejects_an_empty_key(tmp_path, monkeypatch, druks_db):
+    monkeypatch.setattr(
+        ClaudeHarness,
+        "login_kinds",
+        frozenset({"subscription", "api_key"}),
+    )
+
+    with _header_client(tmp_path) as client:
+        response = client.post(
+            "/api/harnesses/claude/connection",
+            json={"key": "   "},
+            headers={HEADER: "operator@example.com"},
+        )
+
+    assert response.status_code == 422
+
+
+async def test_api_key_connect_refuses_setup_scope(tmp_path, monkeypatch, druks_db):
+    monkeypatch.setattr(
+        ClaudeHarness,
+        "login_kinds",
+        frozenset({"subscription", "api_key"}),
+    )
+
+    with _client(tmp_path) as client:
+        response = client.post(
+            "/api/harnesses/claude/connection",
+            json={"key": "api-key-value"},
+        )
+
+    assert response.status_code == 409
+    assert not await Account.list_non_system()
+    assert not await HarnessConnection.list_all()
+
+
 async def test_concurrent_setup_completions_with_one_email_converge(
     tmp_path, monkeypatch, druks_db
 ):

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -520,10 +520,12 @@ def _patch_harness_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("druks.harnesses.registry.get_harness_for_model", _harness_stub)
 
-    async def require(name):
+    async def get_registered(name):
         return SimpleNamespace(effort="high", timeout=60, fast_mode=False)
 
-    monkeypatch.setattr("druks.user_settings.models.HarnessSettings.require", staticmethod(require))
+    monkeypatch.setattr(
+        "druks.user_settings.models.HarnessSettings.get_registered", staticmethod(get_registered)
+    )
 
 
 async def test_run_agent_carries_foreign_failures_as_harness_errors(

--- a/backend/tests/test_user_settings.py
+++ b/backend/tests/test_user_settings.py
@@ -29,22 +29,22 @@ async def test_get_lazy_creates_row_with_default_timezone(session):
 
 async def test_harnesses_seeded_with_shipped_defaults(session):
     # init_db seeds one HarnessSettings row per registered harness.
-    claude = await HarnessSettings.require("claude")
+    claude = await HarnessSettings.get_registered("claude")
     assert (claude.model, claude.fast_mode, claude.effort, claude.timeout) == (
         "claude-opus-4-7",
         False,
         "high",
         1800,
     )
-    assert (await HarnessSettings.require("codex")).model == "gpt-5.5"
+    assert (await HarnessSettings.get_registered("codex")).model == "gpt-5.5"
     assert {harness.name for harness in await HarnessSettings.all()} == {"claude", "codex"}
 
 
 async def test_harness_update_persists(session):
-    claude = await HarnessSettings.require("claude")
+    claude = await HarnessSettings.get_registered("claude")
     await claude.update(model="claude-sonnet-4-6", fast_mode=True)
     await session.commit()
-    claude = await HarnessSettings.require("claude")
+    claude = await HarnessSettings.get_registered("claude")
     assert claude.model == "claude-sonnet-4-6"
     assert claude.fast_mode is True
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -275,6 +275,8 @@ export const api = {
       code,
       connectionId,
     }),
+  connectHarnessKey: (name: string, key: string) =>
+    postJSON<Harness>(`/api/harnesses/${encodeURIComponent(name)}/connection`, { key }),
   disconnectHarness: (name: string) =>
     deleteJSON<Harness>(`/api/harnesses/${encodeURIComponent(name)}/connection`),
   // The appliance's own identities at external services — connect verifies the

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -511,6 +511,7 @@ export interface Harness {
   // The requesting account's own connection; false until this account connects.
   connected: boolean
   kind: string | null
+  loginKinds: string[]
   account: string | null
   /** The email the provider reported at connect — display, never authority. */
   providerEmail: string | null

--- a/frontend/src/components/HarnessConnect.test.tsx
+++ b/frontend/src/components/HarnessConnect.test.tsx
@@ -16,6 +16,7 @@ function harness(overrides: Partial<Harness> = {}): Harness {
     timeout: 1800,
     connected: false,
     kind: null,
+    loginKinds: ['subscription'],
     account: null,
     providerEmail: null,
     expiresAt: null,
@@ -46,6 +47,25 @@ async function flush() {
 }
 
 describe('HarnessConnect', () => {
+  it('shows each connect control only for its declared login kind', () => {
+    const subscription = renderCard(harness({ loginKinds: ['subscription'] }))
+
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeTruthy()
+    expect(screen.queryByLabelText('API key')).toBeNull()
+    subscription.view.unmount()
+
+    const apiKey = renderCard(harness({ loginKinds: ['api_key'] }))
+
+    expect(screen.getByLabelText('API key')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Connect' })).toBeNull()
+    apiKey.view.unmount()
+
+    renderCard(harness({ loginKinds: ['subscription', 'api_key'] }))
+
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeTruthy()
+    expect(screen.getByLabelText('API key')).toBeTruthy()
+  })
+
   it('shows each connected subscription identity instead of the operator account', () => {
     renderCard(
       harness({
@@ -107,5 +127,28 @@ describe('HarnessConnect', () => {
     // own identity is untouched, so /api/auth/me is never rechecked.
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['harnesses'] })
     expect(fetchMock.mock.calls.some(([url]) => String(url) === '/api/auth/me')).toBe(false)
+  })
+
+  it('posts a pasted API key and refreshes the harness query', async () => {
+    const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
+      async (url) =>
+        new Response(JSON.stringify(url.endsWith('/connection') ? harness() : {}), {
+          status: 200,
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { invalidate } = renderCard(harness({ loginKinds: ['api_key'] }))
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'the-api-key' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Connect with key' }))
+    await flush()
+
+    const connectCall = fetchMock.mock.calls.find(
+      ([url]) => url === '/api/harnesses/claude/connection',
+    )
+    expect(JSON.parse(String(connectCall?.[1]?.body))).toEqual({ key: 'the-api-key' })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['harnesses'] })
   })
 })

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { Fragment, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type FormEvent, type ReactNode } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { ApiError, api } from '../api/client'
@@ -1293,11 +1293,14 @@ export function HarnessConnect({ harness }: { harness: Harness }) {
   const queryClient = useQueryClient()
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [key, setKey] = useState('')
 
   const refresh = () => queryClient.invalidateQueries({ queryKey: ['harnesses'] })
   const flow = useHarnessConnect(harness.name, async () => {
     await refresh()
   })
+  const acceptsSubscription = harness.loginKinds.includes('subscription')
+  const acceptsApiKey = harness.loginKinds.includes('api_key')
 
   const disconnect = () => {
     if (!window.confirm(`Disconnect ${harness.name}? Reconnect it before agents can run on it.`))
@@ -1307,6 +1310,20 @@ export function HarnessConnect({ harness }: { harness: Harness }) {
     void api
       .disconnectHarness(harness.name)
       .then(refresh)
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setBusy(false))
+  }
+
+  const connectKey = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setBusy(true)
+    setError(null)
+    void api
+      .connectHarnessKey(harness.name, key)
+      .then(() => {
+        setKey('')
+        return refresh()
+      })
       .catch((e) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setBusy(false))
   }
@@ -1327,7 +1344,7 @@ export function HarnessConnect({ harness }: { harness: Harness }) {
               Disconnect
             </button>
           )}
-          {!flow.challenge && (
+          {acceptsSubscription && !flow.challenge && (
             <button
               className={'set-btn ' + (harness.connected ? 'ghost' : 'primary')}
               onClick={() => void flow.start()}
@@ -1338,7 +1355,31 @@ export function HarnessConnect({ harness }: { harness: Harness }) {
           )}
         </span>
       </div>
-      <ConnectSteps flow={flow} />
+      {acceptsSubscription && <ConnectSteps flow={flow} />}
+      {acceptsApiKey && (
+        <form className="hr-conn-flow" onSubmit={connectKey}>
+          <div className="hr-conn-step hr-conn-paste">
+            <input
+              aria-label="API key"
+              autoComplete="off"
+              className="hr-conn-input"
+              disabled={busy || flow.busy}
+              onChange={(event) => setKey(event.target.value)}
+              placeholder="Paste API key"
+              spellCheck={false}
+              type="password"
+              value={key}
+            />
+            <button
+              className="hr-conn-btn"
+              disabled={busy || flow.busy || !key.trim()}
+              type="submit"
+            >
+              {harness.kind === 'api_key' ? 'Replace key' : 'Connect with key'}
+            </button>
+          </div>
+        </form>
+      )}
       {(error ?? flow.error) && (
         <div className="hr-conn-error" role="alert">
           {error ?? flow.error}


### PR DESCRIPTION
A connect door for `kind="api_key"`. One pasted field, no PKCE, no refresh.

- `POST /api/harnesses/{name}/connection` — the plain store is the plain route; the OAuth dance keeps its qualified sub-routes (`/connection/start`, `/connection/complete`), and it sits symmetric with `DELETE /connection`. Session-only (`current_session_account`, never setup). 422 when the harness does not declare the kind in `login_kinds`, and for an empty key. The key is stripped, stored as the connection payload, and never echoed; an API key reports no email, so `provider_email` carries the operator's own username.
- The settings connect card is wire-driven: the OAuth button renders for `subscription`, a paste-a-key field for `api_key`, both when both are declared. No harness names in the FE; `Harness.loginKinds` joins the hand-written mirror.
- Ride-along rename: `HarnessSettings.require` → `get_registered` (all callers) — the get-or-raise read named for the registry fact that guarantees it, beside the nullable `get`. Routes fetch settings into a local before projecting `HarnessResponse.from_row`.
- claude and codex stay `{"subscription"}` — opencode declares `{"api_key"}` when its harness lands (DRU-368).

Frontend: vitest + tsc clean. Backend suite runs in CI.

DRU-367