### PR TITLE
An expired provider login keeps its identity and asks for a Reconnect

### DIFF
--- a/frontend/src/components/ProviderConnect.test.tsx
+++ b/frontend/src/components/ProviderConnect.test.tsx
@@ -78,6 +78,23 @@ describe('ProviderConnect', () => {
     expect(screen.queryByText('ops@corp.com')).toBeNull()
   })
 
+  it('an expired login keeps its identity and asks for a Reconnect', () => {
+    renderCard(provider(), {
+      provider: 'anthropic',
+      kind: 'oauth',
+      connected: false,
+      providerEmail: 'claude-seat@corp.com',
+      expiresAt: '2026-08-01T00:00:00Z',
+    })
+
+    expect(screen.getByText('Expired')).toBeTruthy()
+    expect(screen.getByText('claude-seat@corp.com')).toBeTruthy()
+    expect(screen.getByText(/token expired/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Reconnect' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Disconnect' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Connect' })).toBeNull()
+  })
+
   it('drives the connection flow end to end and refreshes only the providers query', async () => {
     const responses: Record<string, unknown> = {
       '/api/providers/anthropic/connection/start': {

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1016,11 +1016,11 @@ export function ServicesPane() {
   )
 }
 
-function ServiceStatus({ connected }: { connected: boolean }) {
+function ServiceStatus({ connected, label }: { connected: boolean; label?: string }) {
   return (
     <span className={'mcp-conn' + (connected ? ' is-live' : '')}>
       <span className="mcp-conn-dot" />
-      {connected ? 'Connected' : 'Not connected'}
+      {label ?? (connected ? 'Connected' : 'Not connected')}
     </span>
   )
 }
@@ -1433,16 +1433,21 @@ export function ProviderConnect({ provider, login }: { provider: Provider; login
   }
 
   const connected = Boolean(login?.connected)
+  // An expired login is still a login: keep its identity and Disconnect
+  // visible and ask for a Reconnect, not a first-time Connect.
+  const expired = Boolean(login) && !connected
   return (
     <div className="hr-connect">
       <div className="hr-conn-status">
-        <ServiceStatus connected={connected} />
-        {login?.connected && <span className="hr-conn-id">{login.providerEmail}</span>}
-        {login?.connected && login.expiresAt && (
-          <span className="hr-conn-exp">token expires {new Date(login.expiresAt).toLocaleString()}</span>
+        <ServiceStatus connected={connected} label={expired ? 'Expired' : undefined} />
+        {login && <span className="hr-conn-id">{login.providerEmail}</span>}
+        {login?.expiresAt && (
+          <span className="hr-conn-exp">
+            token {expired ? 'expired' : 'expires'} {new Date(login.expiresAt).toLocaleString()}
+          </span>
         )}
         <span className="hr-conn-actions">
-          {connected && (
+          {login && (
             <button className="set-btn danger quiet" onClick={disconnect} disabled={busy || flow.busy}>
               Disconnect
             </button>
@@ -1453,7 +1458,7 @@ export function ProviderConnect({ provider, login }: { provider: Provider; login
               onClick={() => void flow.start()}
               disabled={busy || flow.busy}
             >
-              {connected ? 'Reconnect' : 'Connect'}
+              {login ? 'Reconnect' : 'Connect'}
             </button>
           )}
         </span>


### PR DESCRIPTION
PR #273 made an expired credential read as not connected on the wire, but the provider row keyed identity, Disconnect, and the button label on that flag alone. An expired login rendered like no login at all: no email, no expiry date, and a first-time **Connect** button.

The row now distinguishes a missing login from an expired one. An expired login shows **Expired**, the account email, `token expired <date>`, **Disconnect**, and **Reconnect**. Only a missing login shows **Connect**.

Refs #278. The "alert me when the token expires" half of that issue is still open.

Gates: `npm run lint`, the two affected test files, and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)