### PR TITLE
OpenCode model discovery and usage card

### DIFF
--- a/backend/druks/harnesses/opencode.py
+++ b/backend/druks/harnesses/opencode.py
@@ -1,7 +1,10 @@
 import json
+import logging
 import urllib.parse
 from pathlib import Path
 from typing import Any
+
+import httpx
 
 from druks.sandbox.datastructures import (
     AgentInvocation,
@@ -13,9 +16,15 @@ from druks.sandbox.layout import get_runs_root, get_work_root
 
 from . import exceptions
 from .artifacts import call_dir, write_cost
-from .base import Harness
+from .base import Harness, _error_tag
+from .datastructures import ParsedModels
+from .models import HarnessConnection
+
+logger = logging.getLogger(__name__)
 
 _ABORT_MARGIN_SECONDS = 5
+_CATALOG_URL = "https://models.dev/api.json"
+_DISCOVERY_TIMEOUT_SECONDS = 10.0
 _WRAPPER = (Path(__file__).parent / "opencode_wrapper.sh").read_text()
 _ERROR_TYPES = {
     "ProviderAuthError": exceptions.HarnessNotConnectedError,
@@ -96,12 +105,11 @@ class OpenCodeHarness(Harness):
                     connection_id, model=self.model
                 ),
                 "DRUKS_RUN_DIR": f"{get_runs_root(ssh_username)}/{run_id}",
-                "DRUKS_OPENCODE_CONFIG": json.dumps(
+                "OPENCODE_CONFIG_CONTENT": json.dumps(
                     {"$schema": "https://opencode.ai/config.json", "mcp": mcp},
-                    indent=2,
                     sort_keys=True,
                 ),
-                "DRUKS_SCHEMA": json.dumps(schema, indent=2, sort_keys=True),
+                "DRUKS_SCHEMA": json.dumps(schema, sort_keys=True),
                 "DRUKS_PROVIDER": provider,
                 "DRUKS_MODEL": model,
                 "DRUKS_WORKSPACE_QUERY": urllib.parse.quote(get_work_root(ssh_username), safe=""),
@@ -150,3 +158,41 @@ class OpenCodeHarness(Harness):
         (output_dir / "output.json").write_text(json.dumps(structured, indent=2, sort_keys=True))
         write_cost(output_dir, cost_usd=cost_usd, metadata=metadata)
         return structured
+
+    @classmethod
+    async def fetch_models(cls, _connection: HarnessConnection) -> ParsedModels:
+        # opencode's catalog IS models.dev (same team; its docs say so), so the
+        # picker reads the upstream directly — no opencode binary on the druks
+        # host. Advisory either way: the CLI's own listing gates on key
+        # presence, not validity.
+        try:
+            async with httpx.AsyncClient(timeout=_DISCOVERY_TIMEOUT_SECONDS) as client:
+                response = await client.get(_CATALOG_URL)
+        except httpx.TimeoutException:
+            return ParsedModels(ok=False, error="timeout")
+        except httpx.HTTPError as error:
+            logger.warning("models request failed for %s: %s", cls.name, error, exc_info=True)
+            return ParsedModels(ok=False, error="network")
+        if response.status_code != 200:
+            logger.warning(
+                "models endpoint %s for %s: %s",
+                response.status_code,
+                cls.name,
+                response.text[:300],
+            )
+            return ParsedModels(ok=False, error=_error_tag(response.status_code))
+
+        raw = response.text
+        # The provider is the model namespace — the same rule the auth store
+        # rendering uses.
+        provider, _, _ = cls.default_model.partition("/")
+        try:
+            models = tuple(
+                {"id": f"{provider}/{model['id']}", "label": model["name"]}
+                for model in json.loads(raw)[provider]["models"].values()
+            )
+        except (ValueError, KeyError, TypeError, AttributeError):
+            return ParsedModels(ok=False, error="unexpected_payload", raw=raw)
+        if not models:
+            return ParsedModels(ok=False, error="empty_list", raw=raw)
+        return ParsedModels(ok=True, models=models, raw=raw)

--- a/backend/druks/harnesses/opencode_wrapper.sh
+++ b/backend/druks/harnesses/opencode_wrapper.sh
@@ -1,53 +1,59 @@
-# One structured opencode call: write config and schema, start `opencode
-# serve`, open a session, POST the message with the contract schema, and
-# print the POST response. Inputs ride the environment (DRUKS_*,
-# OPENCODE_AUTH_CONTENT); the prompt rides stdin. The message POST carries
+# One structured opencode call: start `opencode serve`, open a session, POST
+# the message with the contract schema, and print the POST response. Inputs
+# ride the environment (DRUKS_*, OPENCODE_AUTH_CONTENT,
+# OPENCODE_CONFIG_CONTENT); the prompt rides stdin. The message POST carries
 # the deadline — an unsatisfiable schema loops forever server-side, so on
 # expiry the wrapper aborts the session and exits 124.
 
 run_dir="$DRUKS_RUN_DIR"
 mkdir -p "$run_dir" &&
-printf '%s' "$DRUKS_OPENCODE_CONFIG" > "$run_dir/opencode.json" &&
-printf '%s' "$DRUKS_SCHEMA" > "$run_dir/schema.json" &&
 cat > "$run_dir/prompt.txt" &&
 node -e '
   const fs = require("fs");
-  const [schemaPath, promptPath, requestPath, provider, model] = process.argv.slice(1);
+  const [promptPath, requestPath] = process.argv.slice(1);
   const request = {
-    model: {providerID: provider, modelID: model},
+    model: {providerID: process.env.DRUKS_PROVIDER, modelID: process.env.DRUKS_MODEL},
     parts: [{type: "text", text: fs.readFileSync(promptPath, "utf8")}],
-    format: {type: "json_schema", schema: JSON.parse(fs.readFileSync(schemaPath, "utf8"))},
+    format: {type: "json_schema", schema: JSON.parse(process.env.DRUKS_SCHEMA)},
   };
   fs.writeFileSync(requestPath, JSON.stringify(request));
-' "$run_dir/schema.json" "$run_dir/prompt.txt" "$run_dir/request.json" \
-  "$DRUKS_PROVIDER" "$DRUKS_MODEL" || exit $?
+' "$run_dir/prompt.txt" "$run_dir/request.json" || exit $?
 
-OPENCODE_CONFIG="$run_dir/opencode.json" opencode serve \
-  --hostname 127.0.0.1 --port 4096 > "$run_dir/opencode.log" 2>&1 &
+opencode serve --hostname 127.0.0.1 --port 0 > "$run_dir/opencode.log" 2>&1 &
 server_pid=$!
 cleanup() { kill "$server_pid" 2>/dev/null || true; wait "$server_pid" 2>/dev/null || true; }
 trap cleanup EXIT HUP INT TERM
 
-# The first call doubles as the readiness wait: retry only refused
-# connections while the server boots (~0.5s).
-if ! curl --fail --silent --show-error --retry 15 --retry-delay 1 --retry-connrefused \
-    -X POST "http://127.0.0.1:4096/session?directory=$DRUKS_WORKSPACE_QUERY" \
-    -H 'content-type: application/json' --data '{}' > "$run_dir/session.json"; then
+# `--port 0` prefers the default port and falls back to an ephemeral one, so
+# the listening banner is the only source of the base URL.
+base_url=""
+attempt=0
+while [ "$attempt" -lt 50 ]; do
+  base_url=$(sed -n 's/.*listening on \(http:\/\/127\.0\.0\.1:[0-9]*\).*/\1/p' "$run_dir/opencode.log" | head -n 1)
+  if [ -n "$base_url" ]; then break; fi
+  if ! kill -0 "$server_pid" 2>/dev/null; then break; fi
+  sleep 0.1
+  attempt=$((attempt + 1))
+done
+if [ -z "$base_url" ]; then
   cat "$run_dir/opencode.log" >&2
   exit 1
 fi
+
+curl --fail --silent --show-error -X POST \
+  "$base_url/session?directory=$DRUKS_WORKSPACE_QUERY" \
+  -H 'content-type: application/json' --data '{}' > "$run_dir/session.json" || exit $?
 session_id=$(node -e '
   process.stdout.write(JSON.parse(require("fs").readFileSync(process.argv[1], "utf8")).id)
 ' "$run_dir/session.json") || exit $?
-
 curl --fail-with-body --silent --show-error --max-time "$DRUKS_DEADLINE_SECONDS" \
-  -X POST "http://127.0.0.1:4096/session/$session_id/message" \
+  -X POST "$base_url/session/$session_id/message" \
   -H 'content-type: application/json' \
   --data-binary @"$run_dir/request.json" > "$run_dir/response.json"
 message_status=$?
 if [ "$message_status" -eq 28 ]; then
   curl --fail --silent --show-error -X POST \
-    "http://127.0.0.1:4096/session/$session_id/abort" \
+    "$base_url/session/$session_id/abort" \
     -H 'content-type: application/json' --data '{}' > "$run_dir/abort.json" || exit 1
   echo 'opencode hit the agent deadline; session aborted' >&2
   exit 124

--- a/backend/druks/usage/routes.py
+++ b/backend/druks/usage/routes.py
@@ -59,6 +59,7 @@ async def get_usage(account: Account = Depends(current_account)) -> UsageRespons
                 now=now,
                 connected=bool(connection),
                 provider_email=connection.provider_email if connection else None,
+                is_metered=connection.is_metered if connection else True,
             )
         )
     return UsageResponse(harnesses=summaries)
@@ -180,7 +181,16 @@ def _summarize(
     now: datetime,
     connected: bool,
     provider_email: str | None,
+    is_metered: bool,
 ) -> UsageHarnessSummary:
+    if connected and not is_metered:
+        return UsageHarnessSummary(
+            name=name,
+            available=True,
+            connected=True,
+            provider_email=provider_email,
+            unlimited=True,
+        )
     if not row:
         return UsageHarnessSummary(
             name=name,

--- a/backend/tests/test_api_usage.py
+++ b/backend/tests/test_api_usage.py
@@ -84,6 +84,25 @@ def test_get_usage_empty_returns_available_false(client) -> None:
     assert all(entry["available"] is False for entry in body["harnesses"])
 
 
+async def test_get_usage_presents_api_key_connection_as_unmetered(client, druks_db) -> None:
+    await HarnessConnection.connect(
+        harness="opencode",
+        account=await Account.get_or_create("op@example.com"),
+        payload={"apiKey": "key"},
+        expires_at=None,
+        provider_email="op@example.com",
+        kind="api_key",
+    )
+
+    summary = _harness(client.get("/api/usage").json(), "opencode")
+
+    assert summary["available"] is True
+    assert summary["connected"] is True
+    assert summary["unlimited"] is True
+    assert summary["fiveHour"] is None
+    assert summary["weeks"] == []
+
+
 async def test_get_usage_serializes_latest_per_harness(client, app_settings) -> None:
     # Plant a snapshot for claude only — codex should still report
     # ``available=false`` rather than missing-key/404.

--- a/backend/tests/test_opencode.py
+++ b/backend/tests/test_opencode.py
@@ -1,10 +1,12 @@
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from druks.harnesses import opencode as opencode_module
 from druks.harnesses.base import Harness
-from druks.harnesses.datastructures import SandboxSettings
+from druks.harnesses.datastructures import ParsedModels, SandboxSettings
 from druks.harnesses.exceptions import (
     HarnessError,
     HarnessInvalidOutputError,
@@ -46,6 +48,17 @@ def _harness() -> OpenCodeHarness:
     )
 
 
+def _mock_catalog(monkeypatch: pytest.MonkeyPatch, response: SimpleNamespace) -> list[str]:
+    calls: list[str] = []
+
+    async def fake_get(self, url: str, **_kwargs: object) -> SimpleNamespace:
+        calls.append(url)
+        return response
+
+    monkeypatch.setattr(opencode_module.httpx.AsyncClient, "get", fake_get)
+    return calls
+
+
 def test_class_facts_and_registration() -> None:
     assert get_harness("opencode") is OpenCodeHarness
     assert OpenCodeHarness.command == "opencode"
@@ -56,6 +69,66 @@ def test_class_facts_and_registration() -> None:
     assert not hasattr(OpenCodeHarness, "credentials_path")
     assert "_model_discovery_request" not in OpenCodeHarness.__dict__
     assert "_usage_request" not in OpenCodeHarness.__dict__
+
+
+async def test_fetch_models_reads_the_providers_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = {
+        "anthropic": {
+            "id": "anthropic",
+            "name": "Anthropic",
+            "models": {
+                "claude-fable-5": {"id": "claude-fable-5", "name": "Claude Fable 5"},
+                "claude-sonnet-4-5": {"id": "claude-sonnet-4-5", "name": "Claude Sonnet 4.5"},
+            },
+        },
+        "openai": {"id": "openai", "name": "OpenAI", "models": {}},
+    }
+    raw = json.dumps(catalog)
+    calls = _mock_catalog(monkeypatch, SimpleNamespace(status_code=200, text=raw))
+
+    parsed = await OpenCodeHarness.fetch_models(SimpleNamespace(id="connection-1"))
+
+    assert parsed == ParsedModels(
+        ok=True,
+        models=(
+            {"id": "anthropic/claude-fable-5", "label": "Claude Fable 5"},
+            {"id": "anthropic/claude-sonnet-4-5", "label": "Claude Sonnet 4.5"},
+        ),
+        raw=raw,
+    )
+    assert calls == ["https://models.dev/api.json"]
+
+
+async def test_fetch_models_tags_a_catalog_without_the_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = json.dumps({"openai": {"id": "openai", "models": {}}})
+    _mock_catalog(monkeypatch, SimpleNamespace(status_code=200, text=raw))
+
+    parsed = await OpenCodeHarness.fetch_models(SimpleNamespace(id="connection-1"))
+
+    assert parsed == ParsedModels(ok=False, error="unexpected_payload", raw=raw)
+
+
+async def test_fetch_models_tags_a_provider_without_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = json.dumps({"anthropic": {"id": "anthropic", "models": {}}})
+    _mock_catalog(monkeypatch, SimpleNamespace(status_code=200, text=raw))
+
+    parsed = await OpenCodeHarness.fetch_models(SimpleNamespace(id="connection-1"))
+
+    assert parsed == ParsedModels(ok=False, error="empty_list", raw=raw)
+
+
+async def test_fetch_models_tags_a_catalog_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _mock_catalog(monkeypatch, SimpleNamespace(status_code=503, text="down"))
+
+    parsed = await OpenCodeHarness.fetch_models(SimpleNamespace(id="connection-1"))
+
+    assert parsed == ParsedModels(ok=False, error="http_503")
 
 
 def _response(
@@ -111,10 +184,10 @@ async def test_build_invocation_uses_server_schema_and_env_auth(
     assert invocation.args[:2] == ("sh", "-c")
     wrapper = invocation.args[2]
     for text in (
-        "opencode.json",
-        "OPENCODE_CONFIG=",
         "opencode serve",
-        "--hostname 127.0.0.1 --port 4096",
+        "--port 0",
+        "listening on",
+        "--hostname 127.0.0.1 --port 0",
         "/session?directory=",
         "/message",
         "json_schema",
@@ -138,14 +211,14 @@ async def test_build_invocation_uses_server_schema_and_env_auth(
         "type": "object",
         "properties": {"answer": {"type": "string"}},
     }
-    config = json.loads(env["DRUKS_OPENCODE_CONFIG"])
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
     assert config["mcp"]["github"]["headers"] == {
         "Authorization": "Bearer {env:MCP_GITHUB_TOKEN}",
         "X-Trace-Key": "{env:MCP_TRACE_KEY}",
     }
     assert _API_KEY not in wrapper
-    assert "mcp-secret" not in env["DRUKS_OPENCODE_CONFIG"]
-    assert "trace-secret" not in env["DRUKS_OPENCODE_CONFIG"]
+    assert "mcp-secret" not in env["OPENCODE_CONFIG_CONTENT"]
+    assert "trace-secret" not in env["OPENCODE_CONFIG_CONTENT"]
     syntax = subprocess.run(
         ["sh", "-n", "-c", wrapper],
         check=False,


### PR DESCRIPTION
Model discovery and the usage card for opencode, plus the DRU-368 ticket's newer serve shape (all verified live on 1.18.25):

- The wrapper no longer writes `opencode.json` or `schema.json` — config rides `OPENCODE_CONFIG_CONTENT` (like the auth store) and the schema rides `DRUKS_SCHEMA`. `opencode serve --port 0` prefers the default port and falls back to an ephemeral one under collision, so the wrapper parses the base URL from the listening banner (the `@opencode-ai/sdk` shape); the fixed-port collision class and the readiness retry dance are gone.
- Discovery needs no opencode on the druks host and no server: opencode's catalog IS models.dev (same team; its docs say so), so `fetch_models` reads `https://models.dev/api.json` directly and keeps the target provider's models — `{id: "<provider>/<model>", label: <display name>}`, provider derived from the model namespace, the same rule the auth store uses. Advisory either way: the CLI's own listing gates on key presence, not validity (verified — a bogus key still lists the catalog). Failures collapse to tags; empty is `empty_list`, never ok-empty. No hand-kept model list.
- The usage read side presents a connected non-metered (API-key) connection as available + unlimited with no window metrics; the panel already renders "unmetered" plus spend from the run cost sidecars.

42 opencode/harness tests pass locally (mocked catalog, `sh -n` on the template, no Postgres); the usage summary test runs in CI.

DRU-369