### PR TITLE
OpenCode harness class

### DIFF
--- a/backend/druks/harnesses/__init__.py
+++ b/backend/druks/harnesses/__init__.py
@@ -1,1 +1,1 @@
-from . import claude, codex  # noqa: F401 — load the harness implementations so they enrol
+from . import claude, codex, opencode  # noqa: F401 — load harnesses so they enrol

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -93,6 +93,7 @@ class ClaudeHarness(Harness):
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
         connection_id: str | None = None,
+        timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
         if not self.sandbox:
             raise exceptions.HarnessError(

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -583,6 +583,7 @@ class CodexHarness(Harness):
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
         connection_id: str | None = None,
+        timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
         if not self.sandbox:
             raise HarnessError(

--- a/backend/druks/harnesses/opencode.py
+++ b/backend/druks/harnesses/opencode.py
@@ -1,0 +1,152 @@
+import json
+import urllib.parse
+from pathlib import Path
+from typing import Any
+
+from druks.sandbox.datastructures import (
+    AgentInvocation,
+    Credentials,
+    HarnessRunResult,
+    McpServer,
+)
+from druks.sandbox.layout import get_runs_root, get_work_root
+
+from . import exceptions
+from .artifacts import call_dir, write_cost
+from .base import Harness
+
+_ABORT_MARGIN_SECONDS = 5
+_WRAPPER = (Path(__file__).parent / "opencode_wrapper.sh").read_text()
+_ERROR_TYPES = {
+    "ProviderAuthError": exceptions.HarnessNotConnectedError,
+    "StructuredOutputError": exceptions.HarnessInvalidOutputError,
+    "MessageAborted": exceptions.HarnessTimeoutError,
+}
+
+
+class OpenCodeHarness(Harness):
+    name = "opencode"
+    provider = "opencode"
+    models = ("anthropic/claude-sonnet-4-5",)
+    default_model = "anthropic/claude-sonnet-4-5"
+    command = "opencode"
+    login_kinds = frozenset({"api_key"})
+    # The server writes nothing until the message POST completes; the wrapper
+    # owns an earlier deadline so it can abort the OpenCode session cleanly.
+    first_byte_seconds = None
+
+    @classmethod
+    async def render_credentials_file(
+        cls,
+        connection_id: str | None = None,
+        *,
+        model: str | None = None,
+    ) -> str:
+        payload = json.loads(await super().render_credentials_file(connection_id))
+        provider, _, _ = (model or cls.default_model).partition("/")
+        return json.dumps({provider: {"type": "api", "key": payload["api_key"]}})
+
+    async def build_invocation(
+        self,
+        *,
+        prompt: str,
+        schema: dict[str, object],
+        run_id: str,
+        ssh_username: str,
+        github_token: str | None = None,
+        include_plugins: bool = True,
+        add_dirs: tuple[str, ...] = (),
+        skills: tuple[str, ...] = (),
+        extra_env: dict[str, str] | None = None,
+        mcp_servers: tuple[McpServer, ...] = (),
+        connection_id: str | None = None,
+        timeout: int = Harness.default_timeout,
+    ) -> AgentInvocation:
+        if not self.sandbox:
+            raise exceptions.HarnessError(
+                "opencode harness requires sandbox settings — set sandbox.service_url and "
+                "related TOML settings.",
+            )
+
+        mcp = {}
+        for server in mcp_servers:
+            headers = dict(server.headers)
+            if server.bearer_token_env_var:
+                headers["Authorization"] = f"Bearer {{env:{server.bearer_token_env_var}}}"
+            for header, env_var in server.env_headers.items():
+                headers[header] = f"{{env:{env_var}}}"
+            entry: dict[str, object] = {
+                "type": "remote",
+                "url": server.url,
+                "enabled": True,
+            }
+            if headers:
+                entry["headers"] = headers
+            mcp[server.name] = entry
+
+        provider, _, model = self.model.partition("/")
+        return AgentInvocation(
+            name=self.name,
+            args=("sh", "-c", _WRAPPER),
+            stdin=prompt.encode("utf-8"),
+            credentials=Credentials(github_token=github_token),
+            env={
+                **(extra_env or {}),
+                "OPENCODE_AUTH_CONTENT": await self.render_credentials_file(
+                    connection_id, model=self.model
+                ),
+                "DRUKS_RUN_DIR": f"{get_runs_root(ssh_username)}/{run_id}",
+                "DRUKS_OPENCODE_CONFIG": json.dumps(
+                    {"$schema": "https://opencode.ai/config.json", "mcp": mcp},
+                    indent=2,
+                    sort_keys=True,
+                ),
+                "DRUKS_SCHEMA": json.dumps(schema, indent=2, sort_keys=True),
+                "DRUKS_PROVIDER": provider,
+                "DRUKS_MODEL": model,
+                "DRUKS_WORKSPACE_QUERY": urllib.parse.quote(get_work_root(ssh_username), safe=""),
+                "DRUKS_DEADLINE_SECONDS": str(max(1, timeout - _ABORT_MARGIN_SECONDS)),
+            },
+            extra_artifact_filenames=("opencode.log",),
+        )
+
+    def parse(self, result: HarnessRunResult, *, artifact_dir: Path, run_id: str) -> Any:
+        if result.returncode == 124:
+            raise exceptions.HarnessTimeoutError(
+                "opencode hit the agent deadline; the session was aborted."
+            )
+        try:
+            info = json.loads(result.stdout)["info"]
+            if failure := info.get("error"):
+                data = failure.get("data") or {}
+                message = data.get("message")
+                detail = f"{failure['name']}: {message}" if message else failure["name"]
+                if failure["name"] == "APIError" and data.get("isRetryable"):
+                    raise exceptions.HarnessOverloadedError(detail)
+                raise _ERROR_TYPES.get(failure["name"], exceptions.HarnessError)(detail)
+            structured = info["structured"]
+            tokens = info["tokens"]
+            metadata = {
+                "provider": self.provider,
+                "model": self.model,
+                "input_tokens": tokens["input"],
+                "output_tokens": tokens["output"],
+                "reasoning_tokens": tokens["reasoning"],
+                "cached_input_tokens": tokens["cache"]["read"],
+                "cache_creation_tokens": tokens["cache"]["write"],
+            }
+            cost_usd = float(info["cost"])
+        except (ValueError, KeyError, TypeError, AttributeError) as error:
+            try:
+                self.check_returncode(result)
+            except exceptions.HarnessError as process_error:
+                raise exceptions.HarnessInvalidOutputError(str(process_error)) from error
+            raise exceptions.HarnessInvalidOutputError(
+                "opencode wrote no usable response.",
+            ) from error
+
+        self.check_returncode(result)
+        output_dir = call_dir(artifact_dir, run_id)
+        (output_dir / "output.json").write_text(json.dumps(structured, indent=2, sort_keys=True))
+        write_cost(output_dir, cost_usd=cost_usd, metadata=metadata)
+        return structured

--- a/backend/druks/harnesses/opencode_wrapper.sh
+++ b/backend/druks/harnesses/opencode_wrapper.sh
@@ -1,0 +1,61 @@
+# One structured opencode call: write config and schema, start `opencode
+# serve`, open a session, POST the message with the contract schema, and
+# print the POST response. Inputs ride the environment (DRUKS_*,
+# OPENCODE_AUTH_CONTENT); the prompt rides stdin. The message POST carries
+# the deadline — an unsatisfiable schema loops forever server-side, so on
+# expiry the wrapper aborts the session and exits 124.
+
+run_dir="$DRUKS_RUN_DIR"
+mkdir -p "$run_dir" &&
+printf '%s' "$DRUKS_OPENCODE_CONFIG" > "$run_dir/opencode.json" &&
+printf '%s' "$DRUKS_SCHEMA" > "$run_dir/schema.json" &&
+cat > "$run_dir/prompt.txt" &&
+node -e '
+  const fs = require("fs");
+  const [schemaPath, promptPath, requestPath, provider, model] = process.argv.slice(1);
+  const request = {
+    model: {providerID: provider, modelID: model},
+    parts: [{type: "text", text: fs.readFileSync(promptPath, "utf8")}],
+    format: {type: "json_schema", schema: JSON.parse(fs.readFileSync(schemaPath, "utf8"))},
+  };
+  fs.writeFileSync(requestPath, JSON.stringify(request));
+' "$run_dir/schema.json" "$run_dir/prompt.txt" "$run_dir/request.json" \
+  "$DRUKS_PROVIDER" "$DRUKS_MODEL" || exit $?
+
+OPENCODE_CONFIG="$run_dir/opencode.json" opencode serve \
+  --hostname 127.0.0.1 --port 4096 > "$run_dir/opencode.log" 2>&1 &
+server_pid=$!
+cleanup() { kill "$server_pid" 2>/dev/null || true; wait "$server_pid" 2>/dev/null || true; }
+trap cleanup EXIT HUP INT TERM
+
+# The first call doubles as the readiness wait: retry only refused
+# connections while the server boots (~0.5s).
+if ! curl --fail --silent --show-error --retry 15 --retry-delay 1 --retry-connrefused \
+    -X POST "http://127.0.0.1:4096/session?directory=$DRUKS_WORKSPACE_QUERY" \
+    -H 'content-type: application/json' --data '{}' > "$run_dir/session.json"; then
+  cat "$run_dir/opencode.log" >&2
+  exit 1
+fi
+session_id=$(node -e '
+  process.stdout.write(JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).id)
+' "$run_dir/session.json") || exit $?
+
+curl --fail-with-body --silent --show-error --max-time "$DRUKS_DEADLINE_SECONDS" \
+  -X POST "http://127.0.0.1:4096/session/$session_id/message" \
+  -H 'content-type: application/json' \
+  --data-binary @"$run_dir/request.json" > "$run_dir/response.json"
+message_status=$?
+if [ "$message_status" -eq 28 ]; then
+  curl --fail --silent --show-error -X POST \
+    "http://127.0.0.1:4096/session/$session_id/abort" \
+    -H 'content-type: application/json' --data '{}' > "$run_dir/abort.json" || exit 1
+  echo 'opencode hit the agent deadline; session aborted' >&2
+  exit 124
+fi
+
+cat "$run_dir/response.json"
+if [ "$message_status" -ne 0 ]; then exit "$message_status"; fi
+node -e '
+  const payload = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+  process.exit(payload.info && payload.info.error ? 1 : 0);
+' "$run_dir/response.json"

--- a/backend/druks/harnesses/routes.py
+++ b/backend/druks/harnesses/routes.py
@@ -133,7 +133,7 @@ async def connect_harness_key(
     connection = await HarnessConnection.connect(
         harness=harness.name,
         account=account,
-        payload={"apiKey": key},
+        payload={"api_key": key},
         expires_at=None,
         provider_email=account.username,
         kind="api_key",

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -337,6 +337,7 @@ class Host:
             extra_env=extra_env,
             mcp_servers=mcp_servers,
             connection_id=connection_id,
+            timeout=timeout,
         )
         result = await self._exec(
             invocation,

--- a/backend/tests/test_api_usage.py
+++ b/backend/tests/test_api_usage.py
@@ -80,7 +80,7 @@ def test_get_usage_empty_returns_available_false(client) -> None:
     assert response.status_code == 200
     body = response.json()
     # One entry per registered harness, none available pre-first-poll.
-    assert {entry["name"] for entry in body["harnesses"]} == {"claude", "codex"}
+    assert {entry["name"] for entry in body["harnesses"]} == {"claude", "codex", "opencode"}
     assert all(entry["available"] is False for entry in body["harnesses"])
 
 
@@ -359,7 +359,7 @@ async def test_refresh_skips_a_non_metered_connection(client, druks_db, monkeypa
     await HarnessConnection.connect(
         harness="claude",
         account=account,
-        payload={"apiKey": "key"},
+        payload={"api_key": "key"},
         expires_at=None,
         provider_email="op@example.com",
         kind="api_key",

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -486,6 +486,7 @@ async def test_sandbox_e2e_exercises_dial_and_reattach(
         "sandbox_e2e",
         "sandbox_binary:claude",
         "sandbox_binary:codex",
+        "sandbox_binary:opencode",
     ]
     assert all(result.ok for result in results)
     assert calls == [
@@ -493,6 +494,7 @@ async def test_sandbox_e2e_exercises_dial_and_reattach(
         ("acquire", ["echo", "doctor"], 30.0),
         ("acquire", ["sh", "-c", "command -v claude"], 30.0),
         ("acquire", ["sh", "-c", "command -v codex"], 30.0),
+        ("acquire", ["sh", "-c", "command -v opencode"], 30.0),
         "attach:host-doc",
         ("reattach", ["echo", "doctor"], 30.0),
         "release:host-doc",

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -235,7 +235,7 @@ async def test_api_key_connect_stores_the_operator_identity(tmp_path, monkeypatc
     account = await Account.get_for_username("operator@example.com")
     connection = await HarnessConnection.get_for_account("claude", account.id)
     assert connection.kind == "api_key"
-    assert connection.payload == {"apiKey": "api-key-value"}
+    assert connection.payload == {"api_key": "api-key-value"}
     assert connection.provider_email == account.username
     assert not connection.expires_at
 

--- a/backend/tests/test_opencode.py
+++ b/backend/tests/test_opencode.py
@@ -1,0 +1,269 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from druks.harnesses.base import Harness
+from druks.harnesses.datastructures import SandboxSettings
+from druks.harnesses.exceptions import (
+    HarnessError,
+    HarnessInvalidOutputError,
+    HarnessNotConnectedError,
+    HarnessOverloadedError,
+    HarnessTimeoutError,
+)
+from druks.harnesses.opencode import OpenCodeHarness
+from druks.harnesses.registry import get_harness
+from druks.sandbox.datastructures import HarnessRunResult, McpServer
+from pydantic import BaseModel
+
+_MODEL = OpenCodeHarness.default_model
+_API_KEY = "sk-opencode-secret"  # nosec B105
+
+
+class _Contract(BaseModel):
+    answer: str
+    count: int
+
+
+def _sandbox_config() -> SandboxSettings:
+    return SandboxSettings(
+        service_url="https://sandbox.test",
+        service_token="token",
+        service_timeout=30.0,
+        image="image",
+        claude_config_dir=None,
+        codex_config_dir=None,
+    )
+
+
+def _harness() -> OpenCodeHarness:
+    return OpenCodeHarness(
+        model=_MODEL,
+        fast_mode=False,
+        effort=None,
+        sandbox=_sandbox_config(),
+    )
+
+
+def test_class_facts_and_registration() -> None:
+    assert get_harness("opencode") is OpenCodeHarness
+    assert OpenCodeHarness.command == "opencode"
+    assert OpenCodeHarness.login_kinds == frozenset({"api_key"})
+    assert OpenCodeHarness.first_byte_seconds is None
+    assert OpenCodeHarness.failure_markers == {}
+    assert OpenCodeHarness.default_model in OpenCodeHarness.models
+    assert not hasattr(OpenCodeHarness, "credentials_path")
+    assert "_model_discovery_request" not in OpenCodeHarness.__dict__
+    assert "_usage_request" not in OpenCodeHarness.__dict__
+
+
+def _response(
+    *,
+    structured: object = None,
+    error: dict[str, object] | None = None,
+    cost: float = 0.0,
+) -> bytes:
+    info: dict[str, object] = {
+        "role": "assistant",
+        "providerID": "anthropic",
+        "modelID": "claude-sonnet-4-5",
+        "cost": cost,
+        "tokens": {
+            "input": 120,
+            "output": 30,
+            "reasoning": 4,
+            "cache": {"read": 20, "write": 10},
+        },
+    }
+    if error:
+        info["error"] = error
+    else:
+        info["structured"] = structured
+    return json.dumps({"info": info, "parts": []}).encode()
+
+
+async def test_build_invocation_uses_server_schema_and_env_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def credentials(cls: type[Harness]) -> dict[str, str]:
+        return {"api_key": _API_KEY}
+
+    monkeypatch.setattr(OpenCodeHarness, "get_credentials", classmethod(credentials))
+    server = McpServer(
+        name="github",
+        url="https://api.example.test/mcp",
+        bearer_token_env_var="MCP_GITHUB_TOKEN",
+        env_headers={"X-Trace-Key": "MCP_TRACE_KEY"},
+    )
+    invocation = await _harness().build_invocation(
+        prompt="A large prompt stays on stdin.",
+        schema={"type": "object", "properties": {"answer": {"type": "string"}}},
+        run_id="run-1",
+        ssh_username="exedev",
+        github_token="github-token",
+        extra_env={"MCP_GITHUB_TOKEN": "mcp-secret", "MCP_TRACE_KEY": "trace-secret"},
+        mcp_servers=(server,),
+        timeout=60,
+    )
+
+    assert invocation.name == "opencode"
+    assert invocation.args[:2] == ("sh", "-c")
+    wrapper = invocation.args[2]
+    for text in (
+        "opencode.json",
+        "OPENCODE_CONFIG=",
+        "opencode serve",
+        "--hostname 127.0.0.1 --port 4096",
+        "/session?directory=",
+        "/message",
+        "json_schema",
+        '"$DRUKS_DEADLINE_SECONDS"',
+        "/abort",
+    ):
+        assert text in wrapper
+    assert invocation.stdin == b"A large prompt stays on stdin."
+    assert invocation.credentials.files == ()
+    assert invocation.credentials.github_token == "github-token"
+    env = invocation.env
+    assert env is not None
+    assert json.loads(env["OPENCODE_AUTH_CONTENT"]) == {
+        "anthropic": {"type": "api", "key": _API_KEY}
+    }
+    assert env["DRUKS_RUN_DIR"].endswith("/run-1")
+    assert env["DRUKS_PROVIDER"] == "anthropic"
+    assert env["DRUKS_MODEL"] == "claude-sonnet-4-5"
+    assert env["DRUKS_DEADLINE_SECONDS"] == "55"
+    assert json.loads(env["DRUKS_SCHEMA"]) == {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+    }
+    config = json.loads(env["DRUKS_OPENCODE_CONFIG"])
+    assert config["mcp"]["github"]["headers"] == {
+        "Authorization": "Bearer {env:MCP_GITHUB_TOKEN}",
+        "X-Trace-Key": "{env:MCP_TRACE_KEY}",
+    }
+    assert _API_KEY not in wrapper
+    assert "mcp-secret" not in env["DRUKS_OPENCODE_CONFIG"]
+    assert "trace-secret" not in env["DRUKS_OPENCODE_CONFIG"]
+    syntax = subprocess.run(
+        ["sh", "-n", "-c", wrapper],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+
+async def test_render_credentials_file_uses_model_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def credentials(cls: type[Harness]) -> dict[str, str]:
+        return {"api_key": _API_KEY}
+
+    monkeypatch.setattr(OpenCodeHarness, "get_credentials", classmethod(credentials))
+
+    rendered = await _harness().render_credentials_file(model="openai/gpt-5.4")
+
+    assert json.loads(rendered) == {"openai": {"type": "api", "key": _API_KEY}}
+
+
+def test_parse_returns_contract_and_writes_cost_sidecars(tmp_path: Path) -> None:
+    structured = {"answer": "done", "count": 3}
+
+    output = _harness().parse(
+        HarnessRunResult(returncode=0, stdout=_response(structured=structured), stderr=b""),
+        artifact_dir=tmp_path,
+        run_id="run-1",
+    )
+
+    assert _Contract.model_validate(output) == _Contract(answer="done", count=3)
+    assert json.loads((tmp_path / "run-1" / "output.json").read_text()) == structured
+    assert json.loads((tmp_path / "run-1" / "cost.json").read_text()) == {
+        "cost_usd": 0.0,
+        "metadata": {
+            "provider": "opencode",
+            "model": _MODEL,
+            "input_tokens": 120,
+            "output_tokens": 30,
+            "reasoning_tokens": 4,
+            "cached_input_tokens": 20,
+            "cache_creation_tokens": 10,
+        },
+    }
+
+
+@pytest.mark.parametrize("stdout", [b"", b"not-json"])
+def test_parse_rejects_empty_or_non_json_stdout(tmp_path: Path, stdout: bytes) -> None:
+    with pytest.raises(HarnessInvalidOutputError):
+        _harness().parse(
+            HarnessRunResult(returncode=0, stdout=stdout, stderr=b""),
+            artifact_dir=tmp_path,
+            run_id="run-1",
+        )
+
+
+def test_parse_maps_the_deadline_exit_to_timeout(tmp_path: Path) -> None:
+    with pytest.raises(HarnessTimeoutError, match="deadline"):
+        _harness().parse(
+            HarnessRunResult(returncode=124, stdout=b"", stderr=b"session aborted\n"),
+            artifact_dir=tmp_path,
+            run_id="run-1",
+        )
+
+
+def test_parse_includes_stderr_when_failed_process_wrote_no_json(tmp_path: Path) -> None:
+    with pytest.raises(HarnessInvalidOutputError, match="server failed"):
+        _harness().parse(
+            HarnessRunResult(returncode=1, stdout=b"", stderr=b"server failed\n"),
+            artifact_dir=tmp_path,
+            run_id="run-1",
+        )
+
+
+@pytest.mark.parametrize(
+    ("name", "data", "expected"),
+    [
+        (
+            "ProviderAuthError",
+            {"providerID": "anthropic", "message": "bad key"},
+            HarnessNotConnectedError,
+        ),
+        (
+            "StructuredOutputError",
+            {"message": "schema mismatch", "retries": 0},
+            HarnessInvalidOutputError,
+        ),
+        ("ContextOverflowError", {"message": "too much context"}, HarnessError),
+        ("ContentFilterError", {"message": "blocked"}, HarnessError),
+        ("MessageOutputLengthError", {}, HarnessError),
+        ("MessageAborted", {"message": "deadline"}, HarnessTimeoutError),
+        (
+            "APIError",
+            {"message": "busy", "isRetryable": True},
+            HarnessOverloadedError,
+        ),
+        (
+            "APIError",
+            {"message": "bad request", "isRetryable": False},
+            HarnessError,
+        ),
+    ],
+)
+def test_parse_maps_error_union(
+    tmp_path: Path,
+    name: str,
+    data: dict[str, object],
+    expected: type[HarnessError],
+) -> None:
+    result = HarnessRunResult(
+        returncode=1,
+        stdout=_response(error={"name": name, "data": data}),
+        stderr=b"wrapper failed",
+    )
+
+    with pytest.raises(expected) as error:
+        _harness().parse(result, artifact_dir=tmp_path, run_id="run-1")
+
+    assert type(error.value) is expected
+    assert name in str(error.value)

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -330,9 +330,16 @@ async def test_run_prompt_builds_executes_and_parses(
         name = "claude"
         model = "claude-opus-4-8"
         first_byte_seconds = 17
-        # The real manifest method on the stubbed build/parse seam, so the
-        # test exercises what run_prompt actually writes.
-        get_manifest = Harness.get_manifest
+
+        async def get_manifest(self, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "manifest_hash": "hash",
+                "schema_version": 2,
+                "model": self.model,
+                "harness": self.name,
+                "mcp_servers": [],
+                "skills_delivered": [],
+            }
 
         @staticmethod
         def mint_run_id(call_id: str | None) -> str:
@@ -361,6 +368,7 @@ async def test_run_prompt_builds_executes_and_parses(
     # The harness planned from values, not the live sandbox.
     assert seen["build"]["ssh_username"] == "root"
     assert seen["build"]["extra_env"] == {"GITHUB_MCP_TOKEN": "ghs_x"}
+    assert seen["build"]["timeout"] == 60
     assert seen["exec"]["first_byte_kill_seconds"] == 17
     # The prompt was persisted to the artifact dir before exec.
     assert (ctx.artifact_dir / "call-7" / "prompt.md").read_text() == "do the thing"

--- a/backend/tests/test_user_settings.py
+++ b/backend/tests/test_user_settings.py
@@ -37,7 +37,11 @@ async def test_harnesses_seeded_with_shipped_defaults(session):
         1800,
     )
     assert (await HarnessSettings.get_registered("codex")).model == "gpt-5.5"
-    assert {harness.name for harness in await HarnessSettings.all()} == {"claude", "codex"}
+    assert {harness.name for harness in await HarnessSettings.all()} == {
+        "claude",
+        "codex",
+        "opencode",
+    }
 
 
 async def test_harness_update_persists(session):


### PR DESCRIPTION
`backend/druks/harnesses/opencode.py`, registered by one import line. The schema door is the server API, not argv.

- The invocation is a static shell template (`opencode_wrapper.sh`, shipped like `druks-sandbox.sh`): write `opencode.json` into the run dir (MCP headers as `{env:VAR}` refs — no secret in the file), start `opencode serve`, open a session (the session POST doubles as the readiness wait via `--retry-connrefused`), POST the message with `format: json_schema`, print the response, exit non-zero on `info.error`. Python composes no script text — every varying value rides the invocation env (`DRUKS_*`), the prompt rides stdin, and the in-VM helpers are node (the image ships no python; verified against the base image).
- The message POST carries the deadline via `--max-time`: an unsatisfiable schema loops forever upstream, so on expiry the wrapper aborts the session and exits 124, which `parse` maps to `HarnessTimeoutError`. `first_byte_seconds = None` — nothing prints until the final response. `run_prompt` hands `timeout` to `build_invocation` (claude/codex accept it).
- `parse` reads the response directly and converts any malformed shape to `HarnessInvalidOutputError` in one place; the typed `info.error` union maps via one table — `ProviderAuthError`→not-connected, `StructuredOutputError`→invalid output (DRU-360's single retry), `MessageAborted`→timeout, `APIError.isRetryable`→overloaded, anything else terminal. No `failure_markers` word-matching. Cost and tokens (incl. cache read/write) land in the cost sidecar.
- Credential rides `OPENCODE_AUTH_CONTENT` in the invocation env (no credential file — the DRU-362 env-var path); the stored payload key is `api_key`, snake_case like the rest of the backend. `login_kinds = {"api_key"}` lights up the DRU-367 paste door; `command = "opencode"` joins the DRU-364 doctor probe, and the registry-pinning tests (usage, doctor, seeded settings) now count three harnesses.

Tests: 17 opencode unit tests (template + env shape incl. `sh -n` syntax check, secrets never in argv, full error-union map incl. the deadline exit, cost sidecar, auth rendering) — no live sandbox, no DB.

DRU-368