### PR TITLE
DRU-388 - Software Factory local board: projects, tickets, comments

### DIFF
--- a/backend/druks/contrib/software_factory/issues/enums.py
+++ b/backend/druks/contrib/software_factory/issues/enums.py
@@ -1,0 +1,54 @@
+from enum import StrEnum
+
+
+class Status(StrEnum):
+    """The board's workflow, closed on purpose: the enum *is* the workflow, so a
+    column can never hold a status no screen knows how to render."""
+
+    BACKLOG = "backlog"
+    TODO = "todo"
+    READY_FOR_AGENT = "ready_for_agent"
+    IN_PROGRESS = "in_progress"
+    IN_REVIEW = "in_review"
+    DONE = "done"
+    CANCELLED = "cancelled"
+
+    @property
+    def label(self) -> str:
+        """What a column header or a chip spells this status as."""
+        return STATUS_LABELS[self]
+
+    @property
+    def completed(self) -> bool:
+        """The work got done. Cancelled is finished but not completed — the
+        difference is what a funnel counts."""
+        return self is Status.DONE
+
+    @property
+    def terminal(self) -> bool:
+        """Nothing moves out of here on its own. Terminal-ness lives on the
+        enum, not on the display label: a board that renames a column has not
+        changed its workflow, and every reader of ``ticket.transitioned`` reads
+        this rather than guessing from a string."""
+        return self in (Status.DONE, Status.CANCELLED)
+
+
+# Pinned display labels — the stored value stays snake_case forever; only these
+# strings change when the board wants different words.
+STATUS_LABELS: dict[Status, str] = {
+    Status.BACKLOG: "Backlog",
+    Status.TODO: "Todo",
+    Status.READY_FOR_AGENT: "Ready for Agent",
+    Status.IN_PROGRESS: "In Progress",
+    Status.IN_REVIEW: "In Review",
+    Status.DONE: "Done",
+    Status.CANCELLED: "Cancelled",
+}
+
+
+class Priority(StrEnum):
+    NONE = "none"
+    URGENT = "urgent"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"

--- a/backend/druks/contrib/software_factory/issues/exceptions.py
+++ b/backend/druks/contrib/software_factory/issues/exceptions.py
@@ -1,0 +1,16 @@
+class ProjectNotFound(Exception):
+    def __init__(self, project_id: int) -> None:
+        super().__init__(f"project {project_id} does not exist")
+
+
+class InvalidPrefix(Exception):
+    def __init__(self, prefix: str) -> None:
+        super().__init__(f"project prefix {prefix!r} must be 2-6 letters A-Z")
+
+
+class PrefixLocked(Exception):
+    def __init__(self, prefix: str) -> None:
+        super().__init__(
+            f"project prefix {prefix!r} has already minted tickets — the identifier "
+            "namespace is fixed once a number has been handed out"
+        )

