### PR TITLE
Providers own logins, quota, and the connect flow

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,7 +58,7 @@ the error.
 ## 5. Hand back to the operator
 
 Report that the installation succeeded. Tell the operator to open
-<http://127.0.0.1:8001>. Connect a harness under **Settings → Harnesses**.
+<http://127.0.0.1:8001>. Connect a provider under **Settings → Providers**.
 Agent runs do not start with a disconnected harness. Then connect the GitHub
 App that Druks uses. Run `docker compose exec web druks doctor --sandbox` to
 prove the full sandbox path with a real container.

--- a/backend/druks/accounts/dependencies.py
+++ b/backend/druks/accounts/dependencies.py
@@ -90,7 +90,7 @@ async def require_operator(websocket: WebSocket) -> Account:
     if not account:
         raise HTTPException(
             status_code=409,
-            detail="No operator account exists yet — connect a harness to finish setup.",
+            detail="No operator account exists yet — connect a provider to finish setup.",
         )
     return account
 
@@ -108,7 +108,7 @@ async def current_account(
         if not account:
             raise HTTPException(
                 status_code=409,
-                detail="No operator account exists yet — connect a harness to finish setup.",
+                detail="No operator account exists yet — connect a provider to finish setup.",
             )
     token = current_account_id.set(account.id)
     try:
@@ -126,7 +126,7 @@ async def current_session_account(request: Request) -> AsyncIterator[Account]:
     if not account:
         raise HTTPException(
             status_code=409,
-            detail="No operator account exists yet — connect a harness to finish setup.",
+            detail="No operator account exists yet — connect a provider to finish setup.",
         )
     token = current_account_id.set(account.id)
     try:

--- a/backend/druks/accounts/routes.py
+++ b/backend/druks/accounts/routes.py
@@ -4,7 +4,7 @@ from druks.accounts.constants import PAT_NAME_LENGTH
 from druks.accounts.dependencies import current_account_or_setup, current_session_account
 from druks.accounts.models import Account, PersonalAccessToken
 from druks.accounts.schemas import AccountResponse, IdentityResponse, PatResponse
-from druks.harnesses.models import HarnessConnection
+from druks.harnesses.models import ProviderLogin
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -16,9 +16,9 @@ async def get_identity(
     return IdentityResponse(
         auth_mode=request.app.state.settings.identity.mode,
         account=AccountResponse.model_validate(account) if account else None,
-        # An account needs onboarding exactly while it has no harness
-        # connection; none/zero is onboarding before the account exists.
-        onboarding_required=not (account and await HarnessConnection.list_for_account(account.id)),
+        # An account needs onboarding exactly while it holds no provider
+        # login; none/zero is onboarding before the account exists.
+        onboarding_required=not (account and await ProviderLogin.list_for_account(account.id)),
     )
 
 

--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -17,8 +17,12 @@ from druks.durable.engine import _step_engine, step_session
 from druks.durable.exceptions import WorkflowError
 from druks.durable.models import AgentCall, Artifact
 from druks.files.datastructures import File
-from druks.harnesses.exceptions import HarnessError, HarnessInvalidOutputError, Retry
-from druks.harnesses.models import HarnessConnection
+from druks.harnesses.exceptions import (
+    HarnessError,
+    HarnessInvalidOutputError,
+    Retry,
+)
+from druks.harnesses.models import ProviderLogin
 from druks.harnesses.registry import get_harness_for_model
 from druks.prompts import render_prompt
 from druks.sandbox import gate as sandbox_gate
@@ -48,7 +52,7 @@ async def _runner(
 ) -> AsyncIterator["Workspace"]:
     # The agent always runs in a Workspace. A warm run attaches the run's held VM; the
     # rest get a fresh ephemeral VM. Either way workflow.get_workspace() turns the VM into
-    # the runner — fresh per call, so nothing (connection or credential) is held across steps.
+    # the runner — fresh per call, so nothing (connection or login) is held across steps.
     if host_id:
         vm = sandbox_client.attach(host_id=host_id)
     else:
@@ -196,11 +200,12 @@ class Agent:
             # Runs as its own step: the body does no IO, and replay reuses the
             # recorded wait instead of re-reading the scrape.
             async with step_session():
-                harness = await get_harness_for_model(await self.get_model_name())
-                # The scrape belongs to the charged connection — its account
+                model = await self.get_model_name()
+                provider_id = (await get_harness_for_model(model)).provider_for(model)
+                # The scrape belongs to the charged login — its account
                 # differs from the run's on fallback.
-                connection = await HarnessConnection.lookup(harness.name, workflow.account_id)
-                scrape = await UsageScrape.latest_for(harness.name, connection.account_id)
+                login = await ProviderLogin.lookup(provider_id, workflow.account_id)
+                scrape = await UsageScrape.latest_for(provider_id, login.account_id)
                 if scrape:
                     now = datetime.now(UTC)
                     reset = scrape.soonest_reset_after(now)
@@ -267,9 +272,9 @@ class Agent:
         workflow = current_workflow.get()
         # Refusing an unservable call here beats provisioning a VM and
         # 401ing mid-run.
-        connection = await HarnessConnection.lookup(harness.name, workflow.account_id)
+        login = await ProviderLogin.lookup(harness.provider_for(model), workflow.account_id)
         # Plain snapshots: the commits below expire the ORM row mid-flight.
-        connection_id, charged_account_id = connection.id, connection.account_id
+        connection_id, charged_account_id = login.id, login.account_id
         # An agent call is a durability boundary — its effects don't roll back —
         # so commit here rather than hold the step's connection idle through the
         # minutes of provisioning and the run.

--- a/backend/druks/api/server.py
+++ b/backend/druks/api/server.py
@@ -33,7 +33,7 @@ from druks.durable.engine import init_dbos, launch, shutdown
 from druks.durable.exceptions import AgentCallNotFound
 from druks.events.routes import router as events_router
 from druks.files.routes import router as files_router
-from druks.harnesses.routes import router as harness_connection_router
+from druks.harnesses.routes import router as providers_router
 from druks.mcp.catalog import load_mcp_catalog
 from druks.mcp.gateway import exceptions as gate_errors
 from druks.mcp.gateway.routes import router as gateway_router
@@ -280,7 +280,7 @@ app.include_router(health_router)
 app.include_router(notifications_external_router)
 app.include_router(webhooks_router)
 app.include_router(auth_router)
-app.include_router(harness_connection_router)
+app.include_router(providers_router)
 app.include_router(browser_sessions_router)
 app.include_router(settings_router, dependencies=_identity_gate)
 app.include_router(apps_router, dependencies=_identity_gate)

--- a/backend/druks/core/tasks.py
+++ b/backend/druks/core/tasks.py
@@ -2,7 +2,8 @@ import logging
 
 from druks.files.storage import reap_deleted_file_bytes
 from druks.harnesses.datastructures import RotationResult
-from druks.harnesses.models import HarnessConnection
+from druks.harnesses.models import ProviderLogin
+from druks.harnesses.providers import get_provider
 from druks.harnesses.registry import get_harnesses
 from druks.sandbox import gate
 from druks.user_settings.models import HarnessSettings, UserSettings
@@ -29,56 +30,53 @@ async def refresh_tokens() -> None:
 @task(every="0 6 * * *")
 async def refresh_models() -> None:
     fallback_id = (await UserSettings.get()).fallback_account_id
+    logins = await ProviderLogin.list_all()
     for harness in get_harnesses():
-        connections = await HarnessConnection.list_for_harness(harness.name)
-        if not connections:
+        usable = [login for login in logins if harness.accepts(login)]
+        if not usable:
             continue
-        preferred = [c for c in connections if c.account_id == fallback_id]
+        preferred = [c for c in usable if c.account_id == fallback_id]
         settings = await HarnessSettings.get_registered(harness.name)
-        await settings.refresh_models((preferred or connections)[0])
+        await settings.refresh_models((preferred or usable)[0])
 
 
 async def _refresh() -> dict[str, object]:
-    by_name = {harness.name: harness for harness in get_harnesses()}
-    connections = [
-        connection
-        for connection in await HarnessConnection.list_all()
-        if connection.supports_refresh and connection.harness in by_name
-    ]
+    logins = [login for login in await ProviderLogin.list_all() if login.supports_refresh]
 
     # A refresh 401s a VM mid-call holding the old token, so a due rotation
-    # runs only while its connection is idle — busy defers to the next tick;
+    # runs only while its login is idle — busy defers to the next tick;
     # urgent rotates regardless. rotate_token no-ops rows outside their
     # margin. Snapshot plain values: each refresh commits and expires the
     # session's ORM objects mid-loop.
     rows = [
         (
-            connection.harness,
-            connection.id,
-            by_name[connection.harness].needs_refresh(connection),
-            by_name[connection.harness].refresh_is_urgent(connection),
+            login.provider,
+            login.id,
+            get_provider(login.provider).needs_refresh(login),
+            get_provider(login.provider).refresh_is_urgent(login),
         )
-        for connection in connections
+        for login in logins
     ]
 
     results: list[RotationResult] = []
-    for harness_name, connection_id, is_due, is_urgent in rows:
+    for provider_id, login_id, is_due, is_urgent in rows:
+        provider = get_provider(provider_id)
         if is_due:
-            async with gate.shut(connection_id) as is_idle:
+            async with gate.shut(login_id) as is_idle:
                 if is_idle or is_urgent:
-                    result = await by_name[harness_name].rotate_token(connection_id)
+                    result = await provider.rotate_token(login_id)
                 else:
-                    result = RotationResult(harness_name, "busy", connection_id=connection_id)
+                    result = RotationResult(provider_id, "busy", login_id=login_id)
         else:
-            result = await by_name[harness_name].rotate_token(connection_id)
+            result = await provider.rotate_token(login_id)
         _log_result(result)
         results.append(result)
 
     return {
         "results": [
             {
-                "harness": r.harness,
-                "connection_id": r.connection_id,
+                "provider": r.provider,
+                "login_id": r.login_id,
                 "action": r.action,
                 "error": r.error,
             }
@@ -90,13 +88,15 @@ async def _refresh() -> dict[str, object]:
 def _log_result(result: RotationResult) -> None:
     if result.action == "busy":
         logger.info(
-            "deferring %s rotation for login %s; calls active", result.harness, result.connection_id
+            "deferring %s rotation for login %s; calls active",
+            result.provider,
+            result.login_id,
         )
     elif result.action == "refreshed":
         logger.info(
             "refreshed %s token for login %s; expires_at=%s",
-            result.harness,
-            result.connection_id,
+            result.provider,
+            result.login_id,
             result.expires_at,
         )
     elif result.action == "failed" and result.error != "no_credentials":
@@ -104,14 +104,14 @@ def _log_result(result: RotationResult) -> None:
         # no_credentials is a row deleted mid-tick, not a failure — stay quiet.
         logger.warning(
             "token refresh failed for %s login %s: %s",
-            result.harness,
-            result.connection_id,
+            result.provider,
+            result.login_id,
             result.error,
         )
     elif result.action == "no_refresh_token":
         logger.warning(
             "%s login %s has no refresh token; cannot keep it alive",
-            result.harness,
-            result.connection_id,
+            result.provider,
+            result.login_id,
         )
     # "fresh" and "locked" (another worker owns this row's refresh) are quiet no-ops.

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -23,7 +23,8 @@ from .apps.loader import iter_apps
 from .apps.registry import _ROLES, agents, autodiscover, services, webhooks, workflows
 from .core.apis.github import get_github_client
 from .database import create_async_engine_from_url, create_engine_from_url, session_scope
-from .harnesses.models import HarnessConnection
+from .harnesses.models import ProviderLogin
+from .harnesses.providers import get_providers
 from .harnesses.registry import get_harnesses
 from .sandbox.client import sandbox_client
 from .sandbox.exceptions import TemplateNotFound
@@ -139,29 +140,27 @@ async def check_installations(settings: Settings) -> CheckResult:
     )
 
 
-def _harness_credential_check(
-    name: str, *, connected: bool, expires_at: datetime | None
-) -> CheckResult:
-    check_name = f"{name}_credentials"
+def _login_check(provider_id: str, *, connected: bool, expires_at: datetime | None) -> CheckResult:
+    check_name = f"{provider_id}_login"
     if not connected:
         return CheckResult(
             check_name,
             ok=False,
             pending=True,
-            detail=f"not connected — connect {name} in Settings.",
+            detail=f"not connected — connect {provider_id} in Settings.",
         )
     if expires_at and expires_at <= datetime.now(UTC):
         return CheckResult(
             check_name,
             ok=False,
-            detail=f"token expired {expires_at.isoformat()} — reconnect {name}.",
+            detail=f"token expired {expires_at.isoformat()} — reconnect {provider_id}.",
         )
     detail = f"connected; token expires {expires_at.isoformat()}" if expires_at else "connected"
     return CheckResult(check_name, ok=True, detail=detail)
 
 
-def check_harness_credentials(settings: Settings) -> list[CheckResult]:
-    # One result per registered harness, so a newly-registered one is covered
+def check_provider_logins(settings: Settings) -> list[CheckResult]:
+    # One result per registered provider, so a newly-registered one is covered
     # without editing doctor. Credentials live in the DB: this reports the row's
     # presence + expiry, not a host file. A plain session reads it directly —
     # doctor is a one-off, so it never binds the ambient db_session registry.
@@ -174,16 +173,16 @@ def check_harness_credentials(settings: Settings) -> list[CheckResult]:
                 )
             )
             results: list[CheckResult] = []
-            for harness in get_harnesses():
+            for provider in get_providers():
                 row = session.scalar(
-                    select(HarnessConnection).where(
-                        HarnessConnection.harness == harness.name,
-                        HarnessConnection.account_id == fallback_id,
+                    select(ProviderLogin).where(
+                        ProviderLogin.provider == provider.id,
+                        ProviderLogin.account_id == fallback_id,
                     )
                 )
                 results.append(
-                    _harness_credential_check(
-                        harness.name,
+                    _login_check(
+                        provider.id,
                         connected=bool(row),
                         expires_at=row.expires_at if row else None,
                     )
@@ -191,9 +190,7 @@ def check_harness_credentials(settings: Settings) -> list[CheckResult]:
             return results
     except Exception as error:  # noqa: BLE001 — a DB-read failure is one fail, not a doctor crash
         return [
-            CheckResult(
-                name="harness_credentials", ok=False, detail=f"cannot read credentials: {error}"
-            )
+            CheckResult(name="provider_logins", ok=False, detail=f"cannot read logins: {error}")
         ]
     finally:
         engine.dispose()
@@ -546,7 +543,7 @@ CHECKS = (
     check_webhook_ingress,
     check_service_identities,
     check_installations,
-    check_harness_credentials,
+    check_provider_logins,
     check_data_dir,
     check_database,
     check_redis,
@@ -558,8 +555,8 @@ CHECKS = (
 
 
 async def run_checks(settings: Settings, *, sandbox: bool = False) -> list[CheckResult]:
-    # A check yields one result, or several (check_harness_credentials fans out
-    # over the harness registry).
+    # A check yields one result, or several (check_provider_logins fans out
+    # over the provider registry).
     results: list[CheckResult] = []
     for check in CHECKS:
         outcome = check(settings)

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -1,78 +1,52 @@
-import base64
 import hashlib
 import json
 import logging
-import secrets
-import urllib.parse
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Collection
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 import httpx
-from pydantic import TypeAdapter
 
-from druks.database import db_session
 from druks.mcp import models as mcp_models
 from druks.mcp.helpers import get_bearer_token_env_var
-from druks.redis import get_client
-from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
 from druks.skills.models import Skill
-from druks.usage.models import UsageScrape
 
 from . import exceptions
-from .constants import CONNECT_PENDING_PREFIX, REFRESH_LOCK_PREFIX
 from .datastructures import (
     AgentInvocation,
-    CodexToken,
-    CompletedConnect,
     HarnessRunResult,
-    OAuthToken,
-    ParsedMetric,
     ParsedModels,
-    ParsedUsage,
     ProviderRequest,
-    RotationResult,
     SandboxSettings,
 )
-from .models import HarnessConnection
+from .exceptions import OAuthTokenError
+from .models import ProviderLogin
+from .providers import Token, error_tag, get_provider
 
 if TYPE_CHECKING:
     from druks.sandbox.datastructures import McpServer
 
 logger = logging.getLogger(__name__)
 
-_GRANT_TIMEOUT_SECONDS = 30.0
-_USAGE_TIMEOUT_SECONDS = 20.0
-# The connect-flow pending state (PKCE verifier + state) lives in Redis this
-# long — enough to authorize and paste, short enough that an abandoned attempt
-# clears.
-_CONNECT_PENDING_TTL_SECONDS = 600
-# Per-row refresh lock: five minutes outlives the provider grant timeout and
-# expires before the next 15-minute cron tick if the holder dies mid-refresh.
-_REFRESH_LOCK_TTL_SECONDS = 300
+_DISCOVERY_TIMEOUT_SECONDS = 20.0
 
 # The capability manifest is a plain JSON dict written per AgentCall. Bump when
 # the recorded shape changes so a reader can tell manifests apart across
 # versions; the value is part of the hash, so a bump reshuffles the buckets.
 MANIFEST_SCHEMA_VERSION = 2
 
-Token = OAuthToken | CodexToken
-
-_WEEKLY_WINDOWS = TypeAdapter(tuple[ParsedMetric, ...])
-
 
 class Harness(ABC):
     name: str
     command: ClassVar[str]
-    login_kinds: ClassVar[frozenset[str]] = frozenset({"subscription"})
-    credentials_path: ClassVar[str]
-    # Harness identity + shipped config, the seed source for the per-harness
-    # ``HarnessSettings`` row the operator then tunes. Subclasses set provider,
-    # models and default_model; effort/timeout default to the shipped values.
-    provider: ClassVar[str]
+    # The login kinds this CLI consumes: "oauth" for a subscription CLI,
+    # "api_key" for one that runs on a pasted key.
+    login_kinds: ClassVar[frozenset[str]]
+    # The one provider a subscription CLI is bound to. None for a key CLI,
+    # which runs whichever provider the model names.
+    provider: ClassVar[str | None] = None
     # Suggested models for the settings picker and the ``default_model`` seed.
     models: ClassVar[tuple[str, ...]]
     default_model: ClassVar[str]
@@ -86,10 +60,6 @@ class Harness(ABC):
     # Claude's slowest measured cold start is under 60 seconds. This margin
     # covers slow MCP loads, token refresh, and prompt assembly.
     first_byte_seconds: ClassVar[int | None] = 90
-    # Per-CLI OAuth refresh config (set by subclasses).
-    REFRESH_MARGIN: timedelta
-    _TOKEN_URL: str
-    _CLIENT_ID: str
 
     def __init__(
         self,
@@ -127,6 +97,35 @@ class Harness(ABC):
                 if marker in lowered:
                     raise error(message)
             raise exceptions.HarnessError(message)
+
+    @classmethod
+    def provider_for(cls, model: str) -> str:
+        """The provider whose login ``model`` spends: its namespace, else the
+        provider this CLI is bound to."""
+        provider, separator, _ = model.partition("/")
+        if separator:
+            return provider
+        if cls.provider:
+            return cls.provider
+        raise exceptions.HarnessError(f"{cls.name} needs a provider namespace on model {model!r}.")
+
+    @classmethod
+    def accepts(cls, login: ProviderLogin) -> bool:
+        """Whether this CLI runs on ``login``."""
+        bound = not cls.provider or cls.provider == login.provider
+        return bound and login.kind in cls.login_kinds
+
+    async def login(self, login_id: str | None) -> ProviderLogin:
+        """The selected login, read fresh at push time; with none
+        selected, the fallback account's for this model's provider. A vanished
+        row fails the call rather than render another account's."""
+        if login_id:
+            if row := await ProviderLogin.get(login_id):
+                return row
+            raise exceptions.HarnessNotConnectedError(
+                "the selected login was removed — reconnect it in Settings → Providers."
+            )
+        return await ProviderLogin.lookup(self.provider_for(self.model), None)
 
     async def get_manifest(
         self,
@@ -201,347 +200,20 @@ class Harness(ABC):
         return call_id or str(uuid.uuid4())
 
     @classmethod
-    async def get_credentials(cls) -> dict:
-        """The fallback account's credential dict — for callers with no
-        selection."""
-        row = await HarnessConnection.get_for_account(cls.name, fallback=True)
-        data = dict(row.payload) if row else None
-        if data:
-            return data
-        raise exceptions.HarnessNotConnectedError(
-            f"{cls.name} is not connected — connect it in Settings → Harnesses."
-        )
-
-    @classmethod
-    async def render_credentials_file(cls, connection_id: str | None = None) -> str:
-        """The selected connection's payload, read fresh at push time; a
-        vanished row fails the call rather than render another account's."""
-        if not connection_id:
-            return json.dumps(await cls.get_credentials())
-        row = await HarnessConnection.get(connection_id)
-        if row:
-            return json.dumps(dict(row.payload))
-        raise exceptions.HarnessNotConnectedError(
-            f"the selected {cls.name} connection was removed — reconnect it in "
-            "Settings → Harnesses."
-        )
-
-    @classmethod
-    async def connect_start(cls, *, account_id: str | None = None) -> tuple[str, str]:
-        """Mint PKCE state under a single-use flow id; return (authorize URL,
-        flow id). A flow started by a resolved operator binds ``account_id``."""
-        verifier = _b64url(secrets.token_bytes(64))
-        challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
-        url, state = cls.authorize_url(verifier=verifier, challenge=challenge)
-        flow_id = secrets.token_urlsafe(24)
-        pending = json.dumps(
-            {
-                "verifier": verifier,
-                "state": state,
-                "account_id": account_id,
-            }
-        )
-        await get_client().set(
-            f"{CONNECT_PENDING_PREFIX}{flow_id}", pending, ex=_CONNECT_PENDING_TTL_SECONDS
-        )
-        return url, flow_id
-
-    @classmethod
-    async def connect_complete(cls, *, flow_id: str, pasted: str) -> CompletedConnect:
-        """Pop the flow's single-use state, parse the paste, exchange the code.
-        Raises :class:`ConnectError` on failure; the state is gone either way,
-        so a retry re-starts cleanly."""
-        pending = await get_client().getdel(f"{CONNECT_PENDING_PREFIX}{flow_id}")  # single-use
-        if not pending:
-            raise exceptions.ConnectError("This connect attempt expired — start it again.")
-        expected = json.loads(pending)
-
-        code, pasted_state = _parse_pasted(pasted)
-        if not code:
-            raise exceptions.ConnectError("Couldn't find an authorization code in what you pasted.")
-        if pasted_state and pasted_state != expected["state"]:
-            raise exceptions.ConnectError(
-                "That code is from a different connect attempt — start it again."
-            )
-
-        payload, provider_email = await cls.exchange(code=code, verifier=expected["verifier"])
-        if not provider_email:
-            raise exceptions.ConnectError(
-                "The provider returned no account email — authorize with an account "
-                "that has one and try again."
-            )
-        _, expires_at = cls._refresh_state(payload)
-        return CompletedConnect(
-            payload=payload,
-            provider_email=provider_email,
-            expires_at=expires_at,
-            account_id=expected["account_id"],
-        )
-
-    @classmethod
-    def authorize_url(cls, *, verifier: str, challenge: str) -> tuple[str, str]:
-        """Build this provider's PKCE authorize URL; return (url, state), where
-        ``state`` is what the provider echoes back so connect_complete can
-        verify the round-trip."""
-        raise NotImplementedError
-
-    @classmethod
-    async def exchange(cls, *, code: str, verifier: str) -> tuple[dict, str | None]:
-        """Exchange the authorization code for tokens; return (credential-file
-        payload, provider-reported account email)."""
-        raise NotImplementedError
-
-    @classmethod
-    def load_token(cls, connection: HarnessConnection, *, now: datetime | None = None) -> Token:
-        """Read + validate ``connection``'s access token, or raise
-        :class:`OAuthTokenError`. Read-only; never refreshes."""
-        token = cls._token_from_credentials(dict(connection.payload))
-        moment = now or _utc_now()
-        if token.expires_at and token.expires_at <= moment:
-            raise exceptions.OAuthTokenError(
-                "token_expired", f"access token expired at {token.expires_at.isoformat()}"
-            )
-        return token
-
-    @classmethod
-    def _token_from_credentials(cls, data: dict) -> Token:
-        """Extract the token object from the parsed credential file;
-        raise ``OAuthTokenError('no_token')`` if absent."""
-        raise NotImplementedError
-
-    @classmethod
-    async def rotate_token(
-        cls,
-        connection_id: str,
-        *,
-        now: datetime | None = None,
-        margin: timedelta | None = None,
-    ) -> RotationResult:
-        """Refresh one connection row's token if it's within the expiry margin,
-        persisting the new token back to that row. Addressed by row id and
-        read fresh — the caller's tick may span other rows' commits. One
-        refresher per row: a Redis lock elects the winner, and the loser
-        reports ``locked`` without touching the provider — two concurrent
-        grants on one refresh lineage trip the provider's reuse detection."""
-        moment = now or _utc_now()
-        row = await HarnessConnection.reload(connection_id)
-        if not row:
-            return RotationResult(
-                cls.name, "failed", error="no_credentials", connection_id=connection_id
-            )
-        data = dict(row.payload)
-        refresh_token, expires_at = cls._refresh_state(data)
-        if not refresh_token:
-            return RotationResult(cls.name, "no_refresh_token", connection_id=connection_id)
-
-        limit = margin if margin is not None else cls.REFRESH_MARGIN
-        if expires_at and expires_at - moment > limit:
-            return RotationResult(
-                cls.name, "fresh", expires_at=expires_at, connection_id=connection_id
-            )
-
-        redis = get_client()
-        lock_key = f"{REFRESH_LOCK_PREFIX}{connection_id}"
-        if not await redis.set(lock_key, "1", nx=True, ex=_REFRESH_LOCK_TTL_SECONDS):
-            return RotationResult(cls.name, "locked", connection_id=connection_id)
-        try:
-            # Re-read after winning the lock: the previous holder may have
-            # advanced this lineage (or deleted the row) after our first read.
-            row = await HarnessConnection.reload(connection_id)
-            if not row:
-                return RotationResult(
-                    cls.name, "failed", error="no_credentials", connection_id=connection_id
-                )
-            data = dict(row.payload)
-            refresh_token, expires_at = cls._refresh_state(data)
-            if not refresh_token:
-                return RotationResult(cls.name, "no_refresh_token", connection_id=row.id)
-            if expires_at and expires_at - moment > limit:
-                return RotationResult(
-                    cls.name, "fresh", expires_at=expires_at, connection_id=row.id
-                )
-
-            try:
-                grant = await _post_grant(cls._TOKEN_URL, cls._grant_body(refresh_token))
-                new_expiry = cls._apply_refresh(data, grant, moment)
-            except exceptions.GrantError as exc:
-                if exc.tag == "invalid_grant":
-                    # The provider revoked this row's refresh lineage;
-                    # presenting it again can never succeed. Drop only this
-                    # credential so the connection reads as disconnected — the
-                    # UI shows Reconnect and the next tick has no row to hammer.
-                    await row.delete()
-                    await db_session().commit()
-                    logger.warning(
-                        "%s connection %s auto-disconnected after invalid_grant; "
-                        "reconnect to restore",
-                        cls.name,
-                        row.id,
-                    )
-                return RotationResult(cls.name, "failed", error=exc.tag, connection_id=row.id)
-            except ValueError:
-                return RotationResult(
-                    cls.name, "failed", error="bad_response", connection_id=row.id
-                )
-
-            await row.update_payload(data, expires_at=new_expiry)
-            # The grant is externally anchored — the provider may have killed
-            # the old refresh token the moment it issued this one — so the new
-            # lineage must be committed before the lock releases; deferring to
-            # the step's own commit would let a concurrent refresher take the
-            # freed lock and re-present the superseded token.
-            await db_session().commit()
-            return RotationResult(
-                cls.name, "refreshed", expires_at=new_expiry, connection_id=row.id
-            )
-        finally:
-            await redis.delete(lock_key)
-
-    @classmethod
-    def refresh_is_urgent(cls, connection: HarnessConnection) -> bool:
-        """Expiry inside the call horizon: a mid-run 401 is unavoidable."""
-        _, expires_at = cls._refresh_state(dict(connection.payload))
-        if not expires_at:
-            return False
-        return expires_at - _utc_now() < timedelta(seconds=MAX_AGENT_TIMEOUT_SECONDS)
-
-    @classmethod
-    def needs_refresh(cls, connection: HarnessConnection) -> bool:
-        """Whether the access token is inside its refresh margin. Unreadable
-        or expired reads False: nothing live to protect, rotate ungated."""
-        try:
-            token = cls._token_from_credentials(dict(connection.payload))
-        except exceptions.OAuthTokenError:
-            return False
-        if not token.expires_at:
-            return False
-        now = _utc_now()
-        if token.expires_at <= now:
-            return False
-        return token.expires_at - now <= cls.REFRESH_MARGIN
-
-    @classmethod
-    def _refresh_state(cls, data: dict) -> tuple[str | None, datetime | None]:
-        """Return (refresh_token, current_expiry) from the credential file."""
-        raise NotImplementedError
-
-    @classmethod
-    def _grant_body(cls, refresh_token: str) -> dict:
-        """The JSON body for this CLI's refresh grant."""
-        raise NotImplementedError
-
-    @classmethod
-    def _apply_refresh(cls, data: dict, grant: dict, now: datetime) -> datetime | None:
-        """Merge the grant response into ``data`` in place; return the new
-        expiry. Raise ``ValueError`` if the response is unusable."""
-        raise NotImplementedError
-
-    @classmethod
-    async def fetch_usage(
-        cls, connection: HarnessConnection, *, now: datetime | None = None
-    ) -> ParsedUsage:
-        """Fetch + parse the connection's remaining-quota snapshot from its
-        subscription endpoint. Auth/HTTP failures collapse to a
-        ``ParsedUsage(ok=False, error=<tag>)`` so they never look like
-        '0 metrics'."""
-        try:
-            token = cls.load_token(connection, now=now)
-            request = cls._usage_request(token)
-        except exceptions.OAuthTokenError as exc:
-            return ParsedUsage(ok=False, error=exc.tag)
-        except NotImplementedError:
-            return ParsedUsage(ok=False, error="unsupported")
-        try:
-            async with httpx.AsyncClient(timeout=_USAGE_TIMEOUT_SECONDS) as client:
-                response = await client.get(request.url, headers=request.headers)
-        except httpx.TimeoutException:
-            return ParsedUsage(ok=False, error="timeout")
-        except httpx.HTTPError as exc:
-            logger.warning("usage request failed for %s: %s", cls.name, exc, exc_info=True)
-            return ParsedUsage(ok=False, error="network")
-
-        if response.status_code == 200:
-            return cls._parse_usage(response.text)
-        tag = _error_tag(response.status_code)
-        logger.warning(
-            "usage endpoint %s for %s: %s",
-            response.status_code,
-            cls.name,
-            response.text[:300],
-        )
-        return ParsedUsage(ok=False, error=tag)
-
-    @classmethod
-    async def poll_usage(cls, connection: HarnessConnection) -> dict[str, object]:
-        """Fetch the connection's quota snapshot and persist it as that
-        account's UsageScrape row."""
-        account_id = connection.account_id
-        try:
-            parsed = await cls.fetch_usage(connection)
-        except Exception:  # noqa: BLE001 — a crashed scrape records an error row, not a failed refresh
-            logger.warning("usage fetch crashed for %s", cls.name, exc_info=True)
-            await UsageScrape(
-                harness=cls.name,
-                account_id=account_id,
-                parse_ok=False,
-                raw_output=None,
-                error="crashed",
-            ).save()
-            return {
-                "harness": cls.name,
-                "account_id": account_id,
-                "status": "errored",
-                "parse_ok": False,
-                "error": "crashed",
-            }
-
-        snapshot = UsageScrape(
-            harness=cls.name,
-            account_id=account_id,
-            parse_ok=parsed.ok,
-            raw_output=parsed.raw[-8000:] if parsed.raw else None,  # cap to avoid bloat
-            error=parsed.error if not parsed.ok else None,
-            plan_tier=parsed.plan_tier,
-            unlimited=parsed.unlimited,
-        )
-        if parsed.five_hour:
-            snapshot.five_hour_percent_left = parsed.five_hour.percent_left
-            snapshot.five_hour_resets_at = parsed.five_hour.resets_at
-        snapshot.weeks = _WEEKLY_WINDOWS.dump_python(parsed.weeks, mode="json")
-        await snapshot.save()
-        return {
-            "harness": cls.name,
-            "account_id": account_id,
-            "status": "recorded",
-            "parse_ok": parsed.ok,
-            "error": parsed.error if not parsed.ok else None,
-        }
-
-    @classmethod
-    def _usage_request(cls, token: Token) -> ProviderRequest:
-        """The authenticated request for the usage endpoint."""
-        raise NotImplementedError
-
-    @classmethod
-    def _parse_usage(cls, raw: str) -> ParsedUsage:
-        """Map the usage endpoint's JSON body into :class:`ParsedUsage`."""
-        return ParsedUsage(ok=False, error="unsupported")
-
-    @classmethod
-    async def fetch_models(cls, connection: HarnessConnection) -> ParsedModels:
+    async def fetch_models(cls, login: ProviderLogin) -> ParsedModels:
         """Fetch + parse the provider's selectable-model list for the settings
         picker. Auth/HTTP failures collapse to a ``ParsedModels(ok=False,
         error=<tag>)`` so they never look like 'no models' — the stored list
         only ever advances, it is never wiped by a bad fetch."""
         try:
-            token = cls.load_token(connection)
+            token = get_provider(login.provider).load_token(login)
             request = cls._model_discovery_request(token)
-        except exceptions.OAuthTokenError as exc:
+        except OAuthTokenError as exc:
             return ParsedModels(ok=False, error=exc.tag)
         except NotImplementedError:
             return ParsedModels(ok=False, error="unsupported")
         try:
-            async with httpx.AsyncClient(timeout=_USAGE_TIMEOUT_SECONDS) as client:
+            async with httpx.AsyncClient(timeout=_DISCOVERY_TIMEOUT_SECONDS) as client:
                 response = await client.get(request.url, headers=request.headers)
         except httpx.TimeoutException:
             return ParsedModels(ok=False, error="timeout")
@@ -551,7 +223,7 @@ class Harness(ABC):
 
         if response.status_code == 200:
             return cls._parse_models(response.text)
-        tag = _error_tag(response.status_code)
+        tag = error_tag(response.status_code)
         logger.warning(
             "models endpoint %s for %s: %s",
             response.status_code,
@@ -570,126 +242,6 @@ class Harness(ABC):
         """Map the model-list endpoint's JSON body into :class:`ParsedModels`.
         A payload offering nothing is a tagged error, never an ok-empty."""
         return ParsedModels(ok=False, error="unsupported")
-
-
-def _utc_now() -> datetime:
-    return datetime.now(UTC)
-
-
-def jwt_claims(token: str) -> dict | None:
-    """Best-effort read of a JWT's claims (no signature check)."""
-    try:
-        payload = token.split(".")[1]
-        payload += "=" * (-len(payload) % 4)
-        claims = json.loads(base64.urlsafe_b64decode(payload))
-    except (IndexError, ValueError, json.JSONDecodeError):
-        return None
-    return claims if isinstance(claims, dict) else None
-
-
-def jwt_expiry(token: str) -> datetime | None:
-    """Best-effort read of a JWT's ``exp`` claim (no signature check)."""
-    claims = jwt_claims(token) or {}
-    try:
-        return datetime.fromtimestamp(claims["exp"], tz=UTC)
-    except (KeyError, TypeError, OverflowError, OSError, ValueError):
-        return None
-
-
-def parse_epoch_expiry(value: object) -> datetime | None:
-    """Claude stores ``expiresAt`` as epoch millis; tolerate seconds."""
-    if not isinstance(value, (int, float)):
-        return None
-    seconds = value / 1000 if value > 1e12 else value
-    try:
-        return datetime.fromtimestamp(seconds, tz=UTC)
-    except (OverflowError, OSError, ValueError):
-        return None
-
-
-def _error_tag(status_code: int) -> str:
-    return {
-        401: "unauthorized",
-        403: "forbidden_scope",
-        429: "rate_limited",
-    }.get(status_code, f"http_{status_code}")
-
-
-async def _post_grant(url: str, body: dict) -> dict:
-    """POST a refresh grant and return the parsed grant dict. Raises
-    :class:`GrantError` tagged with why no usable grant came back."""
-    try:
-        async with httpx.AsyncClient(timeout=_GRANT_TIMEOUT_SECONDS) as client:
-            response = await client.post(url, json=body)
-    except httpx.HTTPError as exc:
-        logger.warning("token refresh request failed (%s): %s", url, exc, exc_info=True)
-        raise exceptions.GrantError("network") from exc
-    if response.status_code != 200:
-        logger.warning(
-            "token refresh returned %s (%s): %s",
-            response.status_code,
-            url,
-            response.text[:300],
-        )
-        if "invalid_grant" in response.text:
-            tag = "invalid_grant"
-        else:
-            tag = f"http_{response.status_code}"
-        raise exceptions.GrantError(tag)
-    try:
-        return response.json()
-    except ValueError as exc:
-        raise exceptions.GrantError("bad_response") from exc
-
-
-def _b64url(raw: bytes) -> str:
-    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
-
-
-def _parse_pasted(raw: str) -> tuple[str | None, str | None]:
-    """Pull (code, state) out of whatever the operator pasted — a bare code, a
-    ``code#state`` pair, a raw query string, or a full redirect URL."""
-    value = raw.strip().strip("'\"")
-    if not value:
-        return None, None
-    if "://" in value:
-        query = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(value).query))
-        return query.get("code"), query.get("state")
-    if "#" in value:
-        code, _, state = value.partition("#")
-        return code, state
-    if "code=" in value:
-        query = dict(urllib.parse.parse_qsl(value))
-        return query.get("code"), query.get("state")
-    return value, None
-
-
-async def post_token(url: str, body: dict, *, form: bool) -> dict:
-    """POST an authorization-code exchange (form- or JSON-encoded) and return the
-    parsed grant. Raises :class:`ConnectError` with the provider's error text on
-    any failure, so the operator sees why the connect didn't take."""
-    try:
-        async with httpx.AsyncClient(timeout=_GRANT_TIMEOUT_SECONDS) as client:
-            if form:
-                response = await client.post(url, data=body)
-            else:
-                response = await client.post(url, json=body)
-    except httpx.HTTPError as exc:
-        logger.warning("token exchange request failed (%s): %s", url, exc, exc_info=True)
-        raise exceptions.ConnectError("The request to the provider failed — try again.") from exc
-    if response.status_code != 200:
-        logger.warning(
-            "token exchange returned %s (%s): %s",
-            response.status_code,
-            url,
-            response.text[:300],
-        )
-        detail = response.text.strip()[:300] or f"HTTP {response.status_code}"
-        raise exceptions.ConnectError(f"The provider rejected the connect: {detail}")
-    try:
-        return response.json()
-    except ValueError as exc:
-        raise exceptions.ConnectError("The provider returned an unreadable response.") from exc
 
 
 def _terminal_detail(result: HarnessRunResult) -> str:

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -2,16 +2,15 @@ import contextlib
 import json
 import logging
 import shlex
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlencode
 
-from druks.core.utils.time import ensure_utc
 from druks.sandbox.datastructures import (
     AgentInvocation,
     Credentials,
     HarnessRunResult,
+    HomeCopy,
+    HomeFile,
     McpServer,
 )
 from druks.sandbox.layout import get_runs_root
@@ -19,47 +18,24 @@ from druks.skills.models import Skill
 
 from . import exceptions
 from .artifacts import call_dir, write_cost
-from .base import Harness, parse_epoch_expiry, post_token
+from .base import Harness
 from .constants import CLAUDE_DISALLOWED_TOOLS
-from .datastructures import (
-    OAuthToken,
-    ParsedMetric,
-    ParsedModels,
-    ParsedUsage,
-    ProviderRequest,
-    SandboxSettings,
-)
+from .datastructures import OAuthToken, ParsedModels, ProviderRequest, SandboxSettings
+from .models import ProviderLogin
+from .providers import AnthropicProvider
 
 logger = logging.getLogger(__name__)
-
-
-_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
-# Beta flag the Claude CLI sends for OAuth-scoped endpoints.
-_OAUTH_BETA = "oauth-2025-04-20"
-_ANTHROPIC_VERSION = "2023-06-01"
-_CLAUDE_CODE_USER_AGENT = "claude-code/2.1.0"
 
 
 class ClaudeHarness(Harness):
     # Claude streams its rollout as JSONL on stdout
     # (``--output-format stream-json``), so the transcript is the stdout.
     name = "claude"
-    provider = "anthropic"
+    provider = AnthropicProvider.id
+    login_kinds = frozenset({"oauth"})
     models = ("claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5")
     default_model = "claude-opus-4-7"
     command = "claude"
-    credentials_path = ".claude/.credentials.json"
-
-    # OAuth refresh config (consumed by the Harness templates).
-    REFRESH_MARGIN = timedelta(hours=2)
-    _TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
-    # Public Claude-Code OAuth client id.
-    _CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-
-    # Connect-flow (PKCE code-paste): authorize on claude.ai, land on the
-    # console.anthropic.com code page, exchange JSON with the state echoed in the
-    # body.
-    redirect_uri = "https://console.anthropic.com/oauth/code/callback"
 
     # The CLI dies with the raw API error in the result text ("API Error: 529
     # {…overloaded_error…}"), so "api error: 5" covers 529 and every 5xx; 429
@@ -153,7 +129,7 @@ class ClaudeHarness(Harness):
                 github_token=github_token,
                 include_plugins=include_plugins,
                 skills=skills,
-                connection_id=connection_id,
+                login=await self.login(connection_id),
             ),
             env=extra_env,
             extra_artifact_filenames=("debug.log", "session.jsonl"),
@@ -209,6 +185,10 @@ class ClaudeHarness(Harness):
             entries[server.name] = entry
         return ("--mcp-config", json.dumps({"mcpServers": entries}))
 
+    @classmethod
+    def auth_file(cls, login: ProviderLogin) -> HomeFile:
+        return HomeFile(".claude/.credentials.json", json.dumps(dict(login.payload)))
+
     def _command_args(self) -> tuple[str, ...]:
         args = (self.command,)
         if self.model:
@@ -220,125 +200,10 @@ class ClaudeHarness(Harness):
         return args
 
     @classmethod
-    def _token_from_credentials(cls, data: dict) -> OAuthToken:
-        block = _oauth_block(data)
-        access = block.get("accessToken") or block.get("access_token")
-        if not access:
-            raise exceptions.OAuthTokenError("no_token", "credentials file has no access token")
-        return OAuthToken(
-            access_token=access,
-            expires_at=parse_epoch_expiry(block.get("expiresAt")),
-            scopes=tuple(block.get("scopes") or ()),
-            subscription_type=block.get("subscriptionType"),
-        )
-
-    @classmethod
-    def _refresh_state(cls, data: dict) -> tuple[str | None, datetime | None]:
-        block = _oauth_block(data)
-        refresh = block.get("refreshToken") or block.get("refresh_token")
-        return refresh, parse_epoch_expiry(block.get("expiresAt"))
-
-    @classmethod
-    def _grant_body(cls, refresh_token: str) -> dict:
-        return {
-            "grant_type": "refresh_token",
-            "refresh_token": refresh_token,
-            "client_id": cls._CLIENT_ID,
-        }
-
-    @classmethod
-    def authorize_url(cls, *, verifier: str, challenge: str) -> tuple[str, str]:
-        # Anthropic's console flow echoes the PKCE verifier back as the OAuth
-        # state, so that's what connect_complete checks.
-        params = {
-            "code": "true",
-            "client_id": cls._CLIENT_ID,
-            "response_type": "code",
-            "redirect_uri": cls.redirect_uri,
-            "scope": (
-                "org:create_api_key user:profile user:inference "
-                "user:sessions:claude_code user:mcp_servers user:file_upload"
-            ),
-            "code_challenge": challenge,
-            "code_challenge_method": "S256",
-            "state": verifier,
-        }
-        return f"https://claude.ai/oauth/authorize?{urlencode(params)}", verifier
-
-    @classmethod
-    async def exchange(cls, *, code: str, verifier: str) -> tuple[dict, str | None]:
-        grant = await post_token(
-            cls._TOKEN_URL,
-            {
-                "grant_type": "authorization_code",
-                "client_id": cls._CLIENT_ID,
-                "code": code,
-                "state": verifier,
-                "redirect_uri": cls.redirect_uri,
-                "code_verifier": verifier,
-            },
-            form=False,
-        )
-        block: dict[str, object] = {
-            "accessToken": grant["access_token"],
-            "refreshToken": grant["refresh_token"],
-            "scopes": (grant.get("scope") or "").split(),
-        }
-        expires_in = grant.get("expires_in")
-        if expires_in:
-            expiry = datetime.now(UTC) + timedelta(seconds=expires_in)
-            block["expiresAt"] = int(expiry.timestamp() * 1000)
-        account = (grant.get("account") or {}).get("email_address")
-        return {"claudeAiOauth": block}, account
-
-    @classmethod
-    def _apply_refresh(cls, data: dict, grant: dict, now: datetime) -> datetime | None:
-        block = data["claudeAiOauth"] if isinstance(data.get("claudeAiOauth"), dict) else data
-        access = grant.get("access_token")
-        if not access:
-            raise ValueError("refresh response had no access_token")
-        block["accessToken"] = access
-        if grant.get("refresh_token"):
-            block["refreshToken"] = grant["refresh_token"]
-        expires_in = grant.get("expires_in")
-        if isinstance(expires_in, (int, float)):
-            new_expiry = now + timedelta(seconds=expires_in)
-            block["expiresAt"] = int(new_expiry.timestamp() * 1000)
-            return new_expiry
-        return parse_epoch_expiry(block.get("expiresAt"))
-
-    @classmethod
-    def _usage_request(cls, token: OAuthToken) -> ProviderRequest:
-        return ProviderRequest(_USAGE_URL, cls._oauth_headers(token))
-
-    @classmethod
     def _model_discovery_request(cls, token: OAuthToken) -> ProviderRequest:
         return ProviderRequest(
-            "https://api.anthropic.com/v1/models?limit=100", cls._oauth_headers(token)
+            "https://api.anthropic.com/v1/models?limit=100", AnthropicProvider.oauth_headers(token)
         )
-
-    @classmethod
-    def _oauth_headers(cls, token: OAuthToken) -> dict:
-        return {
-            "Authorization": f"Bearer {token.access_token}",
-            "anthropic-beta": _OAUTH_BETA,
-            "anthropic-version": _ANTHROPIC_VERSION,
-            "User-Agent": _CLAUDE_CODE_USER_AGENT,
-        }
-
-    @classmethod
-    def _parse_usage(cls, raw: str) -> ParsedUsage:
-        try:
-            data = json.loads(raw)
-        except (json.JSONDecodeError, TypeError):
-            return ParsedUsage(ok=False, error="unparseable", raw=raw)
-        if not isinstance(data, dict) or not any(k in data for k in ("five_hour", "seven_day")):
-            return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
-        try:
-            five_hour, weeks = _claude_windows(data)
-        except (KeyError, TypeError, ValueError):
-            return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
-        return ParsedUsage(ok=True, five_hour=five_hour, weeks=weeks, raw=raw)
 
     @classmethod
     def _parse_models(cls, raw: str) -> ParsedModels:
@@ -359,121 +224,46 @@ class ClaudeHarness(Harness):
         return ParsedModels(ok=True, models=models, raw=raw)
 
 
-def _oauth_block(data: dict) -> dict:
-    """Claude nests the OAuth fields under ``claudeAiOauth``; tolerate a
-    flat shape too."""
-    block = data.get("claudeAiOauth") if isinstance(data, dict) else None
-    return block if isinstance(block, dict) else data
-
-
-def _claude_windows(data: dict) -> tuple[ParsedMetric | None, tuple[ParsedMetric, ...]]:
-    """The binding five-hour window and every weekly window in provider order."""
-    five_hour, weekly = [], []
-    for limit in data.get("limits") or []:
-        # A limit can be scoped to something other than a model, which leaves
-        # it counting toward the quota but with no model to name.
-        scope = limit["scope"] or {}
-        window = ParsedMetric(
-            percent_left=max(0, min(100, round(100 - limit["percent"]))),
-            resets_at=_parse_iso(limit.get("resets_at")),
-            model=(scope.get("model") or {}).get("display_name"),
-        )
-        if limit["group"] == "weekly":
-            weekly.append(window)
-        elif limit["group"] == "session":
-            five_hour.append(window)
-    if not weekly and (fallback_week := _claude_metric(data.get("seven_day"))):
-        weekly.append(fallback_week)
-    binding_five_hour = ParsedMetric.binding(five_hour) or _claude_metric(data.get("five_hour"))
-    weekly_windows = tuple(weekly)
-    return binding_five_hour, weekly_windows
-
-
-def _claude_metric(block: object) -> ParsedMetric | None:
-    if not isinstance(block, dict):
-        return None
-    utilization = block.get("utilization")
-    percent_left = None
-    if isinstance(utilization, (int, float)):
-        percent_left = max(0, min(100, int(round(100 - utilization))))
-    resets_at = _parse_iso(block.get("resets_at"))
-    if percent_left is None and resets_at is None:
-        return None
-    return ParsedMetric(percent_left=percent_left, resets_at=resets_at)
-
-
-def _parse_iso(value: object) -> datetime | None:
-    if not isinstance(value, str) or not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(value)
-    except ValueError:
-        return None
-    return ensure_utc(parsed)
-
-
 async def _get_credentials(
     sandbox: SandboxSettings,
     *,
     github_token: str | None,
     include_plugins: bool = True,
     skills: tuple[str, ...] = (),
-    connection_id: str | None = None,
+    login: ProviderLogin,
 ) -> Credentials:
-    """Build the Credentials bundle the runner SFTP-pushes into the sandbox.
-    The credential file is synthesized from the DB row (raises when claude
-    isn't connected); the local config dir only adds config carry on top.
-
-    ``include_plugins=False`` skips uploading the operator's local plugin
-    state — ``installed_plugins.json``, ``known_marketplaces.json``, and
-    the ``plugins/marketplaces`` / ``plugins/cache`` dirs. Used by callers
-    (currently scout) whose claude prompt doesn't talk to any MCP server
-    and would otherwise crash on operator-side plugin misconfiguration —
-    e.g. a github MCP plugin that requires ``GITHUB_PERSONAL_ACCESS_TOKEN``
-    and dies mid-call when it isn't set. ``.claude.json``, ``settings.json``
-    and the skills tree are kept either way; those aren't plugins.
-    """
+    """The Credentials bundle the runner pushes into the sandbox: the rendered
+    credentials file, plus any local config, plugins, and skills.
+    ``include_plugins=False`` skips the operator's plugin state, for prompts
+    that use no MCP server and would otherwise die on a misconfigured plugin."""
     config_dir = sandbox.claude_config_dir
-    config_files: tuple[tuple[Path, str], ...] = ()
-    dirs: tuple[tuple[Path, str], ...] = ()
+    home: list[HomeFile | HomeCopy] = [ClaudeHarness.auth_file(login)]
     if config_dir:
-        config_files = (
-            (config_dir.parent / ".claude.json", ".claude.json"),
-            (config_dir / "settings.json", ".claude/settings.json"),
-            (config_dir / "CLAUDE.md", ".claude/CLAUDE.md"),
-        )
+        home += [
+            HomeCopy(".claude.json", config_dir.parent / ".claude.json"),
+            HomeCopy(".claude/settings.json", config_dir / "settings.json"),
+            HomeCopy(".claude/CLAUDE.md", config_dir / "CLAUDE.md"),
+        ]
         if include_plugins:
-            config_files += (
-                (
-                    config_dir / "plugins" / "installed_plugins.json",
-                    ".claude/plugins/installed_plugins.json",
+            plugins = config_dir / "plugins"
+            home += [
+                HomeCopy(
+                    ".claude/plugins/installed_plugins.json", plugins / "installed_plugins.json"
                 ),
-                (
-                    config_dir / "plugins" / "known_marketplaces.json",
-                    ".claude/plugins/known_marketplaces.json",
+                HomeCopy(
+                    ".claude/plugins/known_marketplaces.json", plugins / "known_marketplaces.json"
                 ),
-            )
-            dirs = (
-                (config_dir / "plugins" / "marketplaces", ".claude/plugins/marketplaces"),
-                (config_dir / "plugins" / "cache", ".claude/plugins/cache"),
-            )
+                HomeCopy(".claude/plugins/marketplaces", plugins / "marketplaces"),
+                HomeCopy(".claude/plugins/cache", plugins / "cache"),
+            ]
     # Skills come from the canonical shared dir (DRUKS_SKILLS_DIR) when set;
     # otherwise fall back to the per-CLI skills subdir.
     skills_src = sandbox.skills_dir or (config_dir / "skills" if config_dir else None)
     if skills_src:
-        dirs += ((skills_src, ".claude/skills"),)
-    return Credentials(
-        files=(
-            (
-                ClaudeHarness.credentials_path,
-                await ClaudeHarness.render_credentials_file(connection_id),
-            ),
-        ),
-        github_token=github_token,
-        extra_config_files=config_files,
-        extra_config_dirs=dirs,
-        extra_dir_excludes={".claude/skills": await Skill.delivery_excludes(skills)},
-    )
+        home.append(
+            HomeCopy(".claude/skills", skills_src, excludes=await Skill.delivery_excludes(skills))
+        )
+    return Credentials(home=tuple(home), github_token=github_token)
 
 
 def collapse_claude_stream(stdout: bytes) -> dict[str, Any]:

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -1,57 +1,42 @@
 import json
 import logging
 import os
-import secrets
 import shlex
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlencode
 
 from druks.sandbox.datastructures import (
     AgentInvocation,
     Credentials,
     HarnessRunResult,
+    HomeCopy,
+    HomeFile,
     McpServer,
 )
 from druks.sandbox.layout import get_runs_root, get_work_root
 from druks.skills.models import Skill
 
 from .artifacts import write_cost
-from .base import Harness, jwt_claims, jwt_expiry, post_token
-from .datastructures import CodexToken, ParsedMetric, ParsedModels, ParsedUsage, ProviderRequest
+from .base import Harness
+from .datastructures import CodexToken, ParsedModels, ProviderRequest
 from .exceptions import (
     HarnessAuthError,
     HarnessError,
     HarnessOverloadedError,
     HarnessRateLimitError,
     HarnessUsageLimitError,
-    OAuthTokenError,
 )
+from .models import ProviderLogin
+from .providers import OpenAiCodexProvider
 from .subprocess import read_result_json
 
 logger = logging.getLogger(__name__)
 
-
-# Namespaced claims OpenAI packs into the Codex access-token JWT.
-_OPENAI_AUTH_CLAIM = "https://api.openai.com/auth"
-_OPENAI_PROFILE_CLAIM = "https://api.openai.com/profile"
-
-
 _TOKEN_COUNT_MARKERS = ('"type":"token_count"', '"type": "token_count"')
-
-# Codex (ChatGPT subscription) usage endpoint — the standalone fetch the
-# `codex` CLI's account/rateLimits/read RPC uses for the `chatgpt` auth
-# app. Returns the same numbers /status shows without a completion.
-_CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
-_CODEX_USER_AGENT = "codex-cli"
-
-# A quota window is named by its declared length, not the slot it arrives in:
-# a plan whose only quota is weekly reports it as the primary window.
-_WEEKLY_WINDOW_MINIMUM_SECONDS = 24 * 3600
 
 
 @dataclass(frozen=True)
@@ -281,11 +266,11 @@ class CodexHarness(Harness):
     # messages) to stdout as it runs — so stdout.jsonl is the live transcript,
     # symmetric with claude. session.jsonl is still snapshotted for cost.
     name = "codex"
-    provider = "openai"
+    provider = OpenAiCodexProvider.id
+    login_kinds = frozenset({"oauth"})
     models = ("gpt-5.5",)
     default_model = "gpt-5.5"
     command = "codex"
-    credentials_path = ".codex/auth.json"
 
     # The CLI's terminal {"type":"error"} event carries prose, not status
     # shapes: stream drops after its internal retries, usage windows, 429s.
@@ -301,105 +286,6 @@ class CodexHarness(Harness):
         "internal server error": HarnessOverloadedError,
     }
 
-    # OAuth refresh config (consumed by the Harness templates).
-    REFRESH_MARGIN = timedelta(hours=24)
-    _TOKEN_URL = "https://auth.openai.com/oauth/token"
-    _CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
-
-    # Connect-flow (PKCE): authorize on auth.openai.com; the operator pastes the
-    # failed localhost redirect URL back.
-    redirect_uri = "http://localhost:1455/auth/callback"
-
-    @classmethod
-    def _token_from_credentials(cls, data: dict) -> CodexToken:
-        tokens = data.get("tokens") if isinstance(data.get("tokens"), dict) else {}
-        access = tokens.get("access_token")
-        if not access:
-            raise OAuthTokenError("no_token", "codex auth file has no access token")
-        return CodexToken(
-            access_token=access,
-            expires_at=jwt_expiry(access),
-            account_id=tokens.get("account_id"),
-        )
-
-    @classmethod
-    def _refresh_state(cls, data: dict) -> tuple[str | None, datetime | None]:
-        tokens = data.get("tokens") if isinstance(data.get("tokens"), dict) else {}
-        return tokens.get("refresh_token"), jwt_expiry(tokens.get("access_token") or "")
-
-    @classmethod
-    def _grant_body(cls, refresh_token: str) -> dict:
-        return {
-            "client_id": cls._CLIENT_ID,
-            "grant_type": "refresh_token",
-            "refresh_token": refresh_token,
-        }
-
-    @classmethod
-    def authorize_url(cls, *, verifier: str, challenge: str) -> tuple[str, str]:
-        state = secrets.token_hex(16)
-        params = {
-            "id_token_add_organizations": "true",
-            "codex_cli_simplified_flow": "true",
-            "originator": "pi",  # the only value verified against the live exchange
-            "client_id": cls._CLIENT_ID,
-            "response_type": "code",
-            "redirect_uri": cls.redirect_uri,
-            "scope": "openid profile email offline_access",
-            "code_challenge": challenge,
-            "code_challenge_method": "S256",
-            "state": state,
-        }
-        return f"https://auth.openai.com/oauth/authorize?{urlencode(params)}", state
-
-    @classmethod
-    async def exchange(cls, *, code: str, verifier: str) -> tuple[dict, str | None]:
-        grant = await post_token(
-            cls._TOKEN_URL,
-            {
-                "grant_type": "authorization_code",
-                "client_id": cls._CLIENT_ID,
-                "code": code,
-                "code_verifier": verifier,
-                "redirect_uri": cls.redirect_uri,
-            },
-            form=True,
-        )
-        access = grant["access_token"]
-        claims = jwt_claims(access) or {}
-        auth = claims.get(_OPENAI_AUTH_CLAIM) or {}
-        profile = claims.get(_OPENAI_PROFILE_CLAIM) or {}
-        payload = {
-            "OPENAI_API_KEY": None,
-            "tokens": {
-                "access_token": access,
-                "refresh_token": grant["refresh_token"],
-                "id_token": grant.get("id_token"),
-                "account_id": auth.get("chatgpt_account_id"),
-            },
-            "last_refresh": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-        }
-        return payload, profile.get("email")
-
-    @classmethod
-    def _apply_refresh(cls, data: dict, grant: dict, now: datetime) -> datetime | None:
-        access = grant.get("access_token")
-        if not access:
-            raise ValueError("refresh response had no access_token")
-        tokens = data["tokens"]
-        tokens["access_token"] = access
-
-        if grant.get("refresh_token"):
-            tokens["refresh_token"] = grant["refresh_token"]
-        if grant.get("id_token"):
-            tokens["id_token"] = grant["id_token"]
-        data["last_refresh"] = now.astimezone(UTC).isoformat().replace("+00:00", "Z")
-        return jwt_expiry(access)
-
-    @classmethod
-    def _usage_request(cls, token: CodexToken) -> ProviderRequest:
-        return ProviderRequest(_CODEX_USAGE_URL, cls._chatgpt_headers(token))
-
     @classmethod
     def _model_discovery_request(cls, token: CodexToken) -> ProviderRequest:
         # ``client_version`` is required and lower-bounds the list (the server
@@ -408,64 +294,7 @@ class CodexHarness(Harness):
         # catches it if the server ever starts rejecting unknown versions.
         return ProviderRequest(
             "https://chatgpt.com/backend-api/codex/models?client_version=99.99.99",
-            cls._chatgpt_headers(token),
-        )
-
-    @classmethod
-    def _chatgpt_headers(cls, token: CodexToken) -> dict:
-        headers = {
-            "Authorization": f"Bearer {token.access_token}",
-            "User-Agent": _CODEX_USER_AGENT,
-        }
-        if token.account_id:
-            headers["ChatGPT-Account-Id"] = token.account_id
-        return headers
-
-    @classmethod
-    def _parse_usage(cls, raw: str) -> ParsedUsage:
-        try:
-            data = json.loads(raw)
-        except (json.JSONDecodeError, TypeError):
-            return ParsedUsage(ok=False, error="unparseable", raw=raw)
-        if not isinstance(data, dict) or "rate_limit" not in data:
-            return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
-        plan = data.get("plan_type") if isinstance(data.get("plan_type"), str) else None
-        try:
-            five_hour, weeks = _codex_windows(data)
-            spend = (data.get("spend_control") or {}).get("individual_limit")
-            if not five_hour and not weeks and spend:
-                # Group-based spend controls replace the rate-limit windows;
-                # their weeks-long quota cycle makes it a weekly window.
-                weeks = (
-                    ParsedMetric(
-                        percent_left=max(0, min(100, round(100 - spend["used_percent"]))),
-                        resets_at=datetime.fromtimestamp(spend["reset_at"], tz=UTC),
-                    ),
-                )
-        except (AttributeError, KeyError, TypeError, ValueError):
-            return ParsedUsage(ok=False, error="unexpected_payload", plan_tier=plan, raw=raw)
-        if not five_hour and not weeks:
-            # Business/enterprise accounts with unlimited credits carry
-            # ``rate_limit: null`` — no windows is the expected shape, not
-            # a parse failure. Report permanently-full buckets.
-            credits = data.get("credits")
-            if isinstance(credits, dict) and credits.get("unlimited"):
-                full = ParsedMetric(percent_left=100, resets_at=None)
-                return ParsedUsage(
-                    ok=True,
-                    plan_tier=plan,
-                    five_hour=full,
-                    weeks=(full,),
-                    unlimited=True,
-                    raw=raw,
-                )
-            return ParsedUsage(ok=False, error="parse_failed", plan_tier=plan, raw=raw)
-        return ParsedUsage(
-            ok=True,
-            plan_tier=plan,
-            five_hour=five_hour,
-            weeks=weeks,
-            raw=raw,
+            OpenAiCodexProvider.chatgpt_headers(token),
         )
 
     @classmethod
@@ -611,7 +440,7 @@ class CodexHarness(Harness):
             credentials=await self._get_credentials(
                 github_token=github_token,
                 skills=skills,
-                connection_id=connection_id,
+                login=await self.login(connection_id),
             ),
             env=extra_env,
             extra_artifact_filenames=("output.json", "session.jsonl"),
@@ -691,57 +520,29 @@ class CodexHarness(Harness):
         *,
         github_token: str | None,
         skills: tuple[str, ...] = (),
-        connection_id: str | None = None,
+        login: ProviderLogin,
     ) -> Credentials:
-        # The credential file is synthesized from the DB row (raises when codex
-        # isn't connected); the local config dir only adds config carry on top.
         assert self.sandbox is not None  # callers guard
         config_dir = self.sandbox.codex_config_dir
-        config_files: tuple[tuple[Path, str], ...] = ()
+        home: list[HomeFile | HomeCopy] = [self.auth_file(login)]
         if config_dir:
-            config_files = (
-                (config_dir / "config.toml", ".codex/config.toml"),
-                (config_dir / ".credentials.json", ".codex/.credentials.json"),
-                (config_dir / "AGENTS.md", ".codex/AGENTS.md"),
-            )
+            home += [
+                HomeCopy(".codex/config.toml", config_dir / "config.toml"),
+                HomeCopy(".codex/.credentials.json", config_dir / ".credentials.json"),
+                HomeCopy(".codex/AGENTS.md", config_dir / "AGENTS.md"),
+            ]
         # Skills from the canonical shared dir (DRUKS_SKILLS_DIR) when set — the
         # same set pushed to ~/.claude/skills — else the per-CLI fallback. Must
         # be real dirs (tar follows symlinks).
         skills_src = self.sandbox.skills_dir or (config_dir / "skills" if config_dir else None)
-        dirs: tuple[tuple[Path, str], ...] = ()
         if skills_src:
-            dirs = ((skills_src, ".codex/skills"),)
-        return Credentials(
-            files=((self.credentials_path, await self.render_credentials_file(connection_id)),),
-            github_token=github_token,
-            extra_config_files=config_files,
-            extra_config_dirs=dirs,
-            extra_dir_excludes={".codex/skills": await Skill.delivery_excludes(skills)},
-        )
-
-
-def _codex_windows(usage: dict) -> tuple[ParsedMetric | None, tuple[ParsedMetric, ...]]:
-    """The binding five-hour window and every weekly window in provider order.
-
-    A window's declared length names it, not the slot it arrives in.
-    """
-    rate_limits = [(None, usage["rate_limit"] or {})]
-    for metered in usage.get("additional_rate_limits") or []:
-        rate_limits.append((metered["limit_name"], metered["rate_limit"] or {}))
-
-    five_hour, weekly = [], []
-    for model, rate_limit in rate_limits:
-        for slot in ("primary_window", "secondary_window"):
-            block = rate_limit.get(slot)
-            if not block:
-                continue
-            window = ParsedMetric(
-                percent_left=max(0, min(100, round(100 - block["used_percent"]))),
-                resets_at=datetime.fromtimestamp(block["reset_at"], tz=UTC),
-                model=model,
+            home.append(
+                HomeCopy(
+                    ".codex/skills", skills_src, excludes=await Skill.delivery_excludes(skills)
+                )
             )
-            if block["limit_window_seconds"] >= _WEEKLY_WINDOW_MINIMUM_SECONDS:
-                weekly.append(window)
-            else:
-                five_hour.append(window)
-    return ParsedMetric.binding(five_hour), tuple(weekly)
+        return Credentials(home=tuple(home), github_token=github_token)
+
+    @classmethod
+    def auth_file(cls, login: ProviderLogin) -> HomeFile:
+        return HomeFile(".codex/auth.json", json.dumps(dict(login.payload)))

--- a/backend/druks/harnesses/datastructures.py
+++ b/backend/druks/harnesses/datastructures.py
@@ -44,12 +44,12 @@ class CompletedConnect:
 
 @dataclass(frozen=True)
 class RotationResult:
-    harness: str
+    provider: str
     # "refreshed" | "fresh" | "busy" | "locked" | "no_refresh_token" | "failed"
     action: str
     error: str | None = None
     expires_at: datetime | None = None
-    connection_id: str | None = None
+    login_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -111,7 +111,7 @@ class SandboxSettings:
     service_timeout: float
     image: str
     # Local CLI config dirs the push anchors config/plugin/skills paths on; the
-    # OAuth credential itself is synthesized from the DB at push time, never
+    # OAuth login itself is synthesized from the DB at push time, never
     # read from under these. None — no local config for that CLI on this host —
     # carries nothing, so a CLI's local config never sprays into a sandbox
     # uninvited.

--- a/backend/druks/harnesses/exceptions.py
+++ b/backend/druks/harnesses/exceptions.py
@@ -75,11 +75,11 @@ class HarnessSandboxProvisioningError(HarnessSandboxError):
 
 
 class OAuthTokenError(Exception):
-    """No usable subscription credential is available.
+    """No usable subscription login is available.
 
     ``tag`` is a short, stable code surfaced on the usage snapshot's
     ``error`` column: ``no_credentials`` (harness not connected),
-    ``no_token`` (credential present, no access token), ``token_expired``
+    ``no_token`` (login present, no access token), ``token_expired``
     (past expiry; the refresh cron hasn't caught up).
     """
 
@@ -107,10 +107,8 @@ class ConnectError(Exception):
 
 
 class HarnessNotConnectedError(HarnessError):
-    """The harness has no stored subscription credential, so nothing that needs
-    auth can run. Connecting in Settings → Harnesses is the only credential
-    path — there is no host-file or baked-API-key fallback — which is what
-    makes "is this harness runnable" decidable before any VM work."""
+    """The run's provider holds no login for the account, so nothing that needs
+    auth can run. Settings → Providers is the only credential path."""
 
     code = "not_connected"
 

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import ForeignKey, String, UniqueConstraint, select
 from sqlalchemy.dialects.postgresql import CITEXT
@@ -8,102 +8,103 @@ from sqlalchemy.orm.attributes import flag_modified
 from druks.accounts.models import Account
 from druks.core.models import Uuid7Pk
 from druks.database import db_session
-from druks.harnesses.exceptions import HarnessNotConnectedError
 from druks.models import Base
 from druks.secrets.fields import EncryptedJsonField
 from druks.user_settings.models import UserSettings
 
+from .exceptions import HarnessNotConnectedError
 
-class HarnessConnection(Base, Uuid7Pk):
-    __tablename__ = "harness_logins"
-    __table_args__ = (UniqueConstraint("harness", "account_id"),)
 
-    harness: Mapped[str]
+class ProviderLogin(Base, Uuid7Pk):
+    """One account's grant to one provider: an API key or an OAuth token set.
+    Every harness that drives the provider runs on this row."""
+
+    __tablename__ = "provider_logins"
+    __table_args__ = (UniqueConstraint("provider", "account_id"),)
+
+    provider: Mapped[str]
     account_id: Mapped[str] = mapped_column(ForeignKey("accounts.id", ondelete="RESTRICT"))
-    # The email the provider reported at the token exchange (citext — matched
-    # case-insensitively). Required as a connect-time snapshot because Claude
-    # states it once and its stored payload carries no identity at all. It can
-    # go stale if the account is renamed upstream and refreshes on the next
-    # connect.
+    # The email the provider reported at connect. Snapshotted because an OAuth
+    # payload carries no identity; a later connect refreshes it.
     provider_email: Mapped[str] = mapped_column(CITEXT)
-    kind: Mapped[str] = mapped_column(String, default="subscription")
+    # "oauth" | "api_key"
+    kind: Mapped[str] = mapped_column(String)
     payload = EncryptedJsonField()
     expires_at: Mapped[datetime | None]
     updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
 
     @classmethod
-    async def get(cls, connection_id: str) -> "HarnessConnection | None":
-        return await db_session().get(cls, connection_id)
+    async def get(cls, login_id: str) -> "ProviderLogin | None":
+        return await db_session().get(cls, login_id)
 
     @classmethod
-    async def lookup(cls, harness: str, account_id: str | None) -> "HarnessConnection":
-        """The connection a call runs with: the account's own, else the
+    async def lookup(cls, provider_id: str, account_id: str | None) -> "ProviderLogin":
+        """The login a call runs with: the account's own, else the
         fallback account's — which carries unmatched work so automation keeps
         moving."""
         if account_id:
-            own = await cls.get_for_account(harness, account_id)
+            own = await cls.get_for_account(provider_id, account_id)
             if own:
                 return own
-        fallback = await cls.get_for_account(harness, fallback=True)
+        fallback = await cls.get_for_account(provider_id, fallback=True)
         if fallback:
             return fallback
         raise HarnessNotConnectedError(
-            f"{harness} is not connected for the fallback account — connect it in "
-            "Settings → Harnesses."
+            f"{provider_id} is not connected for the fallback account — connect it in "
+            "Settings → Providers."
         )
 
     @classmethod
     async def get_for_account(
-        cls, harness: str, account_id: str | None = None, *, fallback: bool = False
-    ) -> "HarnessConnection | None":
-        """``fallback=True`` resolves the fallback account's connection — what
+        cls, provider_id: str, account_id: str | None = None, *, fallback: bool = False
+    ) -> "ProviderLogin | None":
+        """``fallback=True`` resolves the fallback account's login — what
         actor-less execution runs as."""
         if fallback:
             account_id = (await UserSettings.get()).fallback_account_id
         return await db_session().scalar(
-            select(cls).where(cls.harness == harness, cls.account_id == account_id)
+            select(cls).where(cls.provider == provider_id, cls.account_id == account_id)
         )
 
     @classmethod
-    async def list_all(cls) -> list["HarnessConnection"]:
-        return list(await db_session().scalars(select(cls).order_by(cls.harness, cls.id)))
+    async def list_all(cls) -> list["ProviderLogin"]:
+        return list(await db_session().scalars(select(cls).order_by(cls.provider, cls.id)))
 
     @classmethod
-    async def list_for_account(cls, account_id: str) -> list["HarnessConnection"]:
-        stmt = select(cls).where(cls.account_id == account_id).order_by(cls.harness)
+    async def list_for_account(cls, account_id: str) -> list["ProviderLogin"]:
+        stmt = select(cls).where(cls.account_id == account_id).order_by(cls.provider)
         return list(await db_session().scalars(stmt))
 
     @classmethod
-    async def list_for_harness(cls, harness: str) -> list["HarnessConnection"]:
-        stmt = select(cls).where(cls.harness == harness).order_by(cls.id)
+    async def list_for_provider(cls, provider_id: str) -> list["ProviderLogin"]:
+        stmt = select(cls).where(cls.provider == provider_id).order_by(cls.id)
         return list(await db_session().scalars(stmt))
 
     @classmethod
-    async def reload(cls, connection_id: str) -> "HarnessConnection | None":
-        """Fresh-from-DB read of one row, past the identity map's cached state
-        — the post-lock re-read that keeps a refresher from re-presenting a
-        refresh token a concurrent winner already advanced."""
+    async def reload(cls, login_id: str) -> "ProviderLogin | None":
+        """Read one row past the identity map — what a refresher does after it
+        wins the lock, so it never re-presents a token a peer already advanced."""
         return await db_session().scalar(
-            select(cls).where(cls.id == connection_id).execution_options(populate_existing=True)
+            select(cls).where(cls.id == login_id).execution_options(populate_existing=True)
         )
 
     @classmethod
     async def connect(
         cls,
         *,
-        harness: str,
+        provider: str,
         account: Account,
         payload: dict,
         expires_at: datetime | None,
         provider_email: str,
-        kind: str = "subscription",
-    ) -> "HarnessConnection":
-        """Upsert ``account``'s connection for this harness — update its
+        kind: str,
+    ) -> "ProviderLogin":
+        """Upsert ``account``'s login for this provider — update its
         existing row or create one."""
         session = db_session()
-        row = await cls.get_for_account(harness, account.id)
+        row = await cls.get_for_account(provider, account.id)
         if not row:
-            row = cls(harness=harness, account_id=account.id)
+            row = cls(provider=provider, account_id=account.id)
             session.add(row)
         row.kind = kind
         row.payload = payload
@@ -113,20 +114,20 @@ class HarnessConnection(Base, Uuid7Pk):
         return row
 
     @property
+    def is_connected(self) -> bool:
+        return not self.expires_at or self.expires_at > datetime.now(UTC)
+
+    @property
     def supports_refresh(self) -> bool:
-        return self.kind == "subscription"
+        return self.kind == "oauth"
 
     @property
     def is_metered(self) -> bool:
-        return self.kind == "subscription"
+        return self.kind == "oauth"
 
     async def update_payload(self, payload: dict, *, expires_at: datetime | None) -> None:
-        # Whole-value reassignment is the write path: the encrypted column
-        # re-encrypts what it's handed. The caller's dict may alias the live
-        # mapping's nested blocks (a dict() copy is shallow), making old and
-        # new compare content-equal at flush and the UPDATE get skipped —
-        # force the write; this is a secrets store, not somewhere to lose a
-        # token.
+        # A shallow copy aliases the live nested blocks, so old and new compare
+        # equal at flush and the UPDATE is skipped; force the write.
         self.payload = payload
         flag_modified(self, "payload")
         self.expires_at = expires_at

--- a/backend/druks/harnesses/opencode.py
+++ b/backend/druks/harnesses/opencode.py
@@ -16,9 +16,10 @@ from druks.sandbox.layout import get_runs_root, get_work_root
 
 from . import exceptions
 from .artifacts import call_dir, write_cost
-from .base import Harness, _error_tag
+from .base import Harness
 from .datastructures import ParsedModels
-from .models import HarnessConnection
+from .models import ProviderLogin
+from .providers import error_tag
 
 logger = logging.getLogger(__name__)
 
@@ -35,25 +36,18 @@ _ERROR_TYPES = {
 
 class OpenCodeHarness(Harness):
     name = "opencode"
-    provider = "opencode"
+    login_kinds = frozenset({"api_key"})
     models = ("anthropic/claude-sonnet-4-5",)
     default_model = "anthropic/claude-sonnet-4-5"
     command = "opencode"
-    login_kinds = frozenset({"api_key"})
     # The server writes nothing until the message POST completes; the wrapper
     # owns an earlier deadline so it can abort the OpenCode session cleanly.
     first_byte_seconds = None
 
     @classmethod
-    async def render_credentials_file(
-        cls,
-        connection_id: str | None = None,
-        *,
-        model: str | None = None,
-    ) -> str:
-        payload = json.loads(await super().render_credentials_file(connection_id))
-        provider, _, _ = (model or cls.default_model).partition("/")
-        return json.dumps({provider: {"type": "api", "key": payload["api_key"]}})
+    def auth_json(cls, login: ProviderLogin) -> str:
+        """The auth store opencode reads from OPENCODE_AUTH_CONTENT."""
+        return json.dumps({login.provider: {"type": "api", "key": login.payload["api_key"]}})
 
     async def build_invocation(
         self,
@@ -101,9 +95,7 @@ class OpenCodeHarness(Harness):
             credentials=Credentials(github_token=github_token),
             env={
                 **(extra_env or {}),
-                "OPENCODE_AUTH_CONTENT": await self.render_credentials_file(
-                    connection_id, model=self.model
-                ),
+                "OPENCODE_AUTH_CONTENT": self.auth_json(await self.login(connection_id)),
                 "DRUKS_RUN_DIR": f"{get_runs_root(ssh_username)}/{run_id}",
                 "OPENCODE_CONFIG_CONTENT": json.dumps(
                     {"$schema": "https://opencode.ai/config.json", "mcp": mcp},
@@ -135,7 +127,7 @@ class OpenCodeHarness(Harness):
             structured = info["structured"]
             tokens = info["tokens"]
             metadata = {
-                "provider": self.provider,
+                "provider": self.name,
                 "model": self.model,
                 "input_tokens": tokens["input"],
                 "output_tokens": tokens["output"],
@@ -160,7 +152,7 @@ class OpenCodeHarness(Harness):
         return structured
 
     @classmethod
-    async def fetch_models(cls, _connection: HarnessConnection) -> ParsedModels:
+    async def fetch_models(cls, _credential: ProviderLogin) -> ParsedModels:
         # opencode's catalog IS models.dev (same team; its docs say so), so the
         # picker reads the upstream directly — no opencode binary on the druks
         # host. Advisory either way: the CLI's own listing gates on key
@@ -180,7 +172,7 @@ class OpenCodeHarness(Harness):
                 cls.name,
                 response.text[:300],
             )
-            return ParsedModels(ok=False, error=_error_tag(response.status_code))
+            return ParsedModels(ok=False, error=error_tag(response.status_code))
 
         raw = response.text
         # The provider is the model namespace — the same rule the auth store

--- a/backend/druks/harnesses/pi.py
+++ b/backend/druks/harnesses/pi.py
@@ -8,6 +8,7 @@ from druks.sandbox.datastructures import (
     AgentInvocation,
     Credentials,
     HarnessRunResult,
+    HomeFile,
     McpServer,
 )
 from druks.sandbox.layout import get_runs_root
@@ -15,6 +16,7 @@ from druks.sandbox.layout import get_runs_root
 from . import exceptions
 from .artifacts import write_cost
 from .base import Harness
+from .models import ProviderLogin
 from .subprocess import read_result_json
 
 _DRUKS_OUTPUT_TEMPLATE = Path(__file__).parent / "druks-output.ts"
@@ -31,23 +33,15 @@ _STATUS_ERRORS = {
 
 class PiHarness(Harness):
     name = "pi"
-    provider = "pi"
     command = "pi"
-    credentials_path = ".pi/agent/auth.json"
     login_kinds = frozenset({"api_key"})
     models = ("openai/gpt-5.5",)
     default_model = "openai/gpt-5.5"
 
     @classmethod
-    async def render_credentials_file(
-        cls,
-        connection_id: str | None = None,
-        *,
-        model: str | None = None,
-    ) -> str:
-        payload = json.loads(await super().render_credentials_file(connection_id))
-        provider, _, _ = (model or cls.default_model).partition("/")
-        return json.dumps({provider: {"type": "api_key", "key": payload["api_key"]}})
+    def auth_file(cls, login: ProviderLogin) -> HomeFile:
+        auth = {login.provider: {"type": "api_key", "key": login.payload["api_key"]}}
+        return HomeFile(".pi/agent/auth.json", json.dumps(auth))
 
     async def build_invocation(
         self,
@@ -128,18 +122,12 @@ class PiHarness(Harness):
         command_line = " ".join(shlex.quote(argument) for argument in command)
         wrapper = " && ".join((*writes, command_line))
 
-        rendered_credentials = await self.render_credentials_file(
-            connection_id,
-            model=self.model,
-        )
+        auth_file = self.auth_file(await self.login(connection_id))
         return AgentInvocation(
             name=self.name,
             args=("sh", "-c", wrapper),
             stdin=prompt.encode("utf-8"),
-            credentials=Credentials(
-                files=((self.credentials_path, rendered_credentials),),
-                github_token=github_token,
-            ),
+            credentials=Credentials(home=(auth_file,), github_token=github_token),
             env={
                 **(extra_env or {}),
                 "DRUKS_SCHEMA_PATH": in_vm_schema,
@@ -187,6 +175,6 @@ class PiHarness(Harness):
         write_cost(
             call_dir,
             cost_usd=cost_usd,
-            metadata={"provider": self.provider, "model": self.model, **tokens},
+            metadata={"provider": self.name, "model": self.model, **tokens},
         )
         return payload

--- a/backend/druks/harnesses/providers.py
+++ b/backend/druks/harnesses/providers.py
@@ -1,0 +1,871 @@
+import base64
+import hashlib
+import json
+import logging
+import secrets
+import urllib.parse
+from datetime import UTC, datetime, timedelta
+from typing import ClassVar
+from urllib.parse import urlencode
+
+import httpx
+from pydantic import TypeAdapter
+
+from druks.core.utils.time import ensure_utc
+from druks.database import db_session
+from druks.redis import get_client
+from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
+from druks.usage.models import UsageScrape
+
+from . import exceptions
+from .constants import CONNECT_PENDING_PREFIX, REFRESH_LOCK_PREFIX
+from .datastructures import (
+    CodexToken,
+    CompletedConnect,
+    OAuthToken,
+    ParsedMetric,
+    ParsedUsage,
+    ProviderRequest,
+    RotationResult,
+)
+from .models import ProviderLogin
+
+logger = logging.getLogger(__name__)
+
+_GRANT_TIMEOUT_SECONDS = 30.0
+_USAGE_TIMEOUT_SECONDS = 20.0
+# The connect-flow pending state (PKCE verifier + state) lives in Redis this
+# long — enough to authorize and paste, short enough that an abandoned attempt
+# clears.
+_CONNECT_PENDING_TTL_SECONDS = 600
+# Per-row refresh lock: five minutes outlives the provider grant timeout and
+# expires before the next 15-minute cron tick if the holder dies mid-refresh.
+_REFRESH_LOCK_TTL_SECONDS = 300
+
+Token = OAuthToken | CodexToken
+
+_WEEKLY_WINDOWS = TypeAdapter(tuple[ParsedMetric, ...])
+
+
+class Provider:
+    """Who answers and bills a model request. A provider owns how its login
+    is granted, refreshed, and metered; every harness that drives it runs on that row."""
+
+    id: ClassVar[str]
+    label: ClassVar[str]
+    # "oauth" for a subscription login, "api_key" for a pasted key.
+    login_kinds: ClassVar[frozenset[str]]
+    # OAuth refresh config (set by providers with an "oauth" login kind).
+    REFRESH_MARGIN: ClassVar[timedelta]
+    _TOKEN_URL: ClassVar[str]
+    _CLIENT_ID: ClassVar[str]
+
+    @classmethod
+    async def connect_start(cls, *, account_id: str | None = None) -> tuple[str, str]:
+        """Mint PKCE state under a single-use flow id; return (authorize URL,
+        flow id). A flow started by a resolved operator binds ``account_id``."""
+        verifier = _b64url(secrets.token_bytes(64))
+        challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
+        url, state = cls.authorize_url(verifier=verifier, challenge=challenge)
+        flow_id = secrets.token_urlsafe(24)
+        pending = json.dumps(
+            {
+                "verifier": verifier,
+                "state": state,
+                "account_id": account_id,
+            }
+        )
+        await get_client().set(
+            f"{CONNECT_PENDING_PREFIX}{flow_id}", pending, ex=_CONNECT_PENDING_TTL_SECONDS
+        )
+        return url, flow_id
+
+    @classmethod
+    async def connect_complete(cls, *, flow_id: str, pasted: str) -> CompletedConnect:
+        """Pop the flow's single-use state, parse the paste, exchange the code.
+        Raises :class:`ConnectError` on failure; the state is gone either way,
+        so a retry re-starts cleanly."""
+        pending = await get_client().getdel(f"{CONNECT_PENDING_PREFIX}{flow_id}")  # single-use
+        if not pending:
+            raise exceptions.ConnectError("This connect attempt expired — start it again.")
+        expected = json.loads(pending)
+
+        code, pasted_state = _parse_pasted(pasted)
+        if not code:
+            raise exceptions.ConnectError("Couldn't find an authorization code in what you pasted.")
+        if pasted_state and pasted_state != expected["state"]:
+            raise exceptions.ConnectError(
+                "That code is from a different connect attempt — start it again."
+            )
+
+        payload, provider_email = await cls.exchange(code=code, verifier=expected["verifier"])
+        if not provider_email:
+            raise exceptions.ConnectError(
+                "The provider returned no account email — authorize with an account "
+                "that has one and try again."
+            )
+        _, expires_at = cls._refresh_state(payload)
+        return CompletedConnect(
+            payload=payload,
+            provider_email=provider_email,
+            expires_at=expires_at,
+            account_id=expected["account_id"],
+        )
+
+    @classmethod
+    def authorize_url(cls, *, verifier: str, challenge: str) -> tuple[str, str]:
+        """Build this provider's PKCE authorize URL; return (url, state), where
+        ``state`` is what the provider echoes back so connect_complete can
+        verify the round-trip."""
+        raise NotImplementedError
+
+    @classmethod
+    async def exchange(cls, *, code: str, verifier: str) -> tuple[dict, str | None]:
+        """Exchange the authorization code for tokens; return (login
+        payload, provider-reported account email)."""
+        raise NotImplementedError
+
+    @classmethod
+    def load_token(cls, login: ProviderLogin, *, now: datetime | None = None) -> Token:
+        """Read + validate ``login``'s access token, or raise
+        :class:`OAuthTokenError`. Read-only; never refreshes."""
+        token = cls._token_from_credentials(dict(login.payload))
+        moment = now or _utc_now()
+        if token.expires_at and token.expires_at <= moment:
+            raise exceptions.OAuthTokenError(
+                "token_expired", f"access token expired at {token.expires_at.isoformat()}"
+            )
+        return token
+
+    @classmethod
+    def _token_from_credentials(cls, data: dict) -> Token:
+        """Extract the token object from the stored payload; raise
+        ``OAuthTokenError('no_token')`` if absent."""
+        raise NotImplementedError
+
+    @classmethod
+    async def rotate_token(
+        cls,
+        login_id: str,
+        *,
+        now: datetime | None = None,
+        margin: timedelta | None = None,
+    ) -> RotationResult:
+        """Refresh one login's token when it is inside the expiry margin.
+        A Redis lock elects one refresher per row; the loser reports ``locked``
+        and never presents the refresh token a concurrent grant may have burned."""
+        moment = now or _utc_now()
+        row = await ProviderLogin.reload(login_id)
+        if not row:
+            return RotationResult(cls.id, "failed", error="no_credentials", login_id=login_id)
+        data = dict(row.payload)
+        refresh_token, expires_at = cls._refresh_state(data)
+        if not refresh_token:
+            return RotationResult(cls.id, "no_refresh_token", login_id=login_id)
+
+        limit = margin if margin is not None else cls.REFRESH_MARGIN
+        if expires_at and expires_at - moment > limit:
+            return RotationResult(cls.id, "fresh", expires_at=expires_at, login_id=login_id)
+
+        redis = get_client()
+        lock_key = f"{REFRESH_LOCK_PREFIX}{login_id}"
+        if not await redis.set(lock_key, "1", nx=True, ex=_REFRESH_LOCK_TTL_SECONDS):
+            return RotationResult(cls.id, "locked", login_id=login_id)
+        try:
+            # Re-read after winning the lock: the previous holder may have
+            # advanced this lineage (or deleted the row) after our first read.
+            row = await ProviderLogin.reload(login_id)
+            if not row:
+                return RotationResult(cls.id, "failed", error="no_credentials", login_id=login_id)
+            data = dict(row.payload)
+            refresh_token, expires_at = cls._refresh_state(data)
+            if not refresh_token:
+                return RotationResult(cls.id, "no_refresh_token", login_id=row.id)
+            if expires_at and expires_at - moment > limit:
+                return RotationResult(cls.id, "fresh", expires_at=expires_at, login_id=row.id)
+
+            try:
+                grant = await _post_grant(cls._TOKEN_URL, cls._grant_body(refresh_token))
+                new_expiry = cls._apply_refresh(data, grant, moment)
+            except exceptions.GrantError as exc:
+                if exc.tag == "invalid_grant":
+                    # The provider revoked this row's refresh lineage;
+                    # presenting it again can never succeed. Drop only this
+                    # login so the provider reads as disconnected — the
+                    # UI shows Reconnect and the next tick has no row to hammer.
+                    await row.delete()
+                    await db_session().commit()
+                    logger.warning(
+                        "%s login %s auto-disconnected after invalid_grant; reconnect to restore",
+                        cls.id,
+                        row.id,
+                    )
+                return RotationResult(cls.id, "failed", error=exc.tag, login_id=row.id)
+            except ValueError:
+                return RotationResult(cls.id, "failed", error="bad_response", login_id=row.id)
+
+            await row.update_payload(data, expires_at=new_expiry)
+            # The grant is externally anchored — the provider may have killed
+            # the old refresh token the moment it issued this one — so the new
+            # lineage must be committed before the lock releases; deferring to
+            # the step's own commit would let a concurrent refresher take the
+            # freed lock and re-present the superseded token.
+            await db_session().commit()
+            return RotationResult(cls.id, "refreshed", expires_at=new_expiry, login_id=row.id)
+        finally:
+            await redis.delete(lock_key)
+
+    @classmethod
+    def refresh_is_urgent(cls, login: ProviderLogin) -> bool:
+        """Expiry inside the call horizon: a mid-run 401 is unavoidable."""
+        _, expires_at = cls._refresh_state(dict(login.payload))
+        horizon = timedelta(seconds=MAX_AGENT_TIMEOUT_SECONDS)
+        return bool(expires_at) and expires_at - _utc_now() < horizon
+
+    @classmethod
+    def needs_refresh(cls, login: ProviderLogin) -> bool:
+        """Whether the access token is inside its refresh margin. Unreadable
+        or expired reads False: nothing live to protect, rotate ungated."""
+        try:
+            token = cls._token_from_credentials(dict(login.payload))
+        except exceptions.OAuthTokenError:
+            return False
+        now = _utc_now()
+        return bool(token.expires_at) and now < token.expires_at <= now + cls.REFRESH_MARGIN
+
+    @classmethod
+    def _refresh_state(cls, data: dict) -> tuple[str | None, datetime | None]:
+        """Return (refresh_token, current_expiry) from the stored payload."""
+        raise NotImplementedError
+
+    @classmethod
+    def _grant_body(cls, refresh_token: str) -> dict:
+        """The JSON body for this provider's refresh grant."""
+        raise NotImplementedError
+
+    @classmethod
+    def _apply_refresh(cls, data: dict, grant: dict, now: datetime) -> datetime | None:
+        """Merge the grant response into ``data`` in place; return the new
+        expiry. Raise ``ValueError`` if the response is unusable."""
+        raise NotImplementedError
+
+    @classmethod
+    async def fetch_usage(cls, login: ProviderLogin, *, now: datetime | None = None) -> ParsedUsage:
+        """Fetch + parse the login's remaining-quota snapshot from its
+        subscription endpoint. Auth/HTTP failures collapse to a
+        ``ParsedUsage(ok=False, error=<tag>)`` so they never look like
+        '0 metrics'."""
+        try:
+            token = cls.load_token(login, now=now)
+            request = cls._usage_request(token)
+        except exceptions.OAuthTokenError as exc:
+            return ParsedUsage(ok=False, error=exc.tag)
+        except NotImplementedError:
+            return ParsedUsage(ok=False, error="unsupported")
+        try:
+            async with httpx.AsyncClient(timeout=_USAGE_TIMEOUT_SECONDS) as client:
+                response = await client.get(request.url, headers=request.headers)
+        except httpx.TimeoutException:
+            return ParsedUsage(ok=False, error="timeout")
+        except httpx.HTTPError as exc:
+            logger.warning("usage request failed for %s: %s", cls.id, exc, exc_info=True)
+            return ParsedUsage(ok=False, error="network")
+
+        if response.status_code == 200:
+            return cls._parse_usage(response.text)
+        tag = error_tag(response.status_code)
+        logger.warning(
+            "usage endpoint %s for %s: %s",
+            response.status_code,
+            cls.id,
+            response.text[:300],
+        )
+        return ParsedUsage(ok=False, error=tag)
+
+    @classmethod
+    async def poll_usage(cls, login: ProviderLogin) -> dict[str, object]:
+        """Fetch the login's quota snapshot and persist it as that
+        account's UsageScrape row."""
+        account_id = login.account_id
+        try:
+            parsed = await cls.fetch_usage(login)
+        except Exception:  # noqa: BLE001 — a crashed scrape records an error row, not a failed refresh
+            logger.warning("usage fetch crashed for %s", cls.id, exc_info=True)
+            await UsageScrape(
+                provider=cls.id,
+                account_id=account_id,
+                parse_ok=False,
+                raw_output=None,
+                error="crashed",
+            ).save()
+            return {
+                "provider": cls.id,
+                "account_id": account_id,
+                "status": "errored",
+                "parse_ok": False,
+                "error": "crashed",
+            }
+
+        snapshot = UsageScrape(
+            provider=cls.id,
+            account_id=account_id,
+            parse_ok=parsed.ok,
+            raw_output=parsed.raw[-8000:] if parsed.raw else None,  # cap to avoid bloat
+            error=parsed.error if not parsed.ok else None,
+            plan_tier=parsed.plan_tier,
+            unlimited=parsed.unlimited,
+        )
+        if parsed.five_hour:
+            snapshot.five_hour_percent_left = parsed.five_hour.percent_left
+            snapshot.five_hour_resets_at = parsed.five_hour.resets_at
+        snapshot.weeks = _WEEKLY_WINDOWS.dump_python(parsed.weeks, mode="json")
+        await snapshot.save()
+        return {
+            "provider": cls.id,
+            "account_id": account_id,
+            "status": "recorded",
+            "parse_ok": parsed.ok,
+            "error": parsed.error if not parsed.ok else None,
+        }
+
+    @classmethod
+    def _usage_request(cls, token: Token) -> ProviderRequest:
+        """The authenticated request for the usage endpoint."""
+        raise NotImplementedError
+
+    @classmethod
+    def _parse_usage(cls, raw: str) -> ParsedUsage:
+        """Map the usage endpoint's JSON body into :class:`ParsedUsage`."""
+        return ParsedUsage(ok=False, error="unsupported")
+
+
+def get_providers() -> tuple[Provider, ...]:
+    """The registry: one of every ``Provider`` subclass, sorted by id for a
+    stable order."""
+    return tuple(sorted((provider() for provider in Provider.__subclasses__()), key=lambda p: p.id))
+
+
+def get_provider(provider_id: str) -> Provider:
+    """The provider registered under ``provider_id``; a miss raises ``KeyError``."""
+    for provider in get_providers():
+        if provider.id == provider_id:
+            return provider
+    raise KeyError(provider_id)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def jwt_claims(token: str) -> dict | None:
+    """Best-effort read of a JWT's claims (no signature check)."""
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (-len(payload) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+    except (IndexError, ValueError, json.JSONDecodeError):
+        return
+    return claims if isinstance(claims, dict) else None
+
+
+def jwt_expiry(token: str) -> datetime | None:
+    """Best-effort read of a JWT's ``exp`` claim (no signature check)."""
+    claims = jwt_claims(token) or {}
+    try:
+        return datetime.fromtimestamp(claims["exp"], tz=UTC)
+    except (KeyError, TypeError, OverflowError, OSError, ValueError):
+        return
+
+
+def parse_epoch_expiry(value: object) -> datetime | None:
+    """Claude stores ``expiresAt`` as epoch millis; tolerate seconds."""
+    if not isinstance(value, (int, float)):
+        return
+    seconds = value / 1000 if value > 1e12 else value
+    try:
+        return datetime.fromtimestamp(seconds, tz=UTC)
+    except (OverflowError, OSError, ValueError):
+        return
+
+
+def error_tag(status_code: int) -> str:
+    return {
+        401: "unauthorized",
+        403: "forbidden_scope",
+        429: "rate_limited",
+    }.get(status_code, f"http_{status_code}")
+
+
+async def _post_grant(url: str, body: dict) -> dict:
+    """POST a refresh grant and return the parsed grant dict. Raises
+    :class:`GrantError` tagged with why no usable grant came back."""
+    try:
+        async with httpx.AsyncClient(timeout=_GRANT_TIMEOUT_SECONDS) as client:
+            response = await client.post(url, json=body)
+    except httpx.HTTPError as exc:
+        logger.warning("token refresh request failed (%s): %s", url, exc, exc_info=True)
+        raise exceptions.GrantError("network") from exc
+    if response.status_code != 200:
+        logger.warning(
+            "token refresh returned %s (%s): %s",
+            response.status_code,
+            url,
+            response.text[:300],
+        )
+        if "invalid_grant" in response.text:
+            tag = "invalid_grant"
+        else:
+            tag = f"http_{response.status_code}"
+        raise exceptions.GrantError(tag)
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise exceptions.GrantError("bad_response") from exc
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _parse_pasted(raw: str) -> tuple[str | None, str | None]:
+    """Pull (code, state) out of whatever the operator pasted — a bare code, a
+    ``code#state`` pair, a raw query string, or a full redirect URL."""
+    value = raw.strip().strip("'\"")
+    if not value:
+        return None, None
+    if "://" in value:
+        query = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(value).query))
+        return query.get("code"), query.get("state")
+    if "#" in value:
+        code, _, state = value.partition("#")
+        return code, state
+    if "code=" in value:
+        query = dict(urllib.parse.parse_qsl(value))
+        return query.get("code"), query.get("state")
+    return value, None
+
+
+async def post_token(url: str, body: dict, *, form: bool) -> dict:
+    """POST an authorization-code exchange (form- or JSON-encoded) and return the
+    parsed grant. Raises :class:`ConnectError` with the provider's error text on
+    any failure, so the operator sees why the connect didn't take."""
+    try:
+        async with httpx.AsyncClient(timeout=_GRANT_TIMEOUT_SECONDS) as client:
+            if form:
+                response = await client.post(url, data=body)
+            else:
+                response = await client.post(url, json=body)
+    except httpx.HTTPError as exc:
+        logger.warning("token exchange request failed (%s): %s", url, exc, exc_info=True)
+        raise exceptions.ConnectError("The request to the provider failed — try again.") from exc
+    if response.status_code != 200:
+        logger.warning(
+            "token exchange returned %s (%s): %s",
+            response.status_code,
+            url,
+            response.text[:300],
+        )
+        detail = response.text.strip()[:300] or f"HTTP {response.status_code}"
+        raise exceptions.ConnectError(f"The provider rejected the connect: {detail}")
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise exceptions.ConnectError("The provider returned an unreadable response.") from exc
+
+
+_ANTHROPIC_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
+# Beta flag the Claude CLI sends for OAuth-scoped endpoints.
+_OAUTH_BETA = "oauth-2025-04-20"
+_ANTHROPIC_VERSION = "2023-06-01"
+_CLAUDE_CODE_USER_AGENT = "claude-code/2.1.0"
+
+
+class AnthropicProvider(Provider):
+    id = "anthropic"
+    label = "Anthropic"
+    login_kinds = frozenset({"oauth", "api_key"})
+
+    REFRESH_MARGIN = timedelta(hours=2)
+    _TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+    # Public Claude-Code OAuth client id.
+    _CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+    # Connect-flow (PKCE code-paste): authorize on claude.ai, land on the
+    # console.anthropic.com code page, exchange JSON with the state echoed in the
+    # body.
+    redirect_uri = "https://console.anthropic.com/oauth/code/callback"
+
+    @classmethod
+    def _token_from_credentials(cls, data: dict) -> OAuthToken:
+        block = _oauth_block(data)
+        if access := block.get("accessToken") or block.get("access_token"):
+            return OAuthToken(
+                access_token=access,
+                expires_at=parse_epoch_expiry(block.get("expiresAt")),
+                scopes=tuple(block.get("scopes") or ()),
+                subscription_type=block.get("subscriptionType"),
+            )
+        raise exceptions.OAuthTokenError("no_token", "credentials file has no access token")
+
+    @classmethod
+    def _refresh_state(cls, data: dict) -> tuple[str | None, datetime | None]:
+        block = _oauth_block(data)
+        refresh = block.get("refreshToken") or block.get("refresh_token")
+        return refresh, parse_epoch_expiry(block.get("expiresAt"))
+
+    @classmethod
+    def _grant_body(cls, refresh_token: str) -> dict:
+        return {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": cls._CLIENT_ID,
+        }
+
+    @classmethod
+    def authorize_url(cls, *, verifier: str, challenge: str) -> tuple[str, str]:
+        # Anthropic's console flow echoes the PKCE verifier back as the OAuth
+        # state, so that's what connect_complete checks.
+        params = {
+            "code": "true",
+            "client_id": cls._CLIENT_ID,
+            "response_type": "code",
+            "redirect_uri": cls.redirect_uri,
+            "scope": (
+                "org:create_api_key user:profile user:inference "
+                "user:sessions:claude_code user:mcp_servers user:file_upload"
+            ),
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": verifier,
+        }
+        return f"https://claude.ai/oauth/authorize?{urlencode(params)}", verifier
+
+    @classmethod
+    async def exchange(cls, *, code: str, verifier: str) -> tuple[dict, str | None]:
+        grant = await post_token(
+            cls._TOKEN_URL,
+            {
+                "grant_type": "authorization_code",
+                "client_id": cls._CLIENT_ID,
+                "code": code,
+                "state": verifier,
+                "redirect_uri": cls.redirect_uri,
+                "code_verifier": verifier,
+            },
+            form=False,
+        )
+        block: dict[str, object] = {
+            "accessToken": grant["access_token"],
+            "refreshToken": grant["refresh_token"],
+            "scopes": (grant.get("scope") or "").split(),
+        }
+        expires_in = grant.get("expires_in")
+        if expires_in:
+            expiry = datetime.now(UTC) + timedelta(seconds=expires_in)
+            block["expiresAt"] = int(expiry.timestamp() * 1000)
+        account = (grant.get("account") or {}).get("email_address")
+        return {"claudeAiOauth": block}, account
+
+    @classmethod
+    def _apply_refresh(cls, data: dict, grant: dict, now: datetime) -> datetime | None:
+        block = _oauth_block(data)
+        if access := grant.get("access_token"):
+            block["accessToken"] = access
+            if grant.get("refresh_token"):
+                block["refreshToken"] = grant["refresh_token"]
+            expires_in = grant.get("expires_in")
+            if isinstance(expires_in, (int, float)):
+                new_expiry = now + timedelta(seconds=expires_in)
+                block["expiresAt"] = int(new_expiry.timestamp() * 1000)
+                return new_expiry
+            return parse_epoch_expiry(block.get("expiresAt"))
+        raise ValueError("refresh response had no access_token")
+
+    @classmethod
+    def _usage_request(cls, token: OAuthToken) -> ProviderRequest:
+        return ProviderRequest(_ANTHROPIC_USAGE_URL, cls.oauth_headers(token))
+
+    @classmethod
+    def oauth_headers(cls, token: OAuthToken) -> dict:
+        return {
+            "Authorization": f"Bearer {token.access_token}",
+            "anthropic-beta": _OAUTH_BETA,
+            "anthropic-version": _ANTHROPIC_VERSION,
+            "User-Agent": _CLAUDE_CODE_USER_AGENT,
+        }
+
+    @classmethod
+    def _parse_usage(cls, raw: str) -> ParsedUsage:
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return ParsedUsage(ok=False, error="unparseable", raw=raw)
+        if not isinstance(data, dict) or not any(k in data for k in ("five_hour", "seven_day")):
+            return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
+        try:
+            five_hour, weeks = _claude_windows(data)
+        except (KeyError, TypeError, ValueError):
+            return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
+        return ParsedUsage(ok=True, five_hour=five_hour, weeks=weeks, raw=raw)
+
+
+def _oauth_block(data: dict) -> dict:
+    """Claude nests the OAuth fields under ``claudeAiOauth``; tolerate a
+    flat shape too."""
+    block = data.get("claudeAiOauth") if isinstance(data, dict) else None
+    return block if isinstance(block, dict) else data
+
+
+def _claude_windows(data: dict) -> tuple[ParsedMetric | None, tuple[ParsedMetric, ...]]:
+    """The binding five-hour window and every weekly window in provider order."""
+    five_hour, weekly = [], []
+    for limit in data.get("limits") or []:
+        # A limit can be scoped to something other than a model, which leaves
+        # it counting toward the quota but with no model to name.
+        scope = limit["scope"] or {}
+        window = ParsedMetric(
+            percent_left=max(0, min(100, round(100 - limit["percent"]))),
+            resets_at=_parse_iso(limit.get("resets_at")),
+            model=(scope.get("model") or {}).get("display_name"),
+        )
+        if limit["group"] == "weekly":
+            weekly.append(window)
+        elif limit["group"] == "session":
+            five_hour.append(window)
+    if not weekly and (fallback_week := _claude_metric(data.get("seven_day"))):
+        weekly.append(fallback_week)
+    binding_five_hour = ParsedMetric.binding(five_hour) or _claude_metric(data.get("five_hour"))
+    weekly_windows = tuple(weekly)
+    return binding_five_hour, weekly_windows
+
+
+def _claude_metric(block: object) -> ParsedMetric | None:
+    if not isinstance(block, dict):
+        return
+    utilization = block.get("utilization")
+    percent_left = None
+    if isinstance(utilization, (int, float)):
+        percent_left = max(0, min(100, int(round(100 - utilization))))
+    resets_at = _parse_iso(block.get("resets_at"))
+    if percent_left is None and resets_at is None:
+        return
+    return ParsedMetric(percent_left=percent_left, resets_at=resets_at)
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return
+    return ensure_utc(parsed)
+
+
+# Namespaced claims OpenAI packs into the Codex access-token JWT.
+_OPENAI_AUTH_CLAIM = "https://api.openai.com/auth"
+_OPENAI_PROFILE_CLAIM = "https://api.openai.com/profile"
+
+# ChatGPT subscription usage endpoint — the standalone fetch the codex CLI's
+# account/rateLimits/read RPC uses for the ``chatgpt`` auth app. Returns the
+# same numbers /status shows without a completion.
+_CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage"
+_CODEX_USER_AGENT = "codex-cli"
+
+# A quota window is named by its declared length, not the slot it arrives in:
+# a plan whose only quota is weekly reports it as the primary window.
+_WEEKLY_WINDOW_MINIMUM_SECONDS = 24 * 3600
+
+
+class OpenAiCodexProvider(Provider):
+    """The ChatGPT subscription backend (chatgpt.com/backend-api) — pi's
+    ``openai-codex`` provider id, and what the codex CLI runs on."""
+
+    id = "openai-codex"
+    label = "ChatGPT"
+    login_kinds = frozenset({"oauth"})
+
+    REFRESH_MARGIN = timedelta(hours=24)
+    _TOKEN_URL = "https://auth.openai.com/oauth/token"
+    _CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+    # Connect-flow (PKCE): authorize on auth.openai.com; the operator pastes the
+    # failed localhost redirect URL back.
+    redirect_uri = "http://localhost:1455/auth/callback"
+
+    @classmethod
+    def _token_from_credentials(cls, data: dict) -> CodexToken:
+        tokens = data.get("tokens") if isinstance(data.get("tokens"), dict) else {}
+        if access := tokens.get("access_token"):
+            return CodexToken(
+                access_token=access,
+                expires_at=jwt_expiry(access),
+                account_id=tokens.get("account_id"),
+            )
+        raise exceptions.OAuthTokenError("no_token", "codex auth file has no access token")
+
+    @classmethod
+    def _refresh_state(cls, data: dict) -> tuple[str | None, datetime | None]:
+        tokens = data.get("tokens") if isinstance(data.get("tokens"), dict) else {}
+        return tokens.get("refresh_token"), jwt_expiry(tokens.get("access_token") or "")
+
+    @classmethod
+    def _grant_body(cls, refresh_token: str) -> dict:
+        return {
+            "client_id": cls._CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+
+    @classmethod
+    def authorize_url(cls, *, verifier: str, challenge: str) -> tuple[str, str]:
+        state = secrets.token_hex(16)
+        params = {
+            "id_token_add_organizations": "true",
+            "codex_cli_simplified_flow": "true",
+            "originator": "pi",  # the only value verified against the live exchange
+            "client_id": cls._CLIENT_ID,
+            "response_type": "code",
+            "redirect_uri": cls.redirect_uri,
+            "scope": "openid profile email offline_access",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": state,
+        }
+        return f"https://auth.openai.com/oauth/authorize?{urlencode(params)}", state
+
+    @classmethod
+    async def exchange(cls, *, code: str, verifier: str) -> tuple[dict, str | None]:
+        grant = await post_token(
+            cls._TOKEN_URL,
+            {
+                "grant_type": "authorization_code",
+                "client_id": cls._CLIENT_ID,
+                "code": code,
+                "code_verifier": verifier,
+                "redirect_uri": cls.redirect_uri,
+            },
+            form=True,
+        )
+        access = grant["access_token"]
+        claims = jwt_claims(access) or {}
+        auth = claims.get(_OPENAI_AUTH_CLAIM) or {}
+        profile = claims.get(_OPENAI_PROFILE_CLAIM) or {}
+        payload = {
+            "OPENAI_API_KEY": None,
+            "tokens": {
+                "access_token": access,
+                "refresh_token": grant["refresh_token"],
+                "id_token": grant.get("id_token"),
+                "account_id": auth.get("chatgpt_account_id"),
+            },
+            "last_refresh": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        }
+        return payload, profile.get("email")
+
+    @classmethod
+    def _apply_refresh(cls, data: dict, grant: dict, now: datetime) -> datetime | None:
+        if access := grant.get("access_token"):
+            tokens = data["tokens"]
+            tokens["access_token"] = access
+            if grant.get("refresh_token"):
+                tokens["refresh_token"] = grant["refresh_token"]
+            if grant.get("id_token"):
+                tokens["id_token"] = grant["id_token"]
+            data["last_refresh"] = now.astimezone(UTC).isoformat().replace("+00:00", "Z")
+            return jwt_expiry(access)
+        raise ValueError("refresh response had no access_token")
+
+    @classmethod
+    def _usage_request(cls, token: CodexToken) -> ProviderRequest:
+        return ProviderRequest(_CODEX_USAGE_URL, cls.chatgpt_headers(token))
+
+    @classmethod
+    def chatgpt_headers(cls, token: CodexToken) -> dict:
+        headers = {
+            "Authorization": f"Bearer {token.access_token}",
+            "User-Agent": _CODEX_USER_AGENT,
+        }
+        if token.account_id:
+            headers["ChatGPT-Account-Id"] = token.account_id
+        return headers
+
+    @classmethod
+    def _parse_usage(cls, raw: str) -> ParsedUsage:
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return ParsedUsage(ok=False, error="unparseable", raw=raw)
+        if not isinstance(data, dict) or "rate_limit" not in data:
+            return ParsedUsage(ok=False, error="unexpected_payload", raw=raw)
+        plan = data.get("plan_type") if isinstance(data.get("plan_type"), str) else None
+        try:
+            five_hour, weeks = _codex_windows(data)
+            spend = (data.get("spend_control") or {}).get("individual_limit")
+            if not five_hour and not weeks and spend:
+                # Group-based spend controls replace the rate-limit windows;
+                # their weeks-long quota cycle makes it a weekly window.
+                weeks = (
+                    ParsedMetric(
+                        percent_left=max(0, min(100, round(100 - spend["used_percent"]))),
+                        resets_at=datetime.fromtimestamp(spend["reset_at"], tz=UTC),
+                    ),
+                )
+        except (AttributeError, KeyError, TypeError, ValueError):
+            return ParsedUsage(ok=False, error="unexpected_payload", plan_tier=plan, raw=raw)
+        if not five_hour and not weeks:
+            # Business/enterprise accounts with unlimited credits carry
+            # ``rate_limit: null`` — no windows is the expected shape, not
+            # a parse failure. Report permanently-full buckets.
+            credits = data.get("credits")
+            if isinstance(credits, dict) and credits.get("unlimited"):
+                full = ParsedMetric(percent_left=100, resets_at=None)
+                return ParsedUsage(
+                    ok=True,
+                    plan_tier=plan,
+                    five_hour=full,
+                    weeks=(full,),
+                    unlimited=True,
+                    raw=raw,
+                )
+            return ParsedUsage(ok=False, error="parse_failed", plan_tier=plan, raw=raw)
+        return ParsedUsage(
+            ok=True,
+            plan_tier=plan,
+            five_hour=five_hour,
+            weeks=weeks,
+            raw=raw,
+        )
+
+
+def _codex_windows(usage: dict) -> tuple[ParsedMetric | None, tuple[ParsedMetric, ...]]:
+    """The binding five-hour window and every weekly window in provider order.
+
+    A window's declared length names it, not the slot it arrives in.
+    """
+    rate_limits = [(None, usage["rate_limit"] or {})]
+    for metered in usage.get("additional_rate_limits") or []:
+        rate_limits.append((metered["limit_name"], metered["rate_limit"] or {}))
+
+    five_hour, weekly = [], []
+    for model, rate_limit in rate_limits:
+        for slot in ("primary_window", "secondary_window"):
+            block = rate_limit.get(slot)
+            if not block:
+                continue
+            window = ParsedMetric(
+                percent_left=max(0, min(100, round(100 - block["used_percent"]))),
+                resets_at=datetime.fromtimestamp(block["reset_at"], tz=UTC),
+                model=model,
+            )
+            if block["limit_window_seconds"] >= _WEEKLY_WINDOW_MINIMUM_SECONDS:
+                weekly.append(window)
+            else:
+                five_hour.append(window)
+    return ParsedMetric.binding(five_hour), tuple(weekly)
+
+
+class OpenAiProvider(Provider):
+    """The OpenAI platform API (api.openai.com), pay per token on a key."""
+
+    id = "openai"
+    label = "OpenAI"
+    login_kinds = frozenset({"api_key"})

--- a/backend/druks/harnesses/routes.py
+++ b/backend/druks/harnesses/routes.py
@@ -7,56 +7,67 @@ from druks.accounts.dependencies import current_session_account, current_session
 from druks.accounts.models import Account
 from druks.accounts.schemas import AccountResponse
 from druks.database import db_session
-from druks.harnesses.base import Harness
-from druks.harnesses.exceptions import ConnectError
-from druks.harnesses.models import HarnessConnection
-from druks.harnesses.registry import get_harness, get_harnesses
-from druks.harnesses.schemas import HarnessSummary
 from druks.user_settings.models import HarnessSettings, UserSettings
-from druks.user_settings.schemas import HarnessResponse
 
-router = APIRouter(prefix="/api/harnesses", tags=["harnesses"])
+from .exceptions import ConnectError
+from .models import ProviderLogin
+from .providers import Provider, get_provider, get_providers
+from .registry import get_harnesses
+from .schemas import ProviderLoginResponse, ProviderResponse
 
-
-@router.get("", response_model=list[HarnessSummary], response_model_by_alias=True)
-async def list_harnesses(
-    _account: Account | None = Depends(current_session_or_setup),
-) -> list[HarnessSummary]:
-    return [HarnessSummary.model_validate(harness) for harness in get_harnesses()]
+router = APIRouter(prefix="/api/providers", tags=["providers"])
 
 
-def _resolve_harness(name: str) -> type[Harness]:
-    harness = get_harness(name)
-    if harness:
-        return harness
-    raise HTTPException(status_code=404, detail=f"Unknown harness: {name!r}")
+@router.get(
+    "",
+    response_model=list[ProviderResponse],
+    response_model_by_alias=True,
+    dependencies=[Depends(current_session_or_setup)],
+)
+async def list_providers() -> list[ProviderResponse]:
+    return [ProviderResponse.model_validate(provider) for provider in get_providers()]
 
 
-@router.post("/{name}/connection/start")
+@router.get("/logins", response_model=list[ProviderLoginResponse], response_model_by_alias=True)
+async def list_logins(
+    account: Account = Depends(current_session_account),
+) -> list[ProviderLoginResponse]:
+    logins = await ProviderLogin.list_for_account(account.id)
+    return [ProviderLoginResponse.model_validate(login) for login in logins]
+
+
+def _resolve_provider(provider_id: str) -> Provider:
+    try:
+        return get_provider(provider_id)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {provider_id!r}") from error
+
+
+@router.post("/{provider_id}/connection/start")
 async def start_connection(
-    name: str, account: Account | None = Depends(current_session_or_setup)
+    provider_id: str, account: Account | None = Depends(current_session_or_setup)
 ) -> dict[str, str]:
-    harness = _resolve_harness(name)
+    provider = _resolve_provider(provider_id)
     # A resolved operator binds the flow; none/zero starts the unbound setup
     # flow whose completion creates the operator.
-    url, connection_id = await harness.connect_start(account_id=account.id if account else None)
-    return {"authorizeUrl": url, "connectionId": connection_id}
+    url, flow_id = await provider.connect_start(account_id=account.id if account else None)
+    return {"authorizeUrl": url, "connectionId": flow_id}
 
 
 @router.post(
-    "/{name}/connection/complete",
+    "/{provider_id}/connection/complete",
     response_model=AccountResponse,
     response_model_by_alias=True,
 )
 async def complete_connection(
-    name: str,
+    provider_id: str,
     account: Account | None = Depends(current_session_or_setup),
     code: str = Body(..., embed=True),
-    connection_id: str = Body(..., embed=True, alias="connectionId"),
+    flow_id: str = Body(..., embed=True, alias="connectionId"),
 ) -> AccountResponse:
-    harness = _resolve_harness(name)
+    provider = _resolve_provider(provider_id)
     try:
-        completed = await harness.connect_complete(flow_id=connection_id, pasted=code)
+        completed = await provider.connect_complete(flow_id=flow_id, pasted=code)
     except ConnectError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     if completed.account_id:
@@ -81,25 +92,29 @@ async def complete_connection(
     settings = await UserSettings.get()
     if not settings.fallback_account_id:
         await settings.set_fallback_account(resolved.id)
-    connection = await HarnessConnection.connect(
-        harness=harness.name,
+    login = await ProviderLogin.connect(
+        provider=provider.id,
         account=resolved,
         payload=completed.payload,
         expires_at=completed.expires_at,
         provider_email=completed.provider_email,
+        kind="oauth",
     )
-    # Materialize the reply, then land the credential before any provider I/O —
+    # Materialize the reply, then land the login before any provider I/O —
     # an await while flushed rows still hold their locks can stall every other
     # writer on this event loop, and nothing past the point of durability may
     # depend on another database read.
     response = AccountResponse.model_validate(resolved)
     await db_session().commit()
     try:
-        # Fresh picker right after connect; fetch failures are tagged inside.
-        # The single-use flow is already spent, so trouble here — including a
-        # database that vanished under the refresh — only logs.
-        settings = await HarnessSettings.get_registered(harness.name)
-        await settings.refresh_models(connection)
+        # Fresh pickers right after connect for every harness this login
+        # serves; fetch failures are tagged inside. The single-use flow is
+        # already spent, so trouble here — including a database that vanished
+        # under the refresh — only logs.
+        for harness in get_harnesses():
+            if harness.accepts(login):
+                settings = await HarnessSettings.get_registered(harness.name)
+                await settings.refresh_models(login)
     except Exception:
         logging.getLogger(__name__).exception("Model refresh after connect failed")
         with suppress(Exception):
@@ -108,48 +123,38 @@ async def complete_connection(
 
 
 @router.post(
-    "/{name}/connection",
-    response_model=HarnessResponse,
+    "/{provider_id}/connection",
+    response_model=ProviderLoginResponse,
     response_model_by_alias=True,
 )
-async def connect_harness_key(
-    name: str,
+async def connect_key(
+    provider_id: str,
     account: Account = Depends(current_session_account),
     key: str = Body(..., embed=True),
-) -> HarnessResponse:
-    harness = _resolve_harness(name)
-    if "api_key" not in harness.login_kinds:
+) -> ProviderLoginResponse:
+    provider = _resolve_provider(provider_id)
+    if "api_key" not in provider.login_kinds:
         raise HTTPException(
             status_code=422,
-            detail=f"Harness {harness.name!r} does not accept API keys.",
+            detail=f"{provider.label} does not accept API keys.",
         )
-    key = key.strip()
-
-    if not key:
-        raise HTTPException(
-            status_code=422,
-            detail="The API key is empty. Paste a key.",
+    if key := key.strip():
+        login = await ProviderLogin.connect(
+            provider=provider.id,
+            account=account,
+            payload={"api_key": key},
+            expires_at=None,
+            provider_email=account.username,
+            kind="api_key",
         )
-    connection = await HarnessConnection.connect(
-        harness=harness.name,
-        account=account,
-        payload={"api_key": key},
-        expires_at=None,
-        provider_email=account.username,
-        kind="api_key",
-    )
-    settings = await HarnessSettings.get_registered(harness.name)
-    return HarnessResponse.from_row(settings, connection, account)
+        return ProviderLoginResponse.model_validate(login)
+    raise HTTPException(status_code=422, detail="The API key is empty. Paste a key.")
 
 
-@router.delete("/{name}/connection", response_model=HarnessResponse, response_model_by_alias=True)
-async def disconnect_harness(
-    name: str, account: Account = Depends(current_session_account)
-) -> HarnessResponse:
-    harness = _resolve_harness(name)
-    connection = await HarnessConnection.get_for_account(harness.name, account.id)
-    if connection:
-        # Only the requesting account's own connection — never another's.
-        await connection.delete()
-    settings = await HarnessSettings.get_registered(harness.name)
-    return HarnessResponse.from_row(settings, None, account)
+@router.delete("/{provider_id}/connection", status_code=204)
+async def disconnect(provider_id: str, account: Account = Depends(current_session_account)) -> None:
+    provider = _resolve_provider(provider_id)
+    login = await ProviderLogin.get_for_account(provider.id, account.id)
+    if login:
+        # Only the requesting account's own login — never another's.
+        await login.delete()

--- a/backend/druks/harnesses/schemas.py
+++ b/backend/druks/harnesses/schemas.py
@@ -1,16 +1,29 @@
-from pydantic import ConfigDict, field_validator
+from datetime import datetime
+
+from pydantic import ConfigDict, Field, field_validator
 
 from druks.schemas import Schema
 
 
-class HarnessSummary(Schema):
+class ProviderResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
-    name: str
-    # A frozenset on the class; sorted so the wire is deterministic.
+    id: str
+    label: str
     login_kinds: list[str]
 
-    @field_validator("login_kinds", mode="after")
+    @field_validator("login_kinds", mode="before")
     @classmethod
-    def _sorted(cls, kinds: list[str]) -> list[str]:
+    def _sorted(cls, kinds: frozenset[str]) -> list[str]:
         return sorted(kinds)
+
+
+class ProviderLoginResponse(Schema):
+    model_config = ConfigDict(from_attributes=True)
+
+    provider: str
+    kind: str
+    # The email the provider reported at connect — display, never authority.
+    provider_email: str
+    expires_at: datetime | None
+    connected: bool = Field(validation_alias="is_connected")

--- a/backend/druks/mcp/gateway/schemas.py
+++ b/backend/druks/mcp/gateway/schemas.py
@@ -56,9 +56,9 @@ class AgentCallDetailResponse(Schema):
     artifact: ArtifactContent | None = None
 
 
-class AgentHarnessUsage(Schema):
+class AgentProviderUsage(Schema):
     # *_history: percent-left trend samples, oldest first.
-    name: str
+    id: str
     is_connected: bool = False
     plan_tier: str | None = None
     five_hour_percent_left: int | None = None
@@ -77,4 +77,4 @@ class AgentUsageResponse(Schema):
     spend_today_usd: float
     tokens_today: int
     runs_today: int
-    harnesses: list[AgentHarnessUsage] = Field(default_factory=list)
+    providers: list[AgentProviderUsage] = Field(default_factory=list)

--- a/backend/druks/mcp/gateway/services.py
+++ b/backend/druks/mcp/gateway/services.py
@@ -10,8 +10,8 @@ from druks.durable.models import AgentCall, Artifact, Run
 from druks.durable.reads import read_slice
 from druks.durable.schemas import AgentCallResponse
 from druks.harnesses.artifacts import normalize_token_usage
-from druks.harnesses.models import HarnessConnection
-from druks.harnesses.registry import get_harnesses
+from druks.harnesses.models import ProviderLogin
+from druks.harnesses.providers import get_providers
 from druks.mcp.gateway import exceptions, schemas
 from druks.notifications.exceptions import InvalidChoiceError
 from druks.notifications.services import validate_in_app_answer
@@ -123,16 +123,18 @@ async def get_usage(account: Account) -> schemas.AgentUsageResponse:
         spend_today_usd=round(spend, 4),
         tokens_today=tokens,
         runs_today=len(rows),
-        harnesses=[await _harness_usage(h.name, account.id, now=now) for h in get_harnesses()],
+        providers=[await _provider_usage(p.id, account.id, now=now) for p in get_providers()],
     )
 
 
-async def _harness_usage(name: str, account_id: str, *, now: datetime) -> schemas.AgentHarnessUsage:
-    is_connected = bool(await HarnessConnection.get_for_account(name, account_id))
-    row = await UsageScrape.latest_for(name, account_id)
+async def _provider_usage(
+    provider_id: str, account_id: str, *, now: datetime
+) -> schemas.AgentProviderUsage:
+    is_connected = bool(await ProviderLogin.get_for_account(provider_id, account_id))
+    row = await UsageScrape.latest_for(provider_id, account_id)
     if not row:
-        return schemas.AgentHarnessUsage(name=name, is_connected=is_connected)
-    history = await UsageScrape.history_for(name, account_id, since=now - WEEK_RANGE)
+        return schemas.AgentProviderUsage(id=provider_id, is_connected=is_connected)
+    history = await UsageScrape.history_for(provider_id, account_id, since=now - WEEK_RANGE)
     five_hour_cutoff = now - FIVE_HOUR_RANGE
     five_hour = [
         UsageHistoryPoint(t=point.scraped_at, pct=point.five_hour_percent_left)
@@ -145,8 +147,8 @@ async def _harness_usage(name: str, account_id: str, *, now: datetime) -> schema
         if (binding := point.binding_week())
     ]
     binding_week = row.binding_week() or {}
-    return schemas.AgentHarnessUsage(
-        name=name,
+    return schemas.AgentProviderUsage(
+        id=provider_id,
         is_connected=is_connected,
         plan_tier=row.plan_tier,
         five_hour_percent_left=row.five_hour_percent_left,

--- a/backend/druks/sandbox/constants.py
+++ b/backend/druks/sandbox/constants.py
@@ -11,3 +11,22 @@ SANDBOX_HOST_ROTATE_BEFORE_SECONDS = MAX_AGENT_TIMEOUT_SECONDS + 10 * 60  # 75 m
 # a refresh runs, and the zset of active users scored by expiry.
 ROTATING_PREFIX = "druks:sandbox:rotating:"
 GATE_USERS_PREFIX = "druks:sandbox:gate:users:"
+
+# Tar excludes for every tree copied into a sandbox home. These never carry
+# value into the VM and dominate upload time when shipped naively:
+#
+# - ``.in_use`` — Claude's plugin cache writes a marker file per *host* PID
+#   to track which processes pin a plugin version. The VM has a fresh PID
+#   space, so our host's markers are meaningless noise — and there are
+#   thousands of them across the plugin tree.
+# - ``.git`` — marketplace plugin checkouts ship the full repo metadata.
+# - ``node_modules`` — some plugins (e.g. ones with TS tooling) ship deps
+#   that re-install fine inside the VM.
+# - ``__pycache__`` / ``*.pyc`` — Python bytecode is host-arch sensitive.
+DEFAULT_DIR_EXCLUDES: tuple[str, ...] = (
+    ".in_use",
+    ".git",
+    "node_modules",
+    "__pycache__",
+    "*.pyc",
+)

--- a/backend/druks/sandbox/credentials.py
+++ b/backend/druks/sandbox/credentials.py
@@ -6,33 +6,11 @@ from .layout import get_github_token_remote_path, get_remote_home
 if TYPE_CHECKING:
     from .host import Host
 
-# Tar excludes for credential-dir uploads. These never carry value into the
-# VM and dominate upload time when shipped naively:
-#
-# - ``.in_use`` — Claude's plugin cache writes a marker file per *host* PID
-#   to track which processes pin a plugin version. The VM has a fresh PID
-#   space, so our host's markers are meaningless noise — and there are
-#   thousands of them across the plugin tree.
-# - ``.git`` — marketplace plugin checkouts ship the full repo metadata.
-# - ``node_modules`` — some plugins (e.g. ones with TS tooling) ship deps
-#   that re-install fine inside the VM.
-# - ``__pycache__`` / ``*.pyc`` — Python bytecode is host-arch sensitive.
-DEFAULT_DIR_EXCLUDES: tuple[str, ...] = (
-    ".in_use",
-    ".git",
-    "node_modules",
-    "__pycache__",
-    "*.pyc",
-)
-
 
 async def push(host: "Host", credentials: Credentials) -> None:
     home = get_remote_home(host.ssh_username)
-    for remote_path_suffix, rendered_content in credentials.files:
-        await host.write_secret(
-            secret=rendered_content,
-            remote=f"{home}/{remote_path_suffix}",
-        )
+    for entry in credentials.home:
+        await entry.push(host, home)
     if credentials.github_token:
         # TODO: This token expires in ~60 min and is not refreshed, so a run
         # outliving it 401s on late git pushes. The in-VM credential helper
@@ -41,21 +19,4 @@ async def push(host: "Host", credentials: Credentials) -> None:
         await host.write_secret(
             secret=credentials.github_token,
             remote=get_github_token_remote_path(host.ssh_username),
-        )
-
-    for local, dest_suffix in credentials.extra_config_files:
-        # Optional — a dev box may not have config.toml etc., and a Docker bind
-        # mount whose host file never existed leaves a directory at the path.
-        # Push real files only; missing config isn't fatal (the CLIs mint their
-        # own defaults in the VM).
-        if not local.is_file():
-            continue
-        await host.upload_file(local=local, remote=f"{home}/{dest_suffix}")
-    for local, dest_suffix in credentials.extra_config_dirs:
-        if not local.is_dir():
-            continue
-        await host.upload_dir(
-            local=local,
-            remote=f"{home}/{dest_suffix}",
-            excludes=DEFAULT_DIR_EXCLUDES + credentials.extra_dir_excludes.get(dest_suffix, ()),
         )

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -9,11 +9,14 @@ from pydantic import BaseModel, Field
 
 from druks.apps import loader
 
+from .constants import DEFAULT_DIR_EXCLUDES
 from .exceptions import SetupScriptError
 
 if TYPE_CHECKING:
     from druks.durable.enums import AgentCallStatus
     from druks.harnesses.exceptions import HarnessError
+
+    from .host import Host
 
 
 class Profile(BaseModel):
@@ -23,6 +26,10 @@ class Profile(BaseModel):
 
     image: str | None = None
     env: dict[str, str] = Field(default_factory=dict)
+
+
+if TYPE_CHECKING:
+    from .host import Host
 
 
 @dataclass(frozen=True)
@@ -158,28 +165,40 @@ class RequiredMcpServer:
 
 
 @dataclass(frozen=True)
+class HomeFile:
+    """Rendered content written at a home-relative path, never staged on the host."""
+
+    path: str
+    content: str
+
+    async def push(self, host: "Host", home: str) -> None:
+        await host.write_secret(secret=self.content, remote=f"{home}/{self.path}")
+
+
+@dataclass(frozen=True)
+class HomeCopy:
+    """A host file or tree copied to a home-relative path. What the host lacks
+    is skipped: config is optional, and the CLIs mint their own defaults."""
+
+    path: str
+    source: Path
+    excludes: tuple[str, ...] = ()
+
+    async def push(self, host: "Host", home: str) -> None:
+        remote = f"{home}/{self.path}"
+        # A Docker bind mount whose host file never existed leaves a directory
+        # at a file's path; is_file() keeps that out.
+        if self.source.is_file():
+            await host.upload_file(local=self.source, remote=remote)
+        elif self.source.is_dir():
+            await host.upload_dir(
+                local=self.source, remote=remote, excludes=DEFAULT_DIR_EXCLUDES + self.excludes
+            )
+
+
+@dataclass(frozen=True)
 class Credentials:
-    # Home-relative paths and rendered content for files written as VM secrets.
-    files: tuple[tuple[str, str], ...] = ()
+    """What lands in the sandbox home before the CLI runs."""
+
+    home: tuple[HomeFile | HomeCopy, ...] = ()
     github_token: str | None = None
-    # Extra config files to carry into the VM, as
-    # ``(local_path, home_relative_dest)`` pairs. This is how the
-    # agents' MCP / plugin config travels — e.g.
-    # ``(~/.codex/config.toml, ".codex/config.toml")`` brings the
-    # curated remote plugins (linear / notion / figma) along, and the
-    # sibling ``.credentials.json`` carries their auth. Each is pushed
-    # under the agent user's in-VM home (so ``.codex/config.toml`` ->
-    # ``/home/<user>/.codex/config.toml``) and **skipped if the local
-    # file is absent** — config is optional, missing it isn't fatal.
-    extra_config_files: tuple[tuple[Path, str], ...] = ()
-    # Directory trees to carry into the VM, same
-    # ``(local_path, home_relative_dest)`` shape, copied recursively.
-    # This is how Claude's managed-plugin trees travel
-    # (``~/.claude/plugins/marketplaces`` + ``.../cache``) since those
-    # are directories, not flat files. Skipped if the local dir is
-    # absent.
-    extra_config_dirs: tuple[tuple[Path, str], ...] = ()
-    # Per-destination extra tar excludes, keyed by the same home-relative dest
-    # as ``extra_config_dirs``, merged with ``DEFAULT_DIR_EXCLUDES`` at push.
-    # The skills projection uses this to drop disabled skills from the upload.
-    extra_dir_excludes: dict[str, tuple[str, ...]] = field(default_factory=dict)

--- a/backend/druks/usage/models.py
+++ b/backend/druks/usage/models.py
@@ -11,11 +11,11 @@ from druks.db import Base, db_session
 class UsageScrape(Base):
     __tablename__ = "usage_scrapes"
     __table_args__ = (
-        Index("usage_scrapes_account_harness_time_idx", "account_id", "harness", "scraped_at"),
+        Index("usage_scrapes_account_provider_time_idx", "account_id", "provider", "scraped_at"),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    harness: Mapped[str]  # a registered harness name (get_harnesses())
+    provider: Mapped[str]  # a registered provider id (get_providers())
     # The account this snapshot describes.
     account_id: Mapped[str] = mapped_column(ForeignKey("accounts.id", ondelete="RESTRICT"))
     scraped_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
@@ -44,10 +44,10 @@ class UsageScrape(Base):
     unlimited: Mapped[bool] = mapped_column(default=False)
 
     @classmethod
-    async def latest_for(cls, harness: str, account_id: str) -> "UsageScrape | None":
+    async def latest_for(cls, provider_id: str, account_id: str) -> "UsageScrape | None":
         stmt = (
             select(cls)
-            .where(cls.harness == harness, cls.account_id == account_id)
+            .where(cls.provider == provider_id, cls.account_id == account_id)
             .order_by(cls.scraped_at.desc())
             .limit(1)
         )
@@ -55,14 +55,14 @@ class UsageScrape(Base):
 
     @classmethod
     async def history_for(
-        cls, harness: str, account_id: str, *, since: datetime
+        cls, provider_id: str, account_id: str, *, since: datetime
     ) -> list["UsageScrape"]:
-        """The account's successful scrapes for ``harness`` since ``since``,
+        """The account's successful scrapes for ``provider_id`` since ``since``,
         oldest first. Feeds the usage page's trend sparklines / burn-rate
         math, so failed scrapes (no percentages) are excluded."""
         stmt = (
             select(cls)
-            .where(cls.harness == harness, cls.account_id == account_id)
+            .where(cls.provider == provider_id, cls.account_id == account_id)
             .where(cls.scraped_at >= since)
             .where(cls.parse_ok.is_(True))
             .order_by(cls.scraped_at.asc())

--- a/backend/druks/usage/routes.py
+++ b/backend/druks/usage/routes.py
@@ -6,17 +6,17 @@ from druks.accounts.dependencies import current_account
 from druks.accounts.models import Account
 from druks.core.utils.time import operator_local_day
 from druks.harnesses.artifacts import normalize_token_usage
-from druks.harnesses.models import HarnessConnection
-from druks.harnesses.registry import get_harnesses
+from druks.harnesses.models import ProviderLogin
+from druks.harnesses.providers import Provider, get_providers
 from druks.usage.models import UsageScrape
 from druks.usage.reads import list_finished_calls
 from druks.usage.schemas import (
-    UsageHarnessHistory,
-    UsageHarnessSummary,
-    UsageHarnessToday,
     UsageHistoryPoint,
     UsageHistoryResponse,
     UsageMetricSummary,
+    UsageProviderHistory,
+    UsageProviderSummary,
+    UsageProviderToday,
     UsageResponse,
     UsageTodayResponse,
     UsageWindowHistory,
@@ -26,7 +26,7 @@ from druks.user_settings.models import HarnessSettings, UserSettings
 
 router = APIRouter()
 
-# The /today bucket for calls whose model no current harness claims.
+# The /today bucket for calls whose model no current picker claims.
 UNATTRIBUTED = "unattributed"
 
 # An open tab must not hammer the providers.
@@ -50,30 +50,30 @@ _MAX_SPARK_POINTS = 72
 async def get_usage(account: Account = Depends(current_account)) -> UsageResponse:
     now = datetime.now(UTC)
     summaries = []
-    for harness in get_harnesses():
-        connection = await HarnessConnection.get_for_account(harness.name, account.id)
+    for provider in get_providers():
+        login = await ProviderLogin.get_for_account(provider.id, account.id)
         summaries.append(
             _summarize(
-                await UsageScrape.latest_for(harness.name, account.id),
-                name=harness.name,
+                await UsageScrape.latest_for(provider.id, account.id),
+                provider=provider,
                 now=now,
-                connected=bool(connection),
-                provider_email=connection.provider_email if connection else None,
-                is_metered=connection.is_metered if connection else True,
+                connected=bool(login),
+                provider_email=login.provider_email if login else None,
+                is_metered=login.is_metered if login else True,
             )
         )
-    return UsageResponse(harnesses=summaries)
+    return UsageResponse(providers=summaries)
 
 
 @router.post("/refresh")
 async def refresh_usage(account: Account = Depends(current_account)) -> None:
     now = datetime.now(UTC)
-    for harness in get_harnesses():
-        connection = await HarnessConnection.get_for_account(harness.name, account.id)
-        row = await UsageScrape.latest_for(harness.name, account.id)
+    for provider in get_providers():
+        login = await ProviderLogin.get_for_account(provider.id, account.id)
+        row = await UsageScrape.latest_for(provider.id, account.id)
         age = _age_seconds(row.scraped_at, now=now) if row else None
-        if connection and connection.is_metered and (age is None or age >= _REFRESH_FLOOR_SECONDS):
-            await harness.poll_usage(connection)
+        if login and login.is_metered and (age is None or age >= _REFRESH_FLOOR_SECONDS):
+            await provider.poll_usage(login)
 
 
 @router.get(
@@ -84,7 +84,10 @@ async def refresh_usage(account: Account = Depends(current_account)) -> None:
 async def get_usage_history(account: Account = Depends(current_account)) -> UsageHistoryResponse:
     now = datetime.now(UTC)
     return UsageHistoryResponse(
-        harnesses=[await _harness_history(h.name, account.id, now=now) for h in get_harnesses()],
+        providers=[
+            await _provider_history(provider.id, account.id, now=now)
+            for provider in get_providers()
+        ],
     )
 
 
@@ -108,18 +111,18 @@ async def get_usage_today(account: Account = Depends(current_account)) -> UsageT
     # outside the list, or an id that churned): money spent must not vanish from
     # the display, and the strip's total_run_spend_between counts them too.
     # Unclaimed calls land in an extra "unattributed" entry — the panel's
-    # per-harness cards look up by name and skip it, its grand total sums the
+    # per-provider cards look up by id and skip it, its grand total sums the
     # whole list.
-    harness_by_model = {
-        entry["id"]: settings.name
+    provider_by_model = {
+        entry["id"]: settings.harness.provider_for(entry["id"])
         for settings in await HarnessSettings.all()
         for entry in settings.allowed_models
     }
-    names = [h.name for h in get_harnesses()]
-    totals = {name: {"spend": 0.0, "tokens": 0, "runs": 0} for name in [*names, UNATTRIBUTED]}
-    hours: dict[str, list[float]] = {name: [0.0] * 24 for name in [*names, UNATTRIBUTED]}
+    ids = [provider.id for provider in get_providers()]
+    totals = {name: {"spend": 0.0, "tokens": 0, "runs": 0} for name in [*ids, UNATTRIBUTED]}
+    hours: dict[str, list[float]] = {name: [0.0] * 24 for name in [*ids, UNATTRIBUTED]}
     for model, cost_usd, cost_metadata, finished_at in rows:
-        name = harness_by_model.get(model, UNATTRIBUTED)
+        name = provider_by_model.get(model, UNATTRIBUTED)
         bucket = totals[name]
         bucket["runs"] += 1
         usage = normalize_token_usage(cost_metadata)
@@ -129,13 +132,13 @@ async def get_usage_today(account: Account = Depends(current_account)) -> UsageT
             bucket["spend"] += cost_usd
             hours[name][finished_at.astimezone(timezone).hour] += cost_usd
 
-    included = [*names, UNATTRIBUTED] if totals[UNATTRIBUTED]["runs"] else names
+    included = [*ids, UNATTRIBUTED] if totals[UNATTRIBUTED]["runs"] else ids
     return UsageTodayResponse(
         day=local_start.date().isoformat(),
         timezone=timezone_name,
-        harnesses=[
-            UsageHarnessToday(
-                name=name,
+        providers=[
+            UsageProviderToday(
+                id=name,
                 spend_usd=round(float(totals[name]["spend"]), 4),
                 tokens=int(totals[name]["tokens"]),
                 runs=int(totals[name]["runs"]),
@@ -146,8 +149,10 @@ async def get_usage_today(account: Account = Depends(current_account)) -> UsageT
     )
 
 
-async def _harness_history(name: str, account_id: str, *, now: datetime) -> UsageHarnessHistory:
-    rows = await UsageScrape.history_for(name, account_id, since=now - WEEK_RANGE)
+async def _provider_history(
+    provider_id: str, account_id: str, *, now: datetime
+) -> UsageProviderHistory:
+    rows = await UsageScrape.history_for(provider_id, account_id, since=now - WEEK_RANGE)
     five_hour_cutoff = now - FIVE_HOUR_RANGE
     five_hour = [
         UsageHistoryPoint(t=row.scraped_at, pct=row.five_hour_percent_left)
@@ -161,8 +166,8 @@ async def _harness_history(name: str, account_id: str, *, now: datetime) -> Usag
                 weekly_points.setdefault(week["model"], []).append(
                     UsageHistoryPoint(t=row.scraped_at, pct=week["percent_left"])
                 )
-    return UsageHarnessHistory(
-        name=name,
+    return UsageProviderHistory(
+        id=provider_id,
         five_hour=downsample(five_hour, cap=_MAX_SPARK_POINTS),
         weeks=[
             UsageWindowHistory(
@@ -177,23 +182,25 @@ async def _harness_history(name: str, account_id: str, *, now: datetime) -> Usag
 def _summarize(
     row: UsageScrape | None,
     *,
-    name: str,
+    provider: Provider,
     now: datetime,
     connected: bool,
     provider_email: str | None,
     is_metered: bool,
-) -> UsageHarnessSummary:
+) -> UsageProviderSummary:
     if connected and not is_metered:
-        return UsageHarnessSummary(
-            name=name,
+        return UsageProviderSummary(
+            id=provider.id,
+            label=provider.label,
             available=True,
             connected=True,
             provider_email=provider_email,
             unlimited=True,
         )
     if not row:
-        return UsageHarnessSummary(
-            name=name,
+        return UsageProviderSummary(
+            id=provider.id,
+            label=provider.label,
             available=False,
             connected=connected,
             provider_email=provider_email,
@@ -205,8 +212,9 @@ def _summarize(
             percent_left=row.five_hour_percent_left,
             resets_at=row.five_hour_resets_at,
         )
-    return UsageHarnessSummary(
-        name=name,
+    return UsageProviderSummary(
+        id=provider.id,
+        label=provider.label,
         available=row.parse_ok,
         connected=connected,
         provider_email=provider_email,

--- a/backend/druks/usage/schemas.py
+++ b/backend/druks/usage/schemas.py
@@ -13,16 +13,17 @@ class UsageMetricSummary(Schema):
     model: str | None = None
 
 
-class UsageHarnessSummary(Schema):
-    # A registered harness name (get_harnesses()) — the UI keys panels,
+class UsageProviderSummary(Schema):
+    # A registered provider id (get_providers()) — the UI keys panels,
     # colors, and legends off it.
-    name: str
+    id: str
+    label: str
     # True when we have any usable percentage. False covers both "no
     # snapshot yet" (fresh install pre-first-poll) and "all parses
     # failed in the last snapshot".
     available: bool
-    # False renders the connect action — the account has no connection
-    # for this harness.
+    # False renders the connect action — the account holds no login
+    # for this provider.
     connected: bool
     provider_email: str | None
     plan_tier: str | None = None
@@ -51,8 +52,8 @@ class UsageHarnessSummary(Schema):
 
 
 class UsageResponse(Schema):
-    # One summary per registered harness, in registry order.
-    harnesses: list[UsageHarnessSummary]
+    # One summary per registered provider, in registry order.
+    providers: list[UsageProviderSummary]
 
 
 class UsageHistoryPoint(Schema):
@@ -65,22 +66,22 @@ class UsageWindowHistory(Schema):
     points: list[UsageHistoryPoint] = Field(default_factory=list)
 
 
-class UsageHarnessHistory(Schema):
-    name: str
+class UsageProviderHistory(Schema):
+    id: str
     # Percent-left samples, oldest first. ``five_hour`` covers the last
     # ~6h (one full 5h window plus headroom); ``weeks`` covers the last
     # 7 days as one downsampled series per weekly window. Either list is
-    # empty when the harness never reported that window.
+    # empty when the provider never reported that window.
     five_hour: list[UsageHistoryPoint] = Field(default_factory=list)
     weeks: list[UsageWindowHistory] = Field(default_factory=list)
 
 
 class UsageHistoryResponse(Schema):
-    harnesses: list[UsageHarnessHistory]
+    providers: list[UsageProviderHistory]
 
 
-class UsageHarnessToday(Schema):
-    name: str
+class UsageProviderToday(Schema):
+    id: str
     spend_usd: float
     tokens: int
     runs: int
@@ -93,4 +94,4 @@ class UsageTodayResponse(Schema):
     # spend-today figure (operator timezone, finished_at attribution).
     day: str
     timezone: str
-    harnesses: list[UsageHarnessToday]
+    providers: list[UsageProviderToday]

--- a/backend/druks/user_settings/models.py
+++ b/backend/druks/user_settings/models.py
@@ -20,7 +20,7 @@ from .datastructures import (
 
 if TYPE_CHECKING:
     from druks.harnesses.base import Harness
-    from druks.harnesses.models import HarnessConnection
+    from druks.harnesses.models import ProviderLogin
 
 logger = logging.getLogger(__name__)
 
@@ -115,10 +115,6 @@ class HarnessSettings(Base):
         return get_harness(self.name)
 
     @property
-    def provider(self) -> str:
-        return self.harness.provider
-
-    @property
     def allowed_models(self) -> list[dict]:
         """Picker models, ``{"id", "label"}`` each — the provider-fetched
         list when one has landed, else the harness's shipped tuple."""
@@ -126,12 +122,12 @@ class HarnessSettings(Base):
             return [{"id": m["id"], "label": m["label"]} for m in self.models_fetched]
         return [{"id": name, "label": name} for name in self.harness.models]
 
-    async def refresh_models(self, connection: "HarnessConnection") -> dict[str, object]:
-        """Fetch the provider's selectable models over ``connection`` and store
+    async def refresh_models(self, login: "ProviderLogin") -> dict[str, object]:
+        """Fetch the provider's selectable models over ``login`` and store
         them on this row. Every failure is a tag in the report, never a raise,
         and leaves the stored list untouched — connect and the cron shrug it off."""
         try:
-            parsed = await self.harness.fetch_models(connection)
+            parsed = await self.harness.fetch_models(login)
         except Exception:  # noqa: BLE001 — a crashed fetch reports a tag, not a failed caller
             logger.warning("models fetch crashed for %s", self.name, exc_info=True)
             return {"harness": self.name, "ok": False, "error": "crashed"}

--- a/backend/druks/user_settings/routes.py
+++ b/backend/druks/user_settings/routes.py
@@ -2,13 +2,11 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from druks.accounts.dependencies import current_account, current_session_account
-from druks.accounts.models import Account
+from druks.accounts.dependencies import current_session_account
 from druks.apps.loader import get_app, iter_apps
 from druks.apps.registry import workflows
 from druks.durable.engine import apply_schedules
 from druks.harnesses.exceptions import HarnessError
-from druks.harnesses.models import HarnessConnection
 from druks.harnesses.registry import get_harness_for_model, get_harnesses
 from druks.notifications.models import Destination
 
@@ -45,29 +43,18 @@ async def _resolve_harness(name: str) -> tuple[type, HarnessSettings]:
     raise HTTPException(status_code=404, detail=f"Unknown harness: {name!r}")
 
 
-async def _harness_response(settings: HarnessSettings, account: Account) -> HarnessResponse:
-    connection = await HarnessConnection.get_for_account(settings.name, account.id)
-    return HarnessResponse.from_row(settings, connection, account)
-
-
-# Connection state is the requesting operator's own connection —
-# connect/disconnect live on the /api/harnesses connection surface, not here.
 @router.get("/harnesses", response_model=list[HarnessResponse], response_model_by_alias=True)
-async def list_harness_settings(
-    account: Account = Depends(current_account),
-) -> list[HarnessResponse]:
+async def list_harness_settings() -> list[HarnessResponse]:
     registered = {harness.name for harness in get_harnesses()}
     return [
-        await _harness_response(row, account)
+        HarnessResponse.from_row(row)
         for row in await HarnessSettings.all()
         if row.name in registered
     ]
 
 
 @router.patch("/harnesses/{name}", response_model=HarnessResponse, response_model_by_alias=True)
-async def update_harness_settings(
-    name: str, body: HarnessUpdate, account: Account = Depends(current_account)
-) -> HarnessResponse:
+async def update_harness_settings(name: str, body: HarnessUpdate) -> HarnessResponse:
     harness, row = await _resolve_harness(name)
     updates = body.model_dump(exclude_unset=True, by_alias=False)
     if "model" in updates:
@@ -84,7 +71,7 @@ async def update_harness_settings(
     _validate_timeout(updates.get("timeout"))
     if updates:
         await row.update(**updates)
-    return await _harness_response(row, account)
+    return HarnessResponse.from_row(row)
 
 
 @router.get("", response_model=UserSettingsResponse, response_model_by_alias=True)

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -14,8 +14,6 @@ from druks.apps.settings import (
 from druks.schemas import Schema
 
 if TYPE_CHECKING:
-    from druks.accounts.models import Account
-    from druks.harnesses.models import HarnessConnection
     from druks.user_settings.models import HarnessSettings
 
 
@@ -26,45 +24,26 @@ class AllowedModel(Schema):
 
 class HarnessResponse(Schema):
     name: str
-    provider: str
+    # The provider a subscription CLI is bound to; None for a key CLI.
+    provider: str | None
+    login_kinds: list[str]
     model: str
     effort: str
     timeout: int
     fast_mode: bool
     allowed_models: list[AllowedModel]
-    # The requesting account's own connection; false until this account connects.
-    connected: bool
-    kind: str | None
-    login_kinds: list[str]
-    account: str | None
-    # The email the provider reported at connect — display, never authority.
-    provider_email: str | None
-    expires_at: datetime | None
 
     @classmethod
-    def from_row(
-        cls,
-        settings: "HarnessSettings",
-        connection: "HarnessConnection | None",
-        account: "Account",
-    ) -> "HarnessResponse":
-        connected = bool(connection) and (
-            not connection.expires_at or connection.expires_at > datetime.now(UTC)
-        )
+    def from_row(cls, settings: "HarnessSettings") -> "HarnessResponse":
         return cls(
             name=settings.name,
-            provider=settings.provider,
+            provider=settings.harness.provider,
+            login_kinds=sorted(settings.harness.login_kinds),
             model=settings.model,
             effort=settings.effort,
             timeout=settings.timeout,
             fast_mode=settings.fast_mode,
             allowed_models=settings.allowed_models,
-            connected=connected,
-            kind=connection.kind if connection else None,
-            login_kinds=sorted(settings.harness.login_kinds),
-            account=account.username if connection else None,
-            provider_email=connection.provider_email if connection else None,
-            expires_at=connection.expires_at if connection else None,
         )
 
 

--- a/backend/migrations/versions/e3a9c7d1b5f4_providers_own_logins.py
+++ b/backend/migrations/versions/e3a9c7d1b5f4_providers_own_logins.py
@@ -1,0 +1,113 @@
+"""Providers own logins and quota.
+
+Revision ID: e3a9c7d1b5f4
+Revises: b4c7e1a8d052
+Create Date: 2026-09-02
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e3a9c7d1b5f4"
+down_revision: str | Sequence[str] | None = "b4c7e1a8d052"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# The two subscription harnesses each ran one provider; a key harness's
+# provider is the namespace of the model it was set to run.
+_OAUTH_PROVIDER_BY_HARNESS = {"claude": "anthropic", "codex": "openai-codex"}
+_PROVIDERS = ("anthropic", "openai", "openai-codex")
+
+
+def upgrade() -> None:
+    op.rename_table("harness_logins", "provider_logins")
+    op.alter_column("provider_logins", "harness", new_column_name="provider")
+    # Two harness rows can map onto one provider for one account; the guard
+    # below names that case, so the unique constraint returns only after it.
+    op.drop_constraint("harness_logins_harness_account_id_key", "provider_logins")
+    op.execute(sa.text("UPDATE provider_logins SET kind = 'oauth' WHERE kind = 'subscription'"))
+    for harness, provider in _OAUTH_PROVIDER_BY_HARNESS.items():
+        op.execute(
+            sa.text(
+                "UPDATE provider_logins SET provider = :provider WHERE provider = :harness"
+            ).bindparams(provider=provider, harness=harness)
+        )
+    op.execute(
+        sa.text(
+            "UPDATE provider_logins SET provider = split_part(harnesses.model, '/', 1) "
+            "FROM harnesses WHERE harnesses.name = provider_logins.provider "
+            "AND provider_logins.kind = 'api_key' AND position('/' IN harnesses.model) > 0"
+        )
+    )
+    bind = op.get_bind()
+    unmapped = bind.scalar(
+        sa.text("SELECT count(*) FROM provider_logins WHERE provider NOT IN :providers").bindparams(
+            sa.bindparam("providers", expanding=True, value=list(_PROVIDERS))
+        )
+    )
+    if unmapped:
+        raise RuntimeError(f"{unmapped} login rows name no provider; reconnect them first")
+    collisions = bind.scalar(
+        sa.text(
+            "SELECT count(*) FROM (SELECT 1 FROM provider_logins "
+            "GROUP BY provider, account_id HAVING count(*) > 1) AS twice"
+        )
+    )
+    if collisions:
+        raise RuntimeError(
+            f"{collisions} accounts hold two logins for one provider; disconnect one first"
+        )
+    op.create_unique_constraint(
+        "provider_logins_provider_account_id_key", "provider_logins", ["provider", "account_id"]
+    )
+
+    op.drop_index("usage_scrapes_account_harness_time_idx", table_name="usage_scrapes")
+    op.alter_column("usage_scrapes", "harness", new_column_name="provider")
+    for harness, provider in _OAUTH_PROVIDER_BY_HARNESS.items():
+        op.execute(
+            sa.text(
+                "UPDATE usage_scrapes SET provider = :provider WHERE provider = :harness"
+            ).bindparams(provider=provider, harness=harness)
+        )
+    op.create_index(
+        "usage_scrapes_account_provider_time_idx",
+        "usage_scrapes",
+        ["account_id", "provider", "scraped_at"],
+    )
+
+
+def downgrade() -> None:
+    keyed = op.get_bind().scalar(
+        sa.text("SELECT count(*) FROM provider_logins WHERE kind = 'api_key'")
+    )
+    if keyed:
+        raise RuntimeError(f"{keyed} api_key logins cannot be handed back to one harness")
+    op.drop_index("usage_scrapes_account_provider_time_idx", table_name="usage_scrapes")
+    for harness, provider in _OAUTH_PROVIDER_BY_HARNESS.items():
+        op.execute(
+            sa.text(
+                "UPDATE usage_scrapes SET provider = :harness WHERE provider = :provider"
+            ).bindparams(provider=provider, harness=harness)
+        )
+    op.alter_column("usage_scrapes", "provider", new_column_name="harness")
+    op.create_index(
+        "usage_scrapes_account_harness_time_idx",
+        "usage_scrapes",
+        ["account_id", "harness", "scraped_at"],
+    )
+
+    for harness, provider in _OAUTH_PROVIDER_BY_HARNESS.items():
+        op.execute(
+            sa.text(
+                "UPDATE provider_logins SET provider = :harness WHERE provider = :provider"
+            ).bindparams(provider=provider, harness=harness)
+        )
+    op.execute(sa.text("UPDATE provider_logins SET kind = 'subscription' WHERE kind = 'oauth'"))
+    op.drop_constraint("provider_logins_provider_account_id_key", "provider_logins")
+    op.alter_column("provider_logins", "provider", new_column_name="harness")
+    op.rename_table("provider_logins", "harness_logins")
+    op.create_unique_constraint(
+        "harness_logins_harness_account_id_key", "harness_logins", ["harness", "account_id"]
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -162,23 +162,24 @@ def bind_ambient_session(session) -> None:
     db_session.registry.set(session)
 
 
-async def connect_harness(harness_cls, payload: dict, *, provider_email: str = "op@example.com"):
-    """Seed the HarnessConnection row a finished connect flow would leave."""
+async def connect_provider(provider_cls, payload: dict, *, provider_email: str = "op@example.com"):
+    """Seed the ProviderLogin row a finished OAuth connect flow would leave."""
     from druks.accounts.models import Account
-    from druks.harnesses.models import HarnessConnection
+    from druks.harnesses.models import ProviderLogin
     from druks.user_settings.models import UserSettings
 
     account = await Account.get_or_create(provider_email)
     settings = await UserSettings.get()
     if not settings.fallback_account_id:
         await settings.set_fallback_account(account.id)
-    _, expires_at = harness_cls._refresh_state(payload)
-    return await HarnessConnection.connect(
-        harness=harness_cls.name,
+    _, expires_at = provider_cls._refresh_state(payload)
+    return await ProviderLogin.connect(
+        provider=provider_cls.id,
         account=account,
         payload=payload,
         expires_at=expires_at,
         provider_email=provider_email,
+        kind="oauth",
     )
 
 

--- a/backend/tests/test_agent_routes.py
+++ b/backend/tests/test_agent_routes.py
@@ -717,7 +717,7 @@ async def test_usage_agent_route_matches_the_service(client: TestClient, druks_d
     assert len(response.content) <= 4 * 1024
 
     today = client.get("/api/usage/today").json()
-    assert sum(h["spendUsd"] for h in today["harnesses"]) == pytest.approx(body["spendTodayUsd"])
-    assert sum(h["runs"] for h in today["harnesses"]) == body["runsToday"]
-    assert sum(h["tokens"] for h in today["harnesses"]) == body["tokensToday"]
+    assert sum(h["spendUsd"] for h in today["providers"]) == pytest.approx(body["spendTodayUsd"])
+    assert sum(h["runs"] for h in today["providers"]) == body["runsToday"]
+    assert sum(h["tokens"] for h in today["providers"]) == body["tokensToday"]
     assert today["day"] == body["day"]

--- a/backend/tests/test_agent_services.py
+++ b/backend/tests/test_agent_services.py
@@ -428,7 +428,7 @@ async def test_get_usage_is_a_bounded_pure_read(druks_db, account):
         )
     for tick in range(40):
         await UsageScrape(
-            harness="claude",
+            provider="anthropic",
             account_id=account.id,
             scraped_at=now - timedelta(minutes=5 * tick),
             plan_tier="max",
@@ -454,7 +454,7 @@ async def test_get_usage_is_a_bounded_pure_read(druks_db, account):
     assert usage.runs_today == 30
     assert usage.spend_today_usd == pytest.approx(15.0)
     assert usage.tokens_today == sum(100 + i for i in range(30))
-    claude = next(h for h in usage.harnesses if h.name == "claude")
+    claude = next(h for h in usage.providers if h.id == "anthropic")
     assert claude.plan_tier == "max"
     assert claude.five_hour_percent_left == 90
     assert claude.week_percent_left == 40

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -71,10 +71,10 @@ async def _seed_run_for_record(druks_db):
 async def _connected_claude(druks_db):
     # A run refuses to dispatch on an unconnected harness; the runtime tests
     # here resolve to claude models, so connect it once.
-    from conftest import connect_harness
-    from druks.harnesses.claude import ClaudeHarness
+    from conftest import connect_provider
+    from druks.harnesses.providers import AnthropicProvider
 
-    await connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "test-token"}})
+    await connect_provider(AnthropicProvider, {"claudeAiOauth": {"accessToken": "test-token"}})
 
 
 def _patch_runtime(monkeypatch, tmp_path, payload):
@@ -152,11 +152,11 @@ async def test_run_refuses_unconnected_harness(druks_db, tmp_path, monkeypatch, 
     # The precondition fires where the harness is resolved — before any VM work.
     from druks.accounts.models import Account
     from druks.harnesses.exceptions import HarnessNotConnectedError
-    from druks.harnesses.models import HarnessConnection
+    from druks.harnesses.models import ProviderLogin
 
     await (
-        await HarnessConnection.get_for_account(
-            "claude", (await Account.get_for_username("op@example.com")).id
+        await ProviderLogin.get_for_account(
+            "anthropic", (await Account.get_for_username("op@example.com")).id
         )
     ).delete()
     sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})

--- a/backend/tests/test_api_providers.py
+++ b/backend/tests/test_api_providers.py
@@ -1,0 +1,104 @@
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from conftest import connect_provider
+from druks.accounts.models import Account
+from druks.harnesses.models import ProviderLogin
+from druks.harnesses.providers import AnthropicProvider
+from druks.testing import configure_app_for_test, make_settings
+from fastapi.testclient import TestClient
+
+
+def _build_client(tmp_path: Path) -> TestClient:
+    return TestClient(configure_app_for_test(settings=make_settings(tmp_path)))
+
+
+def _providers(client: TestClient) -> dict[str, dict]:
+    return {p["id"]: p for p in client.get("/api/providers").json()}
+
+
+def test_list_carries_login_kinds_and_no_connection(tmp_path: Path):
+    with _build_client(tmp_path) as client:
+        providers = _providers(client)
+    assert providers["anthropic"]["loginKinds"] == ["api_key", "oauth"]
+    assert providers["openai-codex"]["loginKinds"] == ["oauth"]
+    assert providers["openai"]["label"] == "OpenAI"
+
+
+async def test_list_shows_only_the_requesting_accounts_login(tmp_path: Path, druks_db):
+    # The list resolves the edge identity itself; another account's login
+    # never shows on this card.
+    await connect_provider(
+        AnthropicProvider,
+        {"claudeAiOauth": {"accessToken": "x"}},
+        provider_email="someone-else@example.com",
+    )
+    settings = make_settings(tmp_path, identity={"mode": "header", "header": "X-Edge-Email"})
+    with TestClient(configure_app_for_test(settings=settings)) as client:
+        response = client.get("/api/providers/logins", headers={"X-Edge-Email": "op@example.com"})
+    assert response.json() == []
+
+
+async def test_logins_report_the_provider_identity(tmp_path: Path, druks_db):
+    # The provider identity is display, never authority.
+    await ProviderLogin.connect(
+        provider="anthropic",
+        account=await Account.get_or_create("op@example.com"),
+        payload={"claudeAiOauth": {"accessToken": "x"}},
+        expires_at=None,
+        provider_email="seat@corp.com",
+        kind="oauth",
+    )
+    with _build_client(tmp_path) as client:
+        logins = client.get("/api/providers/logins").json()
+    assert logins == [
+        {
+            "provider": "anthropic",
+            "kind": "oauth",
+            "providerEmail": "seat@corp.com",
+            "expiresAt": None,
+            "connected": True,
+        }
+    ]
+
+
+async def test_logins_read_an_expired_token_as_not_connected(tmp_path: Path, druks_db):
+    await ProviderLogin.connect(
+        provider="anthropic",
+        account=await Account.get_or_create("op@example.com"),
+        payload={"claudeAiOauth": {"accessToken": "x"}},
+        expires_at=datetime.now(UTC) - timedelta(hours=1),
+        provider_email="seat@corp.com",
+        kind="oauth",
+    )
+    with _build_client(tmp_path) as client:
+        [login] = client.get("/api/providers/logins").json()
+    assert login["connected"] is False
+
+
+async def test_disconnect_removes_only_the_requesting_accounts_login(tmp_path: Path, druks_db):
+    mine = await connect_provider(AnthropicProvider, {"claudeAiOauth": {"accessToken": "x"}})
+    other = await connect_provider(
+        AnthropicProvider,
+        {"claudeAiOauth": {"accessToken": "y"}},
+        provider_email="someone-else@example.com",
+    )
+    mine_id, other_id = mine.id, other.id
+    with _build_client(tmp_path) as client:
+        response = client.delete("/api/providers/anthropic/connection")
+    assert response.status_code == 204
+    # The request deleted in its own task-scoped session; read past this
+    # task's identity map for what actually persisted.
+    assert not await ProviderLogin.reload(mine_id)
+    assert await ProviderLogin.reload(other_id)
+
+
+def test_disconnect_without_a_login_is_a_no_op(tmp_path: Path):
+    with _build_client(tmp_path) as client:
+        response = client.delete("/api/providers/anthropic/connection")
+    assert response.status_code == 204
+
+
+def test_unknown_provider_is_404(tmp_path: Path):
+    with _build_client(tmp_path) as client:
+        assert client.delete("/api/providers/nope/connection").status_code == 404

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from druks.contrib.review.app import Review
 from druks.contrib.software_factory.app import SoftwareFactory
 from druks.database import db_session
-from druks.harnesses.claude import ClaudeHarness
 from druks.testing import configure_app_for_test, make_settings
 from druks.user_settings.models import SettingsOverride
 from fastapi.testclient import TestClient
@@ -31,113 +30,11 @@ def test_get_harnesses_lists_seeded_defaults(tmp_path: Path):
     assert harnesses["claude"]["model"] == "claude-opus-4-7"
     claude_model_ids = [m["id"] for m in harnesses["claude"]["allowedModels"]]
     assert "claude-sonnet-4-6" in claude_model_ids
-    assert harnesses["codex"]["provider"] == "openai"
+    assert harnesses["codex"]["provider"] == "openai-codex"
+    assert harnesses["pi"]["provider"] is None
+    assert harnesses["pi"]["loginKinds"] == ["api_key"]
     assert (harnesses["codex"]["effort"], harnesses["codex"]["timeout"]) == ("high", 1800)
-
-
-def test_harness_response_carries_sorted_login_kinds(tmp_path: Path, monkeypatch):
-    monkeypatch.setattr(
-        ClaudeHarness,
-        "login_kinds",
-        frozenset({"subscription", "api_key"}),
-    )
-
-    with _build_client(tmp_path) as client:
-        harnesses = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}
-
-    assert harnesses["claude"]["loginKinds"] == ["api_key", "subscription"]
-    assert harnesses["codex"]["loginKinds"] == ["subscription"]
-
-
-def test_harness_response_carries_connection_state(tmp_path: Path):
-    with _build_client(tmp_path) as client:
-        claude = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}["claude"]
-    assert claude["connected"] is False
-    assert not claude["account"]
-    assert not claude["providerEmail"]
-    assert "expiresAt" in claude
-
-
-async def test_harnesses_show_only_the_requesting_accounts_connection(tmp_path: Path, druks_db):
-    from conftest import connect_harness
-    from druks.harnesses.claude import ClaudeHarness
-
-    # The suite's identity gate stands in op@example.com; another account's
-    # connection never shows on this card.
-    await connect_harness(
-        ClaudeHarness,
-        {"claudeAiOauth": {"accessToken": "x"}},
-        provider_email="someone-else@example.com",
-    )
-    with _build_client(tmp_path) as client:
-        claude = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}["claude"]
-    assert claude["connected"] is False
-
-
-async def test_harness_card_reports_identity(tmp_path: Path, druks_db):
-    from druks.accounts.models import Account
-    from druks.harnesses.models import HarnessConnection
-
-    # The provider identity is display, never authority.
-    await HarnessConnection.connect(
-        harness="claude",
-        account=await Account.get_or_create("op@example.com"),
-        payload={"claudeAiOauth": {"accessToken": "x"}},
-        expires_at=None,
-        provider_email="seat@corp.com",
-    )
-    with _build_client(tmp_path) as client:
-        claude = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}["claude"]
-    assert claude["connected"] is True
-    assert claude["account"] == "op@example.com"
-    assert claude["providerEmail"] == "seat@corp.com"
-
-
-async def test_harness_card_reads_expired_token_as_not_connected(tmp_path: Path, druks_db):
-    from datetime import UTC, datetime, timedelta
-
-    from druks.accounts.models import Account
-    from druks.harnesses.models import HarnessConnection
-
-    await HarnessConnection.connect(
-        harness="claude",
-        account=await Account.get_or_create("op@example.com"),
-        payload={"claudeAiOauth": {"accessToken": "x"}},
-        expires_at=datetime.now(UTC) - timedelta(hours=1),
-        provider_email="seat@corp.com",
-    )
-    with _build_client(tmp_path) as client:
-        claude = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}["claude"]
-    assert claude["connected"] is False
-
-
-async def test_disconnect_removes_only_the_requesting_accounts_connection(tmp_path: Path, druks_db):
-    from conftest import connect_harness
-    from druks.harnesses.claude import ClaudeHarness
-    from druks.harnesses.models import HarnessConnection
-
-    mine = await connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "x"}})
-    other = await connect_harness(
-        ClaudeHarness,
-        {"claudeAiOauth": {"accessToken": "y"}},
-        provider_email="someone-else@example.com",
-    )
-    mine_id, other_id = mine.id, other.id
-    with _build_client(tmp_path) as client:
-        response = client.delete("/api/harnesses/claude/connection")
-    assert response.status_code == 200
-    assert response.json()["connected"] is False
-    # The request deleted in its own task-scoped session; read past this
-    # task's identity map for what actually persisted.
-    assert not await HarnessConnection.reload(mine_id)
-    assert await HarnessConnection.reload(other_id)
-
-
-def test_disconnect_without_a_connection_is_a_no_op(tmp_path: Path):
-    with _build_client(tmp_path) as client:
-        response = client.delete("/api/harnesses/claude/connection")
-    assert response.status_code == 200
-    assert response.json()["connected"] is False
+    assert "connected" not in harnesses["claude"]
 
 
 def test_patch_settings_persists_valid_iana_zone(tmp_path: Path, monkeypatch):

--- a/backend/tests/test_api_usage.py
+++ b/backend/tests/test_api_usage.py
@@ -4,11 +4,11 @@ from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
 
 import pytest
-from conftest import connect_harness
+from conftest import connect_provider
 from druks.accounts.models import Account
-from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.datastructures import ParsedMetric, ParsedUsage
-from druks.harnesses.models import HarnessConnection
+from druks.harnesses.models import ProviderLogin
+from druks.harnesses.providers import AnthropicProvider
 from druks.settings import Settings
 from druks.testing import configure_app_for_test, make_settings, seed_call, seed_run
 from druks.usage.models import UsageScrape
@@ -45,8 +45,8 @@ async def _seed(snapshots: list[UsageScrape]) -> None:
         await snap.save()
 
 
-def _harness(body: dict, name: str) -> dict:
-    return next(entry for entry in body["harnesses"] if entry["name"] == name)
+def _provider(body: dict, provider_id: str) -> dict:
+    return next(entry for entry in body["providers"] if entry["id"] == provider_id)
 
 
 async def _seed_agent_call(druks_db, *, model: str = "gpt-5.5"):
@@ -55,11 +55,9 @@ async def _seed_agent_call(druks_db, *, model: str = "gpt-5.5"):
     return await seed_call(druks_db, run, "summarize", status="running", model=model)
 
 
-async def test_usage_today_counts_calls_whose_model_isnt_a_current_harness(
-    client, druks_db
-) -> None:
+async def test_usage_today_counts_calls_whose_model_no_picker_claims(client, druks_db) -> None:
     # Model ids churn on deploys (opus-4-7 → 4-8), so a call finished earlier today
-    # can carry an id no harness claims any more. Money spent must not vanish from
+    # can carry an id no picker claims any more. Money spent must not vanish from
     # the display — the sys-strip's total_run_spend_between counts every call, and
     # the two surfaces must quote the same number. Unclaimed models land in the
     # "unattributed" bucket the panel's grand total sums.
@@ -70,7 +68,7 @@ async def test_usage_today_counts_calls_whose_model_isnt_a_current_harness(
     await druks_db.flush()
 
     body = client.get("/api/usage/today").json()
-    bucket = _harness(body, "unattributed")
+    bucket = _provider(body, "unattributed")
     assert bucket["runs"] == 1
     assert bucket["spendUsd"] == 2.5
 
@@ -79,27 +77,22 @@ def test_get_usage_empty_returns_available_false(client) -> None:
     response = client.get("/api/usage")
     assert response.status_code == 200
     body = response.json()
-    # One entry per registered harness, none available pre-first-poll.
-    assert {entry["name"] for entry in body["harnesses"]} == {
-        "claude",
-        "codex",
-        "opencode",
-        "pi",
-    }
-    assert all(entry["available"] is False for entry in body["harnesses"])
+    # One entry per registered provider, none available pre-first-poll.
+    assert {entry["id"] for entry in body["providers"]} == {"anthropic", "openai", "openai-codex"}
+    assert all(entry["available"] is False for entry in body["providers"])
 
 
 async def test_get_usage_presents_api_key_connection_as_unmetered(client, druks_db) -> None:
-    await HarnessConnection.connect(
-        harness="opencode",
+    await ProviderLogin.connect(
+        provider="openai",
         account=await Account.get_or_create("op@example.com"),
-        payload={"apiKey": "key"},
+        payload={"api_key": "key"},
         expires_at=None,
         provider_email="op@example.com",
         kind="api_key",
     )
 
-    summary = _harness(client.get("/api/usage").json(), "opencode")
+    summary = _provider(client.get("/api/usage").json(), "openai")
 
     assert summary["available"] is True
     assert summary["connected"] is True
@@ -108,13 +101,13 @@ async def test_get_usage_presents_api_key_connection_as_unmetered(client, druks_
     assert summary["weeks"] == []
 
 
-async def test_get_usage_serializes_latest_per_harness(client, app_settings) -> None:
-    # Plant a snapshot for claude only — codex should still report
+async def test_get_usage_serializes_latest_per_provider(client, app_settings) -> None:
+    # Plant a snapshot for anthropic only — openai-codex should still report
     # ``available=false`` rather than missing-key/404.
     await _seed(
         [
             UsageScrape(
-                harness="claude",
+                provider="anthropic",
                 parse_ok=True,
                 plan_tier="Max",
                 five_hour_percent_left=54,
@@ -132,7 +125,7 @@ async def test_get_usage_serializes_latest_per_harness(client, app_settings) -> 
     assert response.status_code == 200
     body = response.json()
 
-    claude = _harness(body, "claude")
+    claude = _provider(body, "anthropic")
     assert claude["available"] is True
     assert claude["planTier"] == "Max"
     assert claude["fiveHour"]["percentLeft"] == 54
@@ -144,14 +137,14 @@ async def test_get_usage_serializes_latest_per_harness(client, app_settings) -> 
     assert 30 <= claude["ageSeconds"] <= 90  # close to the planted 45s
     assert claude["stale"] is False
 
-    assert _harness(body, "codex")["available"] is False
+    assert _provider(body, "openai-codex")["available"] is False
 
 
 async def test_get_usage_flags_stale_after_24h(client, app_settings) -> None:
     await _seed(
         [
             UsageScrape(
-                harness="claude",
+                provider="anthropic",
                 parse_ok=True,
                 five_hour_percent_left=10,
                 scraped_at=datetime.now(UTC) - timedelta(hours=30),
@@ -160,17 +153,17 @@ async def test_get_usage_flags_stale_after_24h(client, app_settings) -> None:
     )
 
     body = client.get("/api/usage").json()
-    assert _harness(body, "claude")["stale"] is True
+    assert _provider(body, "anthropic")["stale"] is True
 
 
 async def test_get_usage_exposes_unlimited_flag(client, app_settings) -> None:
-    # Codex business plan: scraper synthesizes permanently-full buckets
+    # ChatGPT business plan: scraper synthesizes permanently-full buckets
     # and marks the row unmetered so the UI can render "unmetered"
     # instead of a quota bar that never moves.
     await _seed(
         [
             UsageScrape(
-                harness="codex",
+                provider="openai-codex",
                 parse_ok=True,
                 plan_tier="business",
                 five_hour_percent_left=100,
@@ -181,16 +174,16 @@ async def test_get_usage_exposes_unlimited_flag(client, app_settings) -> None:
     )
 
     body = client.get("/api/usage").json()
-    assert _harness(body, "codex")["unlimited"] is True
-    assert _harness(body, "codex")["fiveHour"]["percentLeft"] == 100
-    assert _harness(body, "claude")["unlimited"] is False
+    assert _provider(body, "openai-codex")["unlimited"] is True
+    assert _provider(body, "openai-codex")["fiveHour"]["percentLeft"] == 100
+    assert _provider(body, "anthropic")["unlimited"] is False
 
 
 async def test_usage_history_serializes_series_oldest_first(client, app_settings) -> None:
     now = datetime.now(UTC)
     snaps = [
         UsageScrape(
-            harness="claude",
+            provider="anthropic",
             parse_ok=True,
             five_hour_percent_left=pct,
             weeks=[
@@ -204,7 +197,7 @@ async def test_usage_history_serializes_series_oldest_first(client, app_settings
     # Outside the 6h five-hour range but inside the weekly range.
     snaps.append(
         UsageScrape(
-            harness="claude",
+            provider="anthropic",
             parse_ok=True,
             five_hour_percent_left=95,
             weeks=[
@@ -216,28 +209,28 @@ async def test_usage_history_serializes_series_oldest_first(client, app_settings
     )
     # Failed scrape — no percentages, must not appear in either series.
     snaps.append(
-        UsageScrape(harness="claude", parse_ok=False, scraped_at=now - timedelta(minutes=5))
+        UsageScrape(provider="anthropic", parse_ok=False, scraped_at=now - timedelta(minutes=5))
     )
     await _seed(snaps)
 
     body = client.get("/api/usage/history").json()
 
-    assert [p["pct"] for p in _harness(body, "claude")["fiveHour"]] == [60, 40, 20]
-    assert [series["model"] for series in _harness(body, "claude")["weeks"]] == [None, "Fable"]
-    assert [p["pct"] for p in _harness(body, "claude")["weeks"][0]["points"]] == [
+    assert [p["pct"] for p in _provider(body, "anthropic")["fiveHour"]] == [60, 40, 20]
+    assert [series["model"] for series in _provider(body, "anthropic")["weeks"]] == [None, "Fable"]
+    assert [p["pct"] for p in _provider(body, "anthropic")["weeks"][0]["points"]] == [
         99,
         88,
         89,
         90,
     ]
-    assert [p["pct"] for p in _harness(body, "claude")["weeks"][1]["points"]] == [
+    assert [p["pct"] for p in _provider(body, "anthropic")["weeks"][1]["points"]] == [
         49,
         38,
         39,
         40,
     ]
-    assert _harness(body, "codex")["fiveHour"] == []
-    assert _harness(body, "codex")["weeks"] == []
+    assert _provider(body, "openai-codex")["fiveHour"] == []
+    assert _provider(body, "openai-codex")["weeks"] == []
 
 
 async def test_usage_today_aggregates_spend_and_tokens_by_provider(
@@ -277,11 +270,11 @@ async def test_usage_today_aggregates_spend_and_tokens_by_provider(
 
     body = client.get("/api/usage/today").json()
 
-    codex = _harness(body, "codex")
+    codex = _provider(body, "openai-codex")
     assert codex["spendUsd"] == 1.25
     assert codex["tokens"] == 1250  # 1000 input + (200 + 50) output
     assert codex["runs"] == 1
-    claude = _harness(body, "claude")
+    claude = _provider(body, "anthropic")
     assert claude["spendUsd"] == 2.5
     assert claude["tokens"] == 250  # (100 + 50 + 25) input + 75 output
     assert claude["runs"] == 1
@@ -294,38 +287,40 @@ async def test_usage_today_aggregates_spend_and_tokens_by_provider(
 
 
 async def test_usage_excludes_another_accounts_scrape(client, druks_db) -> None:
-    snap = UsageScrape(harness="claude", parse_ok=True, five_hour_percent_left=54)
+    snap = UsageScrape(provider="anthropic", parse_ok=True, five_hour_percent_left=54)
     snap.account_id = (await Account.get_or_create("other@example.com")).id
     await snap.save()
 
     body = client.get("/api/usage").json()
-    assert _harness(body, "claude")["available"] is False
+    assert _provider(body, "anthropic")["available"] is False
     history = client.get("/api/usage/history").json()
-    assert _harness(history, "claude")["fiveHour"] == []
+    assert _provider(history, "anthropic")["fiveHour"] == []
 
 
-async def test_usage_reports_viewers_connection_identity(client, druks_db) -> None:
-    await HarnessConnection.connect(
-        harness="claude",
+async def test_usage_reports_viewers_login_identity(client, druks_db) -> None:
+    await ProviderLogin.connect(
+        provider="anthropic",
         account=await Account.get_or_create("other@example.com"),
         payload={"claudeAiOauth": {"accessToken": "other"}},
         expires_at=None,
         provider_email="other-seat@example.com",
+        kind="oauth",
     )
     body = client.get("/api/usage").json()
-    assert _harness(body, "claude")["connected"] is False
-    assert _harness(body, "claude")["providerEmail"] is None
+    assert _provider(body, "anthropic")["connected"] is False
+    assert _provider(body, "anthropic")["providerEmail"] is None
 
-    await HarnessConnection.connect(
-        harness="claude",
+    await ProviderLogin.connect(
+        provider="anthropic",
         account=await Account.get_or_create("op@example.com"),
         payload={"claudeAiOauth": {"accessToken": "mine"}},
         expires_at=None,
         provider_email="subscription@example.com",
+        kind="oauth",
     )
     body = client.get("/api/usage").json()
-    assert _harness(body, "claude")["connected"] is True
-    assert _harness(body, "claude")["providerEmail"] == "subscription@example.com"
+    assert _provider(body, "anthropic")["connected"] is True
+    assert _provider(body, "anthropic")["providerEmail"] == "subscription@example.com"
 
 
 async def test_usage_today_counts_only_the_viewers_calls(client, druks_db) -> None:
@@ -345,8 +340,8 @@ async def test_usage_today_counts_only_the_viewers_calls(client, druks_db) -> No
     await druks_db.flush()
 
     body = client.get("/api/usage/today").json()
-    assert _harness(body, "claude")["spendUsd"] == 2.0
-    assert _harness(body, "claude")["runs"] == 1
+    assert _provider(body, "anthropic")["spendUsd"] == 2.0
+    assert _provider(body, "anthropic")["runs"] == 1
 
 
 def _fake_fetch(fetched: list):
@@ -365,23 +360,27 @@ def _fake_fetch(fetched: list):
     return fake
 
 
-async def test_refresh_scrapes_only_the_viewers_connections(client, druks_db, monkeypatch) -> None:
-    viewer = await connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "t"}})
-    await connect_harness(
-        ClaudeHarness, {"claudeAiOauth": {"accessToken": "t2"}}, provider_email="other@example.com"
+async def test_refresh_scrapes_only_the_viewers_logins(client, druks_db, monkeypatch) -> None:
+    viewer = await connect_provider(AnthropicProvider, {"claudeAiOauth": {"accessToken": "t"}})
+    await connect_provider(
+        AnthropicProvider,
+        {"claudeAiOauth": {"accessToken": "t2"}},
+        provider_email="other@example.com",
     )
     fetched: list[str] = []
-    monkeypatch.setattr(ClaudeHarness, "fetch_usage", _fake_fetch(fetched))
+    monkeypatch.setattr(AnthropicProvider, "fetch_usage", _fake_fetch(fetched))
 
     assert client.post("/api/usage/refresh").status_code == 200
     assert fetched == [viewer.account_id]
-    assert (await UsageScrape.latest_for("claude", viewer.account_id)).five_hour_percent_left == 50
+    assert (
+        await UsageScrape.latest_for("anthropic", viewer.account_id)
+    ).five_hour_percent_left == 50
 
 
-async def test_refresh_skips_a_non_metered_connection(client, druks_db, monkeypatch) -> None:
+async def test_refresh_skips_a_non_metered_login(client, druks_db, monkeypatch) -> None:
     account = await Account.get_or_create("op@example.com")
-    await HarnessConnection.connect(
-        harness="claude",
+    await ProviderLogin.connect(
+        provider="anthropic",
         account=account,
         payload={"api_key": "key"},
         expires_at=None,
@@ -389,16 +388,16 @@ async def test_refresh_skips_a_non_metered_connection(client, druks_db, monkeypa
         kind="api_key",
     )
     poll_usage = AsyncMock()
-    monkeypatch.setattr(ClaudeHarness, "poll_usage", poll_usage)
+    monkeypatch.setattr(AnthropicProvider, "poll_usage", poll_usage)
 
     assert client.post("/api/usage/refresh").status_code == 200
     poll_usage.assert_not_awaited()
 
 
 async def test_refresh_floors_repeat_scrapes(client, druks_db, monkeypatch) -> None:
-    await connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "t"}})
+    await connect_provider(AnthropicProvider, {"claudeAiOauth": {"accessToken": "t"}})
     fetched: list[str] = []
-    monkeypatch.setattr(ClaudeHarness, "fetch_usage", _fake_fetch(fetched))
+    monkeypatch.setattr(AnthropicProvider, "fetch_usage", _fake_fetch(fetched))
 
     client.post("/api/usage/refresh")
     client.post("/api/usage/refresh")

--- a/backend/tests/test_app_doctor_checks.py
+++ b/backend/tests/test_app_doctor_checks.py
@@ -37,7 +37,7 @@ async def test_passing_app_check_reports_under_the_app(
     installed, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A satisfied precondition passes and its result is namespaced under the app
-    name — the API-key check with the credential set."""
+    name — the API-key check with the login set."""
     monkeypatch.setenv("FIELD_NOTES_API_KEY", "sk-test")
     settings = make_settings(tmp_path)
 
@@ -48,7 +48,7 @@ async def test_passing_app_check_reports_under_the_app(
 
 
 async def test_failing_app_check_reports_under_the_app(installed, tmp_path: Path) -> None:
-    """The app's API-key check fails when the credential is unset, reported
+    """The app's API-key check fails when the login is unset, reported
     under the app name so the operator knows which app is broken."""
     settings = make_settings(tmp_path)
 
@@ -163,7 +163,7 @@ async def test_raising_settings_clean_is_contained(
 
 async def test_app_checks_are_wired_into_the_check_battery(installed, tmp_path: Path) -> None:
     """``run_checks`` runs the app checks: ``check_apps`` is one of the
-    battery's entries and, like ``check_harness_credentials``, fans its several
+    battery's entries and, like ``check_provider_logins``, fans its several
     results into the run — so the app's checks reach the report beside core's."""
     settings = make_settings(tmp_path)
 

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -7,17 +7,16 @@ from druks.accounts.dependencies import (
 )
 from druks.accounts.models import Account
 from druks.api.server import app
-from druks.harnesses.claude import ClaudeHarness
-from druks.harnesses.registry import get_harnesses
+from druks.harnesses.providers import get_providers
 from fastapi.routing import APIRoute, _IncludedRouter
 
 # Every /api path allowed to skip the identity gate; additions are deliberate.
 EXEMPT_API_PATHS = {
     "/api/system/health",
     "/api/auth/me",
-    "/api/harnesses",
-    "/api/harnesses/{name}/connection/start",
-    "/api/harnesses/{name}/connection/complete",
+    "/api/providers",
+    "/api/providers/{provider_id}/connection/start",
+    "/api/providers/{provider_id}/connection/complete",
     "/api/{path:path}",  # the JSON-404 catch-all
 }
 
@@ -31,8 +30,9 @@ SESSION_ONLY_API_ROUTES = {
     ("GET", "/api/auth/personal-tokens"),
     ("POST", "/api/auth/personal-tokens"),
     ("DELETE", "/api/auth/personal-tokens/{pat_id}"),
-    ("POST", "/api/harnesses/{name}/connection"),
-    ("DELETE", "/api/harnesses/{name}/connection"),
+    ("GET", "/api/providers/logins"),
+    ("POST", "/api/providers/{provider_id}/connection"),
+    ("DELETE", "/api/providers/{provider_id}/connection"),
     ("PATCH", "/api/settings/apps"),
     ("POST", "/api/services/{slug}"),
     ("GET", "/api/oauth/{slug}/connect"),
@@ -50,12 +50,12 @@ DUAL_GATED_API_PATHS = {
     "/api/oauth/connections/{connection_id}",
 }
 
-# Harness discovery and connection must answer during none/zero setup, before
+# Provider discovery and connection must answer during none/zero setup, before
 # any account exists.
 SETUP_CAPABLE_API_PATHS = {
-    "/api/harnesses",
-    "/api/harnesses/{name}/connection/start",
-    "/api/harnesses/{name}/connection/complete",
+    "/api/providers",
+    "/api/providers/{provider_id}/connection/start",
+    "/api/providers/{provider_id}/connection/complete",
 }
 
 
@@ -120,7 +120,7 @@ def test_identity_bootstrap_is_the_only_setup_tolerant_read(api_routes):
             assert not _gated_by(route, current_account_or_setup), route.path
 
 
-def test_harness_setup_uses_only_the_session_or_setup_resolver(api_routes):
+def test_provider_setup_uses_only_the_session_or_setup_resolver(api_routes):
     listed = [route for route in api_routes if route.path in SETUP_CAPABLE_API_PATHS]
     assert {route.path for route in listed} == SETUP_CAPABLE_API_PATHS
     for route in listed:
@@ -131,31 +131,17 @@ def test_harness_setup_uses_only_the_session_or_setup_resolver(api_routes):
             assert not _gated_by(route, current_session_or_setup), route.path
 
 
-async def test_harness_list_answers_before_an_account_exists(
-    druks_client,
-    monkeypatch,
-):
+async def test_provider_list_answers_before_an_account_exists(druks_client):
     assert not await Account.list_non_system()
-    monkeypatch.setattr(
-        ClaudeHarness,
-        "login_kinds",
-        frozenset({"subscription", "api_key"}),
-    )
 
-    response = await druks_client.get("/api/harnesses")
+    response = await druks_client.get("/api/providers")
 
     assert response.status_code == 200
     body = response.json()
-    assert [item["name"] for item in body] == [harness.name for harness in get_harnesses()]
-    by_name = {item["name"]: item for item in body}
-    assert by_name["claude"] == {
-        "name": "claude",
-        "loginKinds": ["api_key", "subscription"],
-    }
-    assert by_name["codex"] == {
-        "name": "codex",
-        "loginKinds": ["subscription"],
-    }
+    assert [item["id"] for item in body] == [provider.id for provider in get_providers()]
+    by_id = {item["id"]: item for item in body}
+    assert by_id["anthropic"]["loginKinds"] == ["api_key", "oauth"]
+    assert by_id["openai-codex"]["loginKinds"] == ["oauth"]
     assert not await Account.list_non_system()
 
 

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -127,7 +127,7 @@ def test_a_shapeless_authorization_header_is_challenged(tmp_path, druks_db, head
 
 @pytest.mark.parametrize("header", ["Bearer a b", "bearer lowercased", "BEARER nope"])
 async def test_any_scheme_case_reaches_authentication_and_fails_closed(tmp_path, druks_db, header):
-    # RFC 7235 schemes are case-insensitive: these parse as credentials and die
+    # RFC 7235 schemes are case-insensitive: these parse as logins and die
     # in authentication — a 401 either way, never a slide to the assertion.
     with _client(tmp_path) as client:
         response = client.get(
@@ -172,15 +172,15 @@ async def test_a_pat_cannot_manage_pats(tmp_path, druks_db):
         assert both.status_code == 401
 
 
-async def test_a_pat_cannot_disconnect_a_harness(tmp_path, druks_db):
+async def test_a_pat_cannot_disconnect_a_provider(tmp_path, druks_db):
     # Disconnect destroys a capability a bearer could never create — the same
     # session-only rule as token management.
     with _client(tmp_path) as client:
         _, token = await _mint("op@example.com")
-        alone = client.delete("/api/harnesses/claude/connection", headers=_bearer(token))
+        alone = client.delete("/api/providers/anthropic/connection", headers=_bearer(token))
         assert alone.status_code == 401
         beside = client.delete(
-            "/api/harnesses/claude/connection", headers={**OPERATOR, **_bearer(token)}
+            "/api/providers/anthropic/connection", headers={**OPERATOR, **_bearer(token)}
         )
         assert beside.status_code == 401
 

--- a/backend/tests/test_core_workflows.py
+++ b/backend/tests/test_core_workflows.py
@@ -5,20 +5,20 @@ from druks.harnesses.datastructures import RotationResult
 
 
 def test_no_credentials_stays_quiet(caplog):
-    # A disconnected harness is not a refresh failure — no warning every tick.
+    # A disconnected provider is not a refresh failure — no warning every tick.
     with caplog.at_level(logging.WARNING):
-        _log_result(RotationResult("claude", "failed", error="no_credentials"))
+        _log_result(RotationResult("anthropic", "failed", error="no_credentials"))
     assert caplog.records == []
 
 
 def test_invalid_grant_warns(caplog):
     with caplog.at_level(logging.WARNING):
-        _log_result(RotationResult("claude", "failed", error="invalid_grant"))
-    assert "token refresh failed for claude" in caplog.text
+        _log_result(RotationResult("anthropic", "failed", error="invalid_grant"))
+    assert "token refresh failed for anthropic" in caplog.text
 
 
 def test_locked_stays_quiet(caplog):
     # Another worker owns that row's refresh — losing the election is routine.
     with caplog.at_level(logging.WARNING):
-        _log_result(RotationResult("claude", "locked", connection_id="L1"))
+        _log_result(RotationResult("anthropic", "locked", login_id="L1"))
     assert caplog.records == []

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -293,8 +293,9 @@ async def test_run_checks_covers_all_check_names(tmp_path: Path) -> None:
         "installations",
         "software_factory:settings",
         "review:settings",
-        "claude_credentials",
-        "codex_credentials",
+        "anthropic_login",
+        "openai_login",
+        "openai-codex_login",
         "data_dir",
         "database",
         "redis",
@@ -303,29 +304,29 @@ async def test_run_checks_covers_all_check_names(tmp_path: Path) -> None:
     }
 
 
-def test_harness_credentials_pending_when_not_connected(tmp_path: Path) -> None:
-    # No credential rows committed => both harnesses read as not connected.
+def test_logins_pending_when_not_connected(tmp_path: Path) -> None:
+    # No login rows committed => every provider reads as not connected.
     settings = make_settings(tmp_path)
 
-    result = _named(doctor.check_harness_credentials(settings), "codex_credentials")
+    result = _named(doctor.check_provider_logins(settings), "openai-codex_login")
 
     assert not result.ok
     assert result.pending
     assert "not connected" in result.detail
 
 
-def test_harness_credential_check_expired() -> None:
+def test_login_check_expired() -> None:
     # An expired token is a genuine fault (runs would fail), not pending setup.
     past = datetime.now(UTC) - timedelta(hours=1)
-    result = doctor._harness_credential_check("claude", connected=True, expires_at=past)
+    result = doctor._login_check("anthropic", connected=True, expires_at=past)
     assert not result.ok
     assert not result.pending
     assert "expired" in result.detail
 
 
-def test_harness_credential_check_connected() -> None:
+def test_login_check_connected() -> None:
     future = datetime.now(UTC) + timedelta(hours=6)
-    result = doctor._harness_credential_check("claude", connected=True, expires_at=future)
+    result = doctor._login_check("anthropic", connected=True, expires_at=future)
     assert result.ok
     assert "connected" in result.detail
 
@@ -387,9 +388,7 @@ def test_print_results_pending_does_not_fail(capsys) -> None:
     # are pending operator setup — the command still exits 0.
     results = [
         doctor.CheckResult(name="database", ok=True, detail="reachable"),
-        doctor.CheckResult(
-            name="claude_credentials", ok=False, pending=True, detail="not connected"
-        ),
+        doctor.CheckResult(name="claude_login", ok=False, pending=True, detail="not connected"),
     ]
 
     exit_code = doctor.print_results(results)
@@ -403,9 +402,7 @@ def test_print_results_pending_does_not_fail(capsys) -> None:
 def test_print_results_fails_on_a_genuine_fault_alongside_pending(capsys) -> None:
     results = [
         doctor.CheckResult(name="database", ok=False, detail="unreachable"),
-        doctor.CheckResult(
-            name="claude_credentials", ok=False, pending=True, detail="not connected"
-        ),
+        doctor.CheckResult(name="claude_login", ok=False, pending=True, detail="not connected"),
     ]
 
     exit_code = doctor.print_results(results)

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -262,12 +262,12 @@ async def rt():
     configure_engine(engine)
     configure_session(engine)
 
-    # An agent run checks the resolved harness is connected before any VM work;
-    # AgentFlow's decider resolves to claude, so connect it for the module —
+    # An agent run checks the resolved provider is connected before any VM work;
+    # AgentFlow's decider resolves to claude, so connect anthropic for the module —
     # and mark the account as the execution fallback, the way the first
-    # harness connection would.
+    # login would.
     from druks.accounts.models import Account
-    from druks.harnesses.models import HarnessConnection
+    from druks.harnesses.models import ProviderLogin
     from druks.user_settings.models import UserSettings
 
     session = get_session(engine)
@@ -280,10 +280,11 @@ async def rt():
             for subject_id in (7, 4242, 636363, 424242, 515151, 878787, 909090, 313131)
         )
         session.add(
-            HarnessConnection(
-                harness="claude",
+            ProviderLogin(
+                provider="anthropic",
                 account_id=account.id,
                 provider_email=account.username,
+                kind="oauth",
                 payload={"claudeAiOauth": {"accessToken": "t"}},
             )
         )

--- a/backend/tests/test_gate.py
+++ b/backend/tests/test_gate.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 
 import druks.redis
 import pytest
-from druks.core import tasks as harness_workflows
+from druks.core import tasks
 from druks.harnesses.datastructures import RotationResult
 from druks.sandbox import gate
 
@@ -11,8 +11,8 @@ from druks.sandbox import gate
 @pytest.fixture(autouse=True)
 def _fast_poll(monkeypatch):
     monkeypatch.setattr(gate, "_POLL", 0.01)
-    _FakeHarness.rotated_connection_ids = []
-    _FakeConnections.refresh_capable_connection_ids = {"login-1", "login-2"}
+    _FakeProvider.rotated_credential_ids = []
+    _FakeLogins.refresh_capable_credential_ids = {"login-1", "login-2"}
 
 
 async def test_use_registers_for_the_span_and_unregisters():
@@ -59,52 +59,52 @@ async def test_expired_registrations_never_defer_a_rotation():
     assert await client.zcard("druks:sandbox:gate:users:login-1") == 0
 
 
-class _FakeHarness:
-    name = "fake"
-    due_connection_ids: set[str] = set()
-    urgent_connection_ids: set[str] = set()
-    rotated_connection_ids: list[str] = []
+class _FakeProvider:
+    id = "fake"
+    due_credential_ids: set[str] = set()
+    urgent_credential_ids: set[str] = set()
+    rotated_credential_ids: list[str] = []
 
     @classmethod
     def needs_refresh(cls, login):
-        return login.id in cls.due_connection_ids
+        return login.id in cls.due_credential_ids
 
     @classmethod
     def refresh_is_urgent(cls, login):
-        return login.id in cls.urgent_connection_ids
+        return login.id in cls.urgent_credential_ids
 
     @classmethod
-    async def rotate_token(cls, connection_id):
-        cls.rotated_connection_ids.append(connection_id)
-        return RotationResult(cls.name, "refreshed", connection_id=connection_id)
+    async def rotate_token(cls, login_id):
+        cls.rotated_credential_ids.append(login_id)
+        return RotationResult(cls.id, "refreshed", login_id=login_id)
 
 
-class _FakeConnection:
-    harness = "fake"
+class _FakeLogin:
+    provider = "fake"
 
-    def __init__(self, connection_id: str, *, supports_refresh: bool) -> None:
-        self.id = connection_id
+    def __init__(self, login_id: str, *, supports_refresh: bool) -> None:
+        self.id = login_id
         self.supports_refresh = supports_refresh
 
 
-class _FakeConnections:
-    refresh_capable_connection_ids = {"login-1", "login-2"}
+class _FakeLogins:
+    refresh_capable_credential_ids = {"login-1", "login-2"}
 
     @classmethod
     async def list_all(cls):
         return [
-            _FakeConnection(
-                connection_id,
-                supports_refresh=connection_id in cls.refresh_capable_connection_ids,
+            _FakeLogin(
+                login_id,
+                supports_refresh=login_id in cls.refresh_capable_credential_ids,
             )
-            for connection_id in ("login-1", "login-2")
+            for login_id in ("login-1", "login-2")
         ]
 
 
 def _fake_shut(shut: list[str], *, idle: bool):
     @asynccontextmanager
-    async def fake(connection_id: str):
-        shut.append(connection_id)
+    async def fake(login_id: str):
+        shut.append(login_id)
         yield idle
 
     return fake
@@ -112,13 +112,13 @@ def _fake_shut(shut: list[str], *, idle: bool):
 
 async def test_refresh_shuts_only_the_due_logins(monkeypatch):
     shut: list[str] = []
-    monkeypatch.setattr(harness_workflows, "get_harnesses", lambda: (_FakeHarness,))
-    monkeypatch.setattr(harness_workflows, "HarnessConnection", _FakeConnections)
-    monkeypatch.setattr(harness_workflows.gate, "shut", _fake_shut(shut, idle=True))
-    _FakeHarness.due_connection_ids = {"login-2"}
-    _FakeHarness.urgent_connection_ids = set()
+    monkeypatch.setattr(tasks, "get_provider", lambda _provider_id: _FakeProvider)
+    monkeypatch.setattr(tasks, "ProviderLogin", _FakeLogins)
+    monkeypatch.setattr(tasks.gate, "shut", _fake_shut(shut, idle=True))
+    _FakeProvider.due_credential_ids = {"login-2"}
+    _FakeProvider.urgent_credential_ids = set()
 
-    result = await harness_workflows._refresh()
+    result = await tasks._refresh()
 
     # Only the due login's gate shut; every row still rotated (the fresh one
     # no-ops inside rotate_token itself).
@@ -126,58 +126,58 @@ async def test_refresh_shuts_only_the_due_logins(monkeypatch):
     assert [r["action"] for r in result["results"]] == ["refreshed", "refreshed"]
 
 
-async def test_refresh_skips_a_connection_that_does_not_refresh(monkeypatch):
+async def test_refresh_skips_a_credential_that_does_not_refresh(monkeypatch):
     shut: list[str] = []
-    monkeypatch.setattr(harness_workflows, "get_harnesses", lambda: (_FakeHarness,))
-    monkeypatch.setattr(harness_workflows, "HarnessConnection", _FakeConnections)
-    monkeypatch.setattr(harness_workflows.gate, "shut", _fake_shut(shut, idle=True))
-    _FakeHarness.due_connection_ids = {"login-1", "login-2"}
-    _FakeHarness.urgent_connection_ids = set()
-    _FakeConnections.refresh_capable_connection_ids = {"login-1"}
+    monkeypatch.setattr(tasks, "get_provider", lambda _provider_id: _FakeProvider)
+    monkeypatch.setattr(tasks, "ProviderLogin", _FakeLogins)
+    monkeypatch.setattr(tasks.gate, "shut", _fake_shut(shut, idle=True))
+    _FakeProvider.due_credential_ids = {"login-1", "login-2"}
+    _FakeProvider.urgent_credential_ids = set()
+    _FakeLogins.refresh_capable_credential_ids = {"login-1"}
 
-    result = await harness_workflows._refresh()
+    result = await tasks._refresh()
 
     assert shut == ["login-1"]
-    assert _FakeHarness.rotated_connection_ids == ["login-1"]
-    assert [row["connection_id"] for row in result["results"]] == ["login-1"]
+    assert _FakeProvider.rotated_credential_ids == ["login-1"]
+    assert [row["login_id"] for row in result["results"]] == ["login-1"]
 
 
 async def test_refresh_defers_a_busy_login(monkeypatch):
     shut: list[str] = []
-    monkeypatch.setattr(harness_workflows, "get_harnesses", lambda: (_FakeHarness,))
-    monkeypatch.setattr(harness_workflows, "HarnessConnection", _FakeConnections)
-    monkeypatch.setattr(harness_workflows.gate, "shut", _fake_shut(shut, idle=False))
-    _FakeHarness.due_connection_ids = {"login-2"}
-    _FakeHarness.urgent_connection_ids = set()
+    monkeypatch.setattr(tasks, "get_provider", lambda _provider_id: _FakeProvider)
+    monkeypatch.setattr(tasks, "ProviderLogin", _FakeLogins)
+    monkeypatch.setattr(tasks.gate, "shut", _fake_shut(shut, idle=False))
+    _FakeProvider.due_credential_ids = {"login-2"}
+    _FakeProvider.urgent_credential_ids = set()
 
-    result = await harness_workflows._refresh()
+    result = await tasks._refresh()
 
     assert [r["action"] for r in result["results"]] == ["refreshed", "busy"]
 
 
-async def test_refresh_rotates_a_busy_login_once_urgent(monkeypatch):
+async def test_refresh_rotates_a_busy_credential_once_urgent(monkeypatch):
     # Expiry inside the call horizon: a mid-run 401 is unavoidable either way,
     # so the rotation no longer defers.
     shut: list[str] = []
-    monkeypatch.setattr(harness_workflows, "get_harnesses", lambda: (_FakeHarness,))
-    monkeypatch.setattr(harness_workflows, "HarnessConnection", _FakeConnections)
-    monkeypatch.setattr(harness_workflows.gate, "shut", _fake_shut(shut, idle=False))
-    _FakeHarness.due_connection_ids = {"login-2"}
-    _FakeHarness.urgent_connection_ids = {"login-2"}
+    monkeypatch.setattr(tasks, "get_provider", lambda _provider_id: _FakeProvider)
+    monkeypatch.setattr(tasks, "ProviderLogin", _FakeLogins)
+    monkeypatch.setattr(tasks.gate, "shut", _fake_shut(shut, idle=False))
+    _FakeProvider.due_credential_ids = {"login-2"}
+    _FakeProvider.urgent_credential_ids = {"login-2"}
 
-    result = await harness_workflows._refresh()
+    result = await tasks._refresh()
 
     assert [r["action"] for r in result["results"]] == ["refreshed", "refreshed"]
 
 
 async def test_refresh_touches_no_gate_on_a_no_op_tick(monkeypatch):
     shut: list[str] = []
-    monkeypatch.setattr(harness_workflows, "get_harnesses", lambda: (_FakeHarness,))
-    monkeypatch.setattr(harness_workflows, "HarnessConnection", _FakeConnections)
-    monkeypatch.setattr(harness_workflows.gate, "shut", _fake_shut(shut, idle=True))
-    _FakeHarness.due_connection_ids = set()
-    _FakeHarness.urgent_connection_ids = set()
+    monkeypatch.setattr(tasks, "get_provider", lambda _provider_id: _FakeProvider)
+    monkeypatch.setattr(tasks, "ProviderLogin", _FakeLogins)
+    monkeypatch.setattr(tasks.gate, "shut", _fake_shut(shut, idle=True))
+    _FakeProvider.due_credential_ids = set()
+    _FakeProvider.urgent_credential_ids = set()
 
-    await harness_workflows._refresh()
+    await tasks._refresh()
 
     assert shut == []

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -4,11 +4,9 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
-import druks.redis
 import httpx
 import pytest
-from conftest import connect_harness
-from druks.accounts.models import Account
+from conftest import connect_provider
 from druks.harnesses import base as hbase
 from druks.harnesses.claude import ClaudeHarness, _get_credentials
 from druks.harnesses.codex import CodexHarness
@@ -16,14 +14,12 @@ from druks.harnesses.datastructures import (
     AgentInvocation,
     HarnessRunResult,
     ParsedModels,
-    ParsedUsage,
     SandboxSettings,
 )
-from druks.harnesses.exceptions import HarnessNotConnectedError, OAuthTokenError
-from druks.harnesses.models import HarnessConnection
-from druks.user_settings.models import UserSettings
-
-_NOW = datetime(2026, 6, 4, 20, 0, tzinfo=UTC)
+from druks.harnesses.exceptions import HarnessNotConnectedError
+from druks.harnesses.models import ProviderLogin
+from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
+from druks.sandbox.datastructures import HomeCopy
 
 
 def _jwt(exp: int) -> str:
@@ -32,34 +28,28 @@ def _jwt(exp: int) -> str:
     return f"{header}.{payload}.sig"
 
 
-def _claude_payload(*, access="A0", refresh="R0", expires_at=None, extra=None) -> dict:
+def _claude_payload(*, access="A0", refresh="R0", expires_at=None) -> dict:
     block = {"accessToken": access, "scopes": ["user:profile"], "subscriptionType": "max"}
     if refresh is not None:
         block["refreshToken"] = refresh
     if expires_at is not None:
         block["expiresAt"] = int(expires_at.timestamp() * 1000)
-    if extra:
-        block.update(extra)
     return {"claudeAiOauth": block}
 
 
-async def _seed_claude(*, provider_email="op@example.com", **kwargs) -> HarnessConnection:
-    return await connect_harness(
-        ClaudeHarness, _claude_payload(**kwargs), provider_email=provider_email
+async def _seed_claude(*, provider_email="op@example.com", **kwargs) -> ProviderLogin:
+    return await connect_provider(
+        AnthropicProvider, _claude_payload(**kwargs), provider_email=provider_email
     )
 
 
-def _codex_payload(*, access=None, refresh="R0", account_id="acc-1", id_token="id-0") -> dict:
-    access = access or _jwt(int((_NOW + timedelta(days=9)).timestamp()))
-    tokens = {"access_token": access, "id_token": id_token, "account_id": account_id}
-    if refresh is not None:
-        tokens["refresh_token"] = refresh
-    return {"auth_mode": "chatgpt", "OPENAI_API_KEY": None, "tokens": tokens}
-
-
-async def _seed_codex(*, provider_email="op@example.com", **kwargs) -> HarnessConnection:
-    return await connect_harness(
-        CodexHarness, _codex_payload(**kwargs), provider_email=provider_email
+async def _seed_codex(*, provider_email="op@example.com", account_id="acc-1") -> ProviderLogin:
+    access = _jwt(int((datetime.now(UTC) + timedelta(days=9)).timestamp()))
+    tokens = {"access_token": access, "refresh_token": "R0", "account_id": account_id}
+    return await connect_provider(
+        OpenAiCodexProvider,
+        {"auth_mode": "chatgpt", "OPENAI_API_KEY": None, "tokens": tokens},
+        provider_email=provider_email,
     )
 
 
@@ -68,374 +58,29 @@ def _resp(status: int, body: object) -> httpx.Response:
     return httpx.Response(status, text=text, request=httpx.Request("GET", "https://x"))
 
 
-def _mock_post(monkeypatch, response):
-    calls = []
-
-    async def fake_post(self, url, *, json=None, **_kwargs):
-        calls.append({"url": url, "json": json})
-        if isinstance(response, Exception):
-            raise response
-        return response
-
-    monkeypatch.setattr(hbase.httpx.AsyncClient, "post", fake_post)
-    return calls
-
-
 def _mock_get(monkeypatch, response):
     calls = []
 
     async def fake_get(self, url, *, headers=None, **_kwargs):
         calls.append({"url": url, "headers": headers})
-        if isinstance(response, Exception):
-            raise response
         return response
 
     monkeypatch.setattr(hbase.httpx.AsyncClient, "get", fake_get)
     return calls
 
 
-async def test_claude_load_token(druks_db):
-    connection = await _seed_claude(access="live", expires_at=_NOW + timedelta(hours=2))
-    token = ClaudeHarness.load_token(connection, now=_NOW)
-    assert token.access_token == "live"
-    assert token.subscription_type == "max"
-    assert "user:profile" in token.scopes
-
-
-async def test_claude_load_token_expired(druks_db):
-    connection = await _seed_claude(expires_at=_NOW - timedelta(hours=1))
-    with pytest.raises(OAuthTokenError) as e:
-        ClaudeHarness.load_token(connection, now=_NOW)
-    assert e.value.tag == "token_expired"
-
-
-async def test_claude_load_token_no_access(druks_db):
-    connection = await connect_harness(
-        ClaudeHarness, {"claudeAiOauth": {"subscriptionType": "max"}}
-    )
-    with pytest.raises(OAuthTokenError) as e:
-        ClaudeHarness.load_token(connection, now=_NOW)
-    assert e.value.tag == "no_token"
-
-
-async def test_codex_load_token(druks_db):
-    connection = await _seed_codex()
-    token = CodexHarness.load_token(connection, now=_NOW)
-    assert "." in token.access_token
-    assert token.account_id == "acc-1"
-
-
-async def test_codex_load_token_expired(druks_db):
-    connection = await _seed_codex(access=_jwt(int((_NOW - timedelta(hours=1)).timestamp())))
-    with pytest.raises(OAuthTokenError) as e:
-        CodexHarness.load_token(connection, now=_NOW)
-    assert e.value.tag == "token_expired"
-
-
-async def test_claude_fresh_not_refreshed(monkeypatch, druks_db):
-    connection = await _seed_claude(expires_at=_NOW + timedelta(hours=6))
-    calls = _mock_post(monkeypatch, _resp(200, {}))
-    result = await ClaudeHarness.rotate_token(connection.id, now=_NOW)
-    assert result.action == "fresh"
-    assert result.connection_id == connection.id
-    assert calls == []
-
-
-async def test_claude_stale_refreshes_and_persists(monkeypatch, druks_db):
-    soon = _NOW + timedelta(minutes=30)
-    connection = await _seed_claude(access="old", refresh="R0", expires_at=soon)
-    calls = _mock_post(
-        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 28800})
-    )
-    result = await ClaudeHarness.rotate_token(connection.id, now=_NOW)
-    assert result.action == "refreshed"
-    assert calls[0]["json"]["refresh_token"] == "R0"
-    block = (await ClaudeHarness.get_credentials())["claudeAiOauth"]
-    assert block["accessToken"] == "new"
-    assert block["refreshToken"] == "R1"
-    assert block["scopes"] == ["user:profile"]  # preserved
-    assert block["subscriptionType"] == "max"  # preserved
-    assert block["expiresAt"] == int((_NOW + timedelta(seconds=28800)).timestamp() * 1000)
-
-
-async def test_claude_invalid_grant_drops_row(monkeypatch, druks_db):
-    connection = await _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
-    _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
-    result = await ClaudeHarness.rotate_token(connection.id, now=_NOW)
-    assert result.action == "failed"
-    assert result.error == "invalid_grant"
-    # A revoked lineage self-disconnects and commits inside the rotation — the
-    # deletion never rides (or rolls back with) the tick's later commit.
-    assert not await HarnessConnection.list_all()
-    with pytest.raises(HarnessNotConnectedError):
-        await ClaudeHarness.get_credentials()
-
-
-async def test_claude_network_error_keeps_row(monkeypatch, druks_db):
-    connection = await _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
-    _mock_post(monkeypatch, httpx.ConnectError("boom"))
-    result = await ClaudeHarness.rotate_token(connection.id, now=_NOW)
-    assert result.error == "network"
-    assert (await ClaudeHarness.get_credentials())["claudeAiOauth"]["accessToken"] == "old"
-
-
-async def test_claude_http_500_keeps_row(monkeypatch, druks_db):
-    connection = await _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
-    _mock_post(monkeypatch, _resp(500, ""))
-    result = await ClaudeHarness.rotate_token(connection.id, now=_NOW)
-    assert result.error == "http_500"
-    assert (await ClaudeHarness.get_credentials())["claudeAiOauth"]["accessToken"] == "old"
-
-
-async def test_claude_bad_response_keeps_row(monkeypatch, druks_db):
-    connection = await _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
-    _mock_post(monkeypatch, _resp(200, "not json"))
-    result = await ClaudeHarness.rotate_token(connection.id, now=_NOW)
-    assert result.error == "bad_response"
-    assert (await ClaudeHarness.get_credentials())["claudeAiOauth"]["accessToken"] == "old"
-
-
-async def test_rotation_of_a_deleted_row_is_a_no_op(monkeypatch, druks_db):
-    connection = await _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
-    connection_id = connection.id
-    _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
-    await ClaudeHarness.rotate_token(connection_id, now=_NOW)
-    # Row is gone; rotating the stale id must short-circuit before any
-    # grant POST.
-    calls = _mock_post(monkeypatch, _resp(200, {"access_token": "x"}))
-    result = await ClaudeHarness.rotate_token(connection_id, now=_NOW)
-    assert result.action == "failed"
-    assert result.error == "no_credentials"
-    assert calls == []
-
-
-async def test_claude_relogin_overwrite_picked_up(monkeypatch, druks_db):
-    connection = await _seed_claude(refresh="R_NEW", expires_at=_NOW - timedelta(minutes=1))
-    calls = _mock_post(
-        monkeypatch, _resp(200, {"access_token": "a", "refresh_token": "b", "expires_in": 100})
-    )
-    await ClaudeHarness.rotate_token(connection.id, now=_NOW)
-    assert calls[0]["json"]["refresh_token"] == "R_NEW"
-
-
-async def test_codex_stale_refreshes_and_preserves(monkeypatch, druks_db):
-    stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
-    fresh = _jwt(int((_NOW + timedelta(days=10)).timestamp()))
-    connection = await _seed_codex(access=stale, refresh="R0", account_id="acc-9")
-    calls = _mock_post(
-        monkeypatch, _resp(200, {"access_token": fresh, "refresh_token": "R1", "id_token": "id-1"})
-    )
-    result = await CodexHarness.rotate_token(connection.id, now=_NOW)
-    assert result.action == "refreshed"
-    assert calls[0]["json"]["client_id"] == "app_EMoamEEZ73f0CkXaXp7hrann"
-    data = await CodexHarness.get_credentials()
-    assert data["tokens"]["access_token"] == fresh
-    assert data["tokens"]["refresh_token"] == "R1"
-    assert data["tokens"]["id_token"] == "id-1"
-    assert data["tokens"]["account_id"] == "acc-9"  # preserved
-    assert data["auth_mode"] == "chatgpt"  # preserved
-    assert "last_refresh" in data
-
-
-async def test_codex_keeps_refresh_when_omitted(monkeypatch, druks_db):
-    stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
-    fresh = _jwt(int((_NOW + timedelta(days=10)).timestamp()))
-    connection = await _seed_codex(access=stale, refresh="KEEP")
-    _mock_post(monkeypatch, _resp(200, {"access_token": fresh}))
-    await CodexHarness.rotate_token(connection.id, now=_NOW)
-    assert (await CodexHarness.get_credentials())["tokens"]["refresh_token"] == "KEEP"
-
-
-async def test_codex_no_refresh_token(monkeypatch, druks_db):
-    stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
-    connection = await _seed_codex(refresh=None, access=stale)
-    calls = _mock_post(monkeypatch, _resp(200, {}))
-    result = await CodexHarness.rotate_token(connection.id, now=_NOW)
-    assert result.action == "no_refresh_token"
-    assert calls == []
-
-
-async def test_rotation_touches_only_the_addressed_row(monkeypatch, druks_db):
-    stale = await _seed_claude(
-        access="old",
-        refresh="R0",
-        expires_at=_NOW + timedelta(minutes=30),
-        provider_email="a@example.com",
-    )
-    other = await _seed_claude(
-        access="keep",
-        refresh="RK",
-        expires_at=_NOW + timedelta(minutes=30),
-        provider_email="b@example.com",
-    )
-    stale_id, other_id = stale.id, other.id
-    _mock_post(
-        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 100})
-    )
-    result = await ClaudeHarness.rotate_token(stale_id, now=_NOW)
-    assert result.action == "refreshed"
-    assert (
-        dict((await HarnessConnection.get(stale_id)).payload)["claudeAiOauth"]["accessToken"]
-        == "new"
-    )
-    assert (
-        dict((await HarnessConnection.get(other_id)).payload)["claudeAiOauth"]["accessToken"]
-        == "keep"
-    )
-
-
-async def test_invalid_grant_drops_only_the_addressed_row(monkeypatch, druks_db):
-    kept = await _seed_claude(access="d", expires_at=_NOW - timedelta(minutes=1))
-    other = await _seed_claude(
-        access="o", expires_at=_NOW - timedelta(minutes=1), provider_email="b@example.com"
-    )
-    kept_id, other_id = kept.id, other.id
-    _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
-    await ClaudeHarness.rotate_token(other_id, now=_NOW)
-    assert not await HarnessConnection.get(other_id)
-    assert await HarnessConnection.get(kept_id)
-
-
-async def test_rotation_stands_down_while_the_lock_is_held(monkeypatch, druks_db):
-    connection = await _seed_claude(
-        access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30)
-    )
-    calls = _mock_post(
-        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 100})
-    )
-    # A second grant on a lineage another refresher is mid-flight on trips the
-    # provider's reuse detection — a held lock means no provider call at all.
-    await druks.redis.get_client().set(f"druks:harness:refresh:{connection.id}", "1", ex=60)
-    result = await ClaudeHarness.rotate_token(connection.id, now=_NOW)
-    assert result.action == "locked"
-    assert calls == []
-
-
-async def test_rotation_lock_is_released_after_refresh(monkeypatch, druks_db):
-    connection = await _seed_claude(
-        access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30)
-    )
-    _mock_post(
-        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 100})
-    )
-    await ClaudeHarness.rotate_token(connection.id, now=_NOW)
-    assert not await druks.redis.get_client().get(f"druks:harness:refresh:{connection.id}")
-
-
-async def test_disconnect_removes_only_the_addressed_login(druks_db):
-    mine = await _seed_claude(provider_email="a@example.com")
-    other = await _seed_claude(provider_email="b@example.com")
-
-    await mine.delete()
-
-    assert await HarnessConnection.get(other.id)
-    # The fallback account (the first) has no claude connection left; another
-    # account's credential never leaks into execution.
-    with pytest.raises(HarnessNotConnectedError):
-        await ClaudeHarness.get_credentials()
-
-
-async def test_reconnect_restores_execution(druks_db):
-    mine = await _seed_claude(provider_email="a@example.com")
-    await mine.delete()
-    with pytest.raises(HarnessNotConnectedError):
-        await ClaudeHarness.get_credentials()
-
-    await _seed_claude(access="fresh", provider_email="a@example.com")
-    assert (await ClaudeHarness.get_credentials())["claudeAiOauth"]["accessToken"] == "fresh"
-
-
-async def test_connect_scopes_rows_by_harness_and_account(druks_db):
-    claude_row = await _seed_claude(provider_email="a@example.com")
-    codex_row = await _seed_codex(provider_email="a@example.com")
-    other = await _seed_claude(provider_email="b@example.com")
-
-    assert len({claude_row.id, codex_row.id, other.id}) == 3
-    assert claude_row.account_id == codex_row.account_id  # same person, one account
-    assert other.account_id != claude_row.account_id
-    assert (await Account.get_for_username("a@example.com")).id == claude_row.account_id
-    # The first account adopted the execution fallback.
-    assert (await UserSettings.get()).fallback_account_id == claude_row.account_id
-
-
-async def test_reconnect_updates_the_existing_login_in_place(druks_db):
-    row = await _seed_claude(access="old", provider_email="a@example.com")
-    # Same email, different case — citext matches it to the existing account,
-    # so the reconnect updates that one connection rather than making a second.
-    again = await _seed_claude(access="new", provider_email="A@Example.com")
-    assert again.id == row.id
-    assert dict(again.payload)["claudeAiOauth"]["accessToken"] == "new"
-    assert again.provider_email == "A@Example.com"  # stored as last given
-
-
-async def test_claude_fetch_usage_success(monkeypatch, druks_db):
-    connection = await _seed_claude(access="tok", expires_at=_NOW + timedelta(hours=2))
-    body = {
-        "five_hour": {"utilization": 16.0, "resets_at": "2026-06-04T23:19:59+00:00"},
-        "seven_day": {"utilization": 48.0, "resets_at": "2026-06-07T16:00:00+00:00"},
-    }
-    calls = _mock_get(monkeypatch, _resp(200, body))
-    parsed = await ClaudeHarness.fetch_usage(connection, now=_NOW)
-    assert parsed.ok is True
-    assert parsed.five_hour.percent_left == 84
-    assert parsed.weeks[0].percent_left == 52
-    assert calls[0]["headers"]["Authorization"] == "Bearer tok"
-    assert calls[0]["headers"]["anthropic-beta"] == "oauth-2025-04-20"
-    assert calls[0]["headers"]["User-Agent"].startswith("claude-code/")
-
-
-async def test_claude_fetch_usage_http_error(monkeypatch, druks_db):
-    connection = await _seed_claude(access="tok", expires_at=_NOW + timedelta(hours=2))
-    _mock_get(monkeypatch, _resp(403, {"error": "x"}))
-    parsed = await ClaudeHarness.fetch_usage(connection, now=_NOW)
-    assert parsed.ok is False
-    assert parsed.error == "forbidden_scope"
-
-
-async def test_fetch_usage_without_a_token_skips_http(monkeypatch, druks_db):
-    # The connection exists but its payload carries no access token — never fetch.
-    connection = await connect_harness(ClaudeHarness, {"claudeAiOauth": {}})
-    calls = _mock_get(monkeypatch, _resp(200, {}))
-    parsed = await ClaudeHarness.fetch_usage(connection, now=_NOW)
-    assert parsed.ok is False
-    assert parsed.error == "no_token"
-    assert calls == []  # no token => no request
-
-
-async def test_codex_fetch_usage_success(monkeypatch, druks_db):
-    connection = await _seed_codex(account_id="acc-7")
-    body = {
-        "plan_type": "pro",
-        "rate_limit": {
-            "primary_window": {
-                "used_percent": 39,
-                "limit_window_seconds": 18000,
-                "reset_at": 1780625132,
-            },
-            "secondary_window": {
-                "used_percent": 39,
-                "limit_window_seconds": 604800,
-                "reset_at": 1781211932,
-            },
-        },
-    }
-    calls = _mock_get(monkeypatch, _resp(200, body))
-    parsed = await CodexHarness.fetch_usage(connection, now=_NOW)
-    assert parsed.ok is True
-    assert parsed.plan_tier == "pro"
-    assert parsed.five_hour.percent_left == 61
-    assert parsed.weeks[0].percent_left == 61
-    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acc-7"
+def _harness() -> ClaudeHarness:
+    return ClaudeHarness(model=ClaudeHarness.default_model, fast_mode=False, effort=None)
 
 
 async def test_claude_fetch_models_success(monkeypatch, druks_db):
     # fetch_models reads the wall clock (no ``now=`` seam), so the token's
     # expiry must be real-future, not _NOW-relative.
-    connection = await _seed_claude(access="tok", expires_at=datetime.now(UTC) + timedelta(hours=2))
+    login = await _seed_claude(access="tok", expires_at=datetime.now(UTC) + timedelta(hours=2))
     body = {"data": [{"id": "claude-fable-5", "display_name": "Claude Fable 5"}]}
     calls = _mock_get(monkeypatch, _resp(200, body))
 
-    parsed = await ClaudeHarness.fetch_models(connection)
+    parsed = await ClaudeHarness.fetch_models(login)
 
     assert parsed == ParsedModels(
         ok=True,
@@ -447,10 +92,7 @@ async def test_claude_fetch_models_success(monkeypatch, druks_db):
 
 
 async def test_codex_fetch_models_success(monkeypatch, druks_db):
-    connection = await _seed_codex(
-        account_id="acc-7",
-        access=_jwt(int((datetime.now(UTC) + timedelta(days=9)).timestamp())),
-    )
+    login = await _seed_codex(account_id="acc-7")
     body = {
         "models": [
             {
@@ -464,7 +106,7 @@ async def test_codex_fetch_models_success(monkeypatch, druks_db):
     }
     calls = _mock_get(monkeypatch, _resp(200, body))
 
-    parsed = await CodexHarness.fetch_models(connection)
+    parsed = await CodexHarness.fetch_models(login)
 
     assert parsed == ParsedModels(
         ok=True,
@@ -484,20 +126,8 @@ async def test_codex_fetch_models_success(monkeypatch, druks_db):
     assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acc-7"
 
 
-async def test_render_credentials_file_serializes_stored_payload(druks_db):
-    connection = await _seed_claude(access="tok", refresh="R0")
-    rendered = await ClaudeHarness.render_credentials_file(connection.id)
-    assert json.loads(rendered)["claudeAiOauth"]["accessToken"] == "tok"
-
-
-async def test_render_credentials_file_raises_when_not_connected(druks_db):
-    # No selection and no fallback connection at all.
-    with pytest.raises(HarnessNotConnectedError, match="connect it in Settings"):
-        await ClaudeHarness.render_credentials_file()
-
-
 async def test_claude_builder_puts_db_credentials_on_the_bundle(druks_db):
-    await _seed_claude(access="live", refresh="R0")
+    login = await _seed_claude(access="live", refresh="R0")
     sandbox = SandboxSettings(
         service_url="x",
         service_token="x",
@@ -506,15 +136,15 @@ async def test_claude_builder_puts_db_credentials_on_the_bundle(druks_db):
         claude_config_dir=Path("/home/agent/.claude"),
         codex_config_dir=Path("/home/agent/.codex"),
     )
-    bundle = await _get_credentials(sandbox, github_token=None)
-    [(credential_path, rendered_content)] = bundle.files
-    assert credential_path == ".claude/.credentials.json"
-    assert json.loads(rendered_content)["claudeAiOauth"]["accessToken"] == "live"
+    bundle = await _get_credentials(sandbox, github_token=None, login=login)
+    auth = bundle.home[0]
+    assert auth.path == ".claude/.credentials.json"
+    assert json.loads(auth.content)["claudeAiOauth"]["accessToken"] == "live"
 
 
 async def test_credentials_builders_carry_global_instructions(druks_db):
-    await _seed_claude()
-    await _seed_codex()
+    claude_login = await _seed_claude()
+    codex_login = await _seed_codex()
     claude_config_dir = Path("/home/agent/.claude")
     codex_config_dir = Path("/home/agent/.codex")
     sandbox = SandboxSettings(
@@ -526,31 +156,25 @@ async def test_credentials_builders_carry_global_instructions(druks_db):
         codex_config_dir=codex_config_dir,
     )
 
-    claude_bundle = await _get_credentials(sandbox, github_token=None)
+    claude_bundle = await _get_credentials(sandbox, github_token=None, login=claude_login)
     codex_bundle = await CodexHarness(
         model=CodexHarness.default_model,
         fast_mode=False,
         effort=None,
         sandbox=sandbox,
-    )._get_credentials(github_token=None)
+    )._get_credentials(github_token=None, login=codex_login)
 
-    assert claude_bundle.files[0][0] == ".claude/.credentials.json"
-    assert codex_bundle.files[0][0] == ".codex/auth.json"
-    assert (
-        claude_config_dir / "CLAUDE.md",
-        ".claude/CLAUDE.md",
-    ) in claude_bundle.extra_config_files
-    assert (
-        codex_config_dir / "AGENTS.md",
-        ".codex/AGENTS.md",
-    ) in codex_bundle.extra_config_files
+    assert claude_bundle.home[0].path == ".claude/.credentials.json"
+    assert codex_bundle.home[0].path == ".codex/auth.json"
+    assert HomeCopy(".claude/CLAUDE.md", claude_config_dir / "CLAUDE.md") in claude_bundle.home
+    assert HomeCopy(".codex/AGENTS.md", codex_config_dir / "AGENTS.md") in codex_bundle.home
 
 
 async def test_no_config_dir_ships_credential_only(druks_db):
     # No local config dir for the CLI => nothing of the host's config/plugins
-    # reaches the sandbox — but the DB credential still ships: connection state
-    # alone decides whether a harness can run.
-    await _seed_claude(access="live")
+    # reaches the sandbox — but the DB login still ships: the login
+    # row alone decides whether a harness can run.
+    login = await _seed_claude(access="live")
     sandbox = SandboxSettings(
         service_url="x",
         service_token="x",
@@ -559,75 +183,50 @@ async def test_no_config_dir_ships_credential_only(druks_db):
         claude_config_dir=None,
         codex_config_dir=None,
     )
-    bundle = await _get_credentials(sandbox, github_token="gh")
-    [(_, rendered_content)] = bundle.files
-    assert json.loads(rendered_content)["claudeAiOauth"]["accessToken"] == "live"
-    assert bundle.extra_config_files == ()
-    assert bundle.extra_config_dirs == ()
+    bundle = await _get_credentials(sandbox, github_token="gh", login=login)
+    [auth] = bundle.home
+    assert json.loads(auth.content)["claudeAiOauth"]["accessToken"] == "live"
     assert bundle.github_token == "gh"
 
 
-async def test_claude_builder_raises_when_not_connected(druks_db):
-    sandbox = SandboxSettings(
-        service_url="x",
-        service_token="x",
-        service_timeout=30.0,
-        image="x",
-        claude_config_dir=Path("/home/agent/.claude"),
-        codex_config_dir=None,
-    )
-    with pytest.raises(HarnessNotConnectedError, match="claude is not connected"):
-        await _get_credentials(sandbox, github_token=None)
+async def test_credential_without_a_selection_reads_the_fallback_account(druks_db):
+    fallback = await _seed_claude(access="fallback", provider_email="a@example.com")
+
+    assert (await _harness().login(None)).id == fallback.id
 
 
-async def test_lookup_prefers_the_accounts_own_connection(druks_db):
-    fallback = await _seed_claude(provider_email="a@example.com")  # a@ adopts the fallback
-    own = await _seed_claude(provider_email="b@example.com")
-
-    assert (await HarnessConnection.lookup("claude", own.account_id)).id == own.id
-    assert (await HarnessConnection.lookup("claude", fallback.account_id)).id == fallback.id
+async def test_credential_without_any_row_raises(druks_db):
+    with pytest.raises(HarnessNotConnectedError, match="anthropic is not connected"):
+        await _harness().login(None)
 
 
-async def test_lookup_falls_back(druks_db):
-    fallback = await _seed_claude(provider_email="a@example.com")
-    codex_only = await _seed_codex(provider_email="b@example.com")
-
-    # An account with no claude connection, and no account at all.
-    assert (await HarnessConnection.lookup("claude", codex_only.account_id)).id == fallback.id
-    assert (await HarnessConnection.lookup("claude", None)).id == fallback.id
-
-
-async def test_lookup_without_any_connection_raises(druks_db):
-    await _seed_codex(provider_email="a@example.com")  # the fallback account has codex only
-    with pytest.raises(HarnessNotConnectedError, match="connect it in Settings"):
-        await HarnessConnection.lookup("claude", None)
-
-
-async def test_render_credentials_file_renders_only_the_selected_login(druks_db):
+async def test_credential_renders_only_the_selected_row(druks_db):
     mine = await _seed_claude(access="mine-token", provider_email="a@example.com")
     other = await _seed_claude(access="other-token", provider_email="b@example.com")
 
-    rendered = json.loads(await ClaudeHarness.render_credentials_file(other.id))
+    rendered = json.loads(ClaudeHarness.auth_file(await _harness().login(other.id)).content)
     assert rendered["claudeAiOauth"]["accessToken"] == "other-token"
     assert "mine-token" not in json.dumps(rendered)
-    rendered = json.loads(await ClaudeHarness.render_credentials_file(mine.id))
+    rendered = json.loads(ClaudeHarness.auth_file(await _harness().login(mine.id)).content)
     assert rendered["claudeAiOauth"]["accessToken"] == "mine-token"
 
 
-async def test_render_credentials_file_for_a_deleted_connection_raises(druks_db):
+async def test_credential_for_a_deleted_row_raises(druks_db):
     await _seed_claude(provider_email="a@example.com")  # the surviving fallback
     gone = await _seed_claude(provider_email="b@example.com")
     gone_id = gone.id
     await gone.delete()
-    # A disconnect between selection and render fails the call — it must never
+    # A disconnect between selection and push fails the call — it must never
     # fall through to another account's payload.
     with pytest.raises(HarnessNotConnectedError, match="removed"):
-        await ClaudeHarness.render_credentials_file(gone_id)
+        await _harness().login(gone_id)
 
 
-async def test_minimal_harness_reports_unsupported_optional_endpoints(monkeypatch):
+async def test_minimal_harness_reports_unsupported_model_discovery(monkeypatch):
     class MinimalHarness(hbase.Harness):
         name = "minimal"
+        provider = "anthropic"
+        login_kinds = frozenset({"oauth"})
 
         async def build_invocation(self, **kwargs: object) -> AgentInvocation:
             raise AssertionError("not called")
@@ -641,13 +240,8 @@ async def test_minimal_harness_reports_unsupported_optional_endpoints(monkeypatc
         ) -> object:
             return {}
 
-    harness = MinimalHarness(model="minimal", fast_mode=False, effort=None)
-    connection = SimpleNamespace(payload={})
+    login = SimpleNamespace(provider="anthropic", payload={"claudeAiOauth": {"accessToken": "t"}})
     calls = _mock_get(monkeypatch, _resp(200, {}))
 
-    usage = await harness.fetch_usage(connection)
-    models = await harness.fetch_models(connection)
-
-    assert usage == ParsedUsage(ok=False, error="unsupported")
-    assert models == ParsedModels(ok=False, error="unsupported")
+    assert await MinimalHarness.fetch_models(login) == ParsedModels(ok=False, error="unsupported")
     assert calls == []

--- a/backend/tests/test_harness_model_routing.py
+++ b/backend/tests/test_harness_model_routing.py
@@ -1,5 +1,4 @@
 import pytest
-from druks.accounts.models import Account
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.exceptions import HarnessError
@@ -52,16 +51,11 @@ async def test_settings_reject_model_missing_from_lists_returns_422(druks_db):
     ],
 )
 async def test_settings_reject_invalid_model_returns_422(druks_db, model, detail):
-    account = await Account.get_or_create("op@example.com")
     settings = await HarnessSettings.get_registered("claude")
     original_model = settings.model
 
     with pytest.raises(HTTPException) as error:
-        await update_harness_settings(
-            name="claude",
-            body=HarnessUpdate(model=model),
-            account=account,
-        )
+        await update_harness_settings(name="claude", body=HarnessUpdate(model=model))
 
     assert error.value.status_code == 422
     assert error.value.detail == detail

--- a/backend/tests/test_harness_reasoning_flags.py
+++ b/backend/tests/test_harness_reasoning_flags.py
@@ -1,17 +1,18 @@
 import pytest
-from conftest import connect_harness
+from conftest import connect_provider
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
+from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
 
 _CODEX_MODEL = CodexHarness.models[0]
 
 
 @pytest.fixture(autouse=True)
 async def _connected_harnesses(druks_db):
-    # build_invocation renders each credential bundle from the DB row and
+    # build_invocation renders each login bundle from the DB row and
     # raises when that harness isn't connected.
-    await connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "t"}})
-    await connect_harness(CodexHarness, {"tokens": {"access_token": "t"}})
+    await connect_provider(AnthropicProvider, {"claudeAiOauth": {"accessToken": "t"}})
+    await connect_provider(OpenAiCodexProvider, {"tokens": {"access_token": "t"}})
 
 
 def _sandbox_config():

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -4,14 +4,14 @@ from pathlib import Path
 
 import httpx
 import pytest
-from conftest import connect_harness
+from conftest import connect_provider
 from druks import database
 from druks.accounts.dependencies import resolve_single_operator
 from druks.accounts.exceptions import AuthConfigurationError
 from druks.accounts.models import Account, PersonalAccessToken
-from druks.harnesses import base as hbase
-from druks.harnesses.claude import ClaudeHarness
-from druks.harnesses.models import HarnessConnection
+from druks.harnesses import providers as pbase
+from druks.harnesses.models import ProviderLogin
+from druks.harnesses.providers import AnthropicProvider
 from druks.testing import configure_app_for_test, make_settings
 from druks.user_settings.models import HarnessSettings, UserSettings
 from fastapi.testclient import TestClient
@@ -45,7 +45,7 @@ def _mock_exchange(monkeypatch, grant: dict):
     async def fake_post(self, url, *, json=None, data=None, **_kwargs):
         return httpx.Response(200, text=_dumps(grant), request=httpx.Request("POST", url))
 
-    monkeypatch.setattr(hbase.httpx.AsyncClient, "post", fake_post)
+    monkeypatch.setattr(pbase.httpx.AsyncClient, "post", fake_post)
 
 
 def _dumps(value: dict) -> str:
@@ -56,18 +56,18 @@ def _connect(
     client: TestClient,
     monkeypatch,
     *,
-    harness: str = "claude",
+    provider: str = "anthropic",
     email: str = "me@example.com",
     headers: dict[str, str] | None = None,
 ):
-    start = client.post(f"/api/harnesses/{harness}/connection/start", headers=headers)
+    start = client.post(f"/api/providers/{provider}/connection/start", headers=headers)
     assert start.status_code == 200
-    if harness == "claude":
+    if provider == "anthropic":
         _mock_exchange(monkeypatch, _grant(email))
     else:
         _mock_exchange_codex(monkeypatch, email=email)
     return client.post(
-        f"/api/harnesses/{harness}/connection/complete",
+        f"/api/providers/{provider}/connection/complete",
         json={"code": "thecode", "connectionId": start.json()["connectionId"]},
         headers=headers,
     )
@@ -90,7 +90,7 @@ def _mock_exchange_codex(monkeypatch, *, email: str):
     async def fake_post(self, url, *, json=None, data=None, **_kwargs):
         return httpx.Response(200, text=_dumps(grant), request=httpx.Request("POST", url))
 
-    monkeypatch.setattr(hbase.httpx.AsyncClient, "post", fake_post)
+    monkeypatch.setattr(pbase.httpx.AsyncClient, "post", fake_post)
 
 
 # --- header mode -----------------------------------------------------------
@@ -151,7 +151,7 @@ async def test_a_valid_pat_wins_over_a_conflicting_header(tmp_path, druks_db):
 
 
 async def test_onboarding_clears_once_the_account_has_a_connection(tmp_path, druks_db):
-    await connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "x"}})
+    await connect_provider(AnthropicProvider, {"claudeAiOauth": {"accessToken": "x"}})
     with _header_client(tmp_path) as client:
         body = client.get("/api/auth/me", headers={HEADER: "op@example.com"}).json()
     assert body["onboardingRequired"] is False
@@ -161,7 +161,7 @@ async def test_onboarding_clears_once_the_account_has_a_connection(tmp_path, dru
 
 
 async def test_none_mode_ignores_a_present_identity_header(tmp_path, druks_db):
-    await connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "x"}})
+    await connect_provider(AnthropicProvider, {"claudeAiOauth": {"accessToken": "x"}})
     with _client(tmp_path) as client:
         body = client.get("/api/auth/me", headers={HEADER: "intruder@example.com"}).json()
     assert body["authMode"] == "none"
@@ -179,7 +179,7 @@ def test_none_zero_reads_as_setup(tmp_path, druks_db):
 
 
 async def test_none_one_resolves_the_operator(tmp_path, druks_db):
-    await connect_harness(ClaudeHarness, {"claudeAiOauth": {"accessToken": "x"}})
+    await connect_provider(AnthropicProvider, {"claudeAiOauth": {"accessToken": "x"}})
     with _client(tmp_path) as client:
         body = client.get("/api/auth/me").json()
         assert body["account"]["username"] == "op@example.com"
@@ -212,19 +212,13 @@ async def test_none_zero_setup_flow_creates_the_operator(tmp_path, monkeypatch, 
         assert body["onboardingRequired"] is False
     account = await Account.get_for_username("me@example.com")
     assert (await UserSettings.get()).fallback_account_id == account.id
-    assert await HarnessConnection.get_for_account("claude", account.id)
+    assert await ProviderLogin.get_for_account("anthropic", account.id)
 
 
-async def test_api_key_connect_stores_the_operator_identity(tmp_path, monkeypatch, druks_db):
-    monkeypatch.setattr(
-        ClaudeHarness,
-        "login_kinds",
-        frozenset({"subscription", "api_key"}),
-    )
-
+async def test_api_key_connect_stores_the_operator_identity(tmp_path, druks_db):
     with _header_client(tmp_path) as client:
         response = client.post(
-            "/api/harnesses/claude/connection",
+            "/api/providers/anthropic/connection",
             json={"key": "  api-key-value  "},
             headers={HEADER: "operator@example.com"},
         )
@@ -233,7 +227,7 @@ async def test_api_key_connect_stores_the_operator_identity(tmp_path, monkeypatc
     assert response.json()["kind"] == "api_key"
     assert "api-key-value" not in response.text
     account = await Account.get_for_username("operator@example.com")
-    connection = await HarnessConnection.get_for_account("claude", account.id)
+    connection = await ProviderLogin.get_for_account("anthropic", account.id)
     assert connection.kind == "api_key"
     assert connection.payload == {"api_key": "api-key-value"}
     assert connection.provider_email == account.username
@@ -243,7 +237,7 @@ async def test_api_key_connect_stores_the_operator_identity(tmp_path, monkeypatc
 async def test_api_key_connect_requires_a_declared_kind(tmp_path, druks_db):
     with _header_client(tmp_path) as client:
         response = client.post(
-            "/api/harnesses/claude/connection",
+            "/api/providers/openai-codex/connection",
             json={"key": "api-key-value"},
             headers={HEADER: "operator@example.com"},
         )
@@ -251,16 +245,10 @@ async def test_api_key_connect_requires_a_declared_kind(tmp_path, druks_db):
     assert response.status_code == 422
 
 
-async def test_api_key_connect_rejects_an_empty_key(tmp_path, monkeypatch, druks_db):
-    monkeypatch.setattr(
-        ClaudeHarness,
-        "login_kinds",
-        frozenset({"subscription", "api_key"}),
-    )
-
+async def test_api_key_connect_rejects_an_empty_key(tmp_path, druks_db):
     with _header_client(tmp_path) as client:
         response = client.post(
-            "/api/harnesses/claude/connection",
+            "/api/providers/anthropic/connection",
             json={"key": "   "},
             headers={HEADER: "operator@example.com"},
         )
@@ -268,22 +256,16 @@ async def test_api_key_connect_rejects_an_empty_key(tmp_path, monkeypatch, druks
     assert response.status_code == 422
 
 
-async def test_api_key_connect_refuses_setup_scope(tmp_path, monkeypatch, druks_db):
-    monkeypatch.setattr(
-        ClaudeHarness,
-        "login_kinds",
-        frozenset({"subscription", "api_key"}),
-    )
-
+async def test_api_key_connect_refuses_setup_scope(tmp_path, druks_db):
     with _client(tmp_path) as client:
         response = client.post(
-            "/api/harnesses/claude/connection",
+            "/api/providers/anthropic/connection",
             json={"key": "api-key-value"},
         )
 
     assert response.status_code == 409
     assert not await Account.list_non_system()
-    assert not await HarnessConnection.list_all()
+    assert not await ProviderLogin.list_all()
 
 
 async def test_concurrent_setup_completions_with_one_email_converge(
@@ -291,12 +273,12 @@ async def test_concurrent_setup_completions_with_one_email_converge(
 ):
     with _client(tmp_path) as client:
         # Both flows start while zero accounts exist — both unbound.
-        first = client.post("/api/harnesses/claude/connection/start")
-        second = client.post("/api/harnesses/codex/connection/start")
+        first = client.post("/api/providers/anthropic/connection/start")
+        second = client.post("/api/providers/openai-codex/connection/start")
         _mock_exchange(monkeypatch, _grant("me@example.com"))
         assert (
             client.post(
-                "/api/harnesses/claude/connection/complete",
+                "/api/providers/anthropic/connection/complete",
                 json={"code": "c1", "connectionId": first.json()["connectionId"]},
             ).status_code
             == 200
@@ -304,13 +286,13 @@ async def test_concurrent_setup_completions_with_one_email_converge(
         _mock_exchange_codex(monkeypatch, email="me@example.com")
         assert (
             client.post(
-                "/api/harnesses/codex/connection/complete",
+                "/api/providers/openai-codex/connection/complete",
                 json={"code": "c2", "connectionId": second.json()["connectionId"]},
             ).status_code
             == 200
         )
     assert len(await Account.list_non_system()) == 1
-    assert len(await HarnessConnection.list_all()) == 2
+    assert len(await ProviderLogin.list_all()) == 2
 
 
 async def test_a_stale_unbound_completion_attaches_to_the_operator(tmp_path, monkeypatch, druks_db):
@@ -319,16 +301,16 @@ async def test_a_stale_unbound_completion_attaches_to_the_operator(tmp_path, mon
         # creates the operator, so the second — a different provider email —
         # must attach to that operator instead of minting a rival account and
         # bricking none mode.
-        first = client.post("/api/harnesses/claude/connection/start")
-        second = client.post("/api/harnesses/codex/connection/start")
+        first = client.post("/api/providers/anthropic/connection/start")
+        second = client.post("/api/providers/openai-codex/connection/start")
         _mock_exchange(monkeypatch, _grant("a@example.com"))
         client.post(
-            "/api/harnesses/claude/connection/complete",
+            "/api/providers/anthropic/connection/complete",
             json={"code": "c1", "connectionId": first.json()["connectionId"]},
         )
         _mock_exchange_codex(monkeypatch, email="b@example.com")
         completed = client.post(
-            "/api/harnesses/codex/connection/complete",
+            "/api/providers/openai-codex/connection/complete",
             json={"code": "c2", "connectionId": second.json()["connectionId"]},
         )
         assert completed.status_code == 200
@@ -336,7 +318,7 @@ async def test_a_stale_unbound_completion_attaches_to_the_operator(tmp_path, mon
         assert client.get("/api/settings").status_code == 200
     operator = await Account.get_for_username("a@example.com")
     assert len(await Account.list_non_system()) == 1
-    codex_connection = await HarnessConnection.get_for_account("codex", operator.id)
+    codex_connection = await ProviderLogin.get_for_account("openai-codex", operator.id)
     # The capability keeps its own provider identity; it never rekeys the account.
     assert codex_connection.provider_email == "b@example.com"
 
@@ -345,14 +327,14 @@ async def test_a_connect_survives_a_failed_model_refresh(tmp_path, monkeypatch, 
     async def _refresh_boom(self, connection):
         raise RuntimeError("picker flush failed")
 
-    # The credential commits before the refresh runs; a refresh failure past
+    # The login commits before the refresh runs; a refresh failure past
     # that point must not turn the durable connect into a client-visible error.
     monkeypatch.setattr(HarnessSettings, "refresh_models", _refresh_boom)
     with _client(tmp_path) as client:
         response = _connect(client, monkeypatch, email="me@example.com")
         assert response.status_code == 200
     account = await Account.get_for_username("me@example.com")
-    assert await HarnessConnection.get_for_account("claude", account.id)
+    assert await ProviderLogin.get_for_account("anthropic", account.id)
 
 
 async def test_a_bound_connect_cannot_complete_under_another_operator(
@@ -360,17 +342,17 @@ async def test_a_bound_connect_cannot_complete_under_another_operator(
 ):
     with _header_client(tmp_path) as client:
         start = client.post(
-            "/api/harnesses/claude/connection/start", headers={HEADER: "alice@example.com"}
+            "/api/providers/anthropic/connection/start", headers={HEADER: "alice@example.com"}
         )
         _mock_exchange(monkeypatch, _grant("seat@corp.com"))
         response = client.post(
-            "/api/harnesses/claude/connection/complete",
+            "/api/providers/anthropic/connection/complete",
             json={"code": "thecode", "connectionId": start.json()["connectionId"]},
             headers={HEADER: "bob@example.com"},
         )
         assert response.status_code == 422
         assert "different operator" in response.json()["detail"]
-    assert not any(row.harness == "claude" for row in await HarnessConnection.list_all())
+    assert not any(row.provider == "anthropic" for row in await ProviderLogin.list_all())
 
 
 async def test_first_connection_claims_the_fallback_slot_once(tmp_path, monkeypatch, druks_db):
@@ -381,7 +363,7 @@ async def test_first_connection_claims_the_fallback_slot_once(tmp_path, monkeypa
         _connect(
             client,
             monkeypatch,
-            harness="codex",
+            provider="openai-codex",
             email="other-seat@corp.com",
             headers={HEADER: "second@example.com"},
         )
@@ -396,14 +378,14 @@ async def test_reconnect_records_provider_email_but_keeps_the_operator(
         response = _connect(
             client,
             monkeypatch,
-            harness="codex",
+            provider="openai-codex",
             email="corp-seat@corp.com",
             headers={HEADER: "me@example.com"},
         )
         assert response.status_code == 200
         assert response.json()["username"] == "me@example.com"
     account = await Account.get_for_username("me@example.com")
-    codex = await HarnessConnection.get_for_account("codex", account.id)
+    codex = await ProviderLogin.get_for_account("openai-codex", account.id)
     assert codex.provider_email == "corp-seat@corp.com"
 
 
@@ -412,7 +394,7 @@ async def test_connection_flow_rejects_a_bearer(tmp_path, druks_db):
     _, token = await PersonalAccessToken.create(account_id=agent.id, name="agent")
     with _client(tmp_path) as client:
         response = client.post(
-            "/api/harnesses/claude/connection/start",
+            "/api/providers/anthropic/connection/start",
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 401

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -332,7 +332,7 @@ async def test_claims_resolve_the_calling_account(app, druks_db):
     _, their_token = await PersonalAccessToken.create(account_id=theirs.id, name="theirs")
     druks_db.add(
         UsageScrape(
-            harness="codex",
+            provider="openai-codex",
             account_id=mine.id,
             scraped_at=datetime.now(UTC),
             five_hour_percent_left=42,
@@ -342,12 +342,12 @@ async def test_claims_resolve_the_calling_account(app, druks_db):
 
     async with live(app), _client(app, my_token) as client:
         usage = (await client.call_tool("get_usage", {})).structured_content
-    codex = next(h for h in usage["harnesses"] if h["name"] == "codex")
+    codex = next(h for h in usage["providers"] if h["id"] == "openai-codex")
     assert codex["fiveHourPercentLeft"] == 42
 
     async with live(app), _client(app, their_token) as client:
         usage = (await client.call_tool("get_usage", {})).structured_content
-    codex = next(h for h in usage["harnesses"] if h["name"] == "codex")
+    codex = next(h for h in usage["providers"] if h["id"] == "openai-codex")
     assert codex["fiveHourPercentLeft"] is None
 
 
@@ -517,7 +517,7 @@ async def test_get_usage_reads_within_budget(app, pat_token):
     async with live(app), _client(app, pat_token) as client:
         usage = (await client.call_tool("get_usage", {})).structured_content
     assert usage["runsToday"] == 0
-    assert {h["name"] for h in usage["harnesses"]} >= {"claude"}
+    assert {h["id"] for h in usage["providers"]} >= {"anthropic"}
     assert _wire_size(usage) <= 4 * 1024
 
 

--- a/backend/tests/test_opencode.py
+++ b/backend/tests/test_opencode.py
@@ -62,11 +62,11 @@ def _mock_catalog(monkeypatch: pytest.MonkeyPatch, response: SimpleNamespace) ->
 def test_class_facts_and_registration() -> None:
     assert get_harness("opencode") is OpenCodeHarness
     assert OpenCodeHarness.command == "opencode"
-    assert OpenCodeHarness.login_kinds == frozenset({"api_key"})
+    assert OpenCodeHarness.provider is None
+    assert OpenCodeHarness.login_kinds == {"api_key"}
     assert OpenCodeHarness.first_byte_seconds is None
     assert OpenCodeHarness.failure_markers == {}
     assert OpenCodeHarness.default_model in OpenCodeHarness.models
-    assert not hasattr(OpenCodeHarness, "credentials_path")
     assert "_model_discovery_request" not in OpenCodeHarness.__dict__
     assert "_usage_request" not in OpenCodeHarness.__dict__
 
@@ -159,10 +159,10 @@ def _response(
 async def test_build_invocation_uses_server_schema_and_env_auth(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def credentials(cls: type[Harness]) -> dict[str, str]:
-        return {"api_key": _API_KEY}
+    async def login(self: Harness, _credential_id: str | None) -> SimpleNamespace:
+        return SimpleNamespace(provider="anthropic", payload={"api_key": _API_KEY})
 
-    monkeypatch.setattr(OpenCodeHarness, "get_credentials", classmethod(credentials))
+    monkeypatch.setattr(OpenCodeHarness, "login", login)
     server = McpServer(
         name="github",
         url="https://api.example.test/mcp",
@@ -196,7 +196,7 @@ async def test_build_invocation_uses_server_schema_and_env_auth(
     ):
         assert text in wrapper
     assert invocation.stdin == b"A large prompt stays on stdin."
-    assert invocation.credentials.files == ()
+    assert invocation.credentials.home == ()
     assert invocation.credentials.github_token == "github-token"
     env = invocation.env
     assert env is not None
@@ -228,15 +228,10 @@ async def test_build_invocation_uses_server_schema_and_env_auth(
     assert syntax.returncode == 0, syntax.stderr
 
 
-async def test_render_credentials_file_uses_model_provider(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    async def credentials(cls: type[Harness]) -> dict[str, str]:
-        return {"api_key": _API_KEY}
+def test_auth_json_keys_the_login_provider() -> None:
+    login = SimpleNamespace(provider="openai", payload={"api_key": _API_KEY})
 
-    monkeypatch.setattr(OpenCodeHarness, "get_credentials", classmethod(credentials))
-
-    rendered = await _harness().render_credentials_file(model="openai/gpt-5.4")
+    rendered = OpenCodeHarness.auth_json(login)
 
     assert json.loads(rendered) == {"openai": {"type": "api", "key": _API_KEY}}
 

--- a/backend/tests/test_pi.py
+++ b/backend/tests/test_pi.py
@@ -2,6 +2,7 @@ import json
 import shlex
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from druks.accounts.models import Account
@@ -14,10 +15,10 @@ from druks.harnesses.exceptions import (
     HarnessOverloadedError,
     HarnessRateLimitError,
 )
-from druks.harnesses.models import HarnessConnection
+from druks.harnesses.models import ProviderLogin
 from druks.harnesses.pi import PiHarness
 from druks.harnesses.registry import get_harness
-from druks.sandbox.datastructures import HarnessRunResult, McpServer
+from druks.sandbox.datastructures import HarnessRunResult, HomeFile, McpServer
 from druks.testing import configure_app_for_test, make_settings
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
@@ -47,8 +48,8 @@ def _harness(*, effort: str | None = "high") -> PiHarness:
     )
 
 
-async def _credentials(cls: type[Harness]) -> dict[str, str]:
-    return {"api_key": _API_KEY}
+async def _login(self: Harness, _login_id: str | None) -> SimpleNamespace:
+    return SimpleNamespace(provider="openai", payload={"api_key": _API_KEY})
 
 
 @pytest.fixture
@@ -74,15 +75,15 @@ def _message_end(role: str, **message: object) -> bytes:
 def test_class_facts_and_registration() -> None:
     assert get_harness("pi") is PiHarness
     assert PiHarness.command == "pi"
-    assert PiHarness.login_kinds == frozenset({"api_key"})
-    assert PiHarness.credentials_path == ".pi/agent/auth.json"
+    assert PiHarness.provider is None
+    assert PiHarness.login_kinds == {"api_key"}
     assert PiHarness.default_model in PiHarness.models
 
 
 async def test_build_invocation_writes_the_run_files_and_pi_argv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
+    monkeypatch.setattr(PiHarness, "login", _login)
     github = McpServer(
         name="github",
         url="https://api.example.test/mcp",
@@ -152,8 +153,10 @@ async def test_build_invocation_writes_the_run_files_and_pi_argv(
         "DRUKS_RESULT_PATH": f"{_RUN_DIR}/output.json",
     }
     assert invocation.credentials.github_token == "github-token"
-    assert invocation.credentials.files == (
-        (".pi/agent/auth.json", json.dumps({"openai": {"type": "api_key", "key": _API_KEY}})),
+    assert invocation.credentials.home == (
+        HomeFile(
+            ".pi/agent/auth.json", json.dumps({"openai": {"type": "api_key", "key": _API_KEY}})
+        ),
     )
     assert invocation.extra_artifact_filenames == ("output.json",)
     for secret in (_API_KEY, "mcp-secret", "trace-secret"):
@@ -167,7 +170,7 @@ async def test_build_invocation_writes_the_run_files_and_pi_argv(
 async def test_build_invocation_without_servers_or_effort_is_bare(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
+    monkeypatch.setattr(PiHarness, "login", _login)
 
     invocation = await _harness(effort=None).build_invocation(
         prompt="Prompt", schema={"type": "object"}, run_id="run-1", ssh_username="exedev"
@@ -180,14 +183,13 @@ async def test_build_invocation_without_servers_or_effort_is_bare(
     assert ".mcp.json" not in wrapper
 
 
-async def test_render_credentials_file_keys_the_model_provider(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(PiHarness, "get_credentials", classmethod(_credentials))
+def test_auth_file_keys_the_login_provider() -> None:
+    login = SimpleNamespace(provider="anthropic", payload={"api_key": _API_KEY})
 
-    rendered = await PiHarness.render_credentials_file(model="anthropic/claude-opus-5")
+    auth = PiHarness.auth_file(login)
 
-    assert json.loads(rendered) == {"anthropic": {"type": "api_key", "key": _API_KEY}}
+    assert auth.path == ".pi/agent/auth.json"
+    assert json.loads(auth.content) == {"anthropic": {"type": "api_key", "key": _API_KEY}}
 
 
 def test_parse_returns_the_contract_and_sums_spend(tmp_path: Path) -> None:
@@ -280,13 +282,14 @@ def test_parse_treats_a_broken_stream_as_invalid_output(tmp_path: Path) -> None:
         _parse(b"not json", tmp_path)
 
 
-async def test_a_pasted_key_renders_under_the_picked_models_provider(client, druks_db) -> None:
-    assert client.post("/api/harnesses/pi/connection", json={"key": _API_KEY}).status_code == 200
-    account = await Account.get_or_create("op@example.com")
-    connection = await HarnessConnection.get_for_account("pi", account.id)
-
-    rendered = await PiHarness.render_credentials_file(
-        connection.id, model="anthropic/claude-opus-5"
+async def test_a_pasted_key_renders_under_its_provider(client, druks_db) -> None:
+    assert (
+        client.post("/api/providers/openai/connection", json={"key": _API_KEY}).status_code == 200
     )
+    account = await Account.get_or_create("op@example.com")
+    login = await ProviderLogin.get_for_account("openai", account.id)
 
-    assert json.loads(rendered) == {"anthropic": {"type": "api_key", "key": _API_KEY}}
+    auth = PiHarness.auth_file(login)
+
+    assert auth.path == ".pi/agent/auth.json"
+    assert json.loads(auth.content) == {"openai": {"type": "api_key", "key": _API_KEY}}

--- a/backend/tests/test_provider_auth.py
+++ b/backend/tests/test_provider_auth.py
@@ -1,0 +1,463 @@
+import base64
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import druks.redis
+import httpx
+import pytest
+from conftest import connect_provider
+from druks.accounts.models import Account
+from druks.database import db_session
+from druks.harnesses import providers as pbase
+from druks.harnesses.datastructures import ParsedUsage
+from druks.harnesses.exceptions import HarnessNotConnectedError, OAuthTokenError
+from druks.harnesses.models import ProviderLogin
+from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
+from druks.user_settings.models import UserSettings
+
+_NOW = datetime(2026, 6, 4, 20, 0, tzinfo=UTC)
+
+
+def _jwt(exp: int) -> str:
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=").decode()
+    return f"{header}.{payload}.sig"
+
+
+def _claude_payload(*, access="A0", refresh="R0", expires_at=None, extra=None) -> dict:
+    block = {"accessToken": access, "scopes": ["user:profile"], "subscriptionType": "max"}
+    if refresh is not None:
+        block["refreshToken"] = refresh
+    if expires_at is not None:
+        block["expiresAt"] = int(expires_at.timestamp() * 1000)
+    if extra:
+        block.update(extra)
+    return {"claudeAiOauth": block}
+
+
+async def _seed_claude(*, provider_email="op@example.com", **kwargs) -> ProviderLogin:
+    return await connect_provider(
+        AnthropicProvider, _claude_payload(**kwargs), provider_email=provider_email
+    )
+
+
+def _codex_payload(*, access=None, refresh="R0", account_id="acc-1", id_token="id-0") -> dict:
+    access = access or _jwt(int((_NOW + timedelta(days=9)).timestamp()))
+    tokens = {"access_token": access, "id_token": id_token, "account_id": account_id}
+    if refresh is not None:
+        tokens["refresh_token"] = refresh
+    return {"auth_mode": "chatgpt", "OPENAI_API_KEY": None, "tokens": tokens}
+
+
+async def _seed_codex(*, provider_email="op@example.com", **kwargs) -> ProviderLogin:
+    return await connect_provider(
+        OpenAiCodexProvider, _codex_payload(**kwargs), provider_email=provider_email
+    )
+
+
+async def _payload(provider_id: str) -> dict:
+    # Rotation commits in its own session; refresh past this session's identity map.
+    row = await ProviderLogin.lookup(provider_id, None)
+    await db_session().refresh(row)
+    return row.payload
+
+
+def _resp(status: int, body: object) -> httpx.Response:
+    text = body if isinstance(body, str) else json.dumps(body)
+    return httpx.Response(status, text=text, request=httpx.Request("GET", "https://x"))
+
+
+def _mock_post(monkeypatch, response):
+    calls = []
+
+    async def fake_post(self, url, *, json=None, **_kwargs):
+        calls.append({"url": url, "json": json})
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(pbase.httpx.AsyncClient, "post", fake_post)
+    return calls
+
+
+def _mock_get(monkeypatch, response):
+    calls = []
+
+    async def fake_get(self, url, *, headers=None, **_kwargs):
+        calls.append({"url": url, "headers": headers})
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(pbase.httpx.AsyncClient, "get", fake_get)
+    return calls
+
+
+async def test_claude_load_token(druks_db):
+    connection = await _seed_claude(access="live", expires_at=_NOW + timedelta(hours=2))
+    token = AnthropicProvider.load_token(connection, now=_NOW)
+    assert token.access_token == "live"
+    assert token.subscription_type == "max"
+    assert "user:profile" in token.scopes
+
+
+async def test_claude_load_token_expired(druks_db):
+    connection = await _seed_claude(expires_at=_NOW - timedelta(hours=1))
+    with pytest.raises(OAuthTokenError) as e:
+        AnthropicProvider.load_token(connection, now=_NOW)
+    assert e.value.tag == "token_expired"
+
+
+async def test_claude_load_token_no_access(druks_db):
+    connection = await connect_provider(
+        AnthropicProvider, {"claudeAiOauth": {"subscriptionType": "max"}}
+    )
+    with pytest.raises(OAuthTokenError) as e:
+        AnthropicProvider.load_token(connection, now=_NOW)
+    assert e.value.tag == "no_token"
+
+
+async def test_codex_load_token(druks_db):
+    connection = await _seed_codex()
+    token = OpenAiCodexProvider.load_token(connection, now=_NOW)
+    assert "." in token.access_token
+    assert token.account_id == "acc-1"
+
+
+async def test_codex_load_token_expired(druks_db):
+    connection = await _seed_codex(access=_jwt(int((_NOW - timedelta(hours=1)).timestamp())))
+    with pytest.raises(OAuthTokenError) as e:
+        OpenAiCodexProvider.load_token(connection, now=_NOW)
+    assert e.value.tag == "token_expired"
+
+
+async def test_claude_fresh_not_refreshed(monkeypatch, druks_db):
+    connection = await _seed_claude(expires_at=_NOW + timedelta(hours=6))
+    calls = _mock_post(monkeypatch, _resp(200, {}))
+    result = await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert result.action == "fresh"
+    assert result.login_id == connection.id
+    assert calls == []
+
+
+async def test_claude_stale_refreshes_and_persists(monkeypatch, druks_db):
+    soon = _NOW + timedelta(minutes=30)
+    connection = await _seed_claude(access="old", refresh="R0", expires_at=soon)
+    calls = _mock_post(
+        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 28800})
+    )
+    result = await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert result.action == "refreshed"
+    assert calls[0]["json"]["refresh_token"] == "R0"
+    block = (await _payload("anthropic"))["claudeAiOauth"]
+    assert block["accessToken"] == "new"
+    assert block["refreshToken"] == "R1"
+    assert block["scopes"] == ["user:profile"]  # preserved
+    assert block["subscriptionType"] == "max"  # preserved
+    assert block["expiresAt"] == int((_NOW + timedelta(seconds=28800)).timestamp() * 1000)
+
+
+async def test_claude_invalid_grant_drops_row(monkeypatch, druks_db):
+    connection = await _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
+    result = await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert result.action == "failed"
+    assert result.error == "invalid_grant"
+    # A revoked lineage self-disconnects and commits inside the rotation — the
+    # deletion never rides (or rolls back with) the tick's later commit.
+    assert not await ProviderLogin.list_all()
+    with pytest.raises(HarnessNotConnectedError):
+        await ProviderLogin.lookup("anthropic", None)
+
+
+async def test_claude_network_error_keeps_row(monkeypatch, druks_db):
+    connection = await _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    _mock_post(monkeypatch, httpx.ConnectError("boom"))
+    result = await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert result.error == "network"
+    assert (await _payload("anthropic"))["claudeAiOauth"]["accessToken"] == "old"
+
+
+async def test_claude_http_500_keeps_row(monkeypatch, druks_db):
+    connection = await _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    _mock_post(monkeypatch, _resp(500, ""))
+    result = await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert result.error == "http_500"
+    assert (await _payload("anthropic"))["claudeAiOauth"]["accessToken"] == "old"
+
+
+async def test_claude_bad_response_keeps_row(monkeypatch, druks_db):
+    connection = await _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    _mock_post(monkeypatch, _resp(200, "not json"))
+    result = await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert result.error == "bad_response"
+    assert (await _payload("anthropic"))["claudeAiOauth"]["accessToken"] == "old"
+
+
+async def test_rotation_of_a_deleted_row_is_a_no_op(monkeypatch, druks_db):
+    connection = await _seed_claude(access="old", expires_at=_NOW - timedelta(minutes=1))
+    connection_id = connection.id
+    _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
+    await AnthropicProvider.rotate_token(connection_id, now=_NOW)
+    # Row is gone; rotating the stale id must short-circuit before any
+    # grant POST.
+    calls = _mock_post(monkeypatch, _resp(200, {"access_token": "x"}))
+    result = await AnthropicProvider.rotate_token(connection_id, now=_NOW)
+    assert result.action == "failed"
+    assert result.error == "no_credentials"
+    assert calls == []
+
+
+async def test_claude_relogin_overwrite_picked_up(monkeypatch, druks_db):
+    connection = await _seed_claude(refresh="R_NEW", expires_at=_NOW - timedelta(minutes=1))
+    calls = _mock_post(
+        monkeypatch, _resp(200, {"access_token": "a", "refresh_token": "b", "expires_in": 100})
+    )
+    await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert calls[0]["json"]["refresh_token"] == "R_NEW"
+
+
+async def test_codex_stale_refreshes_and_preserves(monkeypatch, druks_db):
+    stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
+    fresh = _jwt(int((_NOW + timedelta(days=10)).timestamp()))
+    connection = await _seed_codex(access=stale, refresh="R0", account_id="acc-9")
+    calls = _mock_post(
+        monkeypatch, _resp(200, {"access_token": fresh, "refresh_token": "R1", "id_token": "id-1"})
+    )
+    result = await OpenAiCodexProvider.rotate_token(connection.id, now=_NOW)
+    assert result.action == "refreshed"
+    assert calls[0]["json"]["client_id"] == "app_EMoamEEZ73f0CkXaXp7hrann"
+    data = await _payload("openai-codex")
+    assert data["tokens"]["access_token"] == fresh
+    assert data["tokens"]["refresh_token"] == "R1"
+    assert data["tokens"]["id_token"] == "id-1"
+    assert data["tokens"]["account_id"] == "acc-9"  # preserved
+    assert data["auth_mode"] == "chatgpt"  # preserved
+    assert "last_refresh" in data
+
+
+async def test_codex_keeps_refresh_when_omitted(monkeypatch, druks_db):
+    stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
+    fresh = _jwt(int((_NOW + timedelta(days=10)).timestamp()))
+    connection = await _seed_codex(access=stale, refresh="KEEP")
+    _mock_post(monkeypatch, _resp(200, {"access_token": fresh}))
+    await OpenAiCodexProvider.rotate_token(connection.id, now=_NOW)
+    assert (await _payload("openai-codex"))["tokens"]["refresh_token"] == "KEEP"
+
+
+async def test_codex_no_refresh_token(monkeypatch, druks_db):
+    stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
+    connection = await _seed_codex(refresh=None, access=stale)
+    calls = _mock_post(monkeypatch, _resp(200, {}))
+    result = await OpenAiCodexProvider.rotate_token(connection.id, now=_NOW)
+    assert result.action == "no_refresh_token"
+    assert calls == []
+
+
+async def test_rotation_touches_only_the_addressed_row(monkeypatch, druks_db):
+    stale = await _seed_claude(
+        access="old",
+        refresh="R0",
+        expires_at=_NOW + timedelta(minutes=30),
+        provider_email="a@example.com",
+    )
+    other = await _seed_claude(
+        access="keep",
+        refresh="RK",
+        expires_at=_NOW + timedelta(minutes=30),
+        provider_email="b@example.com",
+    )
+    stale_id, other_id = stale.id, other.id
+    _mock_post(
+        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 100})
+    )
+    result = await AnthropicProvider.rotate_token(stale_id, now=_NOW)
+    assert result.action == "refreshed"
+    assert (
+        dict((await ProviderLogin.get(stale_id)).payload)["claudeAiOauth"]["accessToken"] == "new"
+    )
+    assert (
+        dict((await ProviderLogin.get(other_id)).payload)["claudeAiOauth"]["accessToken"] == "keep"
+    )
+
+
+async def test_invalid_grant_drops_only_the_addressed_row(monkeypatch, druks_db):
+    kept = await _seed_claude(access="d", expires_at=_NOW - timedelta(minutes=1))
+    other = await _seed_claude(
+        access="o", expires_at=_NOW - timedelta(minutes=1), provider_email="b@example.com"
+    )
+    kept_id, other_id = kept.id, other.id
+    _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
+    await AnthropicProvider.rotate_token(other_id, now=_NOW)
+    assert not await ProviderLogin.get(other_id)
+    assert await ProviderLogin.get(kept_id)
+
+
+async def test_rotation_stands_down_while_the_lock_is_held(monkeypatch, druks_db):
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30)
+    )
+    calls = _mock_post(
+        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 100})
+    )
+    # A second grant on a lineage another refresher is mid-flight on trips the
+    # provider's reuse detection — a held lock means no provider call at all.
+    await druks.redis.get_client().set(f"druks:harness:refresh:{connection.id}", "1", ex=60)
+    result = await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert result.action == "locked"
+    assert calls == []
+
+
+async def test_rotation_lock_is_released_after_refresh(monkeypatch, druks_db):
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30)
+    )
+    _mock_post(
+        monkeypatch, _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 100})
+    )
+    await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert not await druks.redis.get_client().get(f"druks:harness:refresh:{connection.id}")
+
+
+async def test_disconnect_removes_only_the_addressed_login(druks_db):
+    mine = await _seed_claude(provider_email="a@example.com")
+    other = await _seed_claude(provider_email="b@example.com")
+
+    await mine.delete()
+
+    assert await ProviderLogin.get(other.id)
+    # The fallback account (the first) has no anthropic login left; another
+    # account's login never leaks into execution.
+    with pytest.raises(HarnessNotConnectedError):
+        await ProviderLogin.lookup("anthropic", None)
+
+
+async def test_reconnect_restores_execution(druks_db):
+    mine = await _seed_claude(provider_email="a@example.com")
+    await mine.delete()
+    with pytest.raises(HarnessNotConnectedError):
+        await ProviderLogin.lookup("anthropic", None)
+
+    await _seed_claude(access="fresh", provider_email="a@example.com")
+    fallback = await ProviderLogin.lookup("anthropic", None)
+    assert dict(fallback.payload)["claudeAiOauth"]["accessToken"] == "fresh"
+
+
+async def test_connect_scopes_rows_by_provider_and_account(druks_db):
+    claude_row = await _seed_claude(provider_email="a@example.com")
+    codex_row = await _seed_codex(provider_email="a@example.com")
+    other = await _seed_claude(provider_email="b@example.com")
+
+    assert len({claude_row.id, codex_row.id, other.id}) == 3
+    assert claude_row.account_id == codex_row.account_id  # same person, one account
+    assert other.account_id != claude_row.account_id
+    assert (await Account.get_for_username("a@example.com")).id == claude_row.account_id
+    # The first account adopted the execution fallback.
+    assert (await UserSettings.get()).fallback_account_id == claude_row.account_id
+
+
+async def test_reconnect_updates_the_existing_credential_in_place(druks_db):
+    row = await _seed_claude(access="old", provider_email="a@example.com")
+    # Same email, different case — citext matches it to the existing account,
+    # so the reconnect updates that one connection rather than making a second.
+    again = await _seed_claude(access="new", provider_email="A@Example.com")
+    assert again.id == row.id
+    assert dict(again.payload)["claudeAiOauth"]["accessToken"] == "new"
+    assert again.provider_email == "A@Example.com"  # stored as last given
+
+
+async def test_claude_fetch_usage_success(monkeypatch, druks_db):
+    connection = await _seed_claude(access="tok", expires_at=_NOW + timedelta(hours=2))
+    body = {
+        "five_hour": {"utilization": 16.0, "resets_at": "2026-06-04T23:19:59+00:00"},
+        "seven_day": {"utilization": 48.0, "resets_at": "2026-06-07T16:00:00+00:00"},
+    }
+    calls = _mock_get(monkeypatch, _resp(200, body))
+    parsed = await AnthropicProvider.fetch_usage(connection, now=_NOW)
+    assert parsed.ok is True
+    assert parsed.five_hour.percent_left == 84
+    assert parsed.weeks[0].percent_left == 52
+    assert calls[0]["headers"]["Authorization"] == "Bearer tok"
+    assert calls[0]["headers"]["anthropic-beta"] == "oauth-2025-04-20"
+    assert calls[0]["headers"]["User-Agent"].startswith("claude-code/")
+
+
+async def test_claude_fetch_usage_http_error(monkeypatch, druks_db):
+    connection = await _seed_claude(access="tok", expires_at=_NOW + timedelta(hours=2))
+    _mock_get(monkeypatch, _resp(403, {"error": "x"}))
+    parsed = await AnthropicProvider.fetch_usage(connection, now=_NOW)
+    assert parsed.ok is False
+    assert parsed.error == "forbidden_scope"
+
+
+async def test_fetch_usage_without_a_token_skips_http(monkeypatch, druks_db):
+    # The connection exists but its payload carries no access token — never fetch.
+    connection = await connect_provider(AnthropicProvider, {"claudeAiOauth": {}})
+    calls = _mock_get(monkeypatch, _resp(200, {}))
+    parsed = await AnthropicProvider.fetch_usage(connection, now=_NOW)
+    assert parsed.ok is False
+    assert parsed.error == "no_token"
+    assert calls == []  # no token => no request
+
+
+async def test_codex_fetch_usage_success(monkeypatch, druks_db):
+    connection = await _seed_codex(account_id="acc-7")
+    body = {
+        "plan_type": "pro",
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 39,
+                "limit_window_seconds": 18000,
+                "reset_at": 1780625132,
+            },
+            "secondary_window": {
+                "used_percent": 39,
+                "limit_window_seconds": 604800,
+                "reset_at": 1781211932,
+            },
+        },
+    }
+    calls = _mock_get(monkeypatch, _resp(200, body))
+    parsed = await OpenAiCodexProvider.fetch_usage(connection, now=_NOW)
+    assert parsed.ok is True
+    assert parsed.plan_tier == "pro"
+    assert parsed.five_hour.percent_left == 61
+    assert parsed.weeks[0].percent_left == 61
+    assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acc-7"
+
+
+async def test_lookup_prefers_the_accounts_own_connection(druks_db):
+    fallback = await _seed_claude(provider_email="a@example.com")  # a@ adopts the fallback
+    own = await _seed_claude(provider_email="b@example.com")
+
+    assert (await ProviderLogin.lookup("anthropic", own.account_id)).id == own.id
+    assert (await ProviderLogin.lookup("anthropic", fallback.account_id)).id == fallback.id
+
+
+async def test_lookup_falls_back(druks_db):
+    fallback = await _seed_claude(provider_email="a@example.com")
+    codex_only = await _seed_codex(provider_email="b@example.com")
+
+    # An account with no anthropic login, and no account at all.
+    assert (await ProviderLogin.lookup("anthropic", codex_only.account_id)).id == fallback.id
+    assert (await ProviderLogin.lookup("anthropic", None)).id == fallback.id
+
+
+async def test_lookup_without_any_connection_raises(druks_db):
+    await _seed_codex(provider_email="a@example.com")  # the fallback account has openai-codex only
+    with pytest.raises(HarnessNotConnectedError, match="connect it in Settings"):
+        await ProviderLogin.lookup("anthropic", None)
+
+
+async def test_minimal_provider_reports_unsupported_usage(monkeypatch):
+    class MinimalProvider(pbase.Provider):
+        id = "minimal"
+        label = "Minimal"
+        login_kinds = frozenset({"api_key"})
+
+    login = SimpleNamespace(payload={})
+    calls = _mock_get(monkeypatch, _resp(200, {}))
+
+    assert await MinimalProvider.fetch_usage(login) == ParsedUsage(ok=False, error="unsupported")
+    assert calls == []

--- a/backend/tests/test_provider_connect.py
+++ b/backend/tests/test_provider_connect.py
@@ -5,10 +5,9 @@ from datetime import UTC, datetime, timedelta
 import druks.redis
 import httpx
 import pytest
-from druks.harnesses import base as hbase
-from druks.harnesses.claude import ClaudeHarness
-from druks.harnesses.codex import CodexHarness
+from druks.harnesses import providers as pbase
 from druks.harnesses.exceptions import ConnectError
+from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
 
 
 def _jwt(claims: dict) -> str:
@@ -29,7 +28,7 @@ def _mock_post(monkeypatch, response):
         calls.append({"url": url, "json": json, "data": data})
         return response
 
-    monkeypatch.setattr(hbase.httpx.AsyncClient, "post", fake_post)
+    monkeypatch.setattr(pbase.httpx.AsyncClient, "post", fake_post)
     return calls
 
 
@@ -48,7 +47,7 @@ _CLAUDE_GRANT = {
 
 
 async def test_claude_connect_start_builds_url_and_stashes_pending(druks_db):
-    url, flow_id = await ClaudeHarness.connect_start()
+    url, flow_id = await AnthropicProvider.connect_start()
     assert url.startswith("https://claude.ai/oauth/authorize?")
     assert "code=true" in url
     assert "code_challenge_method=S256" in url
@@ -61,15 +60,15 @@ async def test_claude_connect_start_builds_url_and_stashes_pending(druks_db):
 
 
 async def test_connect_start_binds_the_operator_account(druks_db):
-    _, flow_id = await ClaudeHarness.connect_start(account_id="acct-1")
+    _, flow_id = await AnthropicProvider.connect_start(account_id="acct-1")
     pending = await _pending(flow_id)
     assert pending["account_id"] == "acct-1"
 
 
 async def test_claude_connect_complete_returns_the_exchange(monkeypatch, druks_db):
-    _, flow_id = await ClaudeHarness.connect_start(account_id="acct-1")
+    _, flow_id = await AnthropicProvider.connect_start(account_id="acct-1")
     calls = _mock_post(monkeypatch, _resp(200, _CLAUDE_GRANT))
-    completed = await ClaudeHarness.connect_complete(flow_id=flow_id, pasted="thecode")
+    completed = await AnthropicProvider.connect_complete(flow_id=flow_id, pasted="thecode")
 
     block = completed.payload["claudeAiOauth"]
     assert block["accessToken"] == "AT"
@@ -87,34 +86,34 @@ async def test_claude_connect_complete_returns_the_exchange(monkeypatch, druks_d
 
 
 async def test_concurrent_connect_flows_do_not_clobber_each_other(monkeypatch, druks_db):
-    # Two people connect the same harness at once: distinct flow ids, both
+    # Two people connect the same provider at once: distinct flow ids, both
     # pendings live, and completing one leaves the other completable.
-    _, first_flow = await ClaudeHarness.connect_start()
-    _, second_flow = await ClaudeHarness.connect_start()
+    _, first_flow = await AnthropicProvider.connect_start()
+    _, second_flow = await AnthropicProvider.connect_start()
     assert first_flow != second_flow
 
     _mock_post(monkeypatch, _resp(200, _CLAUDE_GRANT))
-    first = await ClaudeHarness.connect_complete(flow_id=first_flow, pasted="code-1")
+    first = await AnthropicProvider.connect_complete(flow_id=first_flow, pasted="code-1")
     assert await _pending(second_flow)
 
     second_grant = dict(_CLAUDE_GRANT, account={"email_address": "other@example.com"})
     _mock_post(monkeypatch, _resp(200, second_grant))
-    second = await ClaudeHarness.connect_complete(flow_id=second_flow, pasted="code-2")
+    second = await AnthropicProvider.connect_complete(flow_id=second_flow, pasted="code-2")
 
     assert first.provider_email == "me@example.com"
     assert second.provider_email == "other@example.com"
 
 
 async def test_connect_complete_without_provider_email_raises(monkeypatch, druks_db):
-    _, flow_id = await ClaudeHarness.connect_start()
+    _, flow_id = await AnthropicProvider.connect_start()
     grant = dict(_CLAUDE_GRANT, account={})
     _mock_post(monkeypatch, _resp(200, grant))
     with pytest.raises(ConnectError, match="no account email"):
-        await ClaudeHarness.connect_complete(flow_id=flow_id, pasted="thecode")
+        await AnthropicProvider.connect_complete(flow_id=flow_id, pasted="thecode")
 
 
 async def test_codex_connect_complete_is_form_encoded_and_reads_jwt(monkeypatch, druks_db):
-    _, flow_id = await CodexHarness.connect_start()
+    _, flow_id = await OpenAiCodexProvider.connect_start()
     pending = await _pending(flow_id)
     access = _jwt(
         {
@@ -126,7 +125,7 @@ async def test_codex_connect_complete_is_form_encoded_and_reads_jwt(monkeypatch,
     calls = _mock_post(
         monkeypatch, _resp(200, {"access_token": access, "refresh_token": "RT", "id_token": "ID"})
     )
-    completed = await CodexHarness.connect_complete(
+    completed = await OpenAiCodexProvider.connect_complete(
         flow_id=flow_id,
         pasted=f"http://localhost:1455/auth/callback?code=thecode&state={pending['state']}",
     )
@@ -142,31 +141,31 @@ async def test_codex_connect_complete_is_form_encoded_and_reads_jwt(monkeypatch,
 async def test_connect_complete_unreadable_provider_json_raises_connect_error(
     monkeypatch, druks_db
 ):
-    _, flow_id = await ClaudeHarness.connect_start()
+    _, flow_id = await AnthropicProvider.connect_start()
     _mock_post(monkeypatch, _resp(200, "not json"))
 
     with pytest.raises(ConnectError) as error:
-        await ClaudeHarness.connect_complete(flow_id=flow_id, pasted="code")
+        await AnthropicProvider.connect_complete(flow_id=flow_id, pasted="code")
 
     assert "unreadable response" in str(error.value)
 
 
 async def test_connect_complete_without_pending_raises(druks_db):
     with pytest.raises(ConnectError):
-        await ClaudeHarness.connect_complete(flow_id="not-a-flow", pasted="code")
+        await AnthropicProvider.connect_complete(flow_id="not-a-flow", pasted="code")
 
 
 async def test_connect_complete_state_mismatch_raises(druks_db):
-    _, flow_id = await ClaudeHarness.connect_start()
+    _, flow_id = await AnthropicProvider.connect_start()
     with pytest.raises(ConnectError):
-        await ClaudeHarness.connect_complete(flow_id=flow_id, pasted="code#not-the-state")
+        await AnthropicProvider.connect_complete(flow_id=flow_id, pasted="code#not-the-state")
 
 
 async def test_connect_complete_provider_error_clears_pending(monkeypatch, druks_db):
-    _, flow_id = await ClaudeHarness.connect_start()
+    _, flow_id = await AnthropicProvider.connect_start()
     _mock_post(monkeypatch, _resp(400, "invalid_grant: code expired"))
     with pytest.raises(ConnectError) as error:
-        await ClaudeHarness.connect_complete(flow_id=flow_id, pasted="code")
+        await AnthropicProvider.connect_complete(flow_id=flow_id, pasted="code")
     assert "invalid_grant" in str(error.value)
     # Failure is single-use too — a retry must re-start.
     assert not await _pending(flow_id)

--- a/backend/tests/test_provider_login_persistence.py
+++ b/backend/tests/test_provider_login_persistence.py
@@ -3,20 +3,19 @@ import os
 import psycopg
 import pytest
 from druks.database import configure_session, db_session, get_session
-from druks.harnesses.claude import ClaudeHarness
-from druks.harnesses.models import HarnessConnection
+from druks.harnesses.models import ProviderLogin
 from druks.testing import init_db
 from sqlalchemy import create_engine, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
-# The credential store's whole job is to persist a rotated credential dict
+# The login store's whole job is to persist a rotated login dict
 # through a real commit. The rollback-based suite can't verify that — its identity
 # map hands back the mutated in-memory object no matter what reached the DB — so
 # this module runs against its own database with real commits and fresh sessions,
 # the way rotation actually persists in production.
 
 PG_BASE = os.environ.get("DRUKS_TEST_PG", "postgresql://druks:druks@localhost:5432")
-DB = "druks_harness_login_test"
+DB = "druks_credential_test"
 URL = f"{PG_BASE.replace('postgresql://', 'postgresql+psycopg://')}/{DB}"
 
 
@@ -61,7 +60,7 @@ async def _committed(engine, work):
         await session.close()
 
 
-async def _connect(payload: dict, *, kind: str = "subscription") -> str:
+async def _connect(payload: dict, *, kind: str = "oauth") -> str:
     from druks.accounts.models import Account
     from druks.user_settings.models import UserSettings
 
@@ -69,8 +68,8 @@ async def _connect(payload: dict, *, kind: str = "subscription") -> str:
     settings = await UserSettings.get()
     if not settings.fallback_account_id:
         await settings.set_fallback_account(account.id)
-    row = await HarnessConnection.connect(
-        harness="claude",
+    row = await ProviderLogin.connect(
+        provider="anthropic",
         account=account,
         payload=payload,
         expires_at=None,
@@ -87,17 +86,17 @@ async def test_connect_stores_the_default_kind(engine):
     connection_id = await _committed(engine, connect)
 
     async def read_back():
-        row = await HarnessConnection.get(connection_id)
+        row = await ProviderLogin.get(connection_id)
         return row.kind, row.supports_refresh, row.is_metered
 
-    assert await _committed(engine, read_back) == ("subscription", True, True)
+    assert await _committed(engine, read_back) == ("oauth", True, True)
 
 
 async def test_reconnect_overwrites_the_kind(engine):
-    async def connect_subscription():
-        return await _connect({"claudeAiOauth": {"accessToken": "subscription"}})
+    async def connect_oauth():
+        return await _connect({"claudeAiOauth": {"accessToken": "oauth"}})
 
-    connection_id = await _committed(engine, connect_subscription)
+    connection_id = await _committed(engine, connect_oauth)
 
     async def connect_api_key():
         return await _connect(
@@ -108,7 +107,7 @@ async def test_reconnect_overwrites_the_kind(engine):
     reconnected_id = await _committed(engine, connect_api_key)
 
     async def read_back():
-        row = await HarnessConnection.get(connection_id)
+        row = await ProviderLogin.get(connection_id)
         return row.kind, row.supports_refresh, row.is_metered
 
     assert reconnected_id == connection_id
@@ -126,7 +125,7 @@ async def test_rotation_persists_new_payload_across_sessions(engine):
     connection_id = await _committed(engine, connect_old)
 
     async def rotate_in_place():
-        row = await HarnessConnection.get(connection_id)
+        row = await ProviderLogin.get(connection_id)
         data = dict(row.payload)
         data["claudeAiOauth"]["accessToken"] = "new"
         await row.update_payload(data, expires_at=None)
@@ -134,7 +133,7 @@ async def test_rotation_persists_new_payload_across_sessions(engine):
     await _committed(engine, rotate_in_place)
 
     async def read_back():
-        row = await HarnessConnection.get(connection_id)
+        row = await ProviderLogin.get(connection_id)
         return dict(row.payload)["claudeAiOauth"]
 
     block = await _committed(engine, read_back)
@@ -148,13 +147,15 @@ async def test_payload_is_ciphertext_at_rest(engine):
     await _committed(engine, connect_secret)
 
     async with engine.connect() as connection:
-        stored = (await connection.execute(text("SELECT payload FROM harness_logins"))).scalar_one()
+        stored = (
+            await connection.execute(text("SELECT payload FROM provider_logins"))
+        ).scalar_one()
     raw = bytes(stored)
     assert b"supersecret" not in raw
     assert b"claudeAiOauth" not in raw
 
-    async def read_credentials():
-        return (await ClaudeHarness.get_credentials())["claudeAiOauth"]
+    async def read_logins():
+        return dict((await ProviderLogin.lookup("anthropic", None)).payload)["claudeAiOauth"]
 
-    block = await _committed(engine, read_credentials)
+    block = await _committed(engine, read_logins)
     assert block["accessToken"] == "supersecret"

--- a/backend/tests/test_provider_usage_parsing.py
+++ b/backend/tests/test_provider_usage_parsing.py
@@ -1,12 +1,11 @@
 import json
 from datetime import UTC, datetime
 
-from druks.harnesses.claude import ClaudeHarness
-from druks.harnesses.codex import CodexHarness
+from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
 
 
 def test_claude_parse_keeps_every_weekly_limit_in_provider_order() -> None:
-    parsed = ClaudeHarness._parse_usage(
+    parsed = AnthropicProvider._parse_usage(
         json.dumps(
             {
                 "five_hour": {"utilization": 36.0},
@@ -34,7 +33,7 @@ def test_claude_parse_keeps_every_weekly_limit_in_provider_order() -> None:
 def test_claude_parse_counts_a_limit_scoped_to_something_other_than_a_model() -> None:
     """A limit can be scoped by surface rather than model — it still counts
     toward the quota, it just has no model to name."""
-    parsed = ClaudeHarness._parse_usage(
+    parsed = AnthropicProvider._parse_usage(
         json.dumps(
             {
                 "five_hour": {"utilization": 10.0},
@@ -59,7 +58,7 @@ def test_claude_parse_counts_a_limit_scoped_to_something_other_than_a_model() ->
 
 
 def test_claude_parse_falls_back_to_seven_day_without_limits() -> None:
-    parsed = ClaudeHarness._parse_usage(
+    parsed = AnthropicProvider._parse_usage(
         json.dumps({"five_hour": {"utilization": 16.0}, "seven_day": {"utilization": 48.0}})
     )
 
@@ -70,7 +69,7 @@ def test_claude_parse_falls_back_to_seven_day_without_limits() -> None:
 
 
 def test_codex_parse_keeps_every_weekly_limit_in_provider_order() -> None:
-    parsed = CodexHarness._parse_usage(
+    parsed = OpenAiCodexProvider._parse_usage(
         json.dumps(
             {
                 "plan_type": "prolite",
@@ -117,7 +116,7 @@ def test_codex_parse_treats_unlimited_credits_as_full_buckets() -> None:
         }
     )
 
-    parsed = CodexHarness._parse_usage(payload)
+    parsed = OpenAiCodexProvider._parse_usage(payload)
 
     assert parsed.ok
     assert parsed.plan_tier == "business"
@@ -129,7 +128,7 @@ def test_codex_parse_treats_unlimited_credits_as_full_buckets() -> None:
 def test_codex_parse_reads_a_group_spend_control_as_a_weekly_window() -> None:
     """Under group-based spend controls a business account carries no windows —
     the spend quota is the metered limit, on a cycle that runs weeks."""
-    parsed = CodexHarness._parse_usage(
+    parsed = OpenAiCodexProvider._parse_usage(
         json.dumps(
             {
                 "plan_type": "business",
@@ -162,7 +161,7 @@ def test_codex_parse_reads_a_group_spend_control_as_a_weekly_window() -> None:
 
 def test_codex_parse_places_a_weekly_only_plan_in_the_week_window() -> None:
     """A plan whose only quota is weekly reports it as the primary window."""
-    parsed = CodexHarness._parse_usage(
+    parsed = OpenAiCodexProvider._parse_usage(
         json.dumps(
             {
                 "plan_type": "prolite",
@@ -184,7 +183,7 @@ def test_codex_parse_places_a_weekly_only_plan_in_the_week_window() -> None:
 
 
 def test_codex_parse_rejects_an_unreadable_window() -> None:
-    parsed = CodexHarness._parse_usage(
+    parsed = OpenAiCodexProvider._parse_usage(
         json.dumps(
             {
                 "plan_type": "pro",
@@ -204,7 +203,7 @@ def test_codex_parse_rejects_an_unreadable_window() -> None:
 
 
 def test_codex_parse_still_fails_without_windows_or_unlimited() -> None:
-    parsed = CodexHarness._parse_usage(
+    parsed = OpenAiCodexProvider._parse_usage(
         json.dumps({"plan_type": "plus", "rate_limit": None, "credits": {"unlimited": False}})
     )
 

--- a/backend/tests/test_sandbox_lifecycle.py
+++ b/backend/tests/test_sandbox_lifecycle.py
@@ -16,7 +16,7 @@ from druks.sandbox import credentials as creds_module
 from druks.sandbox import layout, repo
 from druks.sandbox.client import sandbox_client
 from druks.sandbox.constants import SANDBOX_HOST_LEASE_SECONDS
-from druks.sandbox.datastructures import Credentials
+from druks.sandbox.datastructures import Credentials, HomeCopy, HomeFile
 from druks.sandbox.exceptions import ExecFailed, HostGone, SandboxUnreachable
 from druks.sandbox.host import ExecResult
 
@@ -166,7 +166,7 @@ async def test_push_writes_one_credential_file():
 
     await creds_module.push(
         sandbox,  # type: ignore[arg-type]
-        Credentials(files=((".claude/.credentials.json", "{}"),)),
+        Credentials(home=(HomeFile(".claude/.credentials.json", "{}"),)),
     )
 
     assert sandbox.uploads == []
@@ -179,9 +179,9 @@ async def test_push_writes_all_three_when_supplied():
     await creds_module.push(
         sandbox,  # type: ignore[arg-type]
         Credentials(
-            files=(
-                (".claude/.credentials.json", '{"claude": 1}'),
-                (".codex/auth.json", '{"codex": 1}'),
+            home=(
+                HomeFile(".claude/.credentials.json", '{"claude": 1}'),
+                HomeFile(".codex/auth.json", '{"codex": 1}'),
             ),
             github_token="gho_xxx",
         ),
@@ -195,7 +195,7 @@ async def test_push_writes_all_three_when_supplied():
     }
 
 
-async def test_push_uploads_extra_config_files_under_user_home(tmp_path: Path):
+async def test_push_copies_a_host_file_under_user_home(tmp_path: Path):
     sandbox = _FakeSandbox()
     sandbox.ssh_username = "exedev"  # non-root → /home/exedev
     config = tmp_path / "config.toml"
@@ -203,28 +203,24 @@ async def test_push_uploads_extra_config_files_under_user_home(tmp_path: Path):
 
     await creds_module.push(
         sandbox,  # type: ignore[arg-type]
-        Credentials(
-            extra_config_files=((config, ".codex/config.toml"),),
-        ),
+        Credentials(home=(HomeCopy(".codex/config.toml", config),)),
     )
 
     assert sandbox.uploads[0].remote == "/home/exedev/.codex/config.toml"
 
 
-async def test_push_skips_missing_extra_config_files(tmp_path: Path):
+async def test_push_skips_a_host_file_that_is_absent(tmp_path: Path):
     sandbox = _FakeSandbox()
 
     await creds_module.push(
         sandbox,  # type: ignore[arg-type]
-        Credentials(
-            extra_config_files=((tmp_path / "does-not-exist.toml", ".codex/config.toml"),),
-        ),
+        Credentials(home=(HomeCopy(".codex/config.toml", tmp_path / "does-not-exist.toml"),)),
     )
 
     assert sandbox.uploads == []
 
 
-async def test_push_uploads_extra_config_dirs_recursively(tmp_path: Path):
+async def test_push_copies_a_host_tree_recursively(tmp_path: Path):
     sandbox = _FakeSandbox()
     sandbox.ssh_username = "exedev"
     plugins = tmp_path / "plugins" / "cache"
@@ -234,9 +230,9 @@ async def test_push_uploads_extra_config_dirs_recursively(tmp_path: Path):
     await creds_module.push(
         sandbox,  # type: ignore[arg-type]
         Credentials(
-            extra_config_dirs=(
-                (plugins, ".claude/plugins/cache"),
-                (tmp_path / "missing", ".claude/plugins/marketplaces"),  # skipped
+            home=(
+                HomeCopy(".claude/plugins/cache", plugins),
+                HomeCopy(".claude/plugins/marketplaces", tmp_path / "missing"),  # skipped
             ),
         ),
     )

--- a/backend/tests/test_usage_poll.py
+++ b/backend/tests/test_usage_poll.py
@@ -2,19 +2,17 @@ import gc
 import json
 
 import pytest
-from druks.harnesses.base import Harness
-from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.datastructures import ParsedMetric, ParsedUsage
+from druks.harnesses.providers import AnthropicProvider, Provider
 from druks.usage.models import UsageScrape
 
 
 @pytest.fixture(autouse=True)
-def _collect_transient_harnesses():
-    # Each test's ``_Fake(Harness)`` enters the global ``Harness.__subclasses__()``
+def _collect_transient_providers():
+    # Each test's ``_Fake(Provider)`` enters the global ``Provider.__subclasses__()``
     # registry and is held alive by a closure<->class cycle that plain refcounting
-    # can't break. Force a GC pass so it's gone before another module's
-    # ``seed_harnesses`` iterates the registry and trips over a fake with no
-    # ``default_model``.
+    # can't break. Force a GC pass so it's gone before another module iterates
+    # the registry and trips over a fake.
     yield
     gc.collect()
 
@@ -37,14 +35,14 @@ def _usage(
     )
 
 
-def _harness(name_: str, fetch):
-    """A fake Harness: name + the two classmethods poll_usage touches under
-    the real inherited poll. ``fetch`` is a plain callable returning
-    ParsedUsage (or raising). A transient subclass, swept out of
-    ``Harness.__subclasses__()`` by the autouse GC fixture above."""
+def _provider(id_: str, fetch):
+    """A fake Provider: id + the fetch classmethod poll_usage calls under the
+    real inherited poll. ``fetch`` is a plain callable returning ParsedUsage
+    (or raising). A transient subclass, swept out of
+    ``Provider.__subclasses__()`` by the autouse GC fixture above."""
 
-    class _Fake(Harness):
-        name = name_
+    class _Fake(Provider):
+        id = id_
 
         @classmethod
         async def fetch_usage(cls, connection, *, now=None):
@@ -63,17 +61,17 @@ async def _connection(email: str = "op@example.com"):
     return SimpleNamespace(account_id=(await Account.get_or_create(email)).id)
 
 
-async def _poll(*harnesses) -> list[dict[str, object]]:
+async def _poll(*providers) -> list[dict[str, object]]:
     # poll_usage is the unit under test: fetch -> parse -> persist a UsageScrape.
     connection = await _connection()
-    return [await h.poll_usage(connection) for h in harnesses]
+    return [await h.poll_usage(connection) for h in providers]
 
 
-async def test_successful_fetch_persists_per_harness(druks_db) -> None:
+async def test_successful_fetch_persists_per_provider(druks_db) -> None:
     results = await _poll(
-        _harness("claude", lambda: _usage(five=_metric(84), weeks=(_metric(52),))),
-        _harness(
-            "codex",
+        _provider("anthropic", lambda: _usage(five=_metric(84), weeks=(_metric(52),))),
+        _provider(
+            "openai-codex",
             lambda: _usage(plan_tier="prolite", five=_metric(61), weeks=(_metric(61),)),
         ),
     )
@@ -82,21 +80,21 @@ async def test_successful_fetch_persists_per_harness(druks_db) -> None:
     assert [r["status"] for r in results] == ["recorded", "recorded"]
     assert all(r["parse_ok"] for r in results)
 
-    claude_row = await UsageScrape.latest_for("claude", (await _connection()).account_id)
+    claude_row = await UsageScrape.latest_for("anthropic", (await _connection()).account_id)
     assert claude_row is not None
     assert claude_row.five_hour_percent_left == 84
     assert claude_row.weeks == [
         {"percent_left": 52, "resets_at": None, "model": None},
     ]
 
-    codex_row = await UsageScrape.latest_for("codex", (await _connection()).account_id)
+    codex_row = await UsageScrape.latest_for("openai-codex", (await _connection()).account_id)
     assert codex_row is not None
     assert codex_row.plan_tier == "prolite"
     assert codex_row.weeks[0]["percent_left"] == 61
 
 
 async def test_claude_weekly_windows_survive_parse_and_poll_in_order(druks_db) -> None:
-    parsed = ClaudeHarness._parse_usage(
+    parsed = AnthropicProvider._parse_usage(
         json.dumps(
             {
                 "five_hour": {"utilization": 20},
@@ -113,10 +111,10 @@ async def test_claude_weekly_windows_survive_parse_and_poll_in_order(druks_db) -
         )
     )
 
-    await _poll(_harness("claude", lambda: parsed))
+    await _poll(_provider("anthropic", lambda: parsed))
     await druks_db.flush()
 
-    row = await UsageScrape.latest_for("claude", (await _connection()).account_id)
+    row = await UsageScrape.latest_for("anthropic", (await _connection()).account_id)
     assert row is not None
     assert [(week["percent_left"], week["model"]) for week in row.weeks] == [
         (70, None),
@@ -126,14 +124,14 @@ async def test_claude_weekly_windows_survive_parse_and_poll_in_order(druks_db) -
 
 async def test_credential_error_records_error_snapshot(druks_db) -> None:
     results = await _poll(
-        _harness("claude", lambda: _usage(ok=False, error="token_expired")),
-        _harness("codex", lambda: _usage(ok=False, error="no_credentials")),
+        _provider("anthropic", lambda: _usage(ok=False, error="token_expired")),
+        _provider("openai-codex", lambda: _usage(ok=False, error="no_credentials")),
     )
     await druks_db.flush()
     assert all(r["status"] == "recorded" for r in results)
     assert all(not r["parse_ok"] for r in results)
 
-    claude_row = await UsageScrape.latest_for("claude", (await _connection()).account_id)
+    claude_row = await UsageScrape.latest_for("anthropic", (await _connection()).account_id)
     assert claude_row is not None
     assert claude_row.parse_ok is False
     assert claude_row.error == "token_expired"
@@ -144,19 +142,19 @@ async def test_fetch_crash_writes_crash_snapshot(druks_db) -> None:
     def boom() -> ParsedUsage:
         raise RuntimeError("boom")
 
-    results = await _poll(_harness("claude", boom), _harness("codex", boom))
+    results = await _poll(_provider("anthropic", boom), _provider("openai-codex", boom))
     await druks_db.flush()
     assert all(r["status"] == "errored" and r["error"] == "crashed" for r in results)
 
-    row = await UsageScrape.latest_for("claude", (await _connection()).account_id)
+    row = await UsageScrape.latest_for("anthropic", (await _connection()).account_id)
     assert row is not None
     assert row.parse_ok is False
 
 
 async def test_snapshot_persists_unlimited_flag(druks_db) -> None:
     await _poll(
-        _harness(
-            "codex",
+        _provider(
+            "openai-codex",
             lambda: _usage(
                 plan_tier="business",
                 five=_metric(100),
@@ -167,19 +165,23 @@ async def test_snapshot_persists_unlimited_flag(druks_db) -> None:
     )
     await druks_db.flush()
 
-    row = await UsageScrape.latest_for("codex", (await _connection()).account_id)
+    row = await UsageScrape.latest_for("openai-codex", (await _connection()).account_id)
     assert row is not None
     assert row.unlimited is True
 
 
-async def test_two_accounts_of_one_harness_snapshot_independently(druks_db) -> None:
+async def test_two_accounts_of_one_provider_snapshot_independently(druks_db) -> None:
     snapshots = iter([_usage(five=_metric(84)), _usage(five=_metric(30))])
-    fake = _harness("claude", lambda: next(snapshots))
+    fake = _provider("anthropic", lambda: next(snapshots))
     first, second = await _connection("a@example.com"), await _connection("b@example.com")
 
     await fake.poll_usage(first)
     await fake.poll_usage(second)
     await druks_db.flush()
 
-    assert (await UsageScrape.latest_for("claude", first.account_id)).five_hour_percent_left == 84
-    assert (await UsageScrape.latest_for("claude", second.account_id)).five_hour_percent_left == 30
+    assert (
+        await UsageScrape.latest_for("anthropic", first.account_id)
+    ).five_hour_percent_left == 84
+    assert (
+        await UsageScrape.latest_for("anthropic", second.account_id)
+    ).five_hour_percent_left == 30

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -222,7 +222,7 @@ header. Druks maps this email to an account. The edge controls access, so this
 mode permits account creation at first access.
 
 In `none` mode, Druks has no authentication and exactly one operator account.
-The first completed harness connection creates this account. Public
+The first completed provider connection creates this account. Public
 `/_external` routes stay outside the identity gate. These routes include
 webhooks and the token-authenticated notification response.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,7 @@ order:
    profile and does not negotiate it.
 4. **No-authentication mode (`none`).** This mode has no authentication or identity edge. Druks
    resolves the only non-system account. Zero accounts is the setup state. The
-   first completed harness connection creates the operator account from the
+   first completed provider connection creates the operator account from the
    provider-validated email.
 
    More than one non-system account is configuration
@@ -264,7 +264,7 @@ optional. It reports pending setup if the selected tracker lacks a connection.
 
 ## Harnesses
 
-Claude and Codex subscription credentials connect from **Settings → Harnesses**.
+Anthropic and ChatGPT subscription credentials connect from **Settings → Providers**.
 The connection flow stores each credential in Postgres. Druks refreshes the
 credential on a schedule. It creates the CLI credential file inside each
 sandbox. It does not copy a host login. This is a capability connection for

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -110,7 +110,7 @@ docker compose ps
 curl -fsS http://127.0.0.1:8001/health
 ```
 
-Then connect Claude and Codex from **Settings → Harnesses → Connect**. Each card
+Then connect Anthropic and ChatGPT from **Settings → Providers → Connect**. Each card
 opens the provider authorization page. Paste the returned code into the card.
 Subscription tokens live in the database, not in a host CLI login. Agent runs
 do not start with a disconnected harness.

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,7 +29,7 @@ uv run druks init-db
 
 Settings reads `./druks.toml` from the current directory. The example uses
 `[identity].mode = "none"`. The loopback dashboard has no authentication and
-exactly one operator account. Your first harness connection creates this
+exactly one operator account. Your first provider connection creates this
 account.
 
 To use `header` mode with the development server, set

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -76,14 +76,14 @@ Success means the Compose services are up and the health endpoint returns
 
 ## 3. Connect agent harnesses
 
-Open **Settings → Harnesses** in the dashboard and connect Claude and Codex.
+Open **Settings → Providers** in the dashboard and connect Anthropic and ChatGPT.
 Druks stores those subscription credentials in Postgres and writes a fresh
 credential file into each sandbox. It does not use host CLI login files.
 The local profile uses `[identity].mode = "none"`. It has no browser
 authentication and exactly one operator account.
 
 A new installation shows its
-setup page until the first harness connection completes. That connection
+setup page until the first provider connection completes. That connection
 creates the operator account from the provider-verified email. Protect database
 access and backups as credential data. Harness payloads do not use the
 `[secrets].secrets_key` envelope that protects MCP tokens and OAuth grants.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -42,9 +42,9 @@ The health response is:
 
 Open the dashboard at [http://127.0.0.1:8001](http://127.0.0.1:8001).
 
-## Connect a harness
+## Connect a provider
 
-Open **Settings → Harnesses** and connect Claude or Codex. The provider validates
+Open **Settings → Providers** and connect Anthropic or ChatGPT. The provider validates
 the subscription. Druks stores the connection in Postgres. The first harness
 connection completes the setup of a new local installation.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -79,7 +79,7 @@ Distinguish the failure by what you see:
   the configuration. For signature or key errors, examine `identity.jwks_url`.
   For issuer or audience errors, examine the related claim setting. For expiry
   errors, compare the clocks of the edge and host.
-- If onboarding asks you to connect a harness, complete that connection.
+- If onboarding asks you to connect a provider, complete that connection.
 - If `none` mode returns 503, remove extra accounts or switch to `header` mode.
 - If a run refuses to start, connect its selected harness.
 
@@ -134,7 +134,7 @@ Examine the MCP path:
 
 ### Harness not connected or expired
 
-Open **Settings → Harnesses** and reconnect the selected Claude or Codex
+Open **Settings → Providers** and reconnect the selected Anthropic or ChatGPT
 harness. Host CLI logins do not count. Druks validates the database credential
 before provisioning a sandbox.
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -27,7 +27,8 @@ import type {
   PageSnapshot,
   McpServer,
   Service,
-  SetupHarness,
+  Provider,
+  ProviderLogin,
   Skill,
   SkillCollection,
   UserSettings,
@@ -265,20 +266,19 @@ export const api = {
   harnesses: () => getJSON<Harness[]>('/api/settings/harnesses'),
   updateHarness: (name: string, body: UpdateHarnessRequest) =>
     patchJSON<Harness>(`/api/settings/harnesses/${encodeURIComponent(name)}`, body),
-  setupHarnesses: () => getJSON<SetupHarness[]>('/api/harnesses'),
-  // The harness connection flow — the capability connect (and, during setup,
-  // what creates the operator account).
-  startHarnessConnect: (name: string) =>
-    postJSON<ConnectChallenge>(`/api/harnesses/${encodeURIComponent(name)}/connection/start`, {}),
-  completeHarnessConnect: (name: string, code: string, connectionId: string) =>
-    postJSON<Account>(`/api/harnesses/${encodeURIComponent(name)}/connection/complete`, {
+  providers: () => getJSON<Provider[]>('/api/providers'),
+  providerLogins: () => getJSON<ProviderLogin[]>('/api/providers/logins'),
+  startProviderConnect: (id: string) =>
+    postJSON<ConnectChallenge>(`/api/providers/${encodeURIComponent(id)}/connection/start`, {}),
+  completeProviderConnect: (id: string, code: string, connectionId: string) =>
+    postJSON<Account>(`/api/providers/${encodeURIComponent(id)}/connection/complete`, {
       code,
       connectionId,
     }),
-  connectHarnessKey: (name: string, key: string) =>
-    postJSON<Harness>(`/api/harnesses/${encodeURIComponent(name)}/connection`, { key }),
-  disconnectHarness: (name: string) =>
-    deleteJSON<Harness>(`/api/harnesses/${encodeURIComponent(name)}/connection`),
+  connectProviderKey: (id: string, key: string) =>
+    postJSON<ProviderLogin>(`/api/providers/${encodeURIComponent(id)}/connection`, { key }),
+  disconnectProvider: (id: string) =>
+    deleteRequest(`/api/providers/${encodeURIComponent(id)}/connection`),
   // The appliance's own identities at external services — connect verifies the
   // pasted credentials against the provider before anything replaces a working
   // identity. Field names come from each entry's spec.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -502,25 +502,34 @@ export interface AllowedModel {
  * harness's namespace runs. */
 export interface Harness {
   name: string
-  provider: string
+  /** The provider a subscription CLI is bound to; null for a key CLI. */
+  provider: string | null
+  loginKinds: string[]
   model: string
   allowedModels: AllowedModel[]
   fastMode: boolean
   effort: string
   timeout: number
-  // The requesting account's own connection; false until this account connects.
-  connected: boolean
-  kind: string | null
-  loginKinds: string[]
-  account: string | null
-  /** The email the provider reported at connect — display, never authority. */
-  providerEmail: string | null
-  expiresAt: string | null
 }
 
-export interface SetupHarness {
-  name: string
+/** One model provider — who answers and bills a request. An account holds at
+ * most one credential per provider, and every harness that drives the
+ * provider runs on it. */
+export interface Provider {
+  id: string
+  label: string
   loginKinds: string[]
+}
+
+/** One account's login at one provider. */
+export interface ProviderLogin {
+  provider: string
+  kind: string
+  /** The email the provider reported at connect — display, never authority. */
+  providerEmail: string
+  expiresAt: string | null
+  // False once the token has expired.
+  connected: boolean
 }
 
 export interface Account {
@@ -530,7 +539,7 @@ export interface Account {
 
 /** What /api/auth/me answers: how this deployment authenticates, who the
  * request resolved to (null in the none/zero setup state), and whether that
- * identity still needs its first harness connection. */
+ * identity still needs its first provider credential. */
 export interface Identity {
   authMode: 'none' | 'header' | 'jwt'
   account: Account | null
@@ -728,9 +737,10 @@ export interface UsageMetric {
   model: string | null
 }
 
-export interface UsageHarnessSummary {
-  // Panels, colors, and legends key off the registered harness name.
-  name: string
+export interface UsageProviderSummary {
+  // Panels, colors, and legends key off the registered provider id.
+  id: string
+  label: string
   available: boolean
   /** The requesting account has its own connection; false renders a connect action. */
   connected: boolean
@@ -749,7 +759,7 @@ export interface UsageHarnessSummary {
 }
 
 export interface UsageResponse {
-  harnesses: UsageHarnessSummary[]
+  providers: UsageProviderSummary[]
 }
 
 export interface UsageHistoryPoint {
@@ -762,18 +772,18 @@ export interface UsageWindowHistory {
   points: UsageHistoryPoint[]
 }
 
-export interface UsageHarnessHistory {
-  name: string
+export interface UsageProviderHistory {
+  id: string
   fiveHour: UsageHistoryPoint[]
   weeks: UsageWindowHistory[]
 }
 
 export interface UsageHistoryResponse {
-  harnesses: UsageHarnessHistory[]
+  providers: UsageProviderHistory[]
 }
 
-export interface UsageHarnessToday {
-  name: string
+export interface UsageProviderToday {
+  id: string
   spendUsd: number
   tokens: number
   runs: number
@@ -784,7 +794,7 @@ export interface UsageHarnessToday {
 export interface UsageTodayResponse {
   day: string
   timezone: string
-  harnesses: UsageHarnessToday[]
+  providers: UsageProviderToday[]
 }
 
 export const ALLOWED_EFFORTS: readonly AgentEffort[] = ['low', 'medium', 'high']

--- a/frontend/src/components/IdentityBootstrap.test.tsx
+++ b/frontend/src/components/IdentityBootstrap.test.tsx
@@ -76,22 +76,28 @@ describe('IdentityBootstrap', () => {
     renderBootstrap()
     await flush()
     expect(screen.queryByTestId('app')).toBeNull()
-    expect(screen.getByText('Connect a harness to finish setup')).toBeTruthy()
+    expect(screen.getByText('Connect a provider to finish setup')).toBeTruthy()
   })
 
   it('completing onboarding remounts with the created account', async () => {
     let me = identity({ account: null, onboardingRequired: true })
     stubRoutes({
       '/api/auth/me': () => ({ status: 200, body: me }),
-      '/api/harnesses': () => ({
+      '/api/providers': () => ({
         status: 200,
-        body: [{ name: 'claude', loginKinds: ['subscription'] }],
+        body: [
+          {
+            id: 'anthropic',
+            label: 'Anthropic',
+            loginKinds: ['oauth'],
+          },
+        ],
       }),
-      '/api/harnesses/claude/connection/start': () => ({
+      '/api/providers/anthropic/connection/start': () => ({
         status: 200,
         body: { authorizeUrl: 'https://x/auth', connectionId: 'C1' },
       }),
-      '/api/harnesses/claude/connection/complete': () => {
+      '/api/providers/anthropic/connection/complete': () => {
         // The completed connection created the operator; /me now resolves it.
         me = identity()
         return { status: 200, body: { id: 'a1', username: 'me@example.com' } }
@@ -100,7 +106,7 @@ describe('IdentityBootstrap', () => {
     renderBootstrap()
     await flush()
 
-    fireEvent.click(screen.getByText('Connect Claude'))
+    fireEvent.click(screen.getByText('Connect Anthropic'))
     await flush()
     fireEvent.change(screen.getByPlaceholderText('Paste the code or redirect URL'), {
       target: { value: 'the-code' },
@@ -121,7 +127,7 @@ describe('IdentityBootstrap', () => {
     renderBootstrap()
     await flush()
     expect(screen.queryByTestId('app')).toBeNull()
-    expect(screen.queryByText('Connect a harness to finish setup')).toBeNull()
+    expect(screen.queryByText('Connect a provider to finish setup')).toBeNull()
     expect(screen.getByText("Couldn't resolve your identity")).toBeTruthy()
     expect(screen.getByText('The edge asserted no identity.')).toBeTruthy()
   })

--- a/frontend/src/components/Onboarding.test.tsx
+++ b/frontend/src/components/Onboarding.test.tsx
@@ -1,12 +1,12 @@
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { SetupHarness } from '../api/types'
+import type { Provider } from '../api/types'
 import { Onboarding } from './Onboarding'
 
-const REGISTERED_HARNESSES: SetupHarness[] = [
-  { name: 'claude', loginKinds: ['subscription'] },
-  { name: 'codex', loginKinds: ['subscription'] },
+const REGISTERED_PROVIDERS: Provider[] = [
+  { id: 'anthropic', label: 'Anthropic', loginKinds: ['api_key', 'oauth'] },
+  { id: 'openai-codex', label: 'ChatGPT', loginKinds: ['oauth'] },
 ]
 
 afterEach(() => {
@@ -20,36 +20,36 @@ async function flush() {
   })
 }
 
-function harnessListResponse(harnesses: SetupHarness[]) {
-  return new Response(JSON.stringify(harnesses), { status: 200 })
+function providerListResponse(providers: Provider[]) {
+  return new Response(JSON.stringify(providers), { status: 200 })
 }
 
-function stubHarnessList(harnesses = REGISTERED_HARNESSES) {
+function stubProviderList(providers = REGISTERED_PROVIDERS) {
   vi.stubGlobal(
     'fetch',
     vi.fn(async (url: string | URL | Request) => {
-      expect(String(url)).toBe('/api/harnesses')
-      return harnessListResponse(harnesses)
+      expect(String(url)).toBe('/api/providers')
+      return providerListResponse(providers)
     }),
   )
 }
 
 describe('Onboarding', () => {
   it('frames the door as finishing setup, never as signing in', async () => {
-    stubHarnessList()
+    stubProviderList()
     render(<Onboarding onConnected={() => undefined} />)
-    await screen.findByText('Connect Claude')
-    expect(screen.getByText('Connect a harness to finish setup')).toBeTruthy()
+    await screen.findByText('Connect Anthropic')
+    expect(screen.getByText('Connect a provider to finish setup')).toBeTruthy()
     expect(screen.queryByText(/sign in/i)).toBeNull()
   })
 
-  it('an active flow takes over the stage; cancel restores the harness cards', async () => {
+  it('an active flow takes over the stage; cancel restores the provider cards', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async (url: string | URL | Request) => {
         const path = String(url)
-        if (path === '/api/harnesses') return harnessListResponse(REGISTERED_HARNESSES)
-        expect(path).toBe('/api/harnesses/codex/connection/start')
+        if (path === '/api/providers') return providerListResponse(REGISTERED_PROVIDERS)
+        expect(path).toBe('/api/providers/openai-codex/connection/start')
         return new Response(
           JSON.stringify({ authorizeUrl: 'https://x/auth', connectionId: 'C1' }),
           { status: 200 },
@@ -58,27 +58,28 @@ describe('Onboarding', () => {
     )
 
     render(<Onboarding onConnected={() => undefined} />)
-    fireEvent.click(await screen.findByText('Connect Codex'))
+    fireEvent.click(await screen.findByText('Connect ChatGPT'))
     await flush()
 
     // The challenge panel replaces both cards, not just its own.
     expect(screen.getByText('Open the authorization page')).toBeTruthy()
-    expect(screen.queryByText('Connect Claude')).toBeNull()
+    expect(screen.queryByText('Connect Anthropic')).toBeNull()
 
     fireEvent.click(screen.getByText('Cancel'))
     expect(screen.queryByText('Open the authorization page')).toBeNull()
-    expect(await screen.findByText('Connect Claude')).toBeTruthy()
+    expect(await screen.findByText('Connect Anthropic')).toBeTruthy()
   })
 
-  it('renders one card for each harness returned by setup', async () => {
-    stubHarnessList([
-      ...REGISTERED_HARNESSES,
-      { name: 'opencode', loginKinds: ['subscription'] },
+  it('renders one card per subscription provider; a key-only provider waits for Settings', async () => {
+    stubProviderList([
+      ...REGISTERED_PROVIDERS,
+      { id: 'openai', label: 'OpenAI', loginKinds: ['api_key'] },
     ])
 
     render(<Onboarding onConnected={() => undefined} />)
 
-    await screen.findByText('Connect Opencode')
-    expect(screen.getAllByRole('button')).toHaveLength(3)
+    await screen.findByText('Connect ChatGPT')
+    expect(screen.queryByText('Connect OpenAI')).toBeNull()
+    expect(screen.getAllByRole('button')).toHaveLength(2)
   })
 })

--- a/frontend/src/components/Onboarding.tsx
+++ b/frontend/src/components/Onboarding.tsx
@@ -1,31 +1,32 @@
 import { useCallback, useEffect, useState, type CSSProperties } from 'react'
 
-import { ConnectSteps, useHarnessConnect } from './HarnessConnectFlow'
+import { ConnectSteps, useProviderConnect } from './ProviderConnectFlow'
 import { api } from '../api/client'
 import { harnessColors } from '../lib/harnessColors'
-import { harnessLabel } from '../lib/harnessDisplay'
-import type { Account, SetupHarness } from '../api/types'
+import type { Account, Provider } from '../api/types'
 
 type OnboardingEntry = {
   title: string
   mark: string
   fam: string
-  flow: ReturnType<typeof useHarnessConnect>
+  flow: ReturnType<typeof useProviderConnect>
 }
 
 // The setup door: the edge (or none-mode locality) already decided who you
-// are — druks just needs its first harness connection. Works before any
+// are — druks just needs its first provider credential. Works before any
 // account exists (fresh none mode) and for a newly enrolled header identity.
+// Only a subscription login can create the operator, so key-only providers
+// wait for Settings.
 export function Onboarding({ onConnected }: { onConnected: (account: Account) => void }) {
-  const [harnesses, setHarnesses] = useState<SetupHarness[]>([])
+  const [providers, setProviders] = useState<Provider[]>([])
   const [loadError, setLoadError] = useState<string | null>(null)
-  const [activeHarness, setActiveHarness] = useState<string | null>(null)
+  const [activeProvider, setActiveProvider] = useState<string | null>(null)
 
   useEffect(() => {
     let ignore = false
-    api.setupHarnesses().then(
+    api.providers().then(
       (registered) => {
-        if (!ignore) setHarnesses(registered)
+        if (!ignore) setProviders(registered.filter((p) => p.loginKinds.includes('oauth')))
       },
       (error: unknown) => {
         if (!ignore) setLoadError(error instanceof Error ? error.message : String(error))
@@ -36,13 +37,13 @@ export function Onboarding({ onConnected }: { onConnected: (account: Account) =>
     }
   }, [])
 
-  const setHarnessActive = useCallback((name: string, active: boolean) => {
-    setActiveHarness((current) => {
-      if (active) return name
-      return current === name ? null : current
+  const setProviderActive = useCallback((id: string, active: boolean) => {
+    setActiveProvider((current) => {
+      if (active) return id
+      return current === id ? null : current
     })
   }, [])
-  const color = harnessColors(harnesses.map((harness) => harness.name))
+  const color = harnessColors(providers.map((provider) => provider.id))
 
   return (
     <div className="landing">
@@ -52,7 +53,7 @@ export function Onboarding({ onConnected }: { onConnected: (account: Account) =>
         </div>
         <div className="landing-tag">home for durable agent apps</div>
         <div className="landing-head">
-          <h1>Connect a harness to finish setup</h1>
+          <h1>Connect a provider to finish setup</h1>
           <p>
             druks runs agents on your own coding subscription. <b>Connecting one finishes setup</b>.
           </p>
@@ -61,13 +62,13 @@ export function Onboarding({ onConnected }: { onConnected: (account: Account) =>
           {loadError ? (
             <OnboardingError message={loadError} />
           ) : (
-            harnesses.map((harness) => (
-              <HarnessEntry
-                key={harness.name}
-                harness={harness}
-                fam={color[harness.name]!}
-                activeHarness={activeHarness}
-                onActive={setHarnessActive}
+            providers.map((provider) => (
+              <ProviderEntry
+                key={provider.id}
+                provider={provider}
+                fam={color[provider.id]!}
+                activeProvider={activeProvider}
+                onActive={setProviderActive}
                 onConnected={onConnected}
               />
             ))
@@ -78,34 +79,34 @@ export function Onboarding({ onConnected }: { onConnected: (account: Account) =>
   )
 }
 
-function HarnessEntry({
-  harness,
+function ProviderEntry({
+  provider,
   fam,
-  activeHarness,
+  activeProvider,
   onActive,
   onConnected,
 }: {
-  harness: SetupHarness
+  provider: Provider
   fam: string
-  activeHarness: string | null
-  onActive: (name: string, active: boolean) => void
+  activeProvider: string | null
+  onActive: (id: string, active: boolean) => void
   onConnected: (account: Account) => void
 }) {
-  const flow = useHarnessConnect(harness.name, onConnected)
+  const flow = useProviderConnect(provider.id, onConnected)
   const active = flow.busy || Boolean(flow.challenge)
 
   useEffect(() => {
-    onActive(harness.name, active)
-  }, [active, harness.name, onActive])
+    onActive(provider.id, active)
+  }, [active, provider.id, onActive])
 
-  if (activeHarness && activeHarness !== harness.name) return null
+  if (activeProvider && activeProvider !== provider.id) return null
 
-  const title = harnessLabel(harness.name)
+  const title = provider.label
   const entry = { title, mark: title.slice(0, 2), fam, flow }
-  return active ? <ConnectPanel entry={entry} /> : <HarnessCard entry={entry} />
+  return active ? <ConnectPanel entry={entry} /> : <ProviderCard entry={entry} />
 }
 
-function HarnessCard({ entry }: { entry: OnboardingEntry }) {
+function ProviderCard({ entry }: { entry: OnboardingEntry }) {
   return (
     <div className="landing-choice" style={{ '--fam': entry.fam } as CSSProperties}>
       <button className="landing-card" onClick={() => void entry.flow.start()}>

--- a/frontend/src/components/ProviderConnect.test.tsx
+++ b/frontend/src/components/ProviderConnect.test.tsx
@@ -2,34 +2,24 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { Harness } from '../api/types'
-import { HarnessConnect } from './SettingsModal'
+import type { Provider, ProviderLogin } from '../api/types'
+import { ProviderConnect } from './SettingsModal'
 
-function harness(overrides: Partial<Harness> = {}): Harness {
+function provider(overrides: Partial<Provider> = {}): Provider {
   return {
-    name: 'claude',
-    provider: 'anthropic',
-    model: 'claude-opus-4-7',
-    allowedModels: [{ id: 'claude-opus-4-7', label: 'Claude Opus 4.7' }],
-    fastMode: false,
-    effort: 'high',
-    timeout: 1800,
-    connected: false,
-    kind: null,
-    loginKinds: ['subscription'],
-    account: null,
-    providerEmail: null,
-    expiresAt: null,
+    id: 'anthropic',
+    label: 'Anthropic',
+    loginKinds: ['oauth'],
     ...overrides,
   }
 }
 
-function renderCard(value: Harness) {
+function renderCard(value: Provider, login: ProviderLogin | null = null) {
   const queryClient = new QueryClient()
   const invalidate = vi.spyOn(queryClient, 'invalidateQueries')
   const view = render(
     <QueryClientProvider client={queryClient}>
-      <HarnessConnect harness={value} />
+      <ProviderConnect provider={value} login={login} />
     </QueryClientProvider>,
   )
   return { view, invalidate }
@@ -46,42 +36,41 @@ async function flush() {
   })
 }
 
-describe('HarnessConnect', () => {
+describe('ProviderConnect', () => {
   it('shows each connect control only for its declared login kind', () => {
-    const subscription = renderCard(harness({ loginKinds: ['subscription'] }))
+    const subscription = renderCard(provider({ loginKinds: ['oauth'] }))
 
     expect(screen.getByRole('button', { name: 'Connect' })).toBeTruthy()
     expect(screen.queryByLabelText('API key')).toBeNull()
     subscription.view.unmount()
 
-    const apiKey = renderCard(harness({ loginKinds: ['api_key'] }))
+    const apiKey = renderCard(provider({ loginKinds: ['api_key'] }))
 
     expect(screen.getByLabelText('API key')).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Connect' })).toBeNull()
     apiKey.view.unmount()
 
-    renderCard(harness({ loginKinds: ['subscription', 'api_key'] }))
+    renderCard(provider({ loginKinds: ['oauth', 'api_key'] }))
 
     expect(screen.getByRole('button', { name: 'Connect' })).toBeTruthy()
     expect(screen.getByLabelText('API key')).toBeTruthy()
   })
 
   it('shows each connected subscription identity instead of the operator account', () => {
-    renderCard(
-      harness({
-        connected: true,
-        account: 'ops@corp.com',
-        providerEmail: 'claude-seat@corp.com',
-      }),
-    )
-    renderCard(
-      harness({
-        name: 'codex',
-        connected: true,
-        account: 'ops@corp.com',
-        providerEmail: 'codex-seat@corp.com',
-      }),
-    )
+    renderCard(provider(), {
+      provider: 'anthropic',
+      kind: 'oauth',
+      connected: true,
+      providerEmail: 'claude-seat@corp.com',
+      expiresAt: null,
+    })
+    renderCard(provider({ id: 'openai-codex', label: 'ChatGPT' }), {
+      provider: 'openai-codex',
+      kind: 'oauth',
+      connected: true,
+      providerEmail: 'codex-seat@corp.com',
+      expiresAt: null,
+    })
 
     expect(screen.getAllByText('Connected')).toHaveLength(2)
     expect(screen.getByText('claude-seat@corp.com')).toBeTruthy()
@@ -89,13 +78,13 @@ describe('HarnessConnect', () => {
     expect(screen.queryByText('ops@corp.com')).toBeNull()
   })
 
-  it('drives the connection flow end to end and refreshes only the harness query', async () => {
+  it('drives the connection flow end to end and refreshes only the providers query', async () => {
     const responses: Record<string, unknown> = {
-      '/api/harnesses/claude/connection/start': {
+      '/api/providers/anthropic/connection/start': {
         authorizeUrl: 'https://x/auth',
         connectionId: 'C1',
       },
-      '/api/harnesses/claude/connection/complete': { id: 'a1', username: 'me@example.com' },
+      '/api/providers/anthropic/connection/complete': { id: 'a1', username: 'me@example.com' },
     }
     const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
       async (url) => {
@@ -105,7 +94,7 @@ describe('HarnessConnect', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { invalidate } = renderCard(harness())
+    const { invalidate } = renderCard(provider())
     fireEvent.click(screen.getByText('Connect'))
     await flush()
 
@@ -117,28 +106,28 @@ describe('HarnessConnect', () => {
     await flush()
 
     const completeCall = fetchMock.mock.calls.find(
-      ([url]) => url === '/api/harnesses/claude/connection/complete',
+      ([url]) => url === '/api/providers/anthropic/connection/complete',
     )
     expect(JSON.parse(String(completeCall?.[1]?.body))).toEqual({
       code: 'the-code',
       connectionId: 'C1',
     })
-    // Completion refreshes the harness card — and only that: the browser's
+    // Completion refreshes the provider card — and only that: the browser's
     // own identity is untouched, so /api/auth/me is never rechecked.
-    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['harnesses'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['providerLogins'] })
     expect(fetchMock.mock.calls.some(([url]) => String(url) === '/api/auth/me')).toBe(false)
   })
 
-  it('posts a pasted API key and refreshes the harness query', async () => {
+  it('posts a pasted API key and refreshes the providers query', async () => {
     const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
       async (url) =>
-        new Response(JSON.stringify(url.endsWith('/connection') ? harness() : {}), {
+        new Response(JSON.stringify(url.endsWith('/connection') ? provider() : {}), {
           status: 200,
         }),
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { invalidate } = renderCard(harness({ loginKinds: ['api_key'] }))
+    const { invalidate } = renderCard(provider({ loginKinds: ['api_key'] }))
     fireEvent.change(screen.getByLabelText('API key'), {
       target: { value: 'the-api-key' },
     })
@@ -146,9 +135,9 @@ describe('HarnessConnect', () => {
     await flush()
 
     const connectCall = fetchMock.mock.calls.find(
-      ([url]) => url === '/api/harnesses/claude/connection',
+      ([url]) => url === '/api/providers/anthropic/connection',
     )
     expect(JSON.parse(String(connectCall?.[1]?.body))).toEqual({ key: 'the-api-key' })
-    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['harnesses'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['providerLogins'] })
   })
 })

--- a/frontend/src/components/ProviderConnectFlow.tsx
+++ b/frontend/src/components/ProviderConnectFlow.tsx
@@ -5,8 +5,8 @@ import type { Account, ConnectChallenge } from '../api/types'
 
 // The one PKCE paste-back connect flow, shared by onboarding and Settings.
 // eslint-disable-next-line react-refresh/only-export-components -- hook co-located with its steps UI
-export function useHarnessConnect(
-  name: string,
+export function useProviderConnect(
+  id: string,
   onDone: (account: Account) => void | Promise<void>,
 ) {
   const [challenge, setChallenge] = useState<ConnectChallenge | null>(null)
@@ -26,12 +26,12 @@ export function useHarnessConnect(
     }
   }
 
-  const start = () => run(async () => setChallenge(await api.startHarnessConnect(name)))
+  const start = () => run(async () => setChallenge(await api.startProviderConnect(id)))
 
   const finish = () =>
     run(async () => {
       if (!challenge) return
-      const account = await api.completeHarnessConnect(name, code.trim(), challenge.connectionId)
+      const account = await api.completeProviderConnect(id, code.trim(), challenge.connectionId)
       setChallenge(null)
       setCode('')
       await onDone(account)
@@ -49,7 +49,7 @@ export function useHarnessConnect(
 export function ConnectSteps({
   flow,
 }: {
-  flow: ReturnType<typeof useHarnessConnect>
+  flow: ReturnType<typeof useProviderConnect>
 }) {
   if (!flow.challenge) return null
   return (

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -152,6 +152,12 @@ function stubFetch(
       if (path === '/api/settings/harnesses') {
         return new Response('[]', { status: 200 })
       }
+      if (path === '/api/providers/logins') {
+        return new Response('[]', { status: 200 })
+      }
+      if (path === '/api/providers') {
+        return new Response('[]', { status: 200 })
+      }
       if (path === '/api/browser-sessions') {
         return new Response('[]', { status: 200 })
       }

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -6,7 +6,7 @@ import { BrowserSessionsPane } from './BrowserSessionsPane'
 import { TextInput } from './Control'
 import { SettingField } from './SettingField'
 import { AppGlyph } from './AppGlyph'
-import { ConnectSteps, useHarnessConnect } from './HarnessConnectFlow'
+import { ConnectSteps, useProviderConnect } from './ProviderConnectFlow'
 import {
   type Harness,
   type AppSettings,
@@ -14,6 +14,8 @@ import {
   type McpRegistryCandidate,
   type McpServer,
   type Pat,
+  type Provider,
+  type ProviderLogin,
   type Connection,
   type Service,
   type SkillCollection,
@@ -125,6 +127,18 @@ export function SettingsModal({ open, onClose }: Props) {
     enabled: open,
     staleTime: 60_000,
   })
+  // A provider credential persists immediately outside Save, like a harness.
+  const providersQuery = useQuery({
+    queryKey: ['providers'],
+    queryFn: () => api.providers(),
+    enabled: open,
+    staleTime: 60_000,
+  })
+  const providerLoginsQuery = useQuery({
+    queryKey: ['providerLogins'],
+    queryFn: () => api.providerLogins(),
+    enabled: open,
+  })
   const [timezone, setTimezone] = useState<string>('UTC')
   // Pending per-app setting overrides — a sparse UpdateAppsSettingsRequest the
   // app tabs (and the Druks tab's built-in agents) edit and submit() flushes.
@@ -134,7 +148,7 @@ export function SettingsModal({ open, onClose }: Props) {
   // Pending per-harness edits (name -> sparse UpdateHarnessRequest), flushed by
   // submit() — same dirty/save flow as the app and general settings.
   const [harnessEdits, setHarnessEdits] = useState<Record<string, UpdateHarnessRequest>>({})
-  // 'general' | 'harnesses' | 'browser-sessions' | 'skills' | 'mcp' |
+  // 'general' | 'providers' | 'harnesses' | 'browser-sessions' | 'skills' | 'mcp' |
   // 'agent-access' | <app name>
   const [section, setSection] = useState<string>('general')
   const [busy, setBusy] = useState(false)
@@ -265,6 +279,8 @@ export function SettingsModal({ open, onClose }: Props) {
   const allApps = data?.apps ?? []
   const allowedEfforts = data?.allowedEfforts ?? []
   const harnesses = harnessesQuery.data ?? []
+  const providers = providersQuery.data ?? []
+  const providerLogins = providerLoginsQuery.data ?? []
   const harnessByName: Record<string, Harness> = Object.fromEntries(
     harnesses.map((h) => [h.name, h]),
   )
@@ -349,6 +365,7 @@ export function SettingsModal({ open, onClose }: Props) {
         <div className="set-grid">
           <nav className="set-rail">
             <RailItem icon="general" label="General" active={section === 'general'} onClick={() => setSection('general')} />
+            <RailItem icon="services" label="Providers" active={section === 'providers'} onClick={() => setSection('providers')} />
             <RailItem icon="harnesses" label="Harnesses" active={section === 'harnesses'} onClick={() => setSection('harnesses')} />
             <RailItem icon="services" label="Services" active={section === 'services'} onClick={() => setSection('services')} />
             <RailItem icon="services" label="Connections" active={section === 'connections'} onClick={() => setSection('connections')} />
@@ -381,6 +398,7 @@ export function SettingsModal({ open, onClose }: Props) {
                 busy={busy}
               />
             )}
+            {section === 'providers' && <ProvidersPane providers={providers} logins={providerLogins} />}
             {section === 'harnesses' &&
               (harnesses.length > 0 ? (
                 <HarnessesPane
@@ -805,7 +823,7 @@ function HarnessesPane({
               <div className="hr-ident">
                 <span className="hr-ident-dot" />
                 <span className="hr-name">{harness.name}</span>
-                <span className="hr-provider">{harness.provider}</span>
+                <span className="hr-provider">{harness.provider ?? 'API key'}</span>
                 <span className="hr-count">
                   <b>{agentCount(harness.name)}</b> agents
                 </span>
@@ -862,7 +880,6 @@ function HarnessesPane({
                   </span>
                 </div>
               </div>
-              <HarnessConnect harness={harness} />
             </div>
           )
         })}
@@ -1287,28 +1304,58 @@ export function ConnectionsPane() {
   )
 }
 
+// Providers — who answers and bills a model request. One credential per
+// provider per account; every harness that drives the provider runs on it.
+// Connection state persists immediately, outside the modal's Save.
+function ProvidersPane({ providers, logins }: { providers: Provider[]; logins: ProviderLogin[] }) {
+  const providerColor = harnessColors(providers.map((p) => p.id))
+  return (
+    <div className="set-pane mcp-pane hrs-pane">
+      <header className="mcp-pane-head">
+        <h2 className="mcp-pane-title">Providers</h2>
+        <p className="mcp-pane-sub">
+          Your subscription or API key at each model provider. Every harness that can drive a
+          provider runs on the credential you connect here.
+        </p>
+      </header>
+      <div className="hrs-list">
+        {providers.map((provider) => (
+          <div key={provider.id} className="set-card hr-card" style={{ '--fam': providerColor[provider.id] } as CSSProperties}>
+            <div className="hr-ident">
+              <span className="hr-ident-dot" />
+              <span className="hr-name">{provider.label}</span>
+              <span className="hr-provider">{provider.id}</span>
+            </div>
+            <ProviderConnect provider={provider} login={logins.find((l) => l.provider === provider.id) ?? null} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 // Connection state persists immediately, outside the modal's Save, so this
-// manages its own busy/error and refetches the harnesses query on change.
-export function HarnessConnect({ harness }: { harness: Harness }) {
+// manages its own busy/error and refetches the logins query on change.
+export function ProviderConnect({ provider, login }: { provider: Provider; login: ProviderLogin | null }) {
   const queryClient = useQueryClient()
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [key, setKey] = useState('')
 
-  const refresh = () => queryClient.invalidateQueries({ queryKey: ['harnesses'] })
-  const flow = useHarnessConnect(harness.name, async () => {
+  const refresh = () => queryClient.invalidateQueries({ queryKey: ['providerLogins'] })
+  const flow = useProviderConnect(provider.id, async () => {
     await refresh()
   })
-  const acceptsSubscription = harness.loginKinds.includes('subscription')
-  const acceptsApiKey = harness.loginKinds.includes('api_key')
+  const acceptsOauth = provider.loginKinds.includes('oauth')
+  const acceptsApiKey = provider.loginKinds.includes('api_key')
 
   const disconnect = () => {
-    if (!window.confirm(`Disconnect ${harness.name}? Reconnect it before agents can run on it.`))
+    if (!window.confirm(`Disconnect ${provider.label}? Reconnect it before agents can run on it.`))
       return
     setBusy(true)
     setError(null)
     void api
-      .disconnectHarness(harness.name)
+      .disconnectProvider(provider.id)
       .then(refresh)
       .catch((e) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setBusy(false))
@@ -1319,7 +1366,7 @@ export function HarnessConnect({ harness }: { harness: Harness }) {
     setBusy(true)
     setError(null)
     void api
-      .connectHarnessKey(harness.name, key)
+      .connectProviderKey(provider.id, key)
       .then(() => {
         setKey('')
         return refresh()
@@ -1328,34 +1375,33 @@ export function HarnessConnect({ harness }: { harness: Harness }) {
       .finally(() => setBusy(false))
   }
 
+  const connected = Boolean(login?.connected)
   return (
     <div className="hr-connect">
       <div className="hr-conn-status">
-        <ServiceStatus connected={harness.connected} />
-        {harness.connected && harness.providerEmail && (
-          <span className="hr-conn-id">{harness.providerEmail}</span>
-        )}
-        {harness.connected && harness.expiresAt && (
-          <span className="hr-conn-exp">token expires {new Date(harness.expiresAt).toLocaleString()}</span>
+        <ServiceStatus connected={connected} />
+        {login?.connected && <span className="hr-conn-id">{login.providerEmail}</span>}
+        {login?.connected && login.expiresAt && (
+          <span className="hr-conn-exp">token expires {new Date(login.expiresAt).toLocaleString()}</span>
         )}
         <span className="hr-conn-actions">
-          {harness.connected && (
+          {connected && (
             <button className="set-btn danger quiet" onClick={disconnect} disabled={busy || flow.busy}>
               Disconnect
             </button>
           )}
-          {acceptsSubscription && !flow.challenge && (
+          {acceptsOauth && !flow.challenge && (
             <button
-              className={'set-btn ' + (harness.connected ? 'ghost' : 'primary')}
+              className={'set-btn ' + (connected ? 'ghost' : 'primary')}
               onClick={() => void flow.start()}
               disabled={busy || flow.busy}
             >
-              {harness.connected ? 'Reconnect' : 'Connect'}
+              {connected ? 'Reconnect' : 'Connect'}
             </button>
           )}
         </span>
       </div>
-      {acceptsSubscription && <ConnectSteps flow={flow} />}
+      {acceptsOauth && <ConnectSteps flow={flow} />}
       {acceptsApiKey && (
         <form className="hr-conn-flow" onSubmit={connectKey}>
           <div className="hr-conn-step hr-conn-paste">
@@ -1375,7 +1421,7 @@ export function HarnessConnect({ harness }: { harness: Harness }) {
               disabled={busy || flow.busy || !key.trim()}
               type="submit"
             >
-              {harness.kind === 'api_key' ? 'Replace key' : 'Connect with key'}
+              {login?.kind === 'api_key' ? 'Replace key' : 'Connect with key'}
             </button>
           </div>
         </form>

--- a/frontend/src/components/UsagePanel.test.tsx
+++ b/frontend/src/components/UsagePanel.test.tsx
@@ -6,9 +6,10 @@ import type { UsageHistoryResponse, UsageResponse, UsageTodayResponse } from '..
 import { UsagePanel } from './UsagePanel'
 
 const usage: UsageResponse = {
-  harnesses: [
+  providers: [
     {
-      name: 'claude',
+      id: 'anthropic',
+      label: 'Anthropic',
       available: true,
       connected: true,
       providerEmail: 'subscription@example.com',
@@ -29,9 +30,9 @@ const usage: UsageResponse = {
 }
 
 const history: UsageHistoryResponse = {
-  harnesses: [
+  providers: [
     {
-      name: 'claude',
+      id: 'anthropic',
       fiveHour: [],
       weeks: [
         {
@@ -49,7 +50,7 @@ const history: UsageHistoryResponse = {
 const today: UsageTodayResponse = {
   day: '2026-08-01',
   timezone: 'UTC',
-  harnesses: [],
+  providers: [],
 }
 
 function stubFetch(summary: UsageResponse = usage, usageHistory: UsageHistoryResponse = history) {
@@ -87,7 +88,7 @@ describe('UsagePanel', () => {
     expect(await screen.findByText('subscription@example.com')).toBeTruthy()
   })
 
-  it('pages model-scoped weekly capacity without exhausting the harness', async () => {
+  it('pages model-scoped weekly capacity without exhausting the provider', async () => {
     stubFetch()
     const { container } = renderPanel()
 
@@ -98,8 +99,8 @@ describe('UsagePanel', () => {
     expect(screen.getByText('0%')).toBeTruthy()
     expect(container.querySelector('.us-week-carousel .us-spark')).toBeTruthy()
     expect(container.querySelectorAll('.us-week-dot')).toHaveLength(2)
-    expect(screen.getByText(/New claude runs on Fable will fail until the window resets/)).toBeTruthy()
-    expect(screen.queryByText(/New claude runs will fail until the window resets/)).toBeNull()
+    expect(screen.getByText(/New Anthropic runs on Fable will fail until the window resets/)).toBeTruthy()
+    expect(screen.queryByText(/New Anthropic runs will fail until the window resets/)).toBeNull()
 
     fireEvent.click(screen.getByRole('button', { name: 'Next weekly window' }))
 
@@ -110,9 +111,9 @@ describe('UsagePanel', () => {
 
   it('pages between weekly windows with the same scope', async () => {
     const duplicateScopes: UsageResponse = {
-      harnesses: [
+      providers: [
         {
-          ...usage.harnesses[0]!,
+          ...usage.providers[0]!,
           weeks: [
             { percentLeft: 80, resetsAt: null, model: null },
             { percentLeft: 10, resetsAt: null, model: null },
@@ -121,9 +122,9 @@ describe('UsagePanel', () => {
       ],
     }
     const duplicateHistory: UsageHistoryResponse = {
-      harnesses: [
+      providers: [
         {
-          name: 'claude',
+          id: 'anthropic',
           fiveHour: [],
           weeks: [
             { model: null, points: [] },

--- a/frontend/src/components/UsagePanel.tsx
+++ b/frontend/src/components/UsagePanel.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState, type CSSProperties } from 'react'
 
 import { harnessColors } from '../lib/harnessColors'
-import { harnessLabel } from '../lib/harnessDisplay'
 import { usageTone, type UsageTone } from '../lib/usageHealth'
 import { useUsage, useUsageHistory, useUsageToday } from '../lib/useUsage'
 import type {
-  UsageHarnessHistory,
-  UsageHarnessSummary,
-  UsageHarnessToday,
+  UsageProviderHistory,
+  UsageProviderSummary,
+  UsageProviderToday,
   UsageHistoryPoint,
   UsageMetric,
   UsageTodayResponse,
@@ -68,9 +67,9 @@ export function UsagePanel() {
     }
   }
 
-  const ages = data.harnesses.map((h) => h.ageSeconds).filter((v): v is number => v !== null)
+  const ages = data.providers.map((h) => h.ageSeconds).filter((v): v is number => v !== null)
   const updatedLabel = ages.length > 0 ? `updated ${formatAge(Math.min(...ages))} ago` : ''
-  const harnessColor = harnessColors(data.harnesses.map((h) => h.name))
+  const harnessColor = harnessColors(data.providers.map((h) => h.id))
 
   return (
     <section className="us-col">
@@ -90,16 +89,16 @@ export function UsagePanel() {
         </button>
       </header>
 
-      <ExhaustionAlert harnesses={data.harnesses} />
+      <ExhaustionAlert providers={data.providers} />
 
       <div className="us-grid">
-        {data.harnesses.map((usage) => (
+        {data.providers.map((usage) => (
           <ProviderPanel
-            key={usage.name}
+            key={usage.id}
             usage={usage}
-            color={harnessColor[usage.name]}
-            history={history?.harnesses.find((h) => h.name === usage.name)}
-            today={today?.harnesses.find((t) => t.name === usage.name)}
+            color={harnessColor[usage.id]}
+            history={history?.providers.find((h) => h.id === usage.id)}
+            today={today?.providers.find((t) => t.id === usage.id)}
           />
         ))}
       </div>
@@ -112,13 +111,14 @@ export function UsagePanel() {
 // ---- Exhaustion banner ------------------------------------------------------
 
 interface Exhausted {
-  harness: string
+  provider: string
+  label: string
   windowLabel: string
   resetsAt: string | null
   model: string | null
 }
 
-function findExhausted(usage: UsageHarnessSummary): Exhausted | null {
+function findExhausted(usage: UsageProviderSummary): Exhausted | null {
   if (!usage.available || usage.unlimited) return null
   const windows = usage.weeks.map((metric) => ({ label: 'weekly', metric }))
   if (usage.fiveHour) windows.unshift({ label: '5-hour', metric: usage.fiveHour })
@@ -127,14 +127,15 @@ function findExhausted(usage: UsageHarnessSummary): Exhausted | null {
   const exhausted = empty.find(({ metric }) => !metric.model) ?? empty[0]
   if (!exhausted) return null
   return {
-    harness: usage.name,
+    provider: usage.id,
+    label: usage.label,
     windowLabel: exhausted.label,
     resetsAt: exhausted.metric.resetsAt,
     model: exhausted.metric.model,
   }
 }
 
-function hasCapacity(usage: UsageHarnessSummary): boolean {
+function hasCapacity(usage: UsageProviderSummary): boolean {
   if (!usage.available) return false
   if (usage.unlimited) return true
   const windows = usage.fiveHour ? [usage.fiveHour, ...usage.weeks] : usage.weeks
@@ -143,19 +144,19 @@ function hasCapacity(usage: UsageHarnessSummary): boolean {
   return !unscopedExhausted && hasRoom
 }
 
-function ExhaustionAlert({ harnesses }: { harnesses: UsageHarnessSummary[] }) {
+function ExhaustionAlert({ providers }: { providers: UsageProviderSummary[] }) {
   const now = useNow(1000)
-  const exhaustedWindows = harnesses
+  const exhaustedWindows = providers
     .map(findExhausted)
     .filter((window): window is Exhausted => window !== null)
   const exhausted = exhaustedWindows.find((window) => !window.model) ?? exhaustedWindows[0] ?? null
   if (!exhausted) return null
 
-  const alternative = harnesses.find((h) => h.name !== exhausted.harness && hasCapacity(h))
+  const alternative = providers.find((h) => h.id !== exhausted.provider && hasCapacity(h))
   const resetSeconds = secondsUntil(exhausted.resetsAt, now)
   const title = exhausted.model
     ? `${exhausted.model} ${exhausted.windowLabel} limit reached`
-    : `${harnessLabel(exhausted.harness)} ${exhausted.windowLabel} limit reached`
+    : `${exhausted.label} ${exhausted.windowLabel} limit reached`
 
   return (
     <div className="us-alert" role="alert">
@@ -172,15 +173,15 @@ function ExhaustionAlert({ harnesses }: { harnesses: UsageHarnessSummary[] }) {
         <div className="us-alert-sub">
           {exhausted.model ? (
             <span>
-              New {exhausted.harness} runs on {exhausted.model} will fail until the window resets.{' '}
-              <b>{harnessLabel(exhausted.harness)} still has capacity for other models.</b>
+              New {exhausted.label} runs on {exhausted.model} will fail until the window resets.{' '}
+              <b>{exhausted.label} still has capacity for other models.</b>
             </span>
           ) : (
             <>
-              New {exhausted.harness} runs will fail until the window resets.{' '}
+              New {exhausted.label} runs will fail until the window resets.{' '}
               {alternative ? (
                 <span>
-                  <b>{harnessLabel(alternative.name)} has capacity</b> — route new work there to keep
+                  <b>{alternative.label} has capacity</b> — route new work there to keep
                   builds moving.
                 </span>
               ) : (
@@ -208,10 +209,10 @@ function ProviderPanel({
   history,
   today,
 }: {
-  usage: UsageHarnessSummary
+  usage: UsageProviderSummary
   color: string | undefined
-  history: UsageHarnessHistory | undefined
-  today: UsageHarnessToday | undefined
+  history: UsageProviderHistory | undefined
+  today: UsageProviderToday | undefined
 }) {
   const [rawOpen, setRawOpen] = useState(false)
 
@@ -220,7 +221,7 @@ function ProviderPanel({
       <header className="us-prov-head">
         <span className="us-prov-dot" />
         <span className="us-prov-name">
-          {usage.connected ? usage.providerEmail : usage.name}
+          {usage.connected ? usage.providerEmail : usage.label}
         </span>
         {usage.planTier && <span className="us-prov-plan mono">{usage.planTier}</span>}
         <span className="us-prov-spacer" />
@@ -241,12 +242,12 @@ function ProviderPanel({
                   metric={usage.fiveHour}
                   spark={history?.fiveHour}
                   sparkLabel="remaining · last 5h"
-                  sparkId={`${usage.name}-5h`}
+                  sparkId={`${usage.id}-5h`}
                   rateNoun="window"
                 />
               )}
               {usage.weeks.length > 0 && (
-                <WeeklyCarousel harness={usage.name} weeks={usage.weeks} history={history} />
+                <WeeklyCarousel provider={usage.id} weeks={usage.weeks} history={history} />
               )}
             </>
           )}
@@ -286,13 +287,13 @@ function indexOfBinding(weeks: UsageMetric[]): number {
 }
 
 function WeeklyCarousel({
-  harness,
+  provider,
   weeks,
   history,
 }: {
-  harness: string
+  provider: string
   weeks: UsageMetric[]
-  history: UsageHarnessHistory | undefined
+  history: UsageProviderHistory | undefined
 }) {
   const bindingIndex = indexOfBinding(weeks)
   const [selectedIndex, setSelectedIndex] = useState(bindingIndex)
@@ -310,7 +311,7 @@ function WeeklyCarousel({
         metric={metric}
         spark={spark}
         sparkLabel="remaining · this week"
-        sparkId={`${harness}-wk-${currentIndex}`}
+        sparkId={`${provider}-wk-${currentIndex}`}
         rateNoun="week"
       />
       {multiple && (
@@ -435,7 +436,7 @@ function WindowRow({
  * (capacity genuinely is always available) plus actual consumption
  * from run records — that's the number worth watching.
  */
-function UnmeteredWindow({ today }: { today: UsageHarnessToday | undefined }) {
+function UnmeteredWindow({ today }: { today: UsageProviderToday | undefined }) {
   return (
     <div className="us-win">
       <div className="us-win-top">
@@ -525,9 +526,9 @@ function Spark({ data, tone, id }: { data: number[]; tone: UsageTone; id: string
 // ---- Today section ----------------------------------------------------------
 
 function TodaySection({ today }: { today: UsageTodayResponse }) {
-  const totalSpend = today.harnesses.reduce((sum, h) => sum + h.spendUsd, 0)
-  const totalTokens = today.harnesses.reduce((sum, h) => sum + h.tokens, 0)
-  const harnessColor = harnessColors(today.harnesses.map((h) => h.name))
+  const totalSpend = today.providers.reduce((sum, h) => sum + h.spendUsd, 0)
+  const totalTokens = today.providers.reduce((sum, h) => sum + h.tokens, 0)
+  const harnessColor = harnessColors(today.providers.map((h) => h.id))
 
   return (
     <>
@@ -540,20 +541,20 @@ function TodaySection({ today }: { today: UsageTodayResponse }) {
         <SplitTile
           label="spend today"
           value={fmtUsd(totalSpend)}
-          entries={today.harnesses.map((h) => ({
-            name: h.name,
+          entries={today.providers.map((h) => ({
+            name: h.id,
             amount: h.spendUsd,
-            color: harnessColor[h.name],
+            color: harnessColor[h.id],
           }))}
           fmt={fmtUsd}
         />
         <SplitTile
           label="tokens today"
           value={fmtTokens(totalTokens)}
-          entries={today.harnesses.map((h) => ({
-            name: h.name,
+          entries={today.providers.map((h) => ({
+            name: h.id,
             amount: h.tokens,
-            color: harnessColor[h.name],
+            color: harnessColor[h.id],
           }))}
           fmt={fmtTokens}
         />
@@ -564,9 +565,9 @@ function TodaySection({ today }: { today: UsageTodayResponse }) {
 }
 
 function describeLoad(today: UsageTodayResponse): string {
-  const active = today.harnesses.filter((h) => h.spendUsd + h.tokens > 0)
+  const active = today.providers.filter((h) => h.spendUsd + h.tokens > 0)
   if (active.length === 0) return 'no finished runs today'
-  if (active.length === 1 && active[0]) return `all load on ${active[0].name} · others idle`
+  if (active.length === 1 && active[0]) return `all load on ${active[0].id} · others idle`
   return 'load split across providers'
 }
 
@@ -627,7 +628,7 @@ function HoursTile({
   total: string
 }) {
   const stacked = Array.from({ length: 24 }, (_, i) =>
-    today.harnesses.reduce((sum, h) => sum + (h.hours[i] ?? 0), 0),
+    today.providers.reduce((sum, h) => sum + (h.hours[i] ?? 0), 0),
   )
   const max = Math.max(...stacked, 0.01)
   const nowHour = currentHourIn(today.timezone)
@@ -647,13 +648,13 @@ function HoursTile({
             style={{ height: `${Math.max((v / max) * 100, v > 0 ? 6 : 2)}%` }}
             title={`${String(i).padStart(2, '0')}:00 — $${v.toFixed(2)}`}
           >
-            {today.harnesses.map((h) => {
+            {today.providers.map((h) => {
               const amount = h.hours[i] ?? 0
-              const color = harnessColor[h.name]
+              const color = harnessColor[h.id]
               return (
                 amount > 0 && (
                   <div
-                    key={h.name}
+                    key={h.id}
                     className="us-hour-seg"
                     style={{
                       height: `${(amount / v) * 100}%`,
@@ -803,9 +804,9 @@ function currentHourIn(timeZone: string): number {
   }
 }
 
-function describeIdle(usage: UsageHarnessSummary): string {
-  if (!usage.connected) return `connect ${usage.name} in Settings to see your quota`
-  if (usage.error === 'not_installed') return `${usage.name} not installed`
+function describeIdle(usage: UsageProviderSummary): string {
+  if (!usage.connected) return `connect ${usage.id} in Settings to see your quota`
+  if (usage.error === 'not_installed') return `${usage.id} not installed`
   if (usage.error === 'auth_required') return 'not signed in'
   if (usage.error === 'timeout') return 'scrape timed out — try refresh'
   if (usage.error === 'parse_failed') return 'could not parse /status output'

--- a/frontend/src/components/UsagePill.tsx
+++ b/frontend/src/components/UsagePill.tsx
@@ -2,12 +2,12 @@ import { Link } from 'wouter'
 
 import { usageTone } from '../lib/usageHealth'
 import { useUsage } from '../lib/useUsage'
-import type { UsageHarnessSummary } from '../api/types'
+import type { UsageProviderSummary } from '../api/types'
 
 /**
- * Compact appbar pill showing remaining-quota % per harness.
+ * Compact appbar pill showing remaining-quota % per provider.
  *
- * Adjacent mini-pills, one per registered harness:
+ * Adjacent mini-pills, one per registered provider:
  *
  *   ◯ c 82%   ◯ x 36%
  *
@@ -26,8 +26,8 @@ import type { UsageHarnessSummary } from '../api/types'
  * operator's choice, not nag.
  */
 
-// One-letter pill labels; unknown harnesses fall back to their first letter.
-const SHORT_LABELS: Record<string, string> = { claude: 'c', codex: 'x' }
+// One-letter pill labels; unknown providers fall back to their first letter.
+const SHORT_LABELS: Record<string, string> = { anthropic: 'a', 'openai-codex': 'x', openai: 'o' }
 
 export function UsagePill() {
   const { data, isLoading, isError } = useUsage()
@@ -36,21 +36,21 @@ export function UsagePill() {
 
   return (
     <Link href="/usage" className="usage-pill mono dim" aria-label="subscription quota — open details">
-      {data.harnesses.map((usage) => (
-        <MiniPill key={usage.name} usage={usage} short={SHORT_LABELS[usage.name] ?? usage.name.charAt(0)} />
+      {data.providers.map((usage) => (
+        <MiniPill key={usage.id} usage={usage} short={SHORT_LABELS[usage.id] ?? usage.label.charAt(0).toLowerCase()} />
       ))}
     </Link>
   )
 }
 
-function MiniPill({ usage, short }: { usage: UsageHarnessSummary; short: string }) {
+function MiniPill({ usage, short }: { usage: UsageProviderSummary; short: string }) {
   const headline = headlineMetric(usage)
   if (headline === null) {
     return (
       <span
         className="usage-mini usage-tier-idle"
         title={buildTooltip(usage)}
-        aria-label={`${usage.name}: ${describeIdle(usage)}`}
+        aria-label={`${usage.label}: ${describeIdle(usage)}`}
       >
         <span className="usage-mini-dot" />
         <span className="usage-mini-label">{short}</span>
@@ -63,7 +63,7 @@ function MiniPill({ usage, short }: { usage: UsageHarnessSummary; short: string 
     <span
       className={`usage-mini usage-tier-${tone}`}
       title={buildTooltip(usage)}
-      aria-label={`${usage.name}: ${headline}% left`}
+      aria-label={`${usage.label}: ${headline}% left`}
     >
       <span className="usage-mini-dot" />
       <span className="usage-mini-label">{short}</span>
@@ -75,7 +75,7 @@ function MiniPill({ usage, short }: { usage: UsageHarnessSummary; short: string 
 
 // "Headline" metric — the smallest reported window is the one most
 // likely to bite you next; the panel identifies its scope.
-function headlineMetric(usage: UsageHarnessSummary): number | null {
+function headlineMetric(usage: UsageProviderSummary): number | null {
   if (!usage.available) return null
   const candidates: number[] = []
   if (usage.fiveHour && usage.fiveHour.percentLeft !== null) candidates.push(usage.fiveHour.percentLeft)
@@ -86,7 +86,7 @@ function headlineMetric(usage: UsageHarnessSummary): number | null {
   return Math.min(...candidates)
 }
 
-function ageSuffix(usage: UsageHarnessSummary) {
+function ageSuffix(usage: UsageProviderSummary) {
   if (usage.stale) {
     return <span className="usage-mini-age usage-mini-stale">stale</span>
   }
@@ -96,7 +96,7 @@ function ageSuffix(usage: UsageHarnessSummary) {
   return <span className="usage-mini-age">·{text}</span>
 }
 
-function describeIdle(usage: UsageHarnessSummary): string {
+function describeIdle(usage: UsageProviderSummary): string {
   if (!usage.connected) return 'not connected — connect in Settings'
   if (usage.error === 'not_installed') return 'CLI not installed'
   if (usage.error === 'auth_required') return 'not signed in'
@@ -106,9 +106,9 @@ function describeIdle(usage: UsageHarnessSummary): string {
   return 'no scrape yet'
 }
 
-function buildTooltip(usage: UsageHarnessSummary): string {
+function buildTooltip(usage: UsageProviderSummary): string {
   const lines = [
-    `${usage.name}${usage.planTier ? ` (${usage.planTier})` : ''}`,
+    `${usage.label}${usage.planTier ? ` (${usage.planTier})` : ''}`,
   ]
   if (usage.fiveHour && usage.fiveHour.percentLeft !== null) {
     lines.push(`  5h: ${usage.fiveHour.percentLeft}% left${formatResets(usage.fiveHour.resetsAt)}`)


### PR DESCRIPTION
A provider (Anthropic, ChatGPT, OpenAI) now owns the login an account holds for it, its OAuth connect and refresh, and its quota scrape. A harness declares the login kinds it consumes and, for a subscription CLI, the one provider it is bound to.

- `harnesses/providers.py`: the provider registry with the connect, refresh, and usage machinery that sat on `Harness`, `ClaudeHarness`, and `CodexHarness`.
- `HarnessConnection` → `ProviderLogin` (`harness_logins` → `provider_logins`), keyed by provider and account. `Harness.accepts(login)` says whether a CLI runs on it.
- `GET /api/providers` lists the registry, `GET /api/providers/logins` the account's logins; connect and disconnect live under `/api/providers/{provider}/connection`.
- Dispatch, the quota gate, the refresh cron, model discovery, usage, doctor, and the MCP gateway key on the provider.
- The sandbox home is a set of entries (`HomeFile`, `HomeCopy`) a harness renders, replacing the tuple lists on `Credentials`.
- Migration `e3a9c7d1b5f4` renames the table and maps harness names to provider ids; `usage_scrapes` follows.
- Settings gains a Providers section; onboarding and usage read providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
