### PR TITLE
The model selects the harness; the operator owns the model

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -23,7 +23,6 @@ from druks.harnesses.exceptions import (
     Retry,
 )
 from druks.harnesses.models import ProviderLogin
-from druks.harnesses.registry import get_harness_for_model
 from druks.prompts import render_prompt
 from druks.sandbox import gate as sandbox_gate
 from druks.sandbox.client import sandbox_client
@@ -35,6 +34,7 @@ from druks.user_settings.models import SettingsOverride
 from druks.workflows import _in_step, current_workflow
 
 if TYPE_CHECKING:
+    from druks.harnesses.base import Harness
     from druks.sandbox.datastructures import AgentResult
     from druks.workflows import Workflow
     from druks.workspaces import Workspace
@@ -95,10 +95,6 @@ class AgentOutput(BaseModel):
 @dataclass(frozen=True)
 class Agent:
     contract: type[AgentOutput]
-    # Operator-tunable declared default: the model the agent runs unless it is
-    # overridden (per agent or globally) in settings. A family token
-    # (codex/claude) resolves to that family's operator-tunable model.
-    model: str
     # Display label for the settings UI; ``id`` is shown when it's None.
     name: str | None = None
     # Short human-friendly blurb of what the agent does, shown in the settings UI.
@@ -107,9 +103,9 @@ class Agent:
     # prompt inline and drive the harness themselves (planning) instead of
     # going through ``run``.
     prompt: str | None = None
-    # Operator-tunable declared defaults, overridable per agent or globally.
-    # None inherits the global default (effort; timeout in seconds).
-    effort: str | None = None
+    # Declared run timeout in seconds, overridable per agent; None inherits the
+    # harness default. How long a step may take is a fact about the task; the
+    # model and the effort are the operator's, set in Settings.
     timeout: int | None = None
     # ``include_plugins=False`` skips the operator's plugin state for prompts
     # that hit no MCP server.
@@ -136,16 +132,14 @@ class Agent:
     # override → the agent's declared value → the operator's global default.
     # ``run`` uses these; callers that drive the harness themselves call them
     # directly.
-    async def get_model_name(self) -> str:
-        return (await SettingsOverride.agent_model(self.id, self.model)).value
+    async def get_model(self) -> str:
+        return (await SettingsOverride.agent_model(self.id)).value
 
-    async def get_effort(self) -> str:
-        harness = (get_harness_for_model(await self.get_model_name())).name
-        return (await SettingsOverride.agent_effort(self.id, self.effort, harness)).value
+    async def get_effort(self, harness: "type[Harness]") -> str:
+        return (await SettingsOverride.agent_effort(self.id, harness.name)).value
 
-    async def get_timeout(self) -> int:
-        harness = (get_harness_for_model(await self.get_model_name())).name
-        resolved = (await SettingsOverride.agent_timeout(self.id, self.timeout, harness)).value
+    async def get_timeout(self, harness: "type[Harness]") -> int:
+        resolved = (await SettingsOverride.agent_timeout(self.id, self.timeout, harness.name)).value
         # Capped so a single call always fits inside a fresh sandbox lease.
         return min(resolved, MAX_AGENT_TIMEOUT_SECONDS)
 
@@ -200,7 +194,7 @@ class Agent:
             # Runs as its own step: the body does no IO, and replay reuses the
             # recorded wait instead of re-reading the scrape.
             async with step_session():
-                model = await self.get_model_name()
+                model = await self.get_model()
                 provider_id = model.partition("/")[0]
                 # The scrape belongs to the charged login — its account
                 # differs from the run's on fallback.
@@ -267,14 +261,14 @@ class Agent:
         the harness. ``__call__`` handles the durable wrapping + nesting."""
         if not self.prompt:
             raise WorkflowError(f"agent {self.id!r} has no prompt template to render")
-        model = await self.get_model_name()
-        harness = get_harness_for_model(model)
+        model = await self.get_model()
         workflow = current_workflow.get()
         # Refusing an unservable call here beats provisioning a VM and
         # 401ing mid-run.
         login = await ProviderLogin.lookup(model.partition("/")[0], workflow.account_id)
+        harness = login.get_harness()
         # Plain snapshots: the commits below expire the ORM row mid-flight.
-        connection_id, charged_account_id = login.id, login.account_id
+        login_id, charged_account_id = login.id, login.account_id
         # An agent call is a durability boundary — its effects don't roll back —
         # so commit here rather than hold the step's connection idle through the
         # minutes of provisioning and the run.
@@ -285,9 +279,9 @@ class Agent:
         engine = _step_engine()
         call_id = harness.mint_run_id(None)
 
-        # Registered for provisioning through execution — this connection's
+        # Registered for provisioning through execution — this login's
         # rotation defers around it.
-        async with sandbox_gate.use(connection_id, call_id):
+        async with sandbox_gate.use(login_id, call_id):
             await set_run_phase("provisioning_vm")
             host_id = await workflow._lease_host()
 
@@ -321,7 +315,8 @@ class Agent:
                         prompt,
                         artifact_dir,
                         call_id,
-                        connection_id,
+                        login_id,
+                        harness=harness,
                         account_id=workflow.account_id,
                     )
                 except BaseException as error:
@@ -364,8 +359,9 @@ class Agent:
         prompt: str,
         artifact_dir: Path,
         call_id: str,
-        connection_id: str,
+        login_id: str,
         *,
+        harness: "type[Harness]",
         account_id: str | None,
     ) -> "AgentResult":
         schema = self.contract.model_json_schema()
@@ -375,10 +371,10 @@ class Agent:
             prompt=prompt,
             schema=schema,
             agent=self.id,
-            effort=await self.get_effort(),
-            timeout=await self.get_timeout(),
+            effort=await self.get_effort(harness),
+            timeout=await self.get_timeout(harness),
             artifact_dir=artifact_dir,
             call_id=call_id,
             include_plugins=self.include_plugins,
-            connection_id=connection_id,
+            login_id=login_id,
         )

--- a/backend/druks/bootstrap.py
+++ b/backend/druks/bootstrap.py
@@ -26,7 +26,6 @@ def seed_harnesses(engine) -> None:
                 session.add(
                     HarnessSettings(
                         name=harness.name,
-                        model=harness.default_model,
                         effort=harness.default_effort,
                         timeout=harness.default_timeout,
                     )

--- a/backend/druks/contrib/review/app.py
+++ b/backend/druks/contrib/review/app.py
@@ -55,5 +55,4 @@ class Review(App):
         description="reads a pull request and writes the review",
         prompt="review/review_pull_request.md",
         contract=ReviewReport,
-        model="claude",
     )

--- a/backend/druks/contrib/software_factory/app.py
+++ b/backend/druks/contrib/software_factory/app.py
@@ -143,44 +143,36 @@ class SoftwareFactory(App):
         description="ticket → implementation plan",
         prompt="software_factory/build/generate_plan.md",
         contract=PlanOutput,
-        model="codex",
     )
     review_plan = Agent(
         description="critiques the plan before any work starts",
         prompt="software_factory/build/review_plan.md",
         contract=ReviewOutput,
-        model="claude",
     )
     revise_contract = Agent(
         description="revises the plan contract on feedback",
         prompt="software_factory/build/revise_contract.md",
         contract=ContractRevisionOutput,
-        model="codex",
     )
     implement = Agent(
         description="plan → diff, in a drukbox",
         prompt="software_factory/build/implement.md",
         contract=ImplementationOutput,
-        model="claude",
     )
     evaluate_implementation = Agent(
         description="verification + code review of the diff, one verdict",
         prompt="software_factory/build/evaluate_implementation.md",
         contract=EvaluationOutput,
-        model="codex",
-        effort="medium",
     )
     triage_human_feedback = Agent(
         description="routes a human's PR feedback back into the workflow",
         prompt="software_factory/build/triage_human_feedback.md",
         contract=TriageOutput,
-        model="codex",
     )
     repo_profiler = Agent(
         description="reads a repo once and reports its stack, verification commands, and skills",
         prompt="software_factory/profile/repo_profiler.md",
         contract=RepoProfilerOutput,
-        model="codex",
     )
 
     @classmethod

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -108,18 +108,6 @@ class Harness(ABC):
         """The model as the CLI names it, without the provider namespace."""
         return self.model.partition("/")[2]
 
-    async def login(self, login_id: str | None) -> ProviderLogin:
-        """The selected login, read fresh at push time; with none
-        selected, the fallback account's for this model's provider. A vanished
-        row fails the call rather than render another account's."""
-        if login_id:
-            if row := await ProviderLogin.get(login_id):
-                return row
-            raise exceptions.HarnessNotConnectedError(
-                "the selected login was removed — reconnect it in Settings → Providers."
-            )
-        return await ProviderLogin.lookup(self.model.partition("/")[0], None)
-
     async def get_manifest(
         self,
         *,

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -67,7 +67,7 @@ class ClaudeHarness(Harness):
         skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
-        connection_id: str | None = None,
+        login: ProviderLogin,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
         if not self.sandbox:
@@ -128,7 +128,7 @@ class ClaudeHarness(Harness):
                 github_token=github_token,
                 include_plugins=include_plugins,
                 skills=skills,
-                login=await self.login(connection_id),
+                login=login,
             ),
             env=extra_env,
             extra_artifact_filenames=("debug.log", "session.jsonl"),

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -369,7 +369,7 @@ class CodexHarness(Harness):
         skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
-        connection_id: str | None = None,
+        login: ProviderLogin,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
         if not self.sandbox:
@@ -398,7 +398,7 @@ class CodexHarness(Harness):
             credentials=await self._get_credentials(
                 github_token=github_token,
                 skills=skills,
-                login=await self.login(connection_id),
+                login=login,
             ),
             env=extra_env,
             extra_artifact_filenames=("output.json", "session.jsonl"),

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import ForeignKey, String, UniqueConstraint, select
 from sqlalchemy.dialects.postgresql import CITEXT, JSONB
@@ -13,7 +13,10 @@ from druks.models import Base
 from druks.secrets.fields import EncryptedJsonField
 from druks.user_settings.models import UserSettings
 
-from .exceptions import HarnessNotConnectedError
+from .exceptions import HarnessNotConnectedError, UnknownModelError
+
+if TYPE_CHECKING:
+    from .base import Harness
 
 
 class ProviderLogin(Base, Uuid7Pk):
@@ -39,10 +42,18 @@ class ProviderLogin(Base, Uuid7Pk):
         return await db_session().get(cls, login_id)
 
     @classmethod
-    async def lookup(cls, provider_id: str, account_id: str | None) -> "ProviderLogin":
-        """The login a call runs with: the account's own, else the
-        fallback account's — which carries unmatched work so automation keeps
-        moving."""
+    async def lookup(
+        cls, provider_id: str, account_id: str | None, *, login_id: str | None = None
+    ) -> "ProviderLogin":
+        """The login a call runs with: the selected row, read fresh so a vanished
+        one fails the call; else the account's own; else the fallback account's,
+        which carries unmatched work so automation keeps moving."""
+        if login_id:
+            if row := await cls.get(login_id):
+                return row
+            raise HarnessNotConnectedError(
+                "the selected login was removed — reconnect it in Settings → Providers."
+            )
         if account_id:
             own = await cls.get_for_account(provider_id, account_id)
             if own:
@@ -113,6 +124,17 @@ class ProviderLogin(Base, Uuid7Pk):
         row.expires_at = expires_at
         await session.flush()
         return row
+
+    def get_harness(self) -> "type[Harness]":
+        """The first registered harness that runs on this login; a miss raises."""
+        from .registry import get_harnesses  # cycle: registry → base → models
+
+        for harness in get_harnesses():
+            if harness.accepts(self):
+                return harness
+        raise UnknownModelError(
+            f"No installed harness runs {self.provider} on a {self.kind} login."
+        )
 
     @property
     def is_connected(self) -> bool:

--- a/backend/druks/harnesses/opencode.py
+++ b/backend/druks/harnesses/opencode.py
@@ -55,7 +55,7 @@ class OpenCodeHarness(Harness):
         skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
-        connection_id: str | None = None,
+        login: ProviderLogin,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
         if not self.sandbox:
@@ -88,7 +88,7 @@ class OpenCodeHarness(Harness):
             credentials=Credentials(github_token=github_token),
             env={
                 **(extra_env or {}),
-                "OPENCODE_AUTH_CONTENT": self.auth_json(await self.login(connection_id)),
+                "OPENCODE_AUTH_CONTENT": self.auth_json(login),
                 "DRUKS_RUN_DIR": f"{get_runs_root(ssh_username)}/{run_id}",
                 "OPENCODE_CONFIG_CONTENT": json.dumps(
                     {"$schema": "https://opencode.ai/config.json", "mcp": mcp},

--- a/backend/druks/harnesses/pi.py
+++ b/backend/druks/harnesses/pi.py
@@ -58,7 +58,7 @@ class PiHarness(Harness):
         skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
-        connection_id: str | None = None,
+        login: ProviderLogin,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
         if not self.sandbox:
@@ -121,7 +121,7 @@ class PiHarness(Harness):
         command_line = " ".join(shlex.quote(argument) for argument in command)
         wrapper = " && ".join((*writes, command_line))
 
-        auth_file = self.auth_file(await self.login(connection_id))
+        auth_file = self.auth_file(login)
         return AgentInvocation(
             name=self.name,
             args=("sh", "-c", wrapper),

--- a/backend/druks/sandbox/gate.py
+++ b/backend/druks/sandbox/gate.py
@@ -18,11 +18,11 @@ _SHUT_TTL_SECONDS = 60
 
 
 @asynccontextmanager
-async def use(connection_id: str, call_id: str) -> AsyncIterator[None]:
+async def use(login_id: str, call_id: str) -> AsyncIterator[None]:
     """Register the call as an active user of its connection for its span."""
     client = get_client()
-    rotating = f"{ROTATING_PREFIX}{connection_id}"
-    users = f"{GATE_USERS_PREFIX}{connection_id}"
+    rotating = f"{ROTATING_PREFIX}{login_id}"
+    users = f"{GATE_USERS_PREFIX}{login_id}"
     while True:
         waited = 0.0
         while waited < _RUN_HORIZON and await client.exists(rotating):
@@ -41,12 +41,12 @@ async def use(connection_id: str, call_id: str) -> AsyncIterator[None]:
 
 
 @asynccontextmanager
-async def shut(connection_id: str) -> AsyncIterator[bool]:
+async def shut(login_id: str) -> AsyncIterator[bool]:
     """Shut the connection's gate; yield True when idle — rotate now — else
     defer to the next tick. Reopens on exit either way."""
     client = get_client()
-    rotating = f"{ROTATING_PREFIX}{connection_id}"
-    users = f"{GATE_USERS_PREFIX}{connection_id}"
+    rotating = f"{ROTATING_PREFIX}{login_id}"
+    users = f"{GATE_USERS_PREFIX}{login_id}"
     await client.set(rotating, "1", ex=_SHUT_TTL_SECONDS)
     try:
         await client.zremrangebyscore(users, "-inf", time.time())

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -36,6 +36,7 @@ from .layout import get_helper_script_path, get_work_root
 
 if TYPE_CHECKING:
     from druks.harnesses.base import Harness
+    from druks.harnesses.models import ProviderLogin
 
     from .runner import Exec
 
@@ -213,7 +214,7 @@ class Host:
         skills: tuple[str, ...] = (),
         extra_env: dict[str, Any] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
-        connection_id: str | None = None,
+        login_id: str | None = None,
     ) -> AgentResult:
         """Run the harness and return a pure ``AgentResult`` — no database write.
         A failure is carried on the result's ``error``, not raised, so the call
@@ -230,12 +231,13 @@ class Host:
         # that we keep it out of module init either way.
         from druks.durable.enums import AgentCallStatus
         from druks.harnesses.datastructures import SandboxSettings
-        from druks.harnesses.registry import get_harness_for_model
+        from druks.harnesses.models import ProviderLogin
         from druks.user_settings.models import HarnessSettings
 
         settings = load_settings()
-        # Effort/timeout fall back to the model's harness defaults.
-        harness_class = get_harness_for_model(model)
+        login = await ProviderLogin.lookup(model.partition("/")[0], None, login_id=login_id)
+        harness_class = login.get_harness()
+        # Effort/timeout fall back to the harness defaults.
         harness_settings = await HarnessSettings.get_registered(harness_class.name)
         effort = effort or harness_settings.effort
         timeout = timeout if timeout is not None else harness_settings.timeout
@@ -267,7 +269,7 @@ class Host:
                 extra_env=extra_env,
                 mcp_servers=mcp_servers,
                 call_id=run_id,
-                connection_id=connection_id,
+                login=login,
             )
         except HarnessError as exc:
             error = exc
@@ -306,12 +308,16 @@ class Host:
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
         call_id: str | None = None,
-        connection_id: str | None = None,
+        login: "ProviderLogin | None" = None,
     ) -> Any:
         """Drive one prompt through ``harness`` on this VM: the harness
         builds the invocation and parses the result; this sandbox executes it.
         One-shot callers with a hand-built harness use this directly;
         ``run_agent`` adds the harness factory + cost capture on top."""
+        # A one-shot caller with a hand-built harness pushes the fallback login.
+        from druks.harnesses.models import ProviderLogin
+
+        login = login or await ProviderLogin.lookup(harness.model.partition("/")[0], None)
         run_id = harness.mint_run_id(call_id)
         artifact_dir.mkdir(parents=True, exist_ok=True)
         persist_prompt(artifact_dir, call_id=run_id, prompt=prompt)
@@ -336,7 +342,7 @@ class Host:
             skills=skills,
             extra_env=extra_env,
             mcp_servers=mcp_servers,
-            connection_id=connection_id,
+            login=login,
             timeout=timeout,
         )
         result = await self._exec(

--- a/backend/druks/user_settings/constants.py
+++ b/backend/druks/user_settings/constants.py
@@ -1,0 +1,1 @@
+DEFAULT_MODEL = "anthropic/claude-opus-4-7"

--- a/backend/druks/user_settings/datastructures.py
+++ b/backend/druks/user_settings/datastructures.py
@@ -4,7 +4,7 @@ Effort = Literal["low", "medium", "high"]
 ALLOWED_EFFORTS: tuple[str, ...] = get_args(Effort)
 
 # agent: per-agent override; declared: the agent's own field; harness: the
-# agent's harness default (claude/codex effort + timeout).
+# harness default; default: the operator's one default model.
 _SettingSource = Literal["agent", "declared", "harness"]
 
 
@@ -15,7 +15,7 @@ class ResolvedModel(NamedTuple):
 
 class ResolvedEffort(NamedTuple):
     value: str
-    source: _SettingSource
+    source: Literal["agent", "harness"]
 
 
 class ResolvedTimeout(NamedTuple):

--- a/backend/druks/user_settings/models.py
+++ b/backend/druks/user_settings/models.py
@@ -12,6 +12,7 @@ from druks.database import db_session
 from druks.models import Base
 from druks.secrets.fields import EncryptedTextField
 
+from .constants import DEFAULT_MODEL
 from .datastructures import (
     ResolvedEffort,
     ResolvedModel,
@@ -29,6 +30,8 @@ class UserSettings(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     timezone: Mapped[str] = mapped_column(String, default="UTC")
+    # The model every agent runs unless it carries a per-agent override.
+    default_model: Mapped[str] = mapped_column(String, default=DEFAULT_MODEL)
     # The designated gate-park notification destination; unset — or the
     # destination deleted (SET NULL) — turns gate-park notifications off.
     gate_park_destination_id: Mapped[str | None] = mapped_column(
@@ -54,9 +57,17 @@ class UserSettings(Base):
             row = await session.get_one(cls, cls.SINGLETON_ID)
         return row
 
-    async def update_profile(self, *, timezone: str | None = None) -> None:
+    @classmethod
+    async def get_default_model(cls) -> str:
+        return (await cls.get()).default_model
+
+    async def update_profile(
+        self, *, timezone: str | None = None, default_model: str | None = None
+    ) -> None:
         if timezone:
             self.timezone = timezone
+        if default_model:
+            self.default_model = default_model
         self.updated_at = Base.utc_now()
         await db_session().flush()
 
@@ -75,12 +86,11 @@ class UserSettings(Base):
 class HarnessSettings(Base):
     # One row per registered harness (claude, codex, …), seeded from the
     # registry on install and tuned by the operator. An agent inherits its
-    # harness's model / effort / timeout / fast_mode unless it declares its own
-    # or carries a per-agent override.
+    # harness's effort / timeout / fast_mode unless it carries a per-agent
+    # override.
     __tablename__ = "harnesses"
 
     name: Mapped[str] = mapped_column(String, primary_key=True)
-    model: Mapped[str] = mapped_column(String)
     fast_mode: Mapped[bool] = mapped_column(default=False)
     effort: Mapped[str] = mapped_column(String, default="high")
     timeout: Mapped[int] = mapped_column(default=1800)
@@ -152,26 +162,21 @@ class SettingsOverride(Base):
         await session.flush()
 
     @classmethod
-    async def agent_model(cls, name: str, default: str) -> ResolvedModel:
+    async def agent_model(cls, name: str) -> ResolvedModel:
         override = await cls.read(f"agent_model:{name}")
         if override is not None:
             return ResolvedModel(override, "agent")
-        # ``default`` is a harness name (claude/codex) → that harness's model,
-        # or a pinned model string when it names no harness.
-        harness = await HarnessSettings.get(default)
-        return ResolvedModel(harness.model if harness else default, "default")
+        return ResolvedModel(await UserSettings.get_default_model(), "default")
 
     @classmethod
     async def set_agent_model(cls, name: str, model: str | None) -> None:
         await cls.write(f"agent_model:{name}", model)
 
     @classmethod
-    async def agent_effort(cls, name: str, declared: str | None, harness: str) -> ResolvedEffort:
+    async def agent_effort(cls, name: str, harness: str) -> ResolvedEffort:
         override = await cls.read(f"agent_effort:{name}")
         if override is not None:
             return ResolvedEffort(override, "agent")
-        if declared is not None:
-            return ResolvedEffort(declared, "declared")
         return ResolvedEffort((await HarnessSettings.get_registered(harness)).effort, "harness")
 
     @classmethod

--- a/backend/druks/user_settings/reads.py
+++ b/backend/druks/user_settings/reads.py
@@ -6,6 +6,7 @@ from pydantic.fields import FieldInfo
 
 from druks.apps.settings import field_kind
 from druks.database import db_session
+from druks.harnesses.models import ProviderLogin
 from druks.harnesses.registry import get_harness_for_model
 
 from .models import SettingsOverride
@@ -23,16 +24,18 @@ if TYPE_CHECKING:
 
 
 async def get_agent_setting(agent: "Agent") -> AgentSettingResponse:
-    model = await SettingsOverride.agent_model(agent.id, agent.model)
-    harness = (get_harness_for_model(model.value)).name
-    effort = await SettingsOverride.agent_effort(agent.id, agent.effort, harness)
+    model = await SettingsOverride.agent_model(agent.id)
+    # The harness an actor-less run would land on: the one that accepts the
+    # fallback account's login kind, else the first that drives the provider.
+    login = await ProviderLogin.get_for_account(model.value.partition("/")[0], fallback=True)
+    harness = (login.get_harness() if login else get_harness_for_model(model.value)).name
+    effort = await SettingsOverride.agent_effort(agent.id, harness)
     timeout = await SettingsOverride.agent_timeout(agent.id, agent.timeout, harness)
     return AgentSettingResponse(
         name=agent.name or agent.id,
         description=agent.description,
         model=model.value,
         source=model.source,
-        default=agent.model,
         effort=effort.value,
         effort_source=effort.source,
         timeout=timeout.value,

--- a/backend/druks/user_settings/routes.py
+++ b/backend/druks/user_settings/routes.py
@@ -51,10 +51,8 @@ async def list_harness_settings() -> list[HarnessResponse]:
 
 @router.patch("/harnesses/{name}", response_model=HarnessResponse, response_model_by_alias=True)
 async def update_harness_settings(name: str, body: HarnessUpdate) -> HarnessResponse:
-    harness, row = await _resolve_harness(name)
+    _, row = await _resolve_harness(name)
     updates = body.model_dump(exclude_unset=True, by_alias=False)
-    if (model := updates.get("model")) and get_harness_for_model(model) is not harness:
-        raise HTTPException(status_code=422, detail=f"{model!r} is not a {harness.name} model.")
     if updates:
         await row.update(**updates)
     return HarnessResponse.model_validate(row)
@@ -77,6 +75,9 @@ async def update_user_settings(
             # Crons are evaluated in this timezone — repoint them now, not at
             # the next launch.
             await apply_schedules()
+    if body.default_model:
+        get_harness_for_model(body.default_model)
+        await row.update_profile(default_model=body.default_model)
     if "gate_park_destination_id" in body.model_fields_set:
         destination_id = body.gate_park_destination_id
         if destination_id and not await Destination.get(destination_id):

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -27,14 +27,12 @@ class HarnessResponse(Schema):
     # The provider a subscription CLI is bound to; None for a key CLI.
     provider: str | None
     login_kinds: SortedNames
-    model: str
     effort: str
     timeout: int
     fast_mode: bool
 
 
 class HarnessUpdate(BaseModel):
-    model: str | None = None
     fast_mode: bool | None = Field(default=None, validation_alias="fastMode")
     effort: Effort | None = None
     timeout: PositiveInt | None = None
@@ -44,12 +42,14 @@ class UserSettingsResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     timezone: str
+    default_model: str
     gate_park_destination_id: str | None
     updated_at: datetime
 
 
 class UpdateUserSettingsRequest(BaseModel):
     timezone: str | None = None
+    default_model: str | None = Field(default=None, validation_alias="defaultModel")
     # Tri-state: absent = unchanged, null = clear (off), value = designate.
     gate_park_destination_id: str | None = Field(
         default=None, validation_alias="gateParkDestinationId"
@@ -61,10 +61,8 @@ class AgentSettingResponse(Schema):
     description: str
     model: str
     source: Literal["agent", "default"]
-    # The declared default — a family token (codex/claude) the model resolves to.
-    default: str
     effort: str
-    effort_source: Literal["agent", "declared", "harness"]
+    effort_source: Literal["agent", "harness"]
     timeout: int
     timeout_source: Literal["agent", "declared", "harness"]
 

--- a/backend/migrations/versions/c9d1e3f5a7b2_model_selects_harness.py
+++ b/backend/migrations/versions/c9d1e3f5a7b2_model_selects_harness.py
@@ -1,0 +1,46 @@
+"""One operator default model; the model selects the harness.
+
+Revision ID: c9d1e3f5a7b2
+Revises: a7c3e9b1d5f2
+Create Date: 2026-09-02
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c9d1e3f5a7b2"
+down_revision: str | Sequence[str] | None = "a7c3e9b1d5f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_DEFAULT_MODEL = "anthropic/claude-opus-4-7"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_settings",
+        sa.Column("default_model", sa.String(), nullable=False, server_default=_DEFAULT_MODEL),
+    )
+    # The claude row carried the model most agents declared; it becomes the
+    # one default.
+    op.execute(
+        sa.text(
+            "UPDATE user_settings SET default_model = harnesses.model "
+            "FROM harnesses WHERE harnesses.name = 'claude'"
+        )
+    )
+    op.drop_column("harnesses", "model")
+
+
+def downgrade() -> None:
+    op.add_column("harnesses", sa.Column("model", sa.String(), nullable=True))
+    op.execute(
+        sa.text(
+            "UPDATE harnesses SET model = COALESCE("
+            "(SELECT default_model FROM user_settings LIMIT 1), :fallback)"
+        ).bindparams(fallback=_DEFAULT_MODEL)
+    )
+    op.alter_column("harnesses", "model", nullable=False)
+    op.drop_column("user_settings", "default_model")

--- a/backend/tests/druks-field_notes/druks_field_notes/app.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/app.py
@@ -93,7 +93,6 @@ class FieldNotes(App):
         description="reads a note and writes its one-line gist",
         prompt="field_notes/summarize.md",
         contract=GistOutput,
-        model="claude",
     )
 
     # The app's own precondition, reported by `druks doctor` beside the

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -7,6 +7,7 @@ from conftest import make_agent_result
 from druks import agents
 from druks.durable import AgentCall, WorkflowError
 from druks.files import File
+from druks.harnesses.claude import ClaudeHarness
 from druks.sandbox.exceptions import SandboxDownloadError
 from druks.usage.models import UsageScrape
 
@@ -19,7 +20,6 @@ DUMMY_AGENT = agents.Agent(
     id="dummy",
     prompt="dummy/agent.md",
     contract=DummyOutput,
-    model="anthropic/claude-haiku-4-5",
 )
 
 
@@ -31,7 +31,6 @@ FILE_AGENT = agents.Agent(
     id="file",
     prompt="dummy/agent.md",
     contract=FileOutput,
-    model="anthropic/claude-haiku-4-5",
 )
 
 
@@ -43,19 +42,17 @@ async def test_get_timeout_caps_at_the_sandbox_lease_max(druks_db):
         id="over",
         prompt="dummy/agent.md",
         contract=DummyOutput,
-        model="anthropic/claude-haiku-4-5",
         timeout=MAX_AGENT_TIMEOUT_SECONDS * 2,
     )
     under = agents.Agent(
         id="under",
         prompt="dummy/agent.md",
         contract=DummyOutput,
-        model="anthropic/claude-haiku-4-5",
         timeout=600,
     )
 
-    assert await over.get_timeout() == MAX_AGENT_TIMEOUT_SECONDS
-    assert await under.get_timeout() == 600
+    assert await over.get_timeout(ClaudeHarness) == MAX_AGENT_TIMEOUT_SECONDS
+    assert await under.get_timeout(ClaudeHarness) == 600
 
 
 @pytest.fixture(autouse=True)
@@ -143,7 +140,7 @@ async def test_run_outside_workflow_raises():
 async def test_run_refuses_an_agent_with_no_id():
     # Built loose — never assigned to an App, never given an explicit id — so
     # the call it would record would name nobody.
-    loose = agents.Agent(prompt="dummy/agent.md", contract=DummyOutput, model="claude")
+    loose = agents.Agent(prompt="dummy/agent.md", contract=DummyOutput)
     with pytest.raises(WorkflowError, match="runs under its own id"):
         await loose(repo="acme/widget")
 
@@ -169,8 +166,8 @@ async def test_run_refuses_unconnected_harness(druks_db, tmp_path, monkeypatch, 
 
 
 async def test_declaration_drives_run_agent_call(druks_db, tmp_path, monkeypatch, current_run):
-    # The declaration drives what run_agent sees (model/operation/schema/artifact
-    # dir/default timeout); run() returns the validated contract model.
+    # The declaration and the operator default drive what run_agent sees
+    # (model/schema/artifact dir/timeout); run() returns the validated contract.
     sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
     _patch_ephemeral(monkeypatch, sandbox)
 
@@ -178,7 +175,7 @@ async def test_declaration_drives_run_agent_call(druks_db, tmp_path, monkeypatch
 
     assert result == DummyOutput(ok=True)
     kwargs = sandbox.run_agent.await_args.kwargs
-    assert kwargs["model"] == "anthropic/claude-haiku-4-5"
+    assert kwargs["model"] == "anthropic/claude-opus-4-7"
     assert kwargs["agent"] == "dummy"
     assert kwargs["schema"] == DummyOutput.model_json_schema()
     assert kwargs["prompt"] == "PROMPT:dummy/agent.md:repo=acme/widget"
@@ -192,7 +189,6 @@ async def test_declared_timeout_is_forwarded(druks_db, tmp_path, monkeypatch, cu
         id="timeout_probe",
         prompt="dummy/agent.md",
         contract=DummyOutput,
-        model="anthropic/claude-opus-4-7",
         timeout=900,
         include_plugins=False,
     )

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -27,7 +27,6 @@ def test_get_harnesses_lists_seeded_defaults(tmp_path: Path):
     with _build_client(tmp_path) as client:
         harnesses = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}
     assert harnesses["claude"]["provider"] == "anthropic"
-    assert harnesses["claude"]["model"] == "anthropic/claude-opus-4-7"
     assert harnesses["codex"]["provider"] == "openai-codex"
     assert harnesses["pi"]["provider"] is None
     assert harnesses["pi"]["loginKinds"] == ["api_key"]
@@ -78,30 +77,32 @@ def test_timezone_change_reconciles_schedules(tmp_path: Path, monkeypatch):
         assert len(reconciled) == 1
 
 
-def test_patch_harness_updates_model_and_fast_mode(tmp_path: Path):
+def test_patch_harness_updates_fast_mode(tmp_path: Path):
     with _build_client(tmp_path) as client:
-        patch = client.patch(
-            "/api/settings/harnesses/claude",
-            json={"model": "anthropic/claude-sonnet-4-6", "fastMode": True},
-        )
+        patch = client.patch("/api/settings/harnesses/claude", json={"fastMode": True})
         assert patch.status_code == 200
-        body = patch.json()
-        assert body["model"] == "anthropic/claude-sonnet-4-6"
-        assert body["fastMode"] is True
+        assert patch.json()["fastMode"] is True
         listed = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}
-        assert listed["claude"]["model"] == "anthropic/claude-sonnet-4-6"
-        # The other harness is untouched.
-        assert listed["codex"]["model"] == "openai-codex/gpt-5.5"
+        assert listed["claude"]["fastMode"] is True
+        assert listed["codex"]["fastMode"] is False
 
 
-def test_patch_harness_rejects_model_from_another_harness(tmp_path: Path):
+def test_patch_settings_updates_the_default_model_every_agent_inherits(tmp_path: Path):
     with _build_client(tmp_path) as client:
-        # gpt-5.5 belongs to codex, not claude.
-        response = client.patch(
-            "/api/settings/harnesses/claude", json={"model": "openai-codex/gpt-5.5"}
-        )
+        assert client.get("/api/settings").json()["defaultModel"] == "anthropic/claude-opus-4-7"
+        patch = client.patch("/api/settings", json={"defaultModel": "openai-codex/gpt-5.5"})
+        assert patch.status_code == 200
+        assert patch.json()["defaultModel"] == "openai-codex/gpt-5.5"
+        agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
+    assert agents["implement"]["model"] == "openai-codex/gpt-5.5"
+    assert agents["implement"]["source"] == "default"
+
+
+def test_patch_settings_rejects_a_model_no_harness_runs(tmp_path: Path):
+    with _build_client(tmp_path) as client:
+        response = client.patch("/api/settings", json={"defaultModel": "gpt-5.5"})
     assert response.status_code == 422
-    assert "openai-codex/gpt-5.5" in response.json()["detail"]
+    assert "gpt-5.5" in response.json()["detail"]
 
 
 def test_patch_unknown_harness_is_404(tmp_path: Path):
@@ -145,25 +146,20 @@ def test_apps_surface_build_agents_and_workflow_defaults(tmp_path: Path):
         build = _software_factory_app(client)
 
     agents = {a["name"]: a for a in build["agents"]}
-    # An agent's family-token default resolves to the family's model; effort
-    # and timeout inherit the global defaults ("high", 1800s) when the agent
-    # declares neither and the operator set no override.
+    # Every agent runs the operator's default model; effort and timeout inherit
+    # its harness's defaults ("high", 1800s) when the operator set no override.
     assert agents["generate_plan"] == {
         "name": "generate_plan",
         "description": "ticket → implementation plan",
-        "model": "openai-codex/gpt-5.5",
+        "model": "anthropic/claude-opus-4-7",
         "source": "default",
-        "default": "codex",
         "effort": "high",
         "effortSource": "harness",
         "timeout": 1800,
         "timeoutSource": "harness",
     }
     assert agents["implement"]["model"] == "anthropic/claude-opus-4-7"
-    assert agents["implement"]["default"] == "claude"
-    # evaluate declares medium effort; the rest inherit the global default.
-    assert agents["evaluate_implementation"]["effort"] == "medium"
-    assert agents["evaluate_implementation"]["effortSource"] == "declared"
+    assert agents["evaluate_implementation"]["effortSource"] == "harness"
     # The workflow's settings surface alongside its agents.
     fields = {f["name"]: f for f in build["workflows"][0]["fields"]}
     assert fields["max_implementation_revisions"]["value"] == 5
@@ -337,7 +333,7 @@ def test_incoherent_app_save_is_rejected_and_rolled_back_before_schedules(
         assert not reconciled
         assert _review_settings_fields(client)["app_id"]["secretSet"] is False
         agents = {agent["name"]: agent for agent in _software_factory_app(client)["agents"]}
-        assert agents["generate_plan"]["model"] == "openai-codex/gpt-5.5"
+        assert agents["generate_plan"]["model"] == "anthropic/claude-opus-4-7"
 
 
 async def test_clearing_the_identity_deletes_its_overrides_and_stays_coherent(tmp_path: Path):
@@ -391,15 +387,15 @@ def test_apps_override_agent_model_persists(tmp_path: Path):
 def test_apps_harness_effort_and_per_agent_effort_override(tmp_path: Path):
     with _build_client(tmp_path) as client:
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        # generate_plan runs on codex and inherits the codex harness effort.
+        # The default model runs on claude, so every agent inherits its effort.
         assert agents["generate_plan"]["effort"] == "high"
         assert agents["generate_plan"]["effortSource"] == "harness"
 
-        # Retune the codex harness effort + override one agent.
-        client.patch("/api/settings/harnesses/codex", json={"effort": "low"})
+        # Retune the claude harness effort + override one agent.
+        client.patch("/api/settings/harnesses/claude", json={"effort": "low"})
         client.patch("/api/settings/apps", json={"agentEfforts": {"generate_plan": "high"}})
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        # generate_plan overridden; revise_contract (also codex) inherits "low".
+        # generate_plan overridden; revise_contract inherits "low".
         assert agents["generate_plan"]["effort"] == "high"
         assert agents["generate_plan"]["effortSource"] == "agent"
         assert agents["revise_contract"]["effort"] == "low"
@@ -461,7 +457,7 @@ def test_build_review_code_is_a_workflow_setting(tmp_path: Path):
         assert fields["review_code"]["overridden"] is True
 
 
-def test_apps_clearing_an_override_reverts_to_the_family_default(tmp_path: Path):
+def test_apps_clearing_an_override_reverts_to_the_operator_default(tmp_path: Path):
     with _build_client(tmp_path) as client:
         client.patch(
             "/api/settings/apps",
@@ -471,10 +467,10 @@ def test_apps_clearing_an_override_reverts_to_the_family_default(tmp_path: Path)
         assert agents["generate_plan"]["model"] == "anthropic/claude-opus-4-7"
         assert agents["generate_plan"]["source"] == "agent"
 
-        # Null clears the override; the agent falls back to its family default.
+        # Null clears the override; the agent falls back to the operator default.
         client.patch("/api/settings/apps", json={"agentModels": {"generate_plan": None}})
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        assert agents["generate_plan"]["model"] == "openai-codex/gpt-5.5"
+        assert agents["generate_plan"]["model"] == "anthropic/claude-opus-4-7"
         assert agents["generate_plan"]["source"] == "default"
 
 

--- a/backend/tests/test_durable_sdk.py
+++ b/backend/tests/test_durable_sdk.py
@@ -113,7 +113,7 @@ def _build_units():
                 raise FatalError("closed at review")
 
     class AgentFlow(Workflow):
-        DECIDER = Agent(id="decider", contract=Decision, model="claude", prompt="t")
+        DECIDER = Agent(id="decider", contract=Decision, prompt="t")
 
         async def run(self, repo: str) -> None:
             decision = await self.DECIDER(body="x")

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -135,22 +135,24 @@ async def test_no_config_dir_ships_credential_only(druks_db):
 async def test_credential_without_a_selection_reads_the_fallback_account(druks_db):
     fallback = await _seed_claude(access="fallback", provider_email="a@example.com")
 
-    assert (await _harness().login(None)).id == fallback.id
+    assert (await ProviderLogin.lookup("anthropic", None)).id == fallback.id
 
 
 async def test_credential_without_any_row_raises(druks_db):
     with pytest.raises(HarnessNotConnectedError, match="anthropic is not connected"):
-        await _harness().login(None)
+        await ProviderLogin.lookup("anthropic", None)
 
 
 async def test_credential_renders_only_the_selected_row(druks_db):
     mine = await _seed_claude(access="mine-token", provider_email="a@example.com")
     other = await _seed_claude(access="other-token", provider_email="b@example.com")
 
-    rendered = json.loads(ClaudeHarness.auth_file(await _harness().login(other.id)).content)
+    selected = await ProviderLogin.lookup("anthropic", None, login_id=other.id)
+    rendered = json.loads(ClaudeHarness.auth_file(selected).content)
     assert rendered["claudeAiOauth"]["accessToken"] == "other-token"
     assert "mine-token" not in json.dumps(rendered)
-    rendered = json.loads(ClaudeHarness.auth_file(await _harness().login(mine.id)).content)
+    selected = await ProviderLogin.lookup("anthropic", None, login_id=mine.id)
+    rendered = json.loads(ClaudeHarness.auth_file(selected).content)
     assert rendered["claudeAiOauth"]["accessToken"] == "mine-token"
 
 
@@ -162,4 +164,4 @@ async def test_credential_for_a_deleted_row_raises(druks_db):
     # A disconnect between selection and push fails the call — it must never
     # fall through to another account's payload.
     with pytest.raises(HarnessNotConnectedError, match="removed"):
-        await _harness().login(gone_id)
+        await ProviderLogin.lookup("anthropic", None, login_id=gone_id)

--- a/backend/tests/test_harness_model_routing.py
+++ b/backend/tests/test_harness_model_routing.py
@@ -2,18 +2,22 @@ import pytest
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.exceptions import UnknownModelError
+from druks.harnesses.models import ProviderLogin
 from druks.harnesses.opencode import OpenCodeHarness
 from druks.harnesses.registry import get_harness_for_model
-from druks.user_settings.models import HarnessSettings
-from druks.user_settings.routes import update_harness_settings
-from druks.user_settings.schemas import HarnessUpdate
-from fastapi import HTTPException
 
 
 def test_the_namespace_selects_the_first_harness_with_its_provider():
     assert get_harness_for_model("anthropic/claude-opus-4-7") is ClaudeHarness
     assert get_harness_for_model("openai-codex/gpt-5.5") is CodexHarness
     assert get_harness_for_model("openai/gpt-5.5") is OpenCodeHarness
+
+
+def test_a_login_selects_among_the_harnesses_with_its_provider():
+    assert ProviderLogin(provider="anthropic", kind="oauth").get_harness() is ClaudeHarness
+    assert ProviderLogin(provider="anthropic", kind="api_key").get_harness() is OpenCodeHarness
+    with pytest.raises(UnknownModelError, match="anthropic on a device login"):
+        ProviderLogin(provider="anthropic", kind="device").get_harness()
 
 
 @pytest.mark.parametrize(
@@ -33,17 +37,3 @@ def test_a_bare_or_unknown_model_raises(model, message):
     with pytest.raises(UnknownModelError) as error:
         get_harness_for_model(model)
     assert str(error.value) == message
-
-
-async def test_settings_reject_another_harness_model_with_422(druks_db):
-    settings = await HarnessSettings.get_registered("claude")
-    original_model = settings.model
-
-    with pytest.raises(HTTPException) as error:
-        await update_harness_settings(
-            name="claude", body=HarnessUpdate(model="openai-codex/gpt-5.5")
-        )
-
-    assert error.value.status_code == 422
-    assert error.value.detail == "'openai-codex/gpt-5.5' is not a claude model."
-    assert settings.model == original_model

--- a/backend/tests/test_harness_reasoning_flags.py
+++ b/backend/tests/test_harness_reasoning_flags.py
@@ -2,6 +2,7 @@ import pytest
 from conftest import connect_provider
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
+from druks.harnesses.models import ProviderLogin
 from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
 
 _CODEX_MODEL = CodexHarness.default_model
@@ -45,6 +46,7 @@ async def test_claude_build_invocation_carries_every_flag():
         effort="high",
         sandbox=_sandbox_config(),
     ).build_invocation(
+        login=await ProviderLogin.lookup("anthropic", None),
         prompt="hello",
         schema=schema,
         run_id="run-1",
@@ -102,6 +104,7 @@ async def test_codex_build_invocation_carries_every_flag():
         effort="high",
         sandbox=_sandbox_config(),
     ).build_invocation(
+        login=await ProviderLogin.lookup("openai-codex", None),
         prompt="hello",
         schema={"type": "object"},
         run_id="run-1",

--- a/backend/tests/test_manifest.py
+++ b/backend/tests/test_manifest.py
@@ -28,7 +28,9 @@ async def _build(
 ) -> dict:
     # get_manifest never touches the live sandbox, so the harness builds
     # without sandbox settings — the same shape argv unit tests use.
-    harness = harness or ClaudeHarness(model="claude-opus-4-8", fast_mode=False, effort=None)
+    harness = harness or ClaudeHarness(
+        model="anthropic/claude-opus-4-8", fast_mode=False, effort=None
+    )
     return await harness.get_manifest(mcp_servers=mcp_servers, skills=skills, extra_env=extra_env)
 
 
@@ -70,7 +72,7 @@ async def test_manifest_records_the_delivered_capability_set(druks_db):
     )
 
     assert manifest["schema_version"] == 2
-    assert manifest["model"] == "claude-opus-4-8"
+    assert manifest["model"] == "anthropic/claude-opus-4-8"
     assert manifest["harness"] == "claude"
     assert manifest["skills_delivered"] == ["alpha"]
 
@@ -146,7 +148,7 @@ async def test_hash_is_stable_for_identical_capabilities(druks_db):
     assert (await _build(**with_token))["manifest_hash"] == baseline["manifest_hash"]
 
     different_model = await _build(
-        harness=ClaudeHarness(model="claude-sonnet-5", fast_mode=False, effort=None),
+        harness=ClaudeHarness(model="anthropic/claude-sonnet-5", fast_mode=False, effort=None),
         **with_token,
     )
     assert different_model["manifest_hash"] != baseline["manifest_hash"]

--- a/backend/tests/test_opencode.py
+++ b/backend/tests/test_opencode.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from druks.harnesses.base import Harness
 from druks.harnesses.datastructures import SandboxSettings
 from druks.harnesses.exceptions import (
     HarnessError,
@@ -86,10 +85,6 @@ def _response(
 async def test_build_invocation_uses_server_schema_and_env_auth(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def login(self: Harness, _credential_id: str | None) -> SimpleNamespace:
-        return SimpleNamespace(provider="anthropic", payload={"api_key": _API_KEY})
-
-    monkeypatch.setattr(OpenCodeHarness, "login", login)
     server = McpServer(
         name="github",
         url="https://api.example.test/mcp",
@@ -97,6 +92,7 @@ async def test_build_invocation_uses_server_schema_and_env_auth(
         env_headers={"X-Trace-Key": "MCP_TRACE_KEY"},
     )
     invocation = await _harness().build_invocation(
+        login=SimpleNamespace(provider="anthropic", payload={"api_key": _API_KEY}),
         prompt="A large prompt stays on stdin.",
         schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         run_id="run-1",

--- a/backend/tests/test_pi.py
+++ b/backend/tests/test_pi.py
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 
 import pytest
 from druks.accounts.models import Account
-from druks.harnesses.base import Harness
 from druks.harnesses.datastructures import SandboxSettings
 from druks.harnesses.exceptions import (
     HarnessAuthError,
@@ -48,8 +47,7 @@ def _harness(*, effort: str | None = "high") -> PiHarness:
     )
 
 
-async def _login(self: Harness, _login_id: str | None) -> SimpleNamespace:
-    return SimpleNamespace(provider="openai", payload={"api_key": _API_KEY})
+_LOGIN = SimpleNamespace(provider="openai", payload={"api_key": _API_KEY})
 
 
 @pytest.fixture
@@ -82,7 +80,6 @@ def test_class_facts_and_registration() -> None:
 async def test_build_invocation_writes_the_run_files_and_pi_argv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(PiHarness, "login", _login)
     github = McpServer(
         name="github",
         url="https://api.example.test/mcp",
@@ -93,6 +90,7 @@ async def test_build_invocation_writes_the_run_files_and_pi_argv(
     public = McpServer(name="public", url="https://public.example.test/mcp")
 
     invocation = await _harness().build_invocation(
+        login=_LOGIN,
         prompt="A large prompt stays on stdin.",
         schema={"type": "object"},
         run_id="run-1",
@@ -169,10 +167,12 @@ async def test_build_invocation_writes_the_run_files_and_pi_argv(
 async def test_build_invocation_without_servers_or_effort_is_bare(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(PiHarness, "login", _login)
-
     invocation = await _harness(effort=None).build_invocation(
-        prompt="Prompt", schema={"type": "object"}, run_id="run-1", ssh_username="exedev"
+        login=_LOGIN,
+        prompt="Prompt",
+        schema={"type": "object"},
+        run_id="run-1",
+        ssh_username="exedev",
     )
 
     wrapper = invocation.args[2]

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -307,10 +307,6 @@ async def test_sandbox_unreachable_translates_to_harness_error(
     assert downloads == []
 
 
-def _harness_stub(model):
-    return ClaudeHarness
-
-
 async def test_run_prompt_builds_executes_and_parses(
     ctx: SimpleNamespace,
 ):
@@ -361,6 +357,7 @@ async def test_run_prompt_builds_executes_and_parses(
         artifact_dir=ctx.artifact_dir,
         timeout=60,
         call_id="call-7",
+        login=SimpleNamespace(provider="anthropic"),
         extra_env={"GITHUB_MCP_TOKEN": "ghs_x"},
     )
 
@@ -523,17 +520,19 @@ def test_agent_result_names_the_agent_in_its_failure():
 
 
 def _patch_harness_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
-    # run_agent resolves the harness + its settings from the DB; these tests
-    # are about the failure boundary, not resolution.
-
-    monkeypatch.setattr("druks.harnesses.registry.get_harness_for_model", _harness_stub)
+    # run_agent reads the harness settings from the DB; these tests are about
+    # the failure boundary, not resolution.
 
     async def get_registered(name):
         return SimpleNamespace(effort="high", timeout=60, fast_mode=False)
 
+    async def lookup(provider, account_id, *, login_id=None):
+        return SimpleNamespace(id="login-1", account_id="acc", get_harness=lambda: ClaudeHarness)
+
     monkeypatch.setattr(
         "druks.user_settings.models.HarnessSettings.get_registered", staticmethod(get_registered)
     )
+    monkeypatch.setattr("druks.harnesses.models.ProviderLogin.lookup", staticmethod(lookup))
 
 
 async def test_run_agent_carries_foreign_failures_as_harness_errors(

--- a/backend/tests/test_user_settings.py
+++ b/backend/tests/test_user_settings.py
@@ -30,13 +30,8 @@ async def test_get_lazy_creates_row_with_default_timezone(session):
 async def test_harnesses_seeded_with_shipped_defaults(session):
     # init_db seeds one HarnessSettings row per registered harness.
     claude = await HarnessSettings.get_registered("claude")
-    assert (claude.model, claude.fast_mode, claude.effort, claude.timeout) == (
-        "anthropic/claude-opus-4-7",
-        False,
-        "high",
-        1800,
-    )
-    assert (await HarnessSettings.get_registered("codex")).model == "openai-codex/gpt-5.5"
+    assert (claude.fast_mode, claude.effort, claude.timeout) == (False, "high", 1800)
+    assert (await UserSettings.get()).default_model == "anthropic/claude-opus-4-7"
     assert {harness.name for harness in await HarnessSettings.all()} == {
         "claude",
         "codex",
@@ -47,10 +42,9 @@ async def test_harnesses_seeded_with_shipped_defaults(session):
 
 async def test_harness_update_persists(session):
     claude = await HarnessSettings.get_registered("claude")
-    await claude.update(model="anthropic/claude-sonnet-4-6", fast_mode=True)
+    await claude.update(fast_mode=True)
     await session.commit()
     claude = await HarnessSettings.get_registered("claude")
-    assert claude.model == "anthropic/claude-sonnet-4-6"
     assert claude.fast_mode is True
 
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -142,7 +142,7 @@ These terms describe different ownership layers:
 
 | Layer | Responsibility |
 | --- | --- |
-| Agent | App-owned prompt, output contract, and default model/settings |
+| Agent | App-owned prompt, output contract, and run timeout |
 | Harness | Platform adapter that invokes the Claude or Codex CLI for a model |
 | Workspace | App customization of what a call receives, such as a cloned repository |
 | Sandbox | Drukbox-provisioned isolated host where the harness process runs |

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -330,9 +330,10 @@ from replayed orchestration allows later edits to change an in-flight run.
 
 ## Add an agent
 
-An agent belongs to the app class. Its family default (`claude` or `codex`)
-uses the related operator harness setting. A full model id, written
-`provider/model` such as `anthropic/claude-opus-4-7`, fixes the default.
+An agent belongs to the app class. It runs on the operator's default model
+with that model's harness effort; the operator changes either per agent in
+Settings. `timeout` is the one declarable knob, because how long a step may
+take is a fact about the task.
 
 ```python
 from druks.agents import Agent, AgentOutput
@@ -345,7 +346,6 @@ class ReportOutput(AgentOutput):
 
 class NightWatch(App):
     report = Agent(
-        model="claude",
         prompt="night_watch/report.md",
         contract=ReportOutput,
         description="Turns findings into an operator report.",

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -504,7 +504,6 @@ export interface Harness {
   /** The provider a subscription CLI is bound to; null for a key CLI. */
   provider: string | null
   loginKinds: string[]
-  model: string
   fastMode: boolean
   effort: string
   timeout: number
@@ -559,7 +558,6 @@ export interface ConnectChallenge {
 }
 
 export interface UpdateHarnessRequest {
-  model?: string
   fastMode?: boolean
   effort?: string
   timeout?: number
@@ -605,11 +603,14 @@ export interface Service {
 
 export interface UserSettings {
   timezone: string
+  /** The model every agent runs unless it carries a per-agent override. */
+  defaultModel: string
   updatedAt: string
 }
 
 export interface UpdateUserSettingsRequest {
   timezone?: string
+  defaultModel?: string
 }
 
 export type BrowserSessionStatus = 'needs_login' | 'ready' | 'stale' | 'anonymous'
@@ -640,8 +641,6 @@ export interface AgentSetting {
   description: string
   model: string
   source: ModelSource
-  /** The declared family-token default the model resolves to. */
-  default: string
   effort: string
   effortSource: EffortSource
   /** Run timeout in seconds. */

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -165,7 +165,7 @@ function stubFetch(
         return new Response('[]', { status: 200 })
       }
       if (path === '/api/settings') {
-        return new Response(JSON.stringify({ timezone: 'UTC', updatedAt: '2026-08-01T00:00:00Z' }), {
+        return new Response(JSON.stringify({ timezone: 'UTC', defaultModel: 'anthropic/claude-opus-4-7', updatedAt: '2026-08-01T00:00:00Z' }), {
           status: 200,
         })
       }

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -42,10 +42,8 @@ function buildCatalog(harnesses: Harness[], providers: Provider[], catalogs: Pro
     harness.provider ? harness.provider === provider.id : harness.loginKinds.some((k) => provider.loginKinds.includes(k))
   const modelsByProvider = Object.fromEntries(catalogs.map((c) => [c.provider, c.models]))
   return {
-    modelsOf: (harness) => {
-      const models = providers.filter((p) => hasProvider(harness, p)).flatMap((p) => modelsByProvider[p.id] ?? [])
-      return models.length > 0 ? models : [{ id: harness.model, label: harness.model }]
-    },
+    modelsOf: (harness) =>
+      providers.filter((p) => hasProvider(harness, p)).flatMap((p) => modelsByProvider[p.id] ?? []),
     harnessOf: (model) => {
       const provider = providers.find((p) => p.id === model.split('/')[0])
       return (provider && harnesses.find((h) => hasProvider(h, provider))?.name) ?? ''
@@ -165,6 +163,7 @@ export function SettingsModal({ open, onClose }: Props) {
     staleTime: 60_000,
   })
   const [timezone, setTimezone] = useState<string>('UTC')
+  const [defaultModel, setDefaultModel] = useState<string>('')
   // Pending per-app setting overrides — a sparse UpdateAppsSettingsRequest the
   // app tabs (and the Druks tab's built-in agents) edit and submit() flushes.
   // Distinct from ``knobs`` (the column-backed settings) because app settings
@@ -192,6 +191,7 @@ export function SettingsModal({ open, onClose }: Props) {
     }
     if (!initialised.current && settingsQuery.data) {
       setTimezone(settingsQuery.data.timezone)
+      setDefaultModel(settingsQuery.data.defaultModel)
       setAppEdits({})
       setAppProblems({})
       setHarnessEdits({})
@@ -263,6 +263,9 @@ export function SettingsModal({ open, onClose }: Props) {
       if (settingsQuery.data?.timezone !== timezone) {
         body.timezone = timezone
       }
+      if (settingsQuery.data?.defaultModel !== defaultModel) {
+        body.defaultModel = defaultModel
+      }
       if (Object.keys(body).length > 0) {
         await api.updateSettings(body)
         await queryClient.invalidateQueries({ queryKey: ['settings'] })
@@ -296,9 +299,11 @@ export function SettingsModal({ open, onClose }: Props) {
 
   const savedTz = settingsQuery.data?.timezone
   const tzDirty = savedTz !== undefined && savedTz !== timezone
+  const savedModel = settingsQuery.data?.defaultModel
+  const modelDirty = savedModel !== undefined && savedModel !== defaultModel
   const appsDirty = _areAppEditsDirty(appEdits)
   const harnessesDirty = Object.values(harnessEdits).some((patch) => Object.keys(patch).length > 0)
-  const dirty = tzDirty || appsDirty || harnessesDirty
+  const dirty = tzDirty || modelDirty || appsDirty || harnessesDirty
 
   const data = appSettingsQuery.data
   const allApps = data?.apps ?? []
@@ -418,6 +423,10 @@ export function SettingsModal({ open, onClose }: Props) {
             {section === 'general' && (
               <GeneralPane
                 timezone={timezone}
+                model={defaultModel}
+                setModel={setDefaultModel}
+                harnesses={harnesses}
+                catalog={catalog}
                 setTimezone={setTimezone}
                 timezones={timezones}
                 clock={preview}
@@ -456,6 +465,7 @@ export function SettingsModal({ open, onClose }: Props) {
                 harnessColor={harnessColor}
                 catalog={catalog}
                 harnessByName={harnessByName}
+                defaultModel={defaultModel}
                 allowedEfforts={allowedEfforts}
                 onAgentModel={setAgentModel}
                 onAgentEffort={setAgentEffort}
@@ -766,12 +776,20 @@ function GeneralPane({
   timezone,
   setTimezone,
   timezones,
+  model,
+  setModel,
+  harnesses,
+  catalog,
   clock,
   busy,
 }: {
   timezone: string
   setTimezone: (v: string) => void
   timezones: string[]
+  model: string
+  setModel: (v: string) => void
+  harnesses: Harness[]
+  catalog: Catalog
   clock: string
   busy: boolean
 }) {
@@ -779,6 +797,25 @@ function GeneralPane({
     <div className="set-pane">
       <div className="set-pane-head">
         <div className="set-pane-sub">Account-wide preferences.</div>
+      </div>
+      <div className="set-group">
+        <div className="set-group-label">default model</div>
+        <div className="set-field" style={{ maxWidth: 320 }}>
+          <select className="set-select" value={model} onChange={(e) => setModel(e.target.value)} disabled={busy}>
+            {!harnesses.some((h) => catalog.modelsOf(h).some((m) => m.id === model)) && (
+              <option value={model}>{model}</option>
+            )}
+            {harnesses.map((h) => (
+              <optgroup key={h.name} label={h.name}>
+                {catalog.modelsOf(h).map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.label}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </div>
       </div>
       <div className="set-group">
         <div className="set-group-label">timezone</div>
@@ -861,18 +898,6 @@ function HarnessesPane({
                 </span>
               </div>
               <div className="hr-controls">
-                <div className="mcp-field">
-                  <label className="mcp-label" htmlFor={id('model')}>
-                    Default model
-                  </label>
-                  <select id={id('model')} className="set-select" value={h.model} onChange={(e) => onField(harness.name, { model: e.target.value })} disabled={busy}>
-                    {catalog.modelsOf(harness).map((m) => (
-                      <option key={m.id} value={m.id}>
-                        {m.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
                 <div className="mcp-field">
                   <label className="mcp-label" htmlFor={id('effort')}>
                     Effort
@@ -2389,6 +2414,7 @@ function AppPane({
   edits,
   fieldErrors,
   harnessByName,
+  defaultModel,
   harnessColor,
   catalog,
   allowedEfforts,
@@ -2403,6 +2429,7 @@ function AppPane({
   edits: UpdateAppsSettingsRequest
   fieldErrors: Record<string, string>
   harnessByName: Record<string, Harness>
+  defaultModel: string
   harnessColor: Record<string, string>
   catalog: Catalog
   allowedEfforts: string[]
@@ -2556,6 +2583,7 @@ function AppPane({
             app={app}
             edits={edits}
             harnessByName={harnessByName}
+            defaultModel={defaultModel}
             harnessColor={harnessColor}
             catalog={catalog}
             allowedEfforts={allowedEfforts}
@@ -2574,6 +2602,7 @@ function AgentTable({
   app,
   edits,
   harnessByName,
+  defaultModel,
   harnessColor,
   catalog,
   allowedEfforts,
@@ -2585,6 +2614,7 @@ function AgentTable({
   app: AppSettings
   edits: UpdateAppsSettingsRequest
   harnessByName: Record<string, Harness>
+  defaultModel: string
   harnessColor: Record<string, string>
   catalog: Catalog
   allowedEfforts: string[]
@@ -2604,8 +2634,8 @@ function AgentTable({
         <div>harness</div>
       </div>
       {app.agents.map((a) => {
-        // The agent's declared harness supplies its inherited model.
-        const famModel = harnessByName[a.default]?.model ?? a.model
+        // Without an override an agent runs the operator's default model.
+        const famModel = defaultModel
         const modelOver: string | null =
           edits.agentModels && a.name in edits.agentModels
             ? (edits.agentModels[a.name] ?? null)
@@ -2642,7 +2672,7 @@ function AgentTable({
                 kind="model"
                 value={modelOver}
                 resolvedLabel={model}
-                inheritLabel={a.default + ' · ' + famModel}
+                inheritLabel={'default · ' + famModel}
                 harnesses={harnesses}
                 harnessColor={harnessColor}
                 catalog={catalog}


### PR DESCRIPTION
The model selects the harness, and the operator owns the model.

- Dispatch resolves the login first (`ProviderLogin.lookup`, which also reads a selected row fresh), then `get_harness_for_login(login)`: the first registered harness that accepts it. `run_agent` takes the model and the login id and resolves the same way; harnesses receive the login they render.
- One default model: `user_settings.default_model` (`provider/model`) replaces the per-harness `harnesses.model`. `PATCH /api/settings` sets it after `get_harness_for_model` accepts it. Harness rows keep effort, timeout, and fast mode.
- `Agent` loses `model` and `effort`. An agent runs the operator's default model (`UserSettings.get_default_model`) with its harness's effort; the per-agent overrides in Settings are how one agent differs. `timeout` stays declarable. The bundled apps and the proof app drop the declarations.
- Settings UI: the default model moves to General (grouped by harness); the harness cards lose their model select; agent rows inherit "default · model".
- Migration `c9d1e3f5a7b2`: adds `user_settings.default_model` (seeded from the claude row), drops `harnesses.model`.
- Docs: the agent example and the concepts table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