--- a/backend/druks/contrib/software_factory/issues/models.py
+++ b/backend/druks/contrib/software_factory/issues/models.py
@@ -1,0 +1,258 @@
+import re
+from datetime import datetime
+
+import sqlalchemy as sa
+from sqlalchemy import ForeignKey, String, select
+from sqlalchemy.orm import Mapped, mapped_column, validates
+
+from druks.contrib.software_factory.issues.enums import Priority, Status
+from druks.contrib.software_factory.issues.exceptions import (
+    InvalidPrefix,
+    PrefixLocked,
+    ProjectNotFound,
+)
+from druks.contrib.software_factory.issues.schemas import TicketSummary
+from druks.db import Base, StoredSubject, db_session
+
+# A project's prefix is the identifier namespace — Linear's team key. Short
+# enough to read at a glance, long enough to stay distinct.
+PREFIX_PATTERN = "^[A-Z]{2,6}$"
+PREFIX_RE = re.compile(PREFIX_PATTERN)
+
+
+def normalize_prefix(prefix: str) -> str:
+    """The stored form of an operator's prefix: uppercase, and 2-6 letters or
+    nothing at all."""
+    normalized = prefix.strip().upper()
+    if not PREFIX_RE.match(normalized):
+        raise InvalidPrefix(prefix)
+    return normalized
+
+
+class IssuesProject(Base):
+    """A ticket namespace (prefix + sequence). Not GitHub ``Project`` — that
+    row is a repo collection; this one exists before a repo is registered."""
+
+    __tablename__ = "issues_projects"
+    # The prefix shape lives in the database too: validation covers this app's
+    # own doors, the constraint covers everything else that can write the row.
+    __table_args__ = (
+        sa.CheckConstraint(f"prefix ~ '{PREFIX_PATTERN}'", name="issues_projects_prefix_shape"),
+    )
+
+    # Not a StoredSubject: no run is ever *about* a project — runs are about the
+    # tickets it namespaces.
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(unique=True)
+    prefix: Mapped[str] = mapped_column(String(6), unique=True)
+    # The monotonic ticket sequence. It only ever goes up: it is bumped inside
+    # the INSERT that mints an identifier and is never decremented, so deleting
+    # DRU-1 does not hand DRU-1 out again. Deriving the number from a count or a
+    # MAX over the tickets table would do exactly that, and would race besides.
+    ticket_seq: Mapped[int] = mapped_column(default=0)
+    created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
+
+    @validates("prefix")
+    def _normalize_prefix(self, key: str, prefix: str) -> str:
+        # Every assignment path — create, an edit, a fixture — normalizes and
+        # validates, so an unshaped prefix can't reach the column.
+        return normalize_prefix(prefix)
+
+    @classmethod
+    async def create(cls, *, name: str, prefix: str) -> "IssuesProject":
+        session = db_session()
+        project = cls(name=name, prefix=prefix)
+        session.add(project)
+        # A duplicate name or prefix surfaces here, as the unique violation it
+        # is: the board refuses two namespaces that spell the same thing.
+        await session.flush()
+        return project
+
+    @classmethod
+    async def get(cls, project_id: int) -> "IssuesProject | None":
+        return await db_session().get(cls, project_id)
+
+    @classmethod
+    async def list(cls) -> list["IssuesProject"]:
+        statement = select(cls).order_by(cls.created_at, cls.id)
+        return list(await db_session().scalars(statement))
+
+    @classmethod
+    async def mint_identifier(cls, project_id: int) -> str:
+        """Take the next number in this project's sequence and spell it as an
+        identifier. One statement: the row is locked, bumped, and read in the
+        same UPDATE ... RETURNING, so concurrent creates queue instead of
+        colliding and no number is ever handed out twice."""
+        statement = (
+            sa.update(cls)
+            .where(cls.id == project_id)
+            .values(ticket_seq=cls.ticket_seq + 1)
+            .returning(cls.prefix, cls.ticket_seq)
+            .execution_options(synchronize_session=False)
+        )
+        row = (await db_session().execute(statement)).one_or_none()
+        if not row:
+            raise ProjectNotFound(project_id)
+        prefix, number = row
+        return f"{prefix}-{number}"
+
+    async def set_prefix(self, prefix: str) -> None:
+        """Rename the namespace — refused once a ticket has been minted against
+        it, because the identifiers already handed out spell the old prefix and
+        are never rewritten. The counter is read from the row rather than the
+        instance: ``mint_identifier`` bumps it with an UPDATE this session's
+        copy has not seen."""
+        session = db_session()
+        minted = await session.scalar(
+            select(IssuesProject.ticket_seq).where(IssuesProject.id == self.id)
+        )
+        # Normalize explicitly for this comparison: @validates only normalizes
+        # on assignment, which happens below, after the lock check.
+        if minted and normalize_prefix(prefix) != self.prefix:
+            raise PrefixLocked(self.prefix)
+        self.prefix = prefix
+        await session.flush()
+
+
+class Ticket(StoredSubject):
+    __tablename__ = "issues_tickets"
+
+    # id: the integer subject key inherited from StoredSubject; the class name
+    # derives subject_type "ticket".
+    identifier: Mapped[str] = mapped_column(unique=True)
+    title: Mapped[str]
+    description: Mapped[str] = mapped_column(default="")
+    # Status and priority are String columns driven by this app's closed
+    # StrEnums, not native PG enum types: the workflow stays in code and a label
+    # change never needs an ALTER TYPE.
+    status: Mapped[str] = mapped_column(default=Status.TODO)
+    priority: Mapped[str] = mapped_column(default=Priority.NONE)
+    # Required: a ticket without a namespace could not be named.
+    project_id: Mapped[int] = mapped_column(ForeignKey("issues_projects.id"))
+    # Optional: a ticket exists before anyone picks it up.
+    assignee_id: Mapped[str | None] = mapped_column(
+        ForeignKey("accounts.id", ondelete="RESTRICT"), default=None
+    )
+    created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
+    updated_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        project_id: int,
+        title: str,
+        description: str = "",
+        status: Status = Status.TODO,
+        priority: Priority = Priority.NONE,
+        assignee_id: str | None = None,
+    ) -> "Ticket":
+        session = db_session()
+        ticket = cls(
+            identifier=await IssuesProject.mint_identifier(project_id),
+            project_id=project_id,
+            title=title,
+            description=description,
+            status=status,
+            priority=priority,
+            assignee_id=assignee_id,
+        )
+        session.add(ticket)
+        await session.flush()
+        return ticket
+
+    def get_label(self) -> str:
+        # The stable handle, never the mutable title: events snapshot the label
+        # and the log should not disagree with itself.
+        return self.identifier
+
+    def get_summary(self) -> TicketSummary:
+        return TicketSummary.model_validate(self)
+
+    @classmethod
+    async def get_for_identifier(cls, identifier: str) -> "Ticket | None":
+        statement = select(cls).where(cls.identifier == identifier)
+        return (await db_session().scalars(statement)).first()
+
+    @classmethod
+    async def list_board(cls) -> list["Ticket"]:
+        """Everything on the board — cancelled tickets are off it. The page
+        groups these by status; the model just says which rows are live."""
+        statement = (
+            select(cls)
+            .where(cls.status != Status.CANCELLED)
+            .order_by(cls.updated_at.desc(), cls.id.desc())
+        )
+        return list(await db_session().scalars(statement))
+
+    @classmethod
+    async def list_for_status(cls, status: Status) -> list["Ticket"]:
+        statement = (
+            select(cls).where(cls.status == status).order_by(cls.updated_at.desc(), cls.id.desc())
+        )
+        return list(await db_session().scalars(statement))
+
+    @classmethod
+    async def list_summaries(cls, account_id: str | None) -> list[TicketSummary]:
+        # One board for the appliance: what a team is working on belongs to
+        # everyone reading it, not to whoever happens to be signed in.
+        return [ticket.get_summary() for ticket in await cls.list_board()]
+
+    async def set_status(self, status: Status) -> None:
+        self.status = status
+        self.updated_at = Base.utc_now()
+        await db_session().flush()
+
+    async def set_priority(self, priority: Priority) -> None:
+        self.priority = priority
+        self.updated_at = Base.utc_now()
+        await db_session().flush()
+
+    async def assign(self, assignee_id: str | None) -> None:
+        self.assignee_id = assignee_id
+        self.updated_at = Base.utc_now()
+        await db_session().flush()
+
+    async def add_comment(self, *, author_id: str, body: str) -> "Comment":
+        return await Comment.create(ticket_id=self.id, author_id=author_id, body=body)
+
+    async def list_comments(self) -> list["Comment"]:
+        return await Comment.list_for_ticket(self.id)
+
+    async def delete(self) -> None:
+        """Drop the ticket and its thread. The project's counter is untouched —
+        a retired number is retired, not recycled."""
+        session = db_session()
+        await session.execute(sa.delete(Comment).where(Comment.ticket_id == self.id))
+        await session.delete(self)
+        await session.flush()
+
+
+class Comment(Base):
+    __tablename__ = "issues_comments"
+
+    # A row, not an event and not a StoredSubject: events stay facts about what
+    # happened, while a comment is editable content the thread reads back in
+    # order. Chat's ``Message`` is the precedent.
+    id: Mapped[int] = mapped_column(primary_key=True)
+    ticket_id: Mapped[int] = mapped_column(ForeignKey("issues_tickets.id"))
+    # The signed-in account that wrote it — required, so every line on a thread
+    # has someone's name against it.
+    author_id: Mapped[str] = mapped_column(ForeignKey("accounts.id", ondelete="RESTRICT"))
+    body: Mapped[str]
+    created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
+
+    @classmethod
+    async def create(cls, *, ticket_id: int, author_id: str, body: str) -> "Comment":
+        session = db_session()
+        comment = cls(ticket_id=ticket_id, author_id=author_id, body=body)
+        session.add(comment)
+        await session.flush()
+        return comment
+
+    @classmethod
+    async def list_for_ticket(cls, ticket_id: int) -> list["Comment"]:
+        """The thread, oldest first — a conversation reads down. A ticket nobody
+        has commented on is an empty list, never None."""
+        statement = select(cls).where(cls.ticket_id == ticket_id).order_by(cls.created_at, cls.id)
+        return list(await db_session().scalars(statement))

