### PR TITLE
Sandbox image ships pi and the MCP adapter

### DIFF
--- a/deploy/sandbox/Dockerfile
+++ b/deploy/sandbox/Dockerfile
@@ -1,7 +1,7 @@
 # Sandbox images for druks agents: a drukbox base (sshd and its boot
 # contract) plus the tools the build prompts assume are on PATH (git, gh,
-# node, claude, codex, opencode). drukbox publishes one base per provider, and each
-# druks image builds on the matching one — the ``toolchain`` stage applies
+# node, claude, codex, opencode, pi). drukbox publishes one base per provider,
+# and each druks image builds on the matching one — the ``toolchain`` stage applies
 # the same tool layers to whichever base ``BASE`` selects:
 #
 #   - ``sandbox`` (the default target, on ``docker-base``) serves the drukbox
@@ -30,6 +30,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG CLAUDE_CODE_VERSION=2.1.207
 ARG CODEX_VERSION=0.144.1
 ARG OPENCODE_VERSION=1.18.25
+ARG PI_VERSION=0.84.4
+ARG PI_MCP_ADAPTER_VERSION=2.31.0
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Package revisions differ across the base image's architectures and external
@@ -50,10 +52,15 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends nodejs gh \
     && rm -rf /var/lib/apt/lists/*
 
+# pi loads the adapter extension from this absolute path, so a moved npm
+# global root has to fail the build rather than every run.
 RUN npm install -g \
     "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
     "@openai/codex@${CODEX_VERSION}" \
-    "opencode-ai@${OPENCODE_VERSION}"
+    "opencode-ai@${OPENCODE_VERSION}" \
+    "@earendil-works/pi-coding-agent@${PI_VERSION}" \
+    "pi-mcp-adapter@${PI_MCP_ADAPTER_VERSION}" \
+    && test -f /usr/lib/node_modules/pi-mcp-adapter/index.ts
 
 RUN useradd --create-home --shell /bin/bash druks
 


### PR DESCRIPTION
The sandbox image installs the pi coding agent and `pi-mcp-adapter` alongside the CLIs it already ships, both pinned to their own build ARGs.

The pi harness loads the adapter as an explicit extension, so the image asserts the entry file at `/usr/lib/node_modules/pi-mcp-adapter/index.ts` — a moved npm global root fails the build instead of every run.

Verified on the built `sandbox` target: `pi --version` prints 0.84.4 as the `druks` user, and the adapter entry file is in place.

Base: this stacks on #393.