### PR TITLE
Comments and the usage app description say provider login, not harness connection

### DIFF
--- a/backend/druks/accounts/schemas.py
+++ b/backend/druks/accounts/schemas.py
@@ -15,7 +15,7 @@ class AccountResponse(Schema):
 class IdentityResponse(Schema):
     # What /api/auth/me answers: how this deployment authenticates, who the
     # request resolved to (null in the none/zero setup state), and whether that
-    # identity still needs its first harness connection.
+    # identity still needs its first provider login.
     auth_mode: str
     account: AccountResponse | None
     onboarding_required: bool

--- a/backend/druks/harnesses/constants.py
+++ b/backend/druks/harnesses/constants.py
@@ -1,6 +1,5 @@
-# Redis keys for harness connections: a pending connect flow's state while the
-# operator completes it, and the per-connection SET NX lock that serializes
-# refresh.
+# Redis keys for provider logins: a pending connect flow's state while the
+# operator completes it, and the per-login SET NX lock that serializes refresh.
 CONNECT_PENDING_PREFIX = "druks:harness:connect:pending:"
 REFRESH_LOCK_PREFIX = "druks:harness:refresh:"
 

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -221,8 +221,8 @@ class Settings(BaseSettings):
     # ``settings.json`` / ``CLAUDE.md`` + plugin state (plus ``.claude.json`` beside the dir),
     # Codex's ``config.toml`` / ``AGENTS.md`` / MCP ``.credentials.json``, and
     # each CLI's ``skills`` subdir when DRUKS_SKILLS_DIR is unset. Subscription
-    # auth never reads these — credentials live in the DB, written by the
-    # connect flow (Settings → Harnesses). Empty => carry no local config for
+    # auth never reads these — logins live in the DB, written by the
+    # connect flow (Settings → Providers). Empty => carry no local config for
     # that CLI.
     claude_config_dir: OptionalExpandedPath = Field(  # type: ignore[assignment]
         default=Path("~/.claude"),

--- a/backend/druks/usage/app.py
+++ b/backend/druks/usage/app.py
@@ -4,5 +4,5 @@ from druks.apps import App
 class Usage(App):
     name = "usage"
     icon = "gauge"
-    description = "Harness usage metering — quota and spend per account."
+    description = "Provider usage metering — quota and spend per account."
     builtin = True

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -144,7 +144,7 @@ class AppsSettingsResponse(Schema):
 
 
 class AppsSettingsUpdate(BaseModel):
-    # agent name -> model (null clears, i.e. inherit the family default).
+    # agent name -> model (null clears, i.e. inherit the operator default).
     agent_models: dict[str, str | None] = Field(
         default_factory=dict,
         validation_alias="agentModels",

--- a/frontend/src/components/IdentityBootstrap.tsx
+++ b/frontend/src/components/IdentityBootstrap.tsx
@@ -11,7 +11,7 @@ type Phase =
 
 // Resolves who this browser is — the edge (or none-mode locality) asserts
 // identity; druks maps it — then mounts the app, or onboarding while the
-// identity has no harness connection yet. A failed resolution is an edge,
+// identity has no provider login yet. A failed resolution is an edge,
 // configuration, or network problem, never an invitation to onboard.
 export function IdentityBootstrap({
   children,


### PR DESCRIPTION
Six leftovers from the provider redesign: comments in accounts/schemas, harnesses/constants, settings, and user_settings/schemas, the IdentityBootstrap comment, and the usage app's description ("Provider usage metering"). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)