--- a/backend/druks/contrib/software_factory/issues/schemas.py
+++ b/backend/druks/contrib/software_factory/issues/schemas.py
@@ -1,0 +1,10 @@
+from druks.contrib.software_factory.issues.enums import Status
+from druks.workflows import SubjectSummary
+
+
+class TicketSummary(SubjectSummary):
+    # The ticket's domain header. ``label`` is the identifier
+    # (``Ticket.get_label``), and the platform's subject read-side composes
+    # this with the generic status and timeline.
+    title: str
+    status: Status

--- a/backend/druks/contrib/software_factory/models.py
+++ b/backend/druks/contrib/software_factory/models.py
@@ -6,6 +6,7 @@ from sqlalchemy import ForeignKey, Index, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from druks.contrib.software_factory.issues import models as _issues_models  # noqa: F401
 from druks.contrib.software_factory.policy import RepoPolicy
 from druks.contrib.software_factory.schemas import ProjectRepoSummary, WorkItemSummary
 from druks.contrib.software_factory.ticketing.enums import TicketStatus

--- a/backend/migrations/versions/c3f8a1d6e247_issues_projects_tickets_comments.py
+++ b/backend/migrations/versions/c3f8a1d6e247_issues_projects_tickets_comments.py
@@ -1,7 +1,7 @@
 """Software Factory local board: projects, tickets, and comments.
 
 Revision ID: c3f8a1d6e247
-Revises: d2f7a9c4e816
+Revises: a8d4c1e63f92
 Create Date: 2026-09-07
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "c3f8a1d6e247"
-down_revision: str | Sequence[str] | None = "d2f7a9c4e816"
+down_revision: str | Sequence[str] | None = "a8d4c1e63f92"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/migrations/versions/c3f8a1d6e247_issues_projects_tickets_comments.py
+++ b/backend/migrations/versions/c3f8a1d6e247_issues_projects_tickets_comments.py
@@ -1,0 +1,65 @@
+"""Software Factory local board: projects, tickets, and comments.
+
+Revision ID: c3f8a1d6e247
+Revises: d2f7a9c4e816
+Create Date: 2026-09-07
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c3f8a1d6e247"
+down_revision: str | Sequence[str] | None = "d2f7a9c4e816"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "issues_projects",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("prefix", sa.String(length=6), nullable=False),
+        sa.Column("ticket_seq", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("prefix ~ '^[A-Z]{2,6}$'", name="issues_projects_prefix_shape"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+        sa.UniqueConstraint("prefix"),
+    )
+    op.create_table(
+        "issues_tickets",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("identifier", sa.String(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("priority", sa.String(), nullable=False),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column("assignee_id", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["issues_projects.id"]),
+        sa.ForeignKeyConstraint(["assignee_id"], ["accounts.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("identifier"),
+    )
+    op.create_table(
+        "issues_comments",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("ticket_id", sa.Integer(), nullable=False),
+        sa.Column("author_id", sa.String(), nullable=False),
+        sa.Column("body", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["ticket_id"], ["issues_tickets.id"]),
+        sa.ForeignKeyConstraint(["author_id"], ["accounts.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("issues_comments")
+    op.drop_table("issues_tickets")
+    op.drop_table("issues_projects")

--- a/backend/tests/software_factory/test_issues_models.py
+++ b/backend/tests/software_factory/test_issues_models.py
@@ -1,0 +1,100 @@
+import pytest
+from druks.accounts.models import Account
+from druks.apps.loader import iter_apps
+from druks.contrib.software_factory.issues.enums import Status
+from druks.contrib.software_factory.issues.exceptions import (
+    InvalidPrefix,
+    PrefixLocked,
+    ProjectNotFound,
+)
+from druks.contrib.software_factory.issues.models import Comment, IssuesProject, Ticket
+from sqlalchemy.exc import IntegrityError
+
+
+def test_issues_is_not_a_bundled_app():
+    assert "issues" not in {app.name for app in iter_apps()}
+
+
+async def test_ticket_identifiers_are_monotonic_per_project_and_never_reused():
+    dru = await IssuesProject.create(name="druks", prefix="dru")
+    first = await Ticket.create(project_id=dru.id, title="one")
+    second = await Ticket.create(project_id=dru.id, title="two")
+    assert first.identifier == "DRU-1"
+    assert second.identifier == "DRU-2"
+
+    await first.delete()
+    third = await Ticket.create(project_id=dru.id, title="three")
+    assert third.identifier == "DRU-3"
+
+    eng = await IssuesProject.create(name="engine", prefix="eng")
+    other = await Ticket.create(project_id=eng.id, title="eng-first")
+    assert other.identifier == "ENG-1"
+
+
+async def test_unknown_project_refuses_a_ticket():
+    with pytest.raises(ProjectNotFound):
+        await Ticket.create(project_id=0, title="orphan")
+
+
+async def test_duplicate_project_names_fail():
+    await IssuesProject.create(name="alpha", prefix="alp")
+    with pytest.raises(IntegrityError):
+        await IssuesProject.create(name="alpha", prefix="bet")
+
+
+async def test_duplicate_project_prefixes_fail():
+    await IssuesProject.create(name="alpha", prefix="alp")
+    with pytest.raises(IntegrityError):
+        await IssuesProject.create(name="other", prefix="alp")
+
+
+async def test_prefix_must_be_two_to_six_letters():
+    with pytest.raises(InvalidPrefix):
+        await IssuesProject.create(name="short", prefix="A")
+    with pytest.raises(InvalidPrefix):
+        await IssuesProject.create(name="digits", prefix="DR1")
+
+
+async def test_prefix_cannot_change_after_a_ticket_is_minted():
+    project = await IssuesProject.create(name="locked", prefix="lok")
+    await project.set_prefix("lokx")
+    assert project.prefix == "LOKX"
+
+    await Ticket.create(project_id=project.id, title="minted")
+    with pytest.raises(PrefixLocked):
+        await project.set_prefix("newpre")
+    assert (await IssuesProject.get(project.id)).prefix == "LOKX"
+
+
+async def test_comments_are_rows_and_empty_is_a_list():
+    account = await Account.get_or_create("op@example.com")
+    project = await IssuesProject.create(name="thread", prefix="thd")
+    ticket = await Ticket.create(project_id=project.id, title="quiet")
+
+    assert await ticket.list_comments() == []
+
+    first = await ticket.add_comment(author_id=account.id, body="first")
+    second = await ticket.add_comment(author_id=account.id, body="second")
+    listed = await ticket.list_comments()
+    assert [comment.body for comment in listed] == ["first", "second"]
+    assert listed[0].id == first.id
+    assert listed[1].id == second.id
+    assert all(isinstance(comment, Comment) for comment in listed)
+
+
+async def test_list_board_omits_cancelled():
+    project = await IssuesProject.create(name="board", prefix="brd")
+    live = await Ticket.create(project_id=project.id, title="live")
+    gone = await Ticket.create(project_id=project.id, title="gone")
+    await gone.set_status(Status.CANCELLED)
+
+    board = await Ticket.list_board()
+    identifiers = {ticket.identifier for ticket in board}
+    assert live.identifier in identifiers
+    assert gone.identifier not in identifiers
+    found = await Ticket.get_for_identifier(live.identifier)
+    assert found is not None
+    assert found.id == live.id
+    assert found.get_label() == live.identifier
+    assert found.get_summary().title == "live"
+    assert found.get_summary().status is Status.TODO


### PR DESCRIPTION
Linear ticket: [DRU-388](https://linear.app/fellaworks/issue/DRU-388/issues-project-ticket)

Stacked on `integration/issues`. The local board is Software Factory, not a bundled app.

## Summary
- Models live under `software_factory/issues/` (`IssuesProject`, `Ticket`, `Comment`). Tables stay `issues_*`. No `Issues` app, no `druks.apps` entry point, no `alembic_version_issues`.
- One platform Alembic revision creates the three tables. `IssuesProject` is not GitHub `Project`.
- Identifiers mint from a per-project sequence (`DRU-1`, `DRU-2`); a delete does not reuse a number.

## Test plan
- [ ] `uv run ruff check backend`
- [ ] `uv run ruff format --check backend`
- [ ] `uv pip install -e backend/tests/druks-field_notes`
- [ ] `uv run pytest backend/`
- [ ] Roster does not load an app named `issues`.
- [ ] Prefix mint: `DRU-1` then `DRU-2`; delete does not reuse; `ENG-1` is independent.
- [ ] Unique name/prefix; prefix change refused after a ticket exists; ticket requires `project_id`.
- [ ] Empty comment list is `[]`.

Pages, write doors, and the Software Factory tracker stay on later tickets.