### PR TITLE
Pi harness class

### DIFF
--- a/backend/druks/harnesses/__init__.py
+++ b/backend/druks/harnesses/__init__.py
@@ -1,1 +1,1 @@
-from . import claude, codex, opencode  # noqa: F401 — load harnesses so they enrol
+from . import claude, codex, opencode, pi  # noqa: F401 — load harnesses so they enrol

--- a/backend/druks/harnesses/druks-output.ts
+++ b/backend/druks/harnesses/druks-output.ts
@@ -1,0 +1,26 @@
+// Druks' terminating result tool: pi has no output-schema flag, so the run's
+// contract rides as this tool's parameters and the agent ends its turn by
+// calling it. pi loads this file by absolute path from the run directory,
+// which is outside every node_modules — so it imports nothing from pi.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const schemaPath = process.env.DRUKS_SCHEMA_PATH;
+const resultPath = process.env.DRUKS_RESULT_PATH;
+
+export default function (pi) {
+  pi.registerTool({
+    name: "submit_result",
+    label: "Submit result",
+    description: "Return the final result object for this task. Calling this ends the turn.",
+    promptSnippet: "Return the final result object with submit_result",
+    promptGuidelines: [
+      "Finish by calling submit_result exactly once with the final result object.",
+      "Do not send an assistant message after submit_result.",
+    ],
+    parameters: JSON.parse(readFileSync(schemaPath, "utf8")),
+    async execute(_toolCallId, params) {
+      writeFileSync(resultPath, JSON.stringify(params));
+      return { content: [{ type: "text", text: "result recorded" }], terminate: true };
+    },
+  });
+}

--- a/backend/druks/harnesses/pi.py
+++ b/backend/druks/harnesses/pi.py
@@ -22,60 +22,11 @@ _DRUKS_OUTPUT_TEMPLATE = Path(__file__).parent / "druks-output.ts"
 # deploy/sandbox/Dockerfile installs pi-mcp-adapter globally and asserts this path.
 _PI_MCP_ADAPTER_PATH = "/usr/lib/node_modules/pi-mcp-adapter/index.ts"
 _PROVIDER_ERROR_STATUS = re.compile(r" API error \((\d{3})\):")
-
-
-def _assistant_messages(stdout: bytes) -> list[dict]:
-    messages = []
-    for line in stdout.splitlines():
-        try:
-            event = json.loads(line)
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            continue
-        if isinstance(event, dict) and event.get("type") == "message_end":
-            message = event.get("message")
-            if isinstance(message, dict) and message.get("role") == "assistant":
-                messages.append(message)
-    return messages
-
-
-def _provider_error(message: dict) -> exceptions.HarnessError:
-    """pi exits zero on a runtime provider failure, so the HTTP status carried in
-    ``errorMessage`` is what classifies it."""
-    error_message = message.get("errorMessage")
-    if not isinstance(error_message, str):
-        return exceptions.HarnessError("pi reported an error with no message")
-    status_match = _PROVIDER_ERROR_STATUS.search(error_message)
-    if status_match:
-        status = int(status_match.group(1))
-        if status in {401, 403}:
-            return exceptions.HarnessAuthError(error_message)
-        if status == 429:
-            return exceptions.HarnessRateLimitError(error_message)
-        if status >= 500:
-            return exceptions.HarnessOverloadedError(error_message)
-    return exceptions.HarnessError(error_message)
-
-
-def _spend(messages: list[dict]) -> tuple[float, dict[str, int]]:
-    """The run's summed cost and token counts, keyed as the cost sidecar reads them."""
-    cost_usd = 0.0
-    tokens = {
-        "input_tokens": 0,
-        "output_tokens": 0,
-        "cached_input_tokens": 0,
-        "cache_creation_tokens": 0,
-    }
-    for message in messages:
-        usage = message.get("usage")
-        if isinstance(usage, dict):
-            tokens["input_tokens"] += usage.get("input", 0)
-            tokens["output_tokens"] += usage.get("output", 0)
-            tokens["cached_input_tokens"] += usage.get("cacheRead", 0)
-            tokens["cache_creation_tokens"] += usage.get("cacheWrite", 0)
-            cost = usage.get("cost")
-            if isinstance(cost, dict):
-                cost_usd += cost.get("total", 0)
-    return cost_usd, tokens
+_STATUS_ERRORS = {
+    401: exceptions.HarnessAuthError,
+    403: exceptions.HarnessAuthError,
+    429: exceptions.HarnessRateLimitError,
+}
 
 
 class PiHarness(Harness):
@@ -95,7 +46,7 @@ class PiHarness(Harness):
         model: str | None = None,
     ) -> str:
         payload = json.loads(await super().render_credentials_file(connection_id))
-        provider, _ = cls._model_parts(model or cls.default_model)
+        provider, _, _ = (model or cls.default_model).partition("/")
         return json.dumps({provider: {"type": "api_key", "key": payload["apiKey"]}})
 
     async def build_invocation(
@@ -123,7 +74,7 @@ class PiHarness(Harness):
                 "sandbox.service_url and related TOML settings.",
             )
 
-        provider, model = self._model_parts(self.model)
+        provider, _, model = self.model.partition("/")
         in_vm_run_dir = f"{get_runs_root(ssh_username)}/{run_id}"
         in_vm_schema = f"{in_vm_run_dir}/schema.json"
         in_vm_extension = f"{in_vm_run_dir}/druks-output.ts"
@@ -199,30 +150,43 @@ class PiHarness(Harness):
 
     def parse(self, result: HarnessRunResult, *, artifact_dir: Path, run_id: str) -> Any:
         self.check_returncode(result)
-
-        messages = _assistant_messages(result.stdout)
-        for message in messages:
-            if message.get("stopReason") == "error":
-                raise _provider_error(message)
+        try:
+            events = [json.loads(line) for line in result.stdout.splitlines()]
+            # pi repeats an assistant message on turn_end and agent_end;
+            # message_end is the one place each appears once.
+            messages = [
+                event["message"]
+                for event in events
+                if event["type"] == "message_end" and event["message"]["role"] == "assistant"
+            ]
+            for message in messages:
+                # A runtime provider failure exits zero, so the HTTP status in
+                # ``errorMessage`` is what classifies it.
+                if message["stopReason"] == "error":
+                    detail = message["errorMessage"]
+                    status = _PROVIDER_ERROR_STATUS.search(detail)
+                    code = int(status.group(1)) if status else 0
+                    if code >= 500:
+                        raise exceptions.HarnessOverloadedError(detail)
+                    raise _STATUS_ERRORS.get(code, exceptions.HarnessError)(detail)
+            usage = [message["usage"] for message in messages]
+            cost_usd = sum(entry["cost"]["total"] for entry in usage)
+            tokens = {
+                "input_tokens": sum(entry["input"] for entry in usage),
+                "output_tokens": sum(entry["output"] for entry in usage),
+                "cached_input_tokens": sum(entry["cacheRead"] for entry in usage),
+                "cache_creation_tokens": sum(entry["cacheWrite"] for entry in usage),
+            }
+        except (ValueError, KeyError, TypeError) as error:
+            raise exceptions.HarnessInvalidOutputError("pi wrote no usable stream.") from error
 
         call_dir = artifact_dir / run_id
         output_path = call_dir / "output.json"
         payload = read_result_json(output_path, name=self.name)
         output_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
-
-        cost_usd, tokens = _spend(messages)
         write_cost(
             call_dir,
             cost_usd=cost_usd,
             metadata={"provider": self.provider, "model": self.model, **tokens},
         )
         return payload
-
-    @staticmethod
-    def _model_parts(model_id: str | None) -> tuple[str, str]:
-        provider, separator, model = (model_id or "").partition("/")
-        if not separator or not provider or not model:
-            raise exceptions.HarnessError(
-                f"pi model must use provider/model form, got {model_id!r}.",
-            )
-        return provider, model

--- a/backend/druks/harnesses/pi.py
+++ b/backend/druks/harnesses/pi.py
@@ -1,0 +1,228 @@
+import json
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+from druks.sandbox.datastructures import (
+    AgentInvocation,
+    Credentials,
+    HarnessRunResult,
+    McpServer,
+)
+from druks.sandbox.layout import get_runs_root
+
+from . import exceptions
+from .artifacts import write_cost
+from .base import Harness
+from .subprocess import read_result_json
+
+_DRUKS_OUTPUT_TEMPLATE = Path(__file__).parent / "druks-output.ts"
+
+# deploy/sandbox/Dockerfile installs pi-mcp-adapter globally and asserts this path.
+_PI_MCP_ADAPTER_PATH = "/usr/lib/node_modules/pi-mcp-adapter/index.ts"
+_PROVIDER_ERROR_STATUS = re.compile(r" API error \((\d{3})\):")
+
+
+def _assistant_messages(stdout: bytes) -> list[dict]:
+    messages = []
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if isinstance(event, dict) and event.get("type") == "message_end":
+            message = event.get("message")
+            if isinstance(message, dict) and message.get("role") == "assistant":
+                messages.append(message)
+    return messages
+
+
+def _provider_error(message: dict) -> exceptions.HarnessError:
+    """pi exits zero on a runtime provider failure, so the HTTP status carried in
+    ``errorMessage`` is what classifies it."""
+    error_message = message.get("errorMessage")
+    if not isinstance(error_message, str):
+        return exceptions.HarnessError("pi reported an error with no message")
+    status_match = _PROVIDER_ERROR_STATUS.search(error_message)
+    if status_match:
+        status = int(status_match.group(1))
+        if status in {401, 403}:
+            return exceptions.HarnessAuthError(error_message)
+        if status == 429:
+            return exceptions.HarnessRateLimitError(error_message)
+        if status >= 500:
+            return exceptions.HarnessOverloadedError(error_message)
+    return exceptions.HarnessError(error_message)
+
+
+def _spend(messages: list[dict]) -> tuple[float, dict[str, int]]:
+    """The run's summed cost and token counts, keyed as the cost sidecar reads them."""
+    cost_usd = 0.0
+    tokens = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cached_input_tokens": 0,
+        "cache_creation_tokens": 0,
+    }
+    for message in messages:
+        usage = message.get("usage")
+        if isinstance(usage, dict):
+            tokens["input_tokens"] += usage.get("input", 0)
+            tokens["output_tokens"] += usage.get("output", 0)
+            tokens["cached_input_tokens"] += usage.get("cacheRead", 0)
+            tokens["cache_creation_tokens"] += usage.get("cacheWrite", 0)
+            cost = usage.get("cost")
+            if isinstance(cost, dict):
+                cost_usd += cost.get("total", 0)
+    return cost_usd, tokens
+
+
+class PiHarness(Harness):
+    name = "pi"
+    provider = "pi"
+    command = "pi"
+    credentials_path = ".pi/agent/auth.json"
+    login_kinds = frozenset({"api_key"})
+    models = ("openai/gpt-5.5",)
+    default_model = "openai/gpt-5.5"
+
+    @classmethod
+    async def render_credentials_file(
+        cls,
+        connection_id: str | None = None,
+        *,
+        model: str | None = None,
+    ) -> str:
+        payload = json.loads(await super().render_credentials_file(connection_id))
+        provider, _ = cls._model_parts(model or cls.default_model)
+        return json.dumps({provider: {"type": "api_key", "key": payload["apiKey"]}})
+
+    async def build_invocation(
+        self,
+        *,
+        prompt: str,
+        schema: dict[str, object],
+        run_id: str,
+        ssh_username: str,
+        github_token: str | None = None,
+        # Accepted for signature parity and dropped: pi has no plugin layer, it
+        # runs with full filesystem access, and --no-skills is what keeps the
+        # run hermetic.
+        include_plugins: bool = True,
+        add_dirs: tuple[str, ...] = (),
+        skills: tuple[str, ...] = (),
+        extra_env: dict[str, str] | None = None,
+        mcp_servers: tuple[McpServer, ...] = (),
+        connection_id: str | None = None,
+        timeout: int = Harness.default_timeout,
+    ) -> AgentInvocation:
+        if not self.sandbox:
+            raise exceptions.HarnessError(
+                f"{self.name} harness requires sandbox settings — set "
+                "sandbox.service_url and related TOML settings.",
+            )
+
+        provider, model = self._model_parts(self.model)
+        in_vm_run_dir = f"{get_runs_root(ssh_username)}/{run_id}"
+        in_vm_schema = f"{in_vm_run_dir}/schema.json"
+        in_vm_extension = f"{in_vm_run_dir}/druks-output.ts"
+        in_vm_output = f"{in_vm_run_dir}/output.json"
+        in_vm_mcp_config = f"{in_vm_run_dir}/.mcp.json"
+
+        schema_body = json.dumps(schema, indent=2, sort_keys=True)
+        extension_body = _DRUKS_OUTPUT_TEMPLATE.read_text()
+        mcp = {}
+        for server in mcp_servers:
+            headers = dict(server.headers)
+            if server.bearer_token_env_var:
+                headers["Authorization"] = f"Bearer ${{{server.bearer_token_env_var}}}"
+            for header, env_var in server.env_headers.items():
+                headers[header] = f"${{{env_var}}}"
+            # Druks owns MCP authentication, so the adapter must not start headless OAuth.
+            entry: dict[str, object] = {"url": server.url, "auth": False}
+            if headers:
+                entry["headers"] = headers
+            mcp[server.name] = entry
+
+        command = [
+            self.command,
+            "-p",
+            "--mode",
+            "json",
+            "--no-session",
+            "--no-extensions",
+            "--no-skills",
+            "--offline",
+            "--provider",
+            provider,
+            "--model",
+            model,
+            "-e",
+            in_vm_extension,
+        ]
+        if self.effort:
+            command.extend(("--thinking", self.effort))
+        if mcp:
+            command.extend(("-e", _PI_MCP_ADAPTER_PATH, "--mcp-config", in_vm_mcp_config))
+
+        writes = [
+            f"mkdir -p {shlex.quote(in_vm_run_dir)}",
+            f"printf %s {shlex.quote(schema_body)} > {shlex.quote(in_vm_schema)}",
+            f"printf %s {shlex.quote(extension_body)} > {shlex.quote(in_vm_extension)}",
+        ]
+        if mcp:
+            mcp_body = json.dumps({"mcpServers": mcp}, indent=2, sort_keys=True)
+            writes.append(f"printf %s {shlex.quote(mcp_body)} > {shlex.quote(in_vm_mcp_config)}")
+        command_line = " ".join(shlex.quote(argument) for argument in command)
+        wrapper = " && ".join((*writes, command_line))
+
+        rendered_credentials = await self.render_credentials_file(
+            connection_id,
+            model=self.model,
+        )
+        return AgentInvocation(
+            name=self.name,
+            args=("sh", "-c", wrapper),
+            stdin=prompt.encode("utf-8"),
+            credentials=Credentials(
+                files=((self.credentials_path, rendered_credentials),),
+                github_token=github_token,
+            ),
+            env={
+                **(extra_env or {}),
+                "DRUKS_SCHEMA_PATH": in_vm_schema,
+                "DRUKS_RESULT_PATH": in_vm_output,
+            },
+            extra_artifact_filenames=("output.json",),
+        )
+
+    def parse(self, result: HarnessRunResult, *, artifact_dir: Path, run_id: str) -> Any:
+        self.check_returncode(result)
+
+        messages = _assistant_messages(result.stdout)
+        for message in messages:
+            if message.get("stopReason") == "error":
+                raise _provider_error(message)
+
+        call_dir = artifact_dir / run_id
+        output_path = call_dir / "output.json"
+        payload = read_result_json(output_path, name=self.name)
+        output_path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+        cost_usd, tokens = _spend(messages)
+        write_cost(
+            call_dir,
+            cost_usd=cost_usd,
+            metadata={"provider": self.provider, "model": self.model, **tokens},
+        )
+        return payload
+
+    @staticmethod
+    def _model_parts(model_id: str | None) -> tuple[str, str]:
+        provider, separator, model = (model_id or "").partition("/")
+        if not separator or not provider or not model:
+            raise exceptions.HarnessError(
+                f"pi model must use provider/model form, got {model_id!r}.",
+            )
+        return provider, model

--- a/backend/tests/test_api_usage.py
+++ b/backend/tests/test_api_usage.py
@@ -80,7 +80,12 @@ def test_get_usage_empty_returns_available_false(client) -> None:
     assert response.status_code == 200
     body = response.json()
     # One entry per registered harness, none available pre-first-poll.
-    assert {entry["name"] for entry in body["harnesses"]} == {"claude", "codex", "opencode"}
+    assert {entry["name"] for entry in body["harnesses"]} == {
+        "claude",
+        "codex",
+        "opencode",
+        "pi",
+    }
     assert all(entry["available"] is False for entry in body["harnesses"])
 
 

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -487,6 +487,7 @@ async def test_sandbox_e2e_exercises_dial_and_reattach(
         "sandbox_binary:claude",
         "sandbox_binary:codex",
         "sandbox_binary:opencode",
+        "sandbox_binary:pi",
     ]
     assert all(result.ok for result in results)
     assert calls == [
@@ -495,6 +496,7 @@ async def test_sandbox_e2e_exercises_dial_and_reattach(
         ("acquire", ["sh", "-c", "command -v claude"], 30.0),
         ("acquire", ["sh", "-c", "command -v codex"], 30.0),
         ("acquire", ["sh", "-c", "command -v opencode"], 30.0),
+        ("acquire", ["sh", "-c", "command -v pi"], 30.0),
         "attach:host-doc",
         ("reattach", ["echo", "doctor"], 30.0),
         "release:host-doc",

--- a/backend/tests/test_pi.py
+++ b/backend/tests/test_pi.py
@@ -18,9 +18,8 @@ from druks.harnesses.registry import get_harness
 from druks.sandbox.datastructures import HarnessRunResult, McpServer
 from pydantic import BaseModel
 
-_MODEL = PiHarness.default_model
 _API_KEY = "sk-pi-secret"  # nosec B105
-_ADAPTER_PATH = "/usr/lib/node_modules/pi-mcp-adapter/index.ts"
+_RUN_DIR = "/home/exedev/work/runs/run-1"
 
 
 class _Contract(BaseModel):
@@ -28,23 +27,19 @@ class _Contract(BaseModel):
     count: int
 
 
-def _sandbox_config() -> SandboxSettings:
-    return SandboxSettings(
-        service_url="https://sandbox.test",
-        service_token="token",
-        service_timeout=30.0,
-        image="image",
-        claude_config_dir=None,
-        codex_config_dir=None,
-    )
-
-
-def _harness(*, effort: str | None = "high", sandbox: bool = True) -> PiHarness:
+def _harness(*, effort: str | None = "high") -> PiHarness:
     return PiHarness(
-        model=_MODEL,
+        model=PiHarness.default_model,
         fast_mode=False,
         effort=effort,
-        sandbox=_sandbox_config() if sandbox else None,
+        sandbox=SandboxSettings(
+            service_url="https://sandbox.test",
+            service_token="token",
+            service_timeout=30.0,
+            image="image",
+            claude_config_dir=None,
+            codex_config_dir=None,
+        ),
     )
 
 
@@ -52,52 +47,55 @@ async def _credentials(cls: type[Harness]) -> dict[str, str]:
     return {"apiKey": _API_KEY}
 
 
+def _parse(
+    stdout: bytes, artifact_dir: Path, *, returncode: int = 0, stderr: bytes = b""
+) -> object:
+    return _harness().parse(
+        HarnessRunResult(returncode=returncode, stdout=stdout, stderr=stderr),
+        artifact_dir=artifact_dir,
+        run_id="run-1",
+    )
+
+
+def _message_end(role: str, **message: object) -> bytes:
+    return json.dumps({"type": "message_end", "message": {"role": role, **message}}).encode()
+
+
 def test_class_facts_and_registration() -> None:
     assert get_harness("pi") is PiHarness
-    assert PiHarness.name == "pi"
-    assert PiHarness.provider == "pi"
     assert PiHarness.command == "pi"
-    assert PiHarness.credentials_path == ".pi/agent/auth.json"
     assert PiHarness.login_kinds == frozenset({"api_key"})
-    assert PiHarness.models == ("openai/gpt-5.5",)
-    assert PiHarness.default_model == "openai/gpt-5.5"
-    assert PiHarness.first_byte_seconds == Harness.first_byte_seconds == 90
-    assert PiHarness.failure_markers is Harness.failure_markers
-    assert "_model_discovery_request" not in PiHarness.__dict__
-    assert "_usage_request" not in PiHarness.__dict__
+    assert PiHarness.credentials_path == ".pi/agent/auth.json"
+    assert PiHarness.default_model in PiHarness.models
 
 
-async def test_build_invocation_writes_files_and_uses_pi_argv(
+async def test_build_invocation_writes_the_run_files_and_pi_argv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
-    server = McpServer(
+    github = McpServer(
         name="github",
         url="https://api.example.test/mcp",
         bearer_token_env_var="MCP_GITHUB_TOKEN",
         headers={"X-Visible": "public"},
         env_headers={"X-Trace-Key": "MCP_TRACE_KEY"},
     )
-    prompt = "A large prompt stays on stdin."
+    public = McpServer(name="public", url="https://public.example.test/mcp")
+
     invocation = await _harness().build_invocation(
-        prompt=prompt,
-        schema={"type": "object", "properties": {"answer": {"type": "string"}}},
+        prompt="A large prompt stays on stdin.",
+        schema={"type": "object"},
         run_id="run-1",
         ssh_username="exedev",
         github_token="github-token",
-        extra_env={
-            "MCP_GITHUB_TOKEN": "mcp-secret",
-            "MCP_TRACE_KEY": "trace-secret",
-        },
-        mcp_servers=(server,),
+        extra_env={"MCP_GITHUB_TOKEN": "mcp-secret", "MCP_TRACE_KEY": "trace-secret"},
+        mcp_servers=(github, public),
     )
 
-    assert invocation.name == "pi"
     assert invocation.args[:2] == ("sh", "-c")
     wrapper = invocation.args[2]
-    wrapper_parts = shlex.split(wrapper)
-    pi_index = wrapper_parts.index("pi")
-    assert wrapper_parts[pi_index:] == [
+    parts = shlex.split(wrapper)
+    assert parts[parts.index("pi") :] == [
         "pi",
         "-p",
         "--mode",
@@ -111,102 +109,18 @@ async def test_build_invocation_writes_files_and_uses_pi_argv(
         "--model",
         "gpt-5.5",
         "-e",
-        "/home/exedev/work/runs/run-1/druks-output.ts",
+        f"{_RUN_DIR}/druks-output.ts",
         "--thinking",
         "high",
         "-e",
-        _ADAPTER_PATH,
+        "/usr/lib/node_modules/pi-mcp-adapter/index.ts",
         "--mcp-config",
-        "/home/exedev/work/runs/run-1/.mcp.json",
+        f"{_RUN_DIR}/.mcp.json",
     ]
-    for filename in ("schema.json", "druks-output.ts", ".mcp.json"):
-        assert f"/home/exedev/work/runs/run-1/{filename}" in wrapper_parts
-    schema_path_index = wrapper_parts.index("/home/exedev/work/runs/run-1/schema.json")
-    assert json.loads(wrapper_parts[schema_path_index - 2]) == {
-        "type": "object",
-        "properties": {"answer": {"type": "string"}},
-    }
-    extension_path_index = wrapper_parts.index("/home/exedev/work/runs/run-1/druks-output.ts")
-    assert "pi.registerTool" in wrapper_parts[extension_path_index - 2]
-    assert invocation.stdin == prompt.encode()
-    assert prompt not in wrapper
-    assert all(prompt not in argument for argument in invocation.args)
-    for secret in (_API_KEY, "mcp-secret", "trace-secret"):
-        assert secret not in wrapper
-        assert all(secret not in argument for argument in invocation.args)
-    assert invocation.cwd is None
-    assert invocation.env == {
-        "MCP_GITHUB_TOKEN": "mcp-secret",
-        "MCP_TRACE_KEY": "trace-secret",
-        "DRUKS_SCHEMA_PATH": "/home/exedev/work/runs/run-1/schema.json",
-        "DRUKS_RESULT_PATH": "/home/exedev/work/runs/run-1/output.json",
-    }
-    assert invocation.credentials.github_token == "github-token"
-    assert invocation.credentials.files[0][0] == ".pi/agent/auth.json"
-    assert json.loads(invocation.credentials.files[0][1]) == {
-        "openai": {"type": "api_key", "key": _API_KEY}
-    }
-    assert invocation.extra_artifact_filenames == ("output.json",)
-    syntax = subprocess.run(
-        ["sh", "-n", "-c", wrapper],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    assert syntax.returncode == 0, syntax.stderr
-
-
-async def test_build_invocation_omits_mcp_adapter_without_servers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
-
-    invocation = await _harness(effort=None).build_invocation(
-        prompt="Prompt",
-        schema={"type": "object"},
-        run_id="run-1",
-        ssh_username="exedev",
-    )
-
-    wrapper = invocation.args[2]
-    assert _ADAPTER_PATH not in wrapper
-    assert "--mcp-config" not in wrapper
-    assert ".mcp.json" not in wrapper
-    assert "--thinking" not in wrapper
-
-
-async def test_build_invocation_writes_standard_mcp_config(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
-    server = McpServer(
-        name="github",
-        url="https://api.example.test/mcp",
-        bearer_token_env_var="MCP_GITHUB_TOKEN",
-        headers={"X-Visible": "public"},
-        env_headers={"X-Trace-Key": "MCP_TRACE_KEY"},
-    )
-    public_server = McpServer(
-        name="public",
-        url="https://public.example.test/mcp",
-    )
-
-    invocation = await _harness().build_invocation(
-        prompt="Prompt",
-        schema={"type": "object"},
-        run_id="run-1",
-        ssh_username="exedev",
-        extra_env={
-            "MCP_GITHUB_TOKEN": "mcp-secret",
-            "MCP_TRACE_KEY": "trace-secret",
-        },
-        mcp_servers=(server, public_server),
-    )
-
-    wrapper_parts = shlex.split(invocation.args[2])
-    mcp_path_index = wrapper_parts.index("/home/exedev/work/runs/run-1/.mcp.json")
-    mcp_body = wrapper_parts[mcp_path_index - 2]
-    assert json.loads(mcp_body) == {
+    written = {parts[i + 1]: parts[i - 1] for i, part in enumerate(parts) if part == ">"}
+    assert json.loads(written[f"{_RUN_DIR}/schema.json"]) == {"type": "object"}
+    assert "pi.registerTool" in written[f"{_RUN_DIR}/druks-output.ts"]
+    assert json.loads(written[f"{_RUN_DIR}/.mcp.json"]) == {
         "mcpServers": {
             "github": {
                 "url": "https://api.example.test/mcp",
@@ -217,37 +131,60 @@ async def test_build_invocation_writes_standard_mcp_config(
                     "X-Visible": "public",
                 },
             },
-            "public": {
-                "url": "https://public.example.test/mcp",
-                "auth": False,
-            },
+            "public": {"url": "https://public.example.test/mcp", "auth": False},
         }
     }
-    assert "mcp-secret" not in mcp_body
-    assert "trace-secret" not in mcp_body
+    assert invocation.stdin == b"A large prompt stays on stdin."
+    assert invocation.env == {
+        "MCP_GITHUB_TOKEN": "mcp-secret",
+        "MCP_TRACE_KEY": "trace-secret",
+        "DRUKS_SCHEMA_PATH": f"{_RUN_DIR}/schema.json",
+        "DRUKS_RESULT_PATH": f"{_RUN_DIR}/output.json",
+    }
+    assert invocation.credentials.github_token == "github-token"
+    assert invocation.credentials.files == (
+        (".pi/agent/auth.json", json.dumps({"openai": {"type": "api_key", "key": _API_KEY}})),
+    )
+    assert invocation.extra_artifact_filenames == ("output.json",)
+    for secret in (_API_KEY, "mcp-secret", "trace-secret"):
+        assert secret not in wrapper
+    syntax = subprocess.run(
+        ["sh", "-n", "-c", wrapper], check=False, capture_output=True, text=True
+    )
+    assert syntax.returncode == 0, syntax.stderr
 
 
-async def test_build_invocation_requires_sandbox_settings(
+async def test_build_invocation_without_servers_or_effort_is_bare(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
 
-    with pytest.raises(HarnessError, match="pi harness requires sandbox settings"):
-        await _harness(sandbox=False).build_invocation(
-            prompt="Prompt",
-            schema={"type": "object"},
-            run_id="run-1",
-            ssh_username="exedev",
-        )
+    invocation = await _harness(effort=None).build_invocation(
+        prompt="Prompt", schema={"type": "object"}, run_id="run-1", ssh_username="exedev"
+    )
+
+    wrapper = invocation.args[2]
+    assert "--thinking" not in wrapper
+    assert "--mcp-config" not in wrapper
+    assert "pi-mcp-adapter" not in wrapper
+    assert ".mcp.json" not in wrapper
 
 
-def test_parse_returns_contract_and_writes_summed_cost(tmp_path: Path) -> None:
-    structured = {"answer": "done", "count": 3}
-    output_dir = tmp_path / "run-1"
-    output_dir.mkdir()
-    (output_dir / "output.json").write_text(json.dumps(structured))
-    first_message = {
-        "role": "assistant",
+async def test_render_credentials_file_keys_the_model_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
+
+    rendered = await PiHarness.render_credentials_file(model="anthropic/claude-opus-5")
+
+    assert json.loads(rendered) == {"anthropic": {"type": "api_key", "key": _API_KEY}}
+
+
+def test_parse_returns_the_contract_and_sums_spend(tmp_path: Path) -> None:
+    (tmp_path / "run-1").mkdir()
+    (tmp_path / "run-1" / "output.json").write_text('{"answer": "done", "count": 3}')
+    first = {
+        "stopReason": "stop",
         "usage": {
             "input": 100,
             "output": 20,
@@ -256,8 +193,8 @@ def test_parse_returns_contract_and_writes_summed_cost(tmp_path: Path) -> None:
             "cost": {"total": 0.125},
         },
     }
-    second_message = {
-        "role": "assistant",
+    second = {
+        "stopReason": "toolUse",
         "usage": {
             "input": 40,
             "output": 10,
@@ -268,31 +205,23 @@ def test_parse_returns_contract_and_writes_summed_cost(tmp_path: Path) -> None:
     }
     stdout = b"\n".join(
         (
-            b"not json",
-            json.dumps({"type": "message_end", "message": first_message}).encode(),
-            json.dumps({"type": "message_end", "message": second_message}).encode(),
-            json.dumps({"type": "turn_end", "message": second_message}).encode(),
-            json.dumps({"type": "agent_end", "messages": [first_message, second_message]}).encode(),
+            b'{"type":"session","version":3}',
+            _message_end("user", content=[]),
+            _message_end("assistant", **first),
+            _message_end("assistant", **second),
+            json.dumps({"type": "turn_end", "message": {"role": "assistant", **second}}).encode(),
+            json.dumps({"type": "agent_end", "messages": [first, second]}).encode(),
         )
     )
 
-    output = _harness().parse(
-        HarnessRunResult(returncode=0, stdout=stdout, stderr=b""),
-        artifact_dir=tmp_path,
-        run_id="run-1",
-    )
+    output = _parse(stdout, tmp_path)
 
     assert _Contract.model_validate(output) == _Contract(answer="done", count=3)
-    assert (output_dir / "output.json").read_text() == json.dumps(
-        structured,
-        indent=2,
-        sort_keys=True,
-    )
-    assert json.loads((output_dir / "cost.json").read_text()) == {
+    assert json.loads((tmp_path / "run-1" / "cost.json").read_text()) == {
         "cost_usd": 0.5,
         "metadata": {
             "provider": "pi",
-            "model": _MODEL,
+            "model": "openai/gpt-5.5",
             "input_tokens": 140,
             "output_tokens": 30,
             "cached_input_tokens": 9,
@@ -302,91 +231,40 @@ def test_parse_returns_contract_and_writes_summed_cost(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("status", "expected"),
+    ("detail", "expected"),
     [
-        (401, HarnessAuthError),
-        (403, HarnessAuthError),
-        (429, HarnessRateLimitError),
-        (500, HarnessOverloadedError),
-        (503, HarnessOverloadedError),
-        (418, HarnessError),
-        (None, HarnessError),
+        ("OpenAI API error (401): bad key", HarnessAuthError),
+        ("OpenAI API error (429): slow down", HarnessRateLimitError),
+        ("OpenAI API error (503): busy", HarnessOverloadedError),
+        ("stream ended without a status", HarnessError),
     ],
 )
-def test_parse_maps_provider_error_status(
-    tmp_path: Path,
-    status: int | None,
-    expected: type[HarnessError],
+def test_parse_classifies_a_provider_error_by_status(
+    tmp_path: Path, detail: str, expected: type[HarnessError]
 ) -> None:
-    error_message = (
-        f"OpenAI API error ({status}): provider detail"
-        if status
-        else "OpenAI provider error without a status"
-    )
-    stdout = json.dumps(
-        {
-            "type": "message_end",
-            "message": {
-                "role": "assistant",
-                "stopReason": "error",
-                "errorMessage": error_message,
-            },
-        }
-    ).encode()
+    stdout = _message_end("assistant", stopReason="error", errorMessage=detail)
 
     with pytest.raises(expected) as error:
-        _harness().parse(
-            HarnessRunResult(returncode=0, stdout=stdout, stderr=b""),
-            artifact_dir=tmp_path,
-            run_id="run-1",
-        )
+        _parse(stdout, tmp_path)
 
     assert type(error.value) is expected
-    assert str(error.value) == error_message
+    assert str(error.value) == detail
 
 
-def test_parse_checks_returncode_before_provider_error(tmp_path: Path) -> None:
-    stdout = json.dumps(
-        {
-            "type": "message_end",
-            "message": {
-                "stopReason": "error",
-                "errorMessage": "OpenAI API error (401): bad key",
-            },
-        }
-    ).encode()
+def test_parse_reports_a_nonzero_exit_before_reading_the_stream(tmp_path: Path) -> None:
+    stdout = _message_end("assistant", stopReason="error", errorMessage="OpenAI API error (401): x")
 
     with pytest.raises(HarnessError, match="pi exited with 1.*extension failed") as error:
-        _harness().parse(
-            HarnessRunResult(returncode=1, stdout=stdout, stderr=b"extension failed\n"),
-            artifact_dir=tmp_path,
-            run_id="run-1",
-        )
+        _parse(stdout, tmp_path, returncode=1, stderr=b"extension failed\n")
 
     assert type(error.value) is HarnessError
 
 
-def test_parse_rejects_missing_result_without_error_event(tmp_path: Path) -> None:
-    stdout = b'not json\n{"type":"agent_settled"}'
-
-    with pytest.raises(HarnessInvalidOutputError, match="pi did not write result JSON"):
-        _harness().parse(
-            HarnessRunResult(returncode=0, stdout=stdout, stderr=b""),
-            artifact_dir=tmp_path,
-            run_id="run-1",
-        )
+def test_parse_treats_a_missing_result_file_as_invalid_output(tmp_path: Path) -> None:
+    with pytest.raises(HarnessInvalidOutputError, match="did not write result JSON"):
+        _parse(b'{"type":"agent_settled"}', tmp_path)
 
 
-async def test_render_credentials_file_uses_model_provider(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
-
-    rendered = await _harness().render_credentials_file(model="openai/gpt-5.5")
-
-    assert json.loads(rendered) == {"openai": {"type": "api_key", "key": _API_KEY}}
-
-
-def test_model_parts_requires_provider_qualified_model() -> None:
-    with pytest.raises(HarnessError, match="pi model must use provider/model form"):
-        PiHarness._model_parts("gpt-5.5")
+def test_parse_treats_a_broken_stream_as_invalid_output(tmp_path: Path) -> None:
+    with pytest.raises(HarnessInvalidOutputError, match="no usable stream"):
+        _parse(b"not json", tmp_path)

--- a/backend/tests/test_pi.py
+++ b/backend/tests/test_pi.py
@@ -1,0 +1,392 @@
+import json
+import shlex
+import subprocess
+from pathlib import Path
+
+import pytest
+from druks.harnesses.base import Harness
+from druks.harnesses.datastructures import SandboxSettings
+from druks.harnesses.exceptions import (
+    HarnessAuthError,
+    HarnessError,
+    HarnessInvalidOutputError,
+    HarnessOverloadedError,
+    HarnessRateLimitError,
+)
+from druks.harnesses.pi import PiHarness
+from druks.harnesses.registry import get_harness
+from druks.sandbox.datastructures import HarnessRunResult, McpServer
+from pydantic import BaseModel
+
+_MODEL = PiHarness.default_model
+_API_KEY = "sk-pi-secret"  # nosec B105
+_ADAPTER_PATH = "/usr/lib/node_modules/pi-mcp-adapter/index.ts"
+
+
+class _Contract(BaseModel):
+    answer: str
+    count: int
+
+
+def _sandbox_config() -> SandboxSettings:
+    return SandboxSettings(
+        service_url="https://sandbox.test",
+        service_token="token",
+        service_timeout=30.0,
+        image="image",
+        claude_config_dir=None,
+        codex_config_dir=None,
+    )
+
+
+def _harness(*, effort: str | None = "high", sandbox: bool = True) -> PiHarness:
+    return PiHarness(
+        model=_MODEL,
+        fast_mode=False,
+        effort=effort,
+        sandbox=_sandbox_config() if sandbox else None,
+    )
+
+
+async def _credentials(cls: type[Harness]) -> dict[str, str]:
+    return {"apiKey": _API_KEY}
+
+
+def test_class_facts_and_registration() -> None:
+    assert get_harness("pi") is PiHarness
+    assert PiHarness.name == "pi"
+    assert PiHarness.provider == "pi"
+    assert PiHarness.command == "pi"
+    assert PiHarness.credentials_path == ".pi/agent/auth.json"
+    assert PiHarness.login_kinds == frozenset({"api_key"})
+    assert PiHarness.models == ("openai/gpt-5.5",)
+    assert PiHarness.default_model == "openai/gpt-5.5"
+    assert PiHarness.first_byte_seconds == Harness.first_byte_seconds == 90
+    assert PiHarness.failure_markers is Harness.failure_markers
+    assert "_model_discovery_request" not in PiHarness.__dict__
+    assert "_usage_request" not in PiHarness.__dict__
+
+
+async def test_build_invocation_writes_files_and_uses_pi_argv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
+    server = McpServer(
+        name="github",
+        url="https://api.example.test/mcp",
+        bearer_token_env_var="MCP_GITHUB_TOKEN",
+        headers={"X-Visible": "public"},
+        env_headers={"X-Trace-Key": "MCP_TRACE_KEY"},
+    )
+    prompt = "A large prompt stays on stdin."
+    invocation = await _harness().build_invocation(
+        prompt=prompt,
+        schema={"type": "object", "properties": {"answer": {"type": "string"}}},
+        run_id="run-1",
+        ssh_username="exedev",
+        github_token="github-token",
+        extra_env={
+            "MCP_GITHUB_TOKEN": "mcp-secret",
+            "MCP_TRACE_KEY": "trace-secret",
+        },
+        mcp_servers=(server,),
+    )
+
+    assert invocation.name == "pi"
+    assert invocation.args[:2] == ("sh", "-c")
+    wrapper = invocation.args[2]
+    wrapper_parts = shlex.split(wrapper)
+    pi_index = wrapper_parts.index("pi")
+    assert wrapper_parts[pi_index:] == [
+        "pi",
+        "-p",
+        "--mode",
+        "json",
+        "--no-session",
+        "--no-extensions",
+        "--no-skills",
+        "--offline",
+        "--provider",
+        "openai",
+        "--model",
+        "gpt-5.5",
+        "-e",
+        "/home/exedev/work/runs/run-1/druks-output.ts",
+        "--thinking",
+        "high",
+        "-e",
+        _ADAPTER_PATH,
+        "--mcp-config",
+        "/home/exedev/work/runs/run-1/.mcp.json",
+    ]
+    for filename in ("schema.json", "druks-output.ts", ".mcp.json"):
+        assert f"/home/exedev/work/runs/run-1/{filename}" in wrapper_parts
+    schema_path_index = wrapper_parts.index("/home/exedev/work/runs/run-1/schema.json")
+    assert json.loads(wrapper_parts[schema_path_index - 2]) == {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+    }
+    extension_path_index = wrapper_parts.index("/home/exedev/work/runs/run-1/druks-output.ts")
+    assert "pi.registerTool" in wrapper_parts[extension_path_index - 2]
+    assert invocation.stdin == prompt.encode()
+    assert prompt not in wrapper
+    assert all(prompt not in argument for argument in invocation.args)
+    for secret in (_API_KEY, "mcp-secret", "trace-secret"):
+        assert secret not in wrapper
+        assert all(secret not in argument for argument in invocation.args)
+    assert invocation.cwd is None
+    assert invocation.env == {
+        "MCP_GITHUB_TOKEN": "mcp-secret",
+        "MCP_TRACE_KEY": "trace-secret",
+        "DRUKS_SCHEMA_PATH": "/home/exedev/work/runs/run-1/schema.json",
+        "DRUKS_RESULT_PATH": "/home/exedev/work/runs/run-1/output.json",
+    }
+    assert invocation.credentials.github_token == "github-token"
+    assert invocation.credentials.files[0][0] == ".pi/agent/auth.json"
+    assert json.loads(invocation.credentials.files[0][1]) == {
+        "openai": {"type": "api_key", "key": _API_KEY}
+    }
+    assert invocation.extra_artifact_filenames == ("output.json",)
+    syntax = subprocess.run(
+        ["sh", "-n", "-c", wrapper],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+
+async def test_build_invocation_omits_mcp_adapter_without_servers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
+
+    invocation = await _harness(effort=None).build_invocation(
+        prompt="Prompt",
+        schema={"type": "object"},
+        run_id="run-1",
+        ssh_username="exedev",
+    )
+
+    wrapper = invocation.args[2]
+    assert _ADAPTER_PATH not in wrapper
+    assert "--mcp-config" not in wrapper
+    assert ".mcp.json" not in wrapper
+    assert "--thinking" not in wrapper
+
+
+async def test_build_invocation_writes_standard_mcp_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
+    server = McpServer(
+        name="github",
+        url="https://api.example.test/mcp",
+        bearer_token_env_var="MCP_GITHUB_TOKEN",
+        headers={"X-Visible": "public"},
+        env_headers={"X-Trace-Key": "MCP_TRACE_KEY"},
+    )
+    public_server = McpServer(
+        name="public",
+        url="https://public.example.test/mcp",
+    )
+
+    invocation = await _harness().build_invocation(
+        prompt="Prompt",
+        schema={"type": "object"},
+        run_id="run-1",
+        ssh_username="exedev",
+        extra_env={
+            "MCP_GITHUB_TOKEN": "mcp-secret",
+            "MCP_TRACE_KEY": "trace-secret",
+        },
+        mcp_servers=(server, public_server),
+    )
+
+    wrapper_parts = shlex.split(invocation.args[2])
+    mcp_path_index = wrapper_parts.index("/home/exedev/work/runs/run-1/.mcp.json")
+    mcp_body = wrapper_parts[mcp_path_index - 2]
+    assert json.loads(mcp_body) == {
+        "mcpServers": {
+            "github": {
+                "url": "https://api.example.test/mcp",
+                "auth": False,
+                "headers": {
+                    "Authorization": "Bearer ${MCP_GITHUB_TOKEN}",
+                    "X-Trace-Key": "${MCP_TRACE_KEY}",
+                    "X-Visible": "public",
+                },
+            },
+            "public": {
+                "url": "https://public.example.test/mcp",
+                "auth": False,
+            },
+        }
+    }
+    assert "mcp-secret" not in mcp_body
+    assert "trace-secret" not in mcp_body
+
+
+async def test_build_invocation_requires_sandbox_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
+
+    with pytest.raises(HarnessError, match="pi harness requires sandbox settings"):
+        await _harness(sandbox=False).build_invocation(
+            prompt="Prompt",
+            schema={"type": "object"},
+            run_id="run-1",
+            ssh_username="exedev",
+        )
+
+
+def test_parse_returns_contract_and_writes_summed_cost(tmp_path: Path) -> None:
+    structured = {"answer": "done", "count": 3}
+    output_dir = tmp_path / "run-1"
+    output_dir.mkdir()
+    (output_dir / "output.json").write_text(json.dumps(structured))
+    first_message = {
+        "role": "assistant",
+        "usage": {
+            "input": 100,
+            "output": 20,
+            "cacheRead": 5,
+            "cacheWrite": 2,
+            "cost": {"total": 0.125},
+        },
+    }
+    second_message = {
+        "role": "assistant",
+        "usage": {
+            "input": 40,
+            "output": 10,
+            "cacheRead": 4,
+            "cacheWrite": 1,
+            "cost": {"total": 0.375},
+        },
+    }
+    stdout = b"\n".join(
+        (
+            b"not json",
+            json.dumps({"type": "message_end", "message": first_message}).encode(),
+            json.dumps({"type": "message_end", "message": second_message}).encode(),
+            json.dumps({"type": "turn_end", "message": second_message}).encode(),
+            json.dumps({"type": "agent_end", "messages": [first_message, second_message]}).encode(),
+        )
+    )
+
+    output = _harness().parse(
+        HarnessRunResult(returncode=0, stdout=stdout, stderr=b""),
+        artifact_dir=tmp_path,
+        run_id="run-1",
+    )
+
+    assert _Contract.model_validate(output) == _Contract(answer="done", count=3)
+    assert (output_dir / "output.json").read_text() == json.dumps(
+        structured,
+        indent=2,
+        sort_keys=True,
+    )
+    assert json.loads((output_dir / "cost.json").read_text()) == {
+        "cost_usd": 0.5,
+        "metadata": {
+            "provider": "pi",
+            "model": _MODEL,
+            "input_tokens": 140,
+            "output_tokens": 30,
+            "cached_input_tokens": 9,
+            "cache_creation_tokens": 3,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (401, HarnessAuthError),
+        (403, HarnessAuthError),
+        (429, HarnessRateLimitError),
+        (500, HarnessOverloadedError),
+        (503, HarnessOverloadedError),
+        (418, HarnessError),
+        (None, HarnessError),
+    ],
+)
+def test_parse_maps_provider_error_status(
+    tmp_path: Path,
+    status: int | None,
+    expected: type[HarnessError],
+) -> None:
+    error_message = (
+        f"OpenAI API error ({status}): provider detail"
+        if status
+        else "OpenAI provider error without a status"
+    )
+    stdout = json.dumps(
+        {
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "stopReason": "error",
+                "errorMessage": error_message,
+            },
+        }
+    ).encode()
+
+    with pytest.raises(expected) as error:
+        _harness().parse(
+            HarnessRunResult(returncode=0, stdout=stdout, stderr=b""),
+            artifact_dir=tmp_path,
+            run_id="run-1",
+        )
+
+    assert type(error.value) is expected
+    assert str(error.value) == error_message
+
+
+def test_parse_checks_returncode_before_provider_error(tmp_path: Path) -> None:
+    stdout = json.dumps(
+        {
+            "type": "message_end",
+            "message": {
+                "stopReason": "error",
+                "errorMessage": "OpenAI API error (401): bad key",
+            },
+        }
+    ).encode()
+
+    with pytest.raises(HarnessError, match="pi exited with 1.*extension failed") as error:
+        _harness().parse(
+            HarnessRunResult(returncode=1, stdout=stdout, stderr=b"extension failed\n"),
+            artifact_dir=tmp_path,
+            run_id="run-1",
+        )
+
+    assert type(error.value) is HarnessError
+
+
+def test_parse_rejects_missing_result_without_error_event(tmp_path: Path) -> None:
+    stdout = b'not json\n{"type":"agent_settled"}'
+
+    with pytest.raises(HarnessInvalidOutputError, match="pi did not write result JSON"):
+        _harness().parse(
+            HarnessRunResult(returncode=0, stdout=stdout, stderr=b""),
+            artifact_dir=tmp_path,
+            run_id="run-1",
+        )
+
+
+async def test_render_credentials_file_uses_model_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
+
+    rendered = await _harness().render_credentials_file(model="openai/gpt-5.5")
+
+    assert json.loads(rendered) == {"openai": {"type": "api_key", "key": _API_KEY}}
+
+
+def test_model_parts_requires_provider_qualified_model() -> None:
+    with pytest.raises(HarnessError, match="pi model must use provider/model form"):
+        PiHarness._model_parts("gpt-5.5")

--- a/backend/tests/test_user_settings.py
+++ b/backend/tests/test_user_settings.py
@@ -41,6 +41,7 @@ async def test_harnesses_seeded_with_shipped_defaults(session):
         "claude",
         "codex",
         "opencode",
+        "pi",
     }
 
 


### PR DESCRIPTION
`PiHarness` runs one prompt through the pi CLI as pure argv — no sidecar server and no abort protocol.

`build_invocation` writes three files into the run directory and then runs one command. pi has no output-schema flag, so the run's contract rides as the parameters of a terminating `submit_result` tool, declared by a static extension shipped beside the harness. MCP servers get a standard `.mcp.json` next to it, with every secret named by environment variable and never written into the file or into argv.

A runtime provider failure exits zero, so `parse` reads the stream rather than the exit code: the HTTP status carried in the message's `errorMessage` picks the typed error, while a nonzero exit stays a configuration failure. A run that leaves no result file and reported no error is an invalid payload, which the platform retry already covers. The cost sidecar carries the summed spend and token counts.

The credential is one 0600 file at `~/.pi/agent/auth.json`, keyed by the provider half of the model id.

Three suite tests enumerate the harness registry and learn about pi here. Two of them, in `test_user_settings` and `test_doctor`, are already red on the base branch — they were left behind when opencode registered — so they gain both names.

Base: this stacks on #394.
