### PR TITLE
OpenAI is one provider; claude and codex run on a key as well as a subscription

### DIFF
--- a/backend/druks/core/tasks.py
+++ b/backend/druks/core/tasks.py
@@ -5,7 +5,6 @@ from druks.harnesses.datastructures import RotationResult
 from druks.harnesses.models import ProviderLogin
 from druks.harnesses.providers import get_provider, get_providers
 from druks.sandbox import gate
-from druks.user_settings.models import UserSettings
 from druks.workflows import task
 
 logger = logging.getLogger(__name__)
@@ -28,13 +27,8 @@ async def refresh_tokens() -> None:
 
 @task(every="0 6 * * *")
 async def refresh_catalogs() -> None:
-    fallback_id = (await UserSettings.get()).fallback_account_id
-    logins = await ProviderLogin.list_all()
     for provider in get_providers():
-        usable = [login for login in logins if login.provider == provider.id]
-        if usable:
-            preferred = [login for login in usable if login.account_id == fallback_id]
-            await provider.refresh_catalog((preferred or usable)[0])
+        await provider.refresh_catalog()
 
 
 async def _refresh() -> dict[str, object]:

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -32,7 +32,7 @@ class ClaudeHarness(Harness):
     # (``--output-format stream-json``), so the transcript is the stdout.
     name = "claude"
     provider = AnthropicProvider.id
-    login_kinds = frozenset({"oauth"})
+    login_kinds = frozenset({"oauth", "api_key"})
     default_model = "anthropic/claude-opus-4-7"
     command = "claude"
 
@@ -119,6 +119,10 @@ class ClaudeHarness(Harness):
             f'if [ -n "$sf" ]; then cp "$sf" {session_q}; fi; '
             "exit $ec"
         )
+        env = dict(extra_env or {})
+        if login.kind == "api_key":
+            # The CLI bills a key from its environment; no credentials file.
+            env["ANTHROPIC_API_KEY"] = login.payload["api_key"]
         return AgentInvocation(
             name="claude",
             args=("sh", "-c", wrapper),
@@ -130,7 +134,7 @@ class ClaudeHarness(Harness):
                 skills=skills,
                 login=login,
             ),
-            env=extra_env,
+            env=env,
             extra_artifact_filenames=("debug.log", "session.jsonl"),
         )
 
@@ -208,11 +212,14 @@ async def _get_credentials(
     login: ProviderLogin,
 ) -> Credentials:
     """The Credentials bundle the runner pushes into the sandbox: the rendered
-    credentials file, plus any local config, plugins, and skills.
-    ``include_plugins=False`` skips the operator's plugin state, for prompts
-    that use no MCP server and would otherwise die on a misconfigured plugin."""
+    credentials file of a subscription login, plus any local config, plugins,
+    and skills. ``include_plugins=False`` skips the operator's plugin state,
+    for prompts that use no MCP server and would otherwise die on a
+    misconfigured plugin."""
     config_dir = sandbox.claude_config_dir
-    home: list[HomeFile | HomeCopy] = [ClaudeHarness.auth_file(login)]
+    home: list[HomeFile | HomeCopy] = []
+    if login.kind == "oauth":
+        home.append(ClaudeHarness.auth_file(login))
     if config_dir:
         home += [
             HomeCopy(".claude.json", config_dir.parent / ".claude.json"),

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -30,7 +30,7 @@ from .exceptions import (
     HarnessUsageLimitError,
 )
 from .models import ProviderLogin
-from .providers import OpenAiCodexProvider
+from .providers import OpenAiProvider
 from .subprocess import read_result_json
 
 logger = logging.getLogger(__name__)
@@ -59,10 +59,8 @@ class _Rate:
 # Public OpenAI/Codex rates as of the last update. Override via env when prices
 # change. Cached-input defaults to ~10% of input (OpenAI's typical discount).
 _DEFAULT_RATES: dict[str, _Rate] = {
-    # gpt-5.5 is the only Codex model callable on a ChatGPT-subscription
-    # auth (which is how we run). Assumed-equal to gpt-5's rate until
-    # OpenAI publishes specific gpt-5.5 pricing — override via
-    # DRUKS_CODEX_PRICES_JSON when that lands.
+    # Assumed-equal to gpt-5's rate until OpenAI publishes specific gpt-5.5
+    # pricing — override via DRUKS_CODEX_PRICES_JSON when that lands.
     "gpt-5.5": _Rate(input=1.25, cached_input=0.125, output=10.0),
     "gpt-5": _Rate(input=1.25, cached_input=0.125, output=10.0),
     "gpt-5-codex": _Rate(input=1.25, cached_input=0.125, output=10.0),
@@ -265,9 +263,9 @@ class CodexHarness(Harness):
     # messages) to stdout as it runs — so stdout.jsonl is the live transcript,
     # symmetric with claude. session.jsonl is still snapshotted for cost.
     name = "codex"
-    provider = OpenAiCodexProvider.id
-    login_kinds = frozenset({"oauth"})
-    default_model = "openai-codex/gpt-5.5"
+    provider = OpenAiProvider.id
+    login_kinds = frozenset({"oauth", "api_key"})
+    default_model = "openai/gpt-5.5"
     command = "codex"
 
     # The CLI's terminal {"type":"error"} event carries prose, not status
@@ -503,4 +501,10 @@ class CodexHarness(Harness):
 
     @classmethod
     def auth_file(cls, login: ProviderLogin) -> HomeFile:
-        return HomeFile(".codex/auth.json", json.dumps(dict(login.payload)))
+        """``auth.json`` as the CLI reads it: the ChatGPT token set of a
+        subscription, or the platform key it bills per token."""
+        if login.kind == "api_key":
+            auth = {"OPENAI_API_KEY": login.payload["api_key"]}
+        else:
+            auth = dict(login.payload)
+        return HomeFile(".codex/auth.json", json.dumps(auth))

--- a/backend/druks/harnesses/pi.py
+++ b/backend/druks/harnesses/pi.py
@@ -17,6 +17,7 @@ from . import exceptions
 from .artifacts import write_cost
 from .base import Harness
 from .models import ProviderLogin
+from .providers import OpenAiProvider, jwt_expiry
 from .subprocess import read_result_json
 
 _DRUKS_OUTPUT_TEMPLATE = Path(__file__).parent / "druks-output.ts"
@@ -38,9 +39,28 @@ class PiHarness(Harness):
     default_model = "openai/gpt-5.5"
 
     @classmethod
+    def provider_name(cls, login: ProviderLogin) -> str:
+        """The provider as pi names it. pi keeps the ChatGPT backend as its own
+        ``openai-codex`` provider, so an OpenAI subscription renders under
+        that name; every key renders under the vendor's."""
+        if login.kind == "oauth" and login.provider == OpenAiProvider.id:
+            return "openai-codex"
+        return login.provider
+
+    @classmethod
     def auth_file(cls, login: ProviderLogin) -> HomeFile:
-        auth = {login.provider: {"type": "api_key", "key": login.payload["api_key"]}}
-        return HomeFile(".pi/agent/auth.json", json.dumps(auth))
+        if login.kind == "oauth":
+            tokens = login.payload["tokens"]
+            entry = {
+                "type": "oauth",
+                "access": tokens["access_token"],
+                "refresh": tokens["refresh_token"],
+                "expires": int(jwt_expiry(tokens["access_token"]).timestamp() * 1000),
+                "accountId": tokens["account_id"],
+            }
+        else:
+            entry = {"type": "api_key", "key": login.payload["api_key"]}
+        return HomeFile(".pi/agent/auth.json", json.dumps({cls.provider_name(login): entry}))
 
     async def build_invocation(
         self,
@@ -67,7 +87,8 @@ class PiHarness(Harness):
                 "sandbox.service_url and related TOML settings.",
             )
 
-        provider, _, model = self.model.partition("/")
+        model = self.model_id
+        provider = self.provider_name(login)
         in_vm_run_dir = f"{get_runs_root(ssh_username)}/{run_id}"
         in_vm_schema = f"{in_vm_run_dir}/schema.json"
         in_vm_extension = f"{in_vm_run_dir}/druks-output.ts"

--- a/backend/druks/harnesses/providers.py
+++ b/backend/druks/harnesses/providers.py
@@ -354,17 +354,23 @@ class Provider:
             raise exceptions.CatalogError("network") from exc
         if response.status_code != 200:
             raise exceptions.CatalogError(error_tag(response.status_code))
-        return cls._parse_catalog(response.text)
+        return cls._parse_catalog(response.text, kind=login.kind)
 
     @classmethod
-    async def refresh_catalog(cls, login: ProviderLogin) -> None:
-        """Store a fresh catalog. A failed fetch logs and keeps the stored one."""
-        try:
-            models = await cls.fetch_catalog(login)
-        except (exceptions.CatalogError, exceptions.OAuthTokenError) as exc:
-            logger.warning("catalog refresh for %s failed: %s", cls.id, exc.tag)
-        else:
-            await ProviderCatalog.store(cls.id, list(models))
+    async def refresh_catalog(cls) -> None:
+        """Store a fresh catalog over one of this provider's logins, a
+        subscription before a key: the subscription endpoint lists what the
+        vendor CLI runs. No login stores nothing. A failed fetch logs and
+        keeps the stored one."""
+        logins = await ProviderLogin.list_for_provider(cls.id)
+        if logins:
+            login = min(logins, key=lambda row: row.kind != "oauth")
+            try:
+                models = await cls.fetch_catalog(login)
+            except (exceptions.CatalogError, exceptions.OAuthTokenError) as exc:
+                logger.warning("catalog refresh for %s failed: %s", cls.id, exc.tag)
+            else:
+                await ProviderCatalog.store(cls.id, list(models))
 
     @classmethod
     def _catalog_request(cls, login: ProviderLogin) -> ProviderRequest:
@@ -372,9 +378,10 @@ class Provider:
         raise NotImplementedError
 
     @classmethod
-    def _parse_catalog(cls, raw: str) -> tuple[dict, ...]:
-        """Namespaced ``{"id", "label"}`` entries from the model-list body;
-        raises :class:`CatalogError` on a body offering nothing."""
+    def _parse_catalog(cls, raw: str, *, kind: str) -> tuple[dict, ...]:
+        """Namespaced ``{"id", "label"}`` entries from the model-list body
+        fetched over a ``kind`` login; raises :class:`CatalogError` on a body
+        offering nothing."""
         raise NotImplementedError
 
 
@@ -658,7 +665,7 @@ class AnthropicProvider(Provider):
         return ProviderRequest("https://api.anthropic.com/v1/models?limit=100", headers)
 
     @classmethod
-    def _parse_catalog(cls, raw: str) -> tuple[dict, ...]:
+    def _parse_catalog(cls, raw: str, *, kind: str) -> tuple[dict, ...]:
         try:
             models = tuple(
                 {"id": f"{cls.id}/{model['id']}", "label": model.get("display_name") or model["id"]}
@@ -741,13 +748,14 @@ _CODEX_USER_AGENT = "codex-cli"
 _WEEKLY_WINDOW_MINIMUM_SECONDS = 24 * 3600
 
 
-class OpenAiCodexProvider(Provider):
-    """The ChatGPT subscription backend (chatgpt.com/backend-api) — pi's
-    ``openai-codex`` provider id, and what the codex CLI runs on."""
+class OpenAiProvider(Provider):
+    """The OpenAI vendor. An ``oauth`` login is a ChatGPT subscription
+    (chatgpt.com/backend-api); an ``api_key`` login is the platform API
+    (api.openai.com), paid per token."""
 
-    id = "openai-codex"
-    label = "ChatGPT"
-    login_kinds = frozenset({"oauth"})
+    id = "openai"
+    label = "OpenAI"
+    login_kinds = frozenset({"oauth", "api_key"})
 
     REFRESH_MARGIN = timedelta(hours=24)
     _TOKEN_URL = "https://auth.openai.com/oauth/token"
@@ -902,6 +910,8 @@ class OpenAiCodexProvider(Provider):
 
     @classmethod
     def _catalog_request(cls, login: ProviderLogin) -> ProviderRequest:
+        if login.kind == "api_key":
+            return ProviderRequest(_MODELS_DEV_URL, {})
         # ``client_version`` is required and lower-bounds the list (the server
         # returns models with ``minimal_client_version <= client_version``); the
         # high constant asks for the full catalog, and the empty-list guard
@@ -912,20 +922,27 @@ class OpenAiCodexProvider(Provider):
         )
 
     @classmethod
-    def _parse_catalog(cls, raw: str) -> tuple[dict, ...]:
+    def _parse_catalog(cls, raw: str, *, kind: str) -> tuple[dict, ...]:
         try:
-            models = tuple(
-                {
-                    "id": f"{cls.id}/{model['slug']}",
-                    "label": model.get("display_name") or model["slug"],
-                    "efforts": [
-                        level["effort"] for level in model.get("supported_reasoning_levels") or []
-                    ],
-                    "minimal_client_version": model.get("minimal_client_version"),
-                }
-                for model in json.loads(raw)["models"]
-                if model.get("visibility") == "list"
-            )
+            if kind == "api_key":
+                models = tuple(
+                    {"id": f"{cls.id}/{model['id']}", "label": model["name"]}
+                    for model in json.loads(raw)[cls.id]["models"].values()
+                )
+            else:
+                models = tuple(
+                    {
+                        "id": f"{cls.id}/{model['slug']}",
+                        "label": model.get("display_name") or model["slug"],
+                        "efforts": [
+                            level["effort"]
+                            for level in model.get("supported_reasoning_levels") or []
+                        ],
+                        "minimal_client_version": model.get("minimal_client_version"),
+                    }
+                    for model in json.loads(raw)["models"]
+                    if model.get("visibility") == "list"
+                )
         except json.JSONDecodeError as exc:
             raise exceptions.CatalogError("unparseable") from exc
         except (KeyError, TypeError, AttributeError) as exc:
@@ -962,30 +979,3 @@ def _codex_windows(usage: dict) -> tuple[ParsedMetric | None, tuple[ParsedMetric
             else:
                 five_hour.append(window)
     return ParsedMetric.binding(five_hour), tuple(weekly)
-
-
-class OpenAiProvider(Provider):
-    """The OpenAI platform API (api.openai.com), pay per token on a key."""
-
-    id = "openai"
-    label = "OpenAI"
-    login_kinds = frozenset({"api_key"})
-
-    @classmethod
-    def _catalog_request(cls, _login: ProviderLogin) -> ProviderRequest:
-        return ProviderRequest(_MODELS_DEV_URL, {})
-
-    @classmethod
-    def _parse_catalog(cls, raw: str) -> tuple[dict, ...]:
-        try:
-            models = tuple(
-                {"id": f"{cls.id}/{model['id']}", "label": model["name"]}
-                for model in json.loads(raw)[cls.id]["models"].values()
-            )
-        except json.JSONDecodeError as exc:
-            raise exceptions.CatalogError("unparseable") from exc
-        except (KeyError, TypeError, AttributeError) as exc:
-            raise exceptions.CatalogError("unexpected_payload") from exc
-        if models:
-            return models
-        raise exceptions.CatalogError("empty_list")

--- a/backend/druks/harnesses/routes.py
+++ b/backend/druks/harnesses/routes.py
@@ -101,7 +101,7 @@ async def complete_connection(
     settings = await UserSettings.get()
     if not settings.fallback_account_id:
         await settings.set_fallback_account(resolved.id)
-    login = await ProviderLogin.connect(
+    await ProviderLogin.connect(
         provider=provider.id,
         account=resolved,
         payload=completed.payload,
@@ -119,7 +119,7 @@ async def complete_connection(
         # A fresh picker right after connect; fetch failures are tagged inside.
         # The single-use flow is already spent, so trouble here — including a
         # database that vanished under the refresh — only logs.
-        await provider.refresh_catalog(login)
+        await provider.refresh_catalog()
     except Exception:
         logging.getLogger(__name__).exception("Catalog refresh after connect failed")
         with suppress(Exception):
@@ -152,7 +152,7 @@ async def connect_key(
             provider_email=account.username,
             kind="api_key",
         )
-        await provider.refresh_catalog(login)
+        await provider.refresh_catalog()
         return ProviderLoginResponse.model_validate(login)
     raise HTTPException(status_code=422, detail="The API key is empty. Paste a key.")
 

--- a/backend/migrations/versions/4b8d2f6e9a13_one_openai_provider.py
+++ b/backend/migrations/versions/4b8d2f6e9a13_one_openai_provider.py
@@ -1,0 +1,91 @@
+"""One OpenAI provider: openai-codex folds into openai as its oauth login.
+
+Revision ID: 4b8d2f6e9a13
+Revises: c9d1e3f5a7b2
+Create Date: 2026-09-04
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "4b8d2f6e9a13"
+down_revision: str | Sequence[str] | None = "c9d1e3f5a7b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_KNOWN = ("anthropic", "openai", "openai-codex")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    unknown = bind.scalars(
+        sa.text(
+            "SELECT DISTINCT provider FROM provider_logins WHERE provider NOT IN :known"
+        ).bindparams(sa.bindparam("known", expanding=True, value=list(_KNOWN)))
+    ).all()
+    if unknown:
+        raise RuntimeError(f"login rows name unknown providers {unknown}; disconnect them first")
+    # One login per (provider, account): an account holding both rows keeps
+    # neither automatically. Name it so the operator disconnects one.
+    conflicts = bind.scalars(
+        sa.text(
+            "SELECT accounts.username FROM provider_logins AS codex "
+            "JOIN provider_logins AS platform ON platform.account_id = codex.account_id "
+            "AND platform.provider = 'openai' "
+            "JOIN accounts ON accounts.id = codex.account_id "
+            "WHERE codex.provider = 'openai-codex'"
+        )
+    ).all()
+    if conflicts:
+        raise RuntimeError(
+            f"accounts {conflicts} hold both an openai-codex and an openai login; "
+            "disconnect one first"
+        )
+    for table in ("provider_logins", "usage_scrapes"):
+        op.execute(sa.text(f"UPDATE {table} SET provider = 'openai' WHERE provider = 'openai-codex'"))
+    # The subscription catalog is what the codex CLI runs; it wins over the key's.
+    op.execute(
+        sa.text(
+            "DELETE FROM provider_catalogs WHERE provider = 'openai' "
+            "AND EXISTS (SELECT 1 FROM provider_catalogs WHERE provider = 'openai-codex')"
+        )
+    )
+    op.execute(sa.text("UPDATE provider_catalogs SET provider = 'openai' WHERE provider = 'openai-codex'"))
+    op.execute(
+        sa.text(
+            "UPDATE user_settings SET default_model = 'openai/' || substr(default_model, 14) "
+            "WHERE default_model LIKE 'openai-codex/%'"
+        )
+    )
+    op.execute(
+        sa.text(
+            "UPDATE settings_overrides SET value = to_jsonb('openai/' || substr(value #>> '{}', 14)) "
+            "WHERE key LIKE 'agent_model:%' AND value #>> '{}' LIKE 'openai-codex/%'"
+        )
+    )
+
+
+def downgrade() -> None:
+    # A subscription login was the openai-codex row; a key login was always openai's.
+    op.execute(
+        sa.text(
+            "UPDATE provider_logins SET provider = 'openai-codex' "
+            "WHERE provider = 'openai' AND kind = 'oauth'"
+        )
+    )
+    op.execute(sa.text("UPDATE usage_scrapes SET provider = 'openai-codex' WHERE provider = 'openai'"))
+    op.execute(sa.text("UPDATE provider_catalogs SET provider = 'openai-codex' WHERE provider = 'openai'"))
+    op.execute(
+        sa.text(
+            "UPDATE user_settings SET default_model = 'openai-codex/' || substr(default_model, 8) "
+            "WHERE default_model LIKE 'openai/%'"
+        )
+    )
+    op.execute(
+        sa.text(
+            "UPDATE settings_overrides SET value = to_jsonb('openai-codex/' || substr(value #>> '{}', 8)) "
+            "WHERE key LIKE 'agent_model:%' AND value #>> '{}' LIKE 'openai/%'"
+        )
+    )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -234,9 +234,7 @@ async def seed_note_run(session, *, note=None, state: str = "running", **kwargs)
     return await seed_run(session, kind=Summarize.kind, subject=subject, state=state, **kwargs)
 
 
-async def seed_note_agent_run(
-    *, agent: str = "implement", model: str = "openai-codex/gpt-5.5", **kwargs
-):
+async def seed_note_agent_run(*, agent: str = "implement", model: str = "openai/gpt-5.5", **kwargs):
     """A run on a fresh note with one agent call on it — the call is what the caller wants."""
     from druks.database import db_session
     from druks.testing import seed_call

--- a/backend/tests/test_api_providers.py
+++ b/backend/tests/test_api_providers.py
@@ -18,10 +18,12 @@ def _providers(client: TestClient) -> dict[str, dict]:
 
 
 def test_list_carries_login_kinds_and_no_connection(tmp_path: Path):
+    # One card per vendor; each takes a subscription and an API key.
     with _build_client(tmp_path) as client:
         providers = _providers(client)
+    assert list(providers) == ["anthropic", "openai"]
     assert providers["anthropic"]["loginKinds"] == ["api_key", "oauth"]
-    assert providers["openai-codex"]["loginKinds"] == ["oauth"]
+    assert providers["openai"]["loginKinds"] == ["api_key", "oauth"]
     assert providers["openai"]["label"] == "OpenAI"
 
 

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -27,7 +27,8 @@ def test_get_harnesses_lists_seeded_defaults(tmp_path: Path):
     with _build_client(tmp_path) as client:
         harnesses = {h["name"]: h for h in client.get("/api/settings/harnesses").json()}
     assert harnesses["claude"]["provider"] == "anthropic"
-    assert harnesses["codex"]["provider"] == "openai-codex"
+    assert harnesses["codex"]["provider"] == "openai"
+    assert harnesses["codex"]["loginKinds"] == ["api_key", "oauth"]
     assert harnesses["pi"]["provider"] is None
     assert harnesses["pi"]["loginKinds"] == ["api_key"]
     assert (harnesses["codex"]["effort"], harnesses["codex"]["timeout"]) == ("high", 1800)
@@ -90,11 +91,11 @@ def test_patch_harness_updates_fast_mode(tmp_path: Path):
 def test_patch_settings_updates_the_default_model_every_agent_inherits(tmp_path: Path):
     with _build_client(tmp_path) as client:
         assert client.get("/api/settings").json()["defaultModel"] == "anthropic/claude-opus-4-7"
-        patch = client.patch("/api/settings", json={"defaultModel": "openai-codex/gpt-5.5"})
+        patch = client.patch("/api/settings", json={"defaultModel": "openai/gpt-5.5"})
         assert patch.status_code == 200
-        assert patch.json()["defaultModel"] == "openai-codex/gpt-5.5"
+        assert patch.json()["defaultModel"] == "openai/gpt-5.5"
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-    assert agents["implement"]["model"] == "openai-codex/gpt-5.5"
+    assert agents["implement"]["model"] == "openai/gpt-5.5"
     assert agents["implement"]["source"] == "default"
 
 
@@ -375,12 +376,12 @@ def test_apps_override_agent_model_persists(tmp_path: Path):
     with _build_client(tmp_path) as client:
         patch = client.patch(
             "/api/settings/apps",
-            json={"agentModels": {"implement": "openai-codex/gpt-5.5"}},
+            json={"agentModels": {"implement": "openai/gpt-5.5"}},
         )
         assert patch.status_code == 200
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
 
-    assert agents["implement"]["model"] == "openai-codex/gpt-5.5"
+    assert agents["implement"]["model"] == "openai/gpt-5.5"
     assert agents["implement"]["source"] == "agent"
 
 

--- a/backend/tests/test_api_usage.py
+++ b/backend/tests/test_api_usage.py
@@ -49,7 +49,7 @@ def _provider(body: dict, provider_id: str) -> dict:
     return next(entry for entry in body["providers"] if entry["id"] == provider_id)
 
 
-async def _seed_agent_call(druks_db, *, model: str = "openai-codex/gpt-5.5"):
+async def _seed_agent_call(druks_db, *, model: str = "openai/gpt-5.5"):
     note = await Note.create(body="usage accounting")
     run = await seed_run(druks_db, kind=Summarize.kind, subject=note)
     return await seed_call(druks_db, run, "summarize", status="running", model=model)
@@ -78,7 +78,7 @@ def test_get_usage_empty_returns_available_false(client) -> None:
     assert response.status_code == 200
     body = response.json()
     # One entry per registered provider, none available pre-first-poll.
-    assert {entry["id"] for entry in body["providers"]} == {"anthropic", "openai", "openai-codex"}
+    assert {entry["id"] for entry in body["providers"]} == {"anthropic", "openai"}
     assert all(entry["available"] is False for entry in body["providers"])
 
 
@@ -102,7 +102,7 @@ async def test_get_usage_presents_api_key_connection_as_unmetered(client, druks_
 
 
 async def test_get_usage_serializes_latest_per_provider(client, app_settings) -> None:
-    # Plant a snapshot for anthropic only — openai-codex should still report
+    # Plant a snapshot for anthropic only — openai should still report
     # ``available=false`` rather than missing-key/404.
     await _seed(
         [
@@ -137,7 +137,7 @@ async def test_get_usage_serializes_latest_per_provider(client, app_settings) ->
     assert 30 <= claude["ageSeconds"] <= 90  # close to the planted 45s
     assert claude["stale"] is False
 
-    assert _provider(body, "openai-codex")["available"] is False
+    assert _provider(body, "openai")["available"] is False
 
 
 async def test_get_usage_flags_stale_after_24h(client, app_settings) -> None:
@@ -163,7 +163,7 @@ async def test_get_usage_exposes_unlimited_flag(client, app_settings) -> None:
     await _seed(
         [
             UsageScrape(
-                provider="openai-codex",
+                provider="openai",
                 parse_ok=True,
                 plan_tier="business",
                 five_hour_percent_left=100,
@@ -174,8 +174,8 @@ async def test_get_usage_exposes_unlimited_flag(client, app_settings) -> None:
     )
 
     body = client.get("/api/usage").json()
-    assert _provider(body, "openai-codex")["unlimited"] is True
-    assert _provider(body, "openai-codex")["fiveHour"]["percentLeft"] == 100
+    assert _provider(body, "openai")["unlimited"] is True
+    assert _provider(body, "openai")["fiveHour"]["percentLeft"] == 100
     assert _provider(body, "anthropic")["unlimited"] is False
 
 
@@ -229,14 +229,14 @@ async def test_usage_history_serializes_series_oldest_first(client, app_settings
         39,
         40,
     ]
-    assert _provider(body, "openai-codex")["fiveHour"] == []
-    assert _provider(body, "openai-codex")["weeks"] == []
+    assert _provider(body, "openai")["fiveHour"] == []
+    assert _provider(body, "openai")["weeks"] == []
 
 
 async def test_usage_today_aggregates_spend_and_tokens_by_provider(
     client, app_settings, druks_db
 ) -> None:
-    codex_run = await _seed_agent_call(druks_db, model="openai-codex/gpt-5.5")
+    codex_run = await _seed_agent_call(druks_db, model="openai/gpt-5.5")
     codex_run.account_id = await _account_id()
     codex_run.cost_usd = 1.25
     codex_run.cost_metadata = {
@@ -260,17 +260,17 @@ async def test_usage_today_aggregates_spend_and_tokens_by_provider(
     claude_run.finished_at = datetime.now(UTC)
 
     # Finished yesterday — outside today's boundary, must not count.
-    old_run = await _seed_agent_call(druks_db, model="openai-codex/gpt-5.5")
+    old_run = await _seed_agent_call(druks_db, model="openai/gpt-5.5")
     old_run.cost_usd = 99.0
     old_run.finished_at = datetime.now(UTC) - timedelta(days=2)
 
     # Still running — no cost yet, counted nowhere.
-    await _seed_agent_call(druks_db, model="openai-codex/gpt-5.5")
+    await _seed_agent_call(druks_db, model="openai/gpt-5.5")
     await druks_db.flush()
 
     body = client.get("/api/usage/today").json()
 
-    codex = _provider(body, "openai-codex")
+    codex = _provider(body, "openai")
     assert codex["spendUsd"] == 1.25
     assert codex["tokens"] == 1250  # 1000 input + (200 + 50) output
     assert codex["runs"] == 1

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -142,7 +142,7 @@ async def test_provider_list_answers_before_an_account_exists(druks_client):
     assert [item["id"] for item in body] == [provider.id for provider in get_providers()]
     by_id = {item["id"]: item for item in body}
     assert by_id["anthropic"]["loginKinds"] == ["api_key", "oauth"]
-    assert by_id["openai-codex"]["loginKinds"] == ["oauth"]
+    assert by_id["openai"]["loginKinds"] == ["api_key", "oauth"]
     assert not await Account.list_non_system()
 
 

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -295,7 +295,6 @@ async def test_run_checks_covers_all_check_names(tmp_path: Path) -> None:
         "review:settings",
         "anthropic_login",
         "openai_login",
-        "openai-codex_login",
         "data_dir",
         "database",
         "redis",
@@ -308,7 +307,7 @@ def test_logins_pending_when_not_connected(tmp_path: Path) -> None:
     # No login rows committed => every provider reads as not connected.
     settings = make_settings(tmp_path)
 
-    result = _named(doctor.check_provider_logins(settings), "openai-codex_login")
+    result = _named(doctor.check_provider_logins(settings), "openai_login")
 
     assert not result.ok
     assert result.pending

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -14,7 +14,7 @@ from druks.harnesses.datastructures import (
 )
 from druks.harnesses.exceptions import HarnessNotConnectedError
 from druks.harnesses.models import ProviderLogin
-from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
+from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
 from druks.sandbox.datastructures import HomeCopy
 
 
@@ -43,7 +43,7 @@ async def _seed_codex(*, provider_email="op@example.com", account_id="acc-1") ->
     access = _jwt(int((datetime.now(UTC) + timedelta(days=9)).timestamp()))
     tokens = {"access_token": access, "refresh_token": "R0", "account_id": account_id}
     return await connect_provider(
-        OpenAiCodexProvider,
+        OpenAiProvider,
         {"auth_mode": "chatgpt", "OPENAI_API_KEY": None, "tokens": tokens},
         provider_email=provider_email,
     )

--- a/backend/tests/test_harness_model_routing.py
+++ b/backend/tests/test_harness_model_routing.py
@@ -4,18 +4,26 @@ from druks.harnesses.codex import CodexHarness
 from druks.harnesses.exceptions import UnknownModelError
 from druks.harnesses.models import ProviderLogin
 from druks.harnesses.opencode import OpenCodeHarness
+from druks.harnesses.pi import PiHarness
 from druks.harnesses.registry import get_harness_for_model
 
 
 def test_the_namespace_selects_the_first_harness_with_its_provider():
     assert get_harness_for_model("anthropic/claude-opus-4-7") is ClaudeHarness
-    assert get_harness_for_model("openai-codex/gpt-5.5") is CodexHarness
-    assert get_harness_for_model("openai/gpt-5.5") is OpenCodeHarness
+    assert get_harness_for_model("openai/gpt-5.5") is CodexHarness
 
 
 def test_a_login_selects_among_the_harnesses_with_its_provider():
+    # The vendor's own CLI takes either kind of its provider's login; a
+    # key-only CLI is reached only by a provider no vendor CLI is bound to.
     assert ProviderLogin(provider="anthropic", kind="oauth").get_harness() is ClaudeHarness
-    assert ProviderLogin(provider="anthropic", kind="api_key").get_harness() is OpenCodeHarness
+    assert ProviderLogin(provider="anthropic", kind="api_key").get_harness() is ClaudeHarness
+    assert ProviderLogin(provider="openai", kind="oauth").get_harness() is CodexHarness
+    assert ProviderLogin(provider="openai", kind="api_key").get_harness() is CodexHarness
+    assert not any(
+        harness.accepts(ProviderLogin(provider="anthropic", kind="oauth"))
+        for harness in (OpenCodeHarness, PiHarness)
+    )
     with pytest.raises(UnknownModelError, match="anthropic on a device login"):
         ProviderLogin(provider="anthropic", kind="device").get_harness()
 

--- a/backend/tests/test_harness_reasoning_flags.py
+++ b/backend/tests/test_harness_reasoning_flags.py
@@ -1,9 +1,11 @@
+import json
+
 import pytest
 from conftest import connect_provider
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.models import ProviderLogin
-from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
+from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
 
 _CODEX_MODEL = CodexHarness.default_model
 
@@ -13,7 +15,7 @@ async def _connected_harnesses(druks_db):
     # build_invocation renders each login bundle from the DB row and
     # raises when that harness isn't connected.
     await connect_provider(AnthropicProvider, {"claudeAiOauth": {"accessToken": "t"}})
-    await connect_provider(OpenAiCodexProvider, {"tokens": {"access_token": "t"}})
+    await connect_provider(OpenAiProvider, {"tokens": {"access_token": "t"}})
 
 
 def _sandbox_config():
@@ -104,7 +106,7 @@ async def test_codex_build_invocation_carries_every_flag():
         effort="high",
         sandbox=_sandbox_config(),
     ).build_invocation(
-        login=await ProviderLogin.lookup("openai-codex", None),
+        login=await ProviderLogin.lookup("openai", None),
         prompt="hello",
         schema={"type": "object"},
         run_id="run-1",
@@ -152,6 +154,44 @@ async def test_codex_build_invocation_carries_every_flag():
     assert "CODEX_HOME" not in wrapper
     assert inv.env == {"TOK": "secret"}
     assert inv.extra_artifact_filenames == ("output.json", "session.jsonl")
+
+
+def _key_login(provider: str) -> ProviderLogin:
+    return ProviderLogin(provider=provider, kind="api_key", payload={"api_key": "sk-secret"})
+
+
+async def test_claude_runs_a_key_login_from_the_environment():
+    # A key ships as ANTHROPIC_API_KEY; no credentials file lands in the home.
+    inv = await ClaudeHarness(
+        model="anthropic/claude-x", fast_mode=False, effort=None, sandbox=_sandbox_config()
+    ).build_invocation(
+        login=_key_login("anthropic"),
+        prompt="hello",
+        schema={"type": "object"},
+        run_id="run-1",
+        ssh_username="exedev",
+        extra_env={"TOK": "secret"},
+    )
+    assert inv.env == {"TOK": "secret", "ANTHROPIC_API_KEY": "sk-secret"}
+    assert not any(file.path == ".claude/.credentials.json" for file in inv.credentials.home)
+    assert "sk-secret" not in inv.args[2]
+
+
+async def test_codex_runs_a_key_login_from_auth_json():
+    # The CLI reads OPENAI_API_KEY from auth.json for usage-based billing.
+    inv = await CodexHarness(
+        model=_CODEX_MODEL, fast_mode=False, effort=None, sandbox=_sandbox_config()
+    ).build_invocation(
+        login=_key_login("openai"),
+        prompt="hello",
+        schema={"type": "object"},
+        run_id="run-1",
+        ssh_username="exedev",
+    )
+    [auth] = [file for file in inv.credentials.home if file.path == ".codex/auth.json"]
+    assert json.loads(auth.content) == {"OPENAI_API_KEY": "sk-secret"}
+    assert inv.env is None
+    assert "sk-secret" not in inv.args[2]
 
 
 def test_claude_forwards_effort_value_only():

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -11,7 +11,7 @@ from druks.accounts.exceptions import AuthConfigurationError
 from druks.accounts.models import Account, PersonalAccessToken
 from druks.harnesses import providers as pbase
 from druks.harnesses.models import ProviderLogin
-from druks.harnesses.providers import AnthropicProvider
+from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
 from druks.testing import configure_app_for_test, make_settings
 from druks.user_settings.models import UserSettings
 from fastapi.testclient import TestClient
@@ -234,10 +234,11 @@ async def test_api_key_connect_stores_the_operator_identity(tmp_path, druks_db):
     assert not connection.expires_at
 
 
-async def test_api_key_connect_requires_a_declared_kind(tmp_path, druks_db):
+async def test_api_key_connect_requires_a_declared_kind(tmp_path, druks_db, monkeypatch):
+    monkeypatch.setattr(OpenAiProvider, "login_kinds", frozenset({"oauth"}))
     with _header_client(tmp_path) as client:
         response = client.post(
-            "/api/providers/openai-codex/connection",
+            "/api/providers/openai/connection",
             json={"key": "api-key-value"},
             headers={HEADER: "operator@example.com"},
         )
@@ -274,7 +275,7 @@ async def test_concurrent_setup_completions_with_one_email_converge(
     with _client(tmp_path) as client:
         # Both flows start while zero accounts exist — both unbound.
         first = client.post("/api/providers/anthropic/connection/start")
-        second = client.post("/api/providers/openai-codex/connection/start")
+        second = client.post("/api/providers/openai/connection/start")
         _mock_exchange(monkeypatch, _grant("me@example.com"))
         assert (
             client.post(
@@ -286,7 +287,7 @@ async def test_concurrent_setup_completions_with_one_email_converge(
         _mock_exchange_codex(monkeypatch, email="me@example.com")
         assert (
             client.post(
-                "/api/providers/openai-codex/connection/complete",
+                "/api/providers/openai/connection/complete",
                 json={"code": "c2", "connectionId": second.json()["connectionId"]},
             ).status_code
             == 200
@@ -302,7 +303,7 @@ async def test_a_stale_unbound_completion_attaches_to_the_operator(tmp_path, mon
         # must attach to that operator instead of minting a rival account and
         # bricking none mode.
         first = client.post("/api/providers/anthropic/connection/start")
-        second = client.post("/api/providers/openai-codex/connection/start")
+        second = client.post("/api/providers/openai/connection/start")
         _mock_exchange(monkeypatch, _grant("a@example.com"))
         client.post(
             "/api/providers/anthropic/connection/complete",
@@ -310,7 +311,7 @@ async def test_a_stale_unbound_completion_attaches_to_the_operator(tmp_path, mon
         )
         _mock_exchange_codex(monkeypatch, email="b@example.com")
         completed = client.post(
-            "/api/providers/openai-codex/connection/complete",
+            "/api/providers/openai/connection/complete",
             json={"code": "c2", "connectionId": second.json()["connectionId"]},
         )
         assert completed.status_code == 200
@@ -318,13 +319,13 @@ async def test_a_stale_unbound_completion_attaches_to_the_operator(tmp_path, mon
         assert client.get("/api/settings").status_code == 200
     operator = await Account.get_for_username("a@example.com")
     assert len(await Account.list_non_system()) == 1
-    codex_connection = await ProviderLogin.get_for_account("openai-codex", operator.id)
+    codex_connection = await ProviderLogin.get_for_account("openai", operator.id)
     # The capability keeps its own provider identity; it never rekeys the account.
     assert codex_connection.provider_email == "b@example.com"
 
 
 async def test_a_connect_survives_a_failed_catalog_refresh(tmp_path, monkeypatch, druks_db):
-    async def _refresh_boom(cls, login):
+    async def _refresh_boom(cls):
         raise RuntimeError("picker flush failed")
 
     # The login commits before the refresh runs; a refresh failure past
@@ -363,7 +364,7 @@ async def test_first_connection_claims_the_fallback_slot_once(tmp_path, monkeypa
         _connect(
             client,
             monkeypatch,
-            provider="openai-codex",
+            provider="openai",
             email="other-seat@corp.com",
             headers={HEADER: "second@example.com"},
         )
@@ -378,14 +379,14 @@ async def test_reconnect_records_provider_email_but_keeps_the_operator(
         response = _connect(
             client,
             monkeypatch,
-            provider="openai-codex",
+            provider="openai",
             email="corp-seat@corp.com",
             headers={HEADER: "me@example.com"},
         )
         assert response.status_code == 200
         assert response.json()["username"] == "me@example.com"
     account = await Account.get_for_username("me@example.com")
-    codex = await ProviderLogin.get_for_account("openai-codex", account.id)
+    codex = await ProviderLogin.get_for_account("openai", account.id)
     assert codex.provider_email == "corp-seat@corp.com"
 
 

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -332,7 +332,7 @@ async def test_claims_resolve_the_calling_account(app, druks_db):
     _, their_token = await PersonalAccessToken.create(account_id=theirs.id, name="theirs")
     druks_db.add(
         UsageScrape(
-            provider="openai-codex",
+            provider="openai",
             account_id=mine.id,
             scraped_at=datetime.now(UTC),
             five_hour_percent_left=42,
@@ -342,12 +342,12 @@ async def test_claims_resolve_the_calling_account(app, druks_db):
 
     async with live(app), _client(app, my_token) as client:
         usage = (await client.call_tool("get_usage", {})).structured_content
-    codex = next(h for h in usage["providers"] if h["id"] == "openai-codex")
+    codex = next(h for h in usage["providers"] if h["id"] == "openai")
     assert codex["fiveHourPercentLeft"] == 42
 
     async with live(app), _client(app, their_token) as client:
         usage = (await client.call_tool("get_usage", {})).structured_content
-    codex = next(h for h in usage["providers"] if h["id"] == "openai-codex")
+    codex = next(h for h in usage["providers"] if h["id"] == "openai")
     assert codex["fiveHourPercentLeft"] is None
 
 

--- a/backend/tests/test_migration_one_openai_provider.py
+++ b/backend/tests/test_migration_one_openai_provider.py
@@ -1,0 +1,91 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from druks.accounts.models import Account
+from druks.harnesses.models import ProviderCatalog, ProviderLogin
+from druks.usage.models import UsageScrape
+from druks.user_settings.models import SettingsOverride, UserSettings
+from sqlalchemy import text
+
+# Data-only, so it runs inside the suite's rolled-back transaction against the
+# current schema.
+_MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "migrations"
+    / "versions"
+    / "4b8d2f6e9a13_one_openai_provider.py"
+)
+
+
+def _upgrade(connection) -> None:
+    spec = importlib.util.spec_from_file_location("one_openai_provider", _MIGRATION)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    with Operations.context(MigrationContext.configure(connection)):
+        module.upgrade()
+
+
+async def _run_upgrade(druks_db) -> None:
+    await druks_db.flush()
+    await (await druks_db.connection()).run_sync(_upgrade)
+
+
+async def _login(provider: str, email: str, *, kind: str) -> ProviderLogin:
+    account = await Account.get_or_create(email)
+    return await ProviderLogin.connect(
+        provider=provider,
+        account=account,
+        payload={"tokens": {"access_token": "t"}} if kind == "oauth" else {"api_key": "sk"},
+        expires_at=None,
+        provider_email=email,
+        kind=kind,
+    )
+
+
+async def _column(druks_db, statement: str) -> list:
+    return list((await druks_db.execute(text(statement))).scalars())
+
+
+async def test_openai_codex_rows_become_openai_everywhere(druks_db):
+    codex = await _login("openai-codex", "seat@example.com", kind="oauth")
+    await _login("openai", "key@example.com", kind="api_key")
+    await UsageScrape(provider="openai-codex", account_id=codex.account_id, raw_output=None).save()
+    await ProviderCatalog.store("openai-codex", [{"id": "openai-codex/gpt-5.5", "label": "sub"}])
+    await ProviderCatalog.store("openai", [{"id": "openai/gpt-5.5", "label": "key"}])
+    await (await UserSettings.get()).update_profile(default_model="openai-codex/gpt-5.5")
+    await SettingsOverride.set_agent_model("implement", "openai-codex/gpt-5-mini")
+    await SettingsOverride.set_agent_effort("implement", "openai-codex/keep")
+
+    await _run_upgrade(druks_db)
+
+    assert await _column(druks_db, "SELECT provider FROM provider_logins ORDER BY id") == [
+        "openai",
+        "openai",
+    ]
+    assert await _column(druks_db, "SELECT provider FROM usage_scrapes") == ["openai"]
+    # The subscription catalog is the one the codex CLI runs; it survives.
+    assert await _column(druks_db, "SELECT models -> 0 ->> 'label' FROM provider_catalogs") == [
+        "sub"
+    ]
+    assert await _column(druks_db, "SELECT default_model FROM user_settings") == ["openai/gpt-5.5"]
+    assert await _column(
+        druks_db, "SELECT value #>> '{}' FROM settings_overrides ORDER BY key"
+    ) == ["openai-codex/keep", "openai/gpt-5-mini"]
+
+
+async def test_an_account_holding_both_openai_logins_fails_by_name(druks_db):
+    await _login("openai-codex", "both@example.com", kind="oauth")
+    await _login("openai", "both@example.com", kind="api_key")
+
+    with pytest.raises(RuntimeError, match="both@example.com"):
+        await _run_upgrade(druks_db)
+
+
+async def test_an_unknown_provider_fails(druks_db):
+    await _login("mistral", "op@example.com", kind="api_key")
+
+    with pytest.raises(RuntimeError, match="mistral"):
+        await _run_upgrade(druks_db)

--- a/backend/tests/test_pi.py
+++ b/backend/tests/test_pi.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import shlex
 import subprocess
@@ -47,7 +48,7 @@ def _harness(*, effort: str | None = "high") -> PiHarness:
     )
 
 
-_LOGIN = SimpleNamespace(provider="openai", payload={"api_key": _API_KEY})
+_LOGIN = SimpleNamespace(provider="openai", kind="api_key", payload={"api_key": _API_KEY})
 
 
 @pytest.fixture
@@ -75,6 +76,42 @@ def test_class_facts_and_registration() -> None:
     assert PiHarness.command == "pi"
     assert PiHarness.provider is None
     assert PiHarness.login_kinds == {"api_key"}
+
+
+def test_auth_file_renders_a_key_under_the_vendor() -> None:
+    rendered = PiHarness.auth_file(
+        SimpleNamespace(provider="anthropic", kind="api_key", payload={"api_key": _API_KEY})
+    )
+    assert rendered.path == ".pi/agent/auth.json"
+    assert json.loads(rendered.content) == {"anthropic": {"type": "api_key", "key": _API_KEY}}
+
+
+def test_auth_file_renders_an_openai_subscription_as_pis_openai_codex() -> None:
+    # pi keeps the ChatGPT backend as its own provider name; the login's kind
+    # says which one it is, not the druks provider id.
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    claims = base64.urlsafe_b64encode(b'{"exp": 1800000000}').rstrip(b"=").decode()
+    login = SimpleNamespace(
+        provider="openai",
+        kind="oauth",
+        payload={
+            "tokens": {
+                "access_token": f"{header}.{claims}.sig",
+                "refresh_token": "R0",
+                "account_id": "acc-1",
+            }
+        },
+    )
+    assert json.loads(PiHarness.auth_file(login).content) == {
+        "openai-codex": {
+            "type": "oauth",
+            "access": f"{header}.{claims}.sig",
+            "refresh": "R0",
+            "expires": 1800000000000,
+            "accountId": "acc-1",
+        }
+    }
+    assert PiHarness.provider_name(login) == "openai-codex"
 
 
 async def test_build_invocation_writes_the_run_files_and_pi_argv(
@@ -183,7 +220,7 @@ async def test_build_invocation_without_servers_or_effort_is_bare(
 
 
 def test_auth_file_keys_the_login_provider() -> None:
-    login = SimpleNamespace(provider="anthropic", payload={"api_key": _API_KEY})
+    login = SimpleNamespace(provider="anthropic", kind="api_key", payload={"api_key": _API_KEY})
 
     auth = PiHarness.auth_file(login)
 

--- a/backend/tests/test_provider_auth.py
+++ b/backend/tests/test_provider_auth.py
@@ -13,7 +13,7 @@ from druks.harnesses import providers as pbase
 from druks.harnesses.datastructures import ParsedUsage
 from druks.harnesses.exceptions import HarnessNotConnectedError, OAuthTokenError
 from druks.harnesses.models import ProviderLogin
-from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
+from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
 from druks.user_settings.models import UserSettings
 
 _NOW = datetime(2026, 6, 4, 20, 0, tzinfo=UTC)
@@ -52,7 +52,7 @@ def _codex_payload(*, access=None, refresh="R0", account_id="acc-1", id_token="i
 
 async def _seed_codex(*, provider_email="op@example.com", **kwargs) -> ProviderLogin:
     return await connect_provider(
-        OpenAiCodexProvider, _codex_payload(**kwargs), provider_email=provider_email
+        OpenAiProvider, _codex_payload(**kwargs), provider_email=provider_email
     )
 
 
@@ -120,7 +120,7 @@ async def test_claude_load_token_no_access(druks_db):
 
 async def test_codex_load_token(druks_db):
     connection = await _seed_codex()
-    token = OpenAiCodexProvider.load_token(connection, now=_NOW)
+    token = OpenAiProvider.load_token(connection, now=_NOW)
     assert "." in token.access_token
     assert token.account_id == "acc-1"
 
@@ -128,7 +128,7 @@ async def test_codex_load_token(druks_db):
 async def test_codex_load_token_expired(druks_db):
     connection = await _seed_codex(access=_jwt(int((_NOW - timedelta(hours=1)).timestamp())))
     with pytest.raises(OAuthTokenError) as e:
-        OpenAiCodexProvider.load_token(connection, now=_NOW)
+        OpenAiProvider.load_token(connection, now=_NOW)
     assert e.value.tag == "token_expired"
 
 
@@ -225,10 +225,10 @@ async def test_codex_stale_refreshes_and_preserves(monkeypatch, druks_db):
     calls = _mock_post(
         monkeypatch, _resp(200, {"access_token": fresh, "refresh_token": "R1", "id_token": "id-1"})
     )
-    result = await OpenAiCodexProvider.rotate_token(connection.id, now=_NOW)
+    result = await OpenAiProvider.rotate_token(connection.id, now=_NOW)
     assert result.action == "refreshed"
     assert calls[0]["json"]["client_id"] == "app_EMoamEEZ73f0CkXaXp7hrann"
-    data = await _payload("openai-codex")
+    data = await _payload("openai")
     assert data["tokens"]["access_token"] == fresh
     assert data["tokens"]["refresh_token"] == "R1"
     assert data["tokens"]["id_token"] == "id-1"
@@ -242,15 +242,15 @@ async def test_codex_keeps_refresh_when_omitted(monkeypatch, druks_db):
     fresh = _jwt(int((_NOW + timedelta(days=10)).timestamp()))
     connection = await _seed_codex(access=stale, refresh="KEEP")
     _mock_post(monkeypatch, _resp(200, {"access_token": fresh}))
-    await OpenAiCodexProvider.rotate_token(connection.id, now=_NOW)
-    assert (await _payload("openai-codex"))["tokens"]["refresh_token"] == "KEEP"
+    await OpenAiProvider.rotate_token(connection.id, now=_NOW)
+    assert (await _payload("openai"))["tokens"]["refresh_token"] == "KEEP"
 
 
 async def test_codex_no_refresh_token(monkeypatch, druks_db):
     stale = _jwt(int((_NOW + timedelta(hours=1)).timestamp()))
     connection = await _seed_codex(refresh=None, access=stale)
     calls = _mock_post(monkeypatch, _resp(200, {}))
-    result = await OpenAiCodexProvider.rotate_token(connection.id, now=_NOW)
+    result = await OpenAiProvider.rotate_token(connection.id, now=_NOW)
     assert result.action == "no_refresh_token"
     assert calls == []
 
@@ -419,7 +419,7 @@ async def test_codex_fetch_usage_success(monkeypatch, druks_db):
         },
     }
     calls = _mock_get(monkeypatch, _resp(200, body))
-    parsed = await OpenAiCodexProvider.fetch_usage(connection, now=_NOW)
+    parsed = await OpenAiProvider.fetch_usage(connection, now=_NOW)
     assert parsed.ok is True
     assert parsed.plan_tier == "pro"
     assert parsed.five_hour.percent_left == 61
@@ -445,7 +445,7 @@ async def test_lookup_falls_back(druks_db):
 
 
 async def test_lookup_without_any_connection_raises(druks_db):
-    await _seed_codex(provider_email="a@example.com")  # the fallback account has openai-codex only
+    await _seed_codex(provider_email="a@example.com")  # the fallback account has openai only
     with pytest.raises(HarnessNotConnectedError, match="connect it in Settings"):
         await ProviderLogin.lookup("anthropic", None)
 

--- a/backend/tests/test_provider_catalogs.py
+++ b/backend/tests/test_provider_catalogs.py
@@ -8,7 +8,7 @@ from druks.accounts.models import Account
 from druks.harnesses import providers as pbase
 from druks.harnesses.exceptions import CatalogError
 from druks.harnesses.models import ProviderCatalog, ProviderLogin
-from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider, OpenAiProvider
+from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
 
 
 def _resp(status: int, body: object) -> httpx.Response:
@@ -46,7 +46,7 @@ def test_anthropic_parse_namespaces_ids_and_keeps_labels() -> None:
         }
     )
 
-    assert AnthropicProvider._parse_catalog(payload) == (
+    assert AnthropicProvider._parse_catalog(payload, kind="oauth") == (
         {"id": "anthropic/claude-fable-5", "label": "Claude Fable 5"},
         {"id": "anthropic/claude-opus-4-8", "label": "claude-opus-4-8"},
     )
@@ -62,7 +62,7 @@ def test_anthropic_parse_namespaces_ids_and_keeps_labels() -> None:
 )
 def test_anthropic_parse_names_why_a_body_offers_nothing(body, tag) -> None:
     with pytest.raises(CatalogError) as error:
-        AnthropicProvider._parse_catalog(body)
+        AnthropicProvider._parse_catalog(body, kind="oauth")
     assert error.value.tag == tag
 
 
@@ -86,9 +86,9 @@ def test_codex_parse_keeps_only_listed_models() -> None:
         }
     )
 
-    assert OpenAiCodexProvider._parse_catalog(payload) == (
+    assert OpenAiProvider._parse_catalog(payload, kind="oauth") == (
         {
-            "id": "openai-codex/gpt-5.6-sol",
+            "id": "openai/gpt-5.6-sol",
             "label": "GPT-5.6-Sol",
             "efforts": ["low", "xhigh"],
             "minimal_client_version": "0.144.0",
@@ -100,7 +100,7 @@ def test_codex_parse_empty_catalog_is_an_error() -> None:
     """A stale-low ``client_version`` yields ``200 {"models": []}`` — that must
     never read as "no models" and wipe the stored list."""
     with pytest.raises(CatalogError, match="empty_list"):
-        OpenAiCodexProvider._parse_catalog(json.dumps({"models": []}))
+        OpenAiProvider._parse_catalog(json.dumps({"models": []}), kind="oauth")
 
 
 def test_openai_parse_reads_its_models_dev_section() -> None:
@@ -111,11 +111,13 @@ def test_openai_parse_reads_its_models_dev_section() -> None:
         }
     )
 
-    assert OpenAiProvider._parse_catalog(raw) == ({"id": "openai/gpt-5.5", "label": "GPT-5.5"},)
+    assert OpenAiProvider._parse_catalog(raw, kind="api_key") == (
+        {"id": "openai/gpt-5.5", "label": "GPT-5.5"},
+    )
     with pytest.raises(CatalogError, match="unexpected_payload"):
-        OpenAiProvider._parse_catalog(json.dumps({"anthropic": {}}))
+        OpenAiProvider._parse_catalog(json.dumps({"anthropic": {}}), kind="api_key")
     with pytest.raises(CatalogError, match="empty_list"):
-        OpenAiProvider._parse_catalog(json.dumps({"openai": {"models": {}}}))
+        OpenAiProvider._parse_catalog(json.dumps({"openai": {"models": {}}}), kind="api_key")
 
 
 async def test_anthropic_fetch_uses_the_oauth_token(monkeypatch, druks_db):
@@ -149,11 +151,11 @@ async def test_anthropic_fetch_uses_the_api_key(monkeypatch, druks_db):
 
 async def test_codex_fetch_sends_the_account_header(monkeypatch, druks_db):
     tokens = {"access_token": "a.b.c", "account_id": "acc-7"}
-    login = await connect_provider(OpenAiCodexProvider, {"tokens": tokens})
+    login = await connect_provider(OpenAiProvider, {"tokens": tokens})
     calls = _mock_get(monkeypatch, _resp(200, {"models": []}))
 
     with pytest.raises(CatalogError, match="empty_list"):
-        await OpenAiCodexProvider.fetch_catalog(login)
+        await OpenAiProvider.fetch_catalog(login)
     assert calls[0]["url"] == "https://chatgpt.com/backend-api/codex/models?client_version=99.99.99"
     assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acc-7"
 
@@ -167,14 +169,57 @@ async def test_fetch_names_an_http_failure(monkeypatch, druks_db):
 
 
 async def test_refresh_stores_the_catalog_and_keeps_it_on_failure(monkeypatch, druks_db):
-    login = await _claude_login()
+    await _claude_login()
     _mock_get(monkeypatch, _resp(200, {"data": [{"id": "claude-fable-5"}]}))
-    await AnthropicProvider.refresh_catalog(login)
+    await AnthropicProvider.refresh_catalog()
     [stored] = await ProviderCatalog.list_all()
     assert stored.provider == "anthropic"
     assert stored.models == [{"id": "anthropic/claude-fable-5", "label": "claude-fable-5"}]
 
     _mock_get(monkeypatch, _resp(200, {"data": []}))
-    await AnthropicProvider.refresh_catalog(login)
+    await AnthropicProvider.refresh_catalog()
     [kept] = await ProviderCatalog.list_all()
     assert kept.models == stored.models
+
+
+async def test_refresh_without_a_login_stores_nothing(monkeypatch, druks_db):
+    calls = _mock_get(monkeypatch, _resp(200, {"data": [{"id": "claude-fable-5"}]}))
+    await AnthropicProvider.refresh_catalog()
+    assert calls == []
+    assert await ProviderCatalog.list_all() == []
+
+
+async def test_openai_refresh_reads_the_subscription_over_the_key(monkeypatch, druks_db):
+    # A key alone reads models.dev; once a subscription exists its endpoint
+    # lists what the codex CLI runs, and that catalog wins.
+    account = await Account.get_or_create("op@example.com")
+    await ProviderLogin.connect(
+        provider="openai",
+        account=account,
+        payload={"api_key": "sk-openai"},
+        expires_at=None,
+        provider_email="op@example.com",
+        kind="api_key",
+    )
+    calls = _mock_get(
+        monkeypatch,
+        _resp(200, {"openai": {"models": {"gpt-5.5": {"id": "gpt-5.5", "name": "GPT-5.5"}}}}),
+    )
+    await OpenAiProvider.refresh_catalog()
+    assert calls[0]["url"] == "https://models.dev/api.json"
+    [stored] = await ProviderCatalog.list_all()
+    assert stored.models == [{"id": "openai/gpt-5.5", "label": "GPT-5.5"}]
+
+    await connect_provider(
+        OpenAiProvider,
+        {"tokens": {"access_token": "a.b.c", "account_id": "acc-7"}},
+        provider_email="seat@example.com",
+    )
+    calls = _mock_get(
+        monkeypatch,
+        _resp(200, {"models": [{"slug": "gpt-5.6", "visibility": "list"}]}),
+    )
+    await OpenAiProvider.refresh_catalog()
+    assert calls[0]["url"].startswith("https://chatgpt.com/backend-api/codex/models")
+    [stored] = await ProviderCatalog.list_all()
+    assert [model["id"] for model in stored.models] == ["openai/gpt-5.6"]

--- a/backend/tests/test_provider_connect.py
+++ b/backend/tests/test_provider_connect.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 from druks.harnesses import providers as pbase
 from druks.harnesses.exceptions import ConnectError
-from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
+from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
 
 
 def _jwt(claims: dict) -> str:
@@ -113,7 +113,7 @@ async def test_connect_complete_without_provider_email_raises(monkeypatch, druks
 
 
 async def test_codex_connect_complete_is_form_encoded_and_reads_jwt(monkeypatch, druks_db):
-    _, flow_id = await OpenAiCodexProvider.connect_start()
+    _, flow_id = await OpenAiProvider.connect_start()
     pending = await _pending(flow_id)
     access = _jwt(
         {
@@ -125,7 +125,7 @@ async def test_codex_connect_complete_is_form_encoded_and_reads_jwt(monkeypatch,
     calls = _mock_post(
         monkeypatch, _resp(200, {"access_token": access, "refresh_token": "RT", "id_token": "ID"})
     )
-    completed = await OpenAiCodexProvider.connect_complete(
+    completed = await OpenAiProvider.connect_complete(
         flow_id=flow_id,
         pasted=f"http://localhost:1455/auth/callback?code=thecode&state={pending['state']}",
     )

--- a/backend/tests/test_provider_usage_parsing.py
+++ b/backend/tests/test_provider_usage_parsing.py
@@ -1,7 +1,7 @@
 import json
 from datetime import UTC, datetime
 
-from druks.harnesses.providers import AnthropicProvider, OpenAiCodexProvider
+from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
 
 
 def test_claude_parse_keeps_every_weekly_limit_in_provider_order() -> None:
@@ -69,7 +69,7 @@ def test_claude_parse_falls_back_to_seven_day_without_limits() -> None:
 
 
 def test_codex_parse_keeps_every_weekly_limit_in_provider_order() -> None:
-    parsed = OpenAiCodexProvider._parse_usage(
+    parsed = OpenAiProvider._parse_usage(
         json.dumps(
             {
                 "plan_type": "prolite",
@@ -116,7 +116,7 @@ def test_codex_parse_treats_unlimited_credits_as_full_buckets() -> None:
         }
     )
 
-    parsed = OpenAiCodexProvider._parse_usage(payload)
+    parsed = OpenAiProvider._parse_usage(payload)
 
     assert parsed.ok
     assert parsed.plan_tier == "business"
@@ -128,7 +128,7 @@ def test_codex_parse_treats_unlimited_credits_as_full_buckets() -> None:
 def test_codex_parse_reads_a_group_spend_control_as_a_weekly_window() -> None:
     """Under group-based spend controls a business account carries no windows —
     the spend quota is the metered limit, on a cycle that runs weeks."""
-    parsed = OpenAiCodexProvider._parse_usage(
+    parsed = OpenAiProvider._parse_usage(
         json.dumps(
             {
                 "plan_type": "business",
@@ -161,7 +161,7 @@ def test_codex_parse_reads_a_group_spend_control_as_a_weekly_window() -> None:
 
 def test_codex_parse_places_a_weekly_only_plan_in_the_week_window() -> None:
     """A plan whose only quota is weekly reports it as the primary window."""
-    parsed = OpenAiCodexProvider._parse_usage(
+    parsed = OpenAiProvider._parse_usage(
         json.dumps(
             {
                 "plan_type": "prolite",
@@ -183,7 +183,7 @@ def test_codex_parse_places_a_weekly_only_plan_in_the_week_window() -> None:
 
 
 def test_codex_parse_rejects_an_unreadable_window() -> None:
-    parsed = OpenAiCodexProvider._parse_usage(
+    parsed = OpenAiProvider._parse_usage(
         json.dumps(
             {
                 "plan_type": "pro",
@@ -203,7 +203,7 @@ def test_codex_parse_rejects_an_unreadable_window() -> None:
 
 
 def test_codex_parse_still_fails_without_windows_or_unlimited() -> None:
-    parsed = OpenAiCodexProvider._parse_usage(
+    parsed = OpenAiProvider._parse_usage(
         json.dumps({"plan_type": "plus", "rate_limit": None, "credits": {"unlimited": False}})
     )
 

--- a/backend/tests/test_usage_poll.py
+++ b/backend/tests/test_usage_poll.py
@@ -71,7 +71,7 @@ async def test_successful_fetch_persists_per_provider(druks_db) -> None:
     results = await _poll(
         _provider("anthropic", lambda: _usage(five=_metric(84), weeks=(_metric(52),))),
         _provider(
-            "openai-codex",
+            "openai",
             lambda: _usage(plan_tier="prolite", five=_metric(61), weeks=(_metric(61),)),
         ),
     )
@@ -87,7 +87,7 @@ async def test_successful_fetch_persists_per_provider(druks_db) -> None:
         {"percent_left": 52, "resets_at": None, "model": None},
     ]
 
-    codex_row = await UsageScrape.latest_for("openai-codex", (await _connection()).account_id)
+    codex_row = await UsageScrape.latest_for("openai", (await _connection()).account_id)
     assert codex_row is not None
     assert codex_row.plan_tier == "prolite"
     assert codex_row.weeks[0]["percent_left"] == 61
@@ -125,7 +125,7 @@ async def test_claude_weekly_windows_survive_parse_and_poll_in_order(druks_db) -
 async def test_credential_error_records_error_snapshot(druks_db) -> None:
     results = await _poll(
         _provider("anthropic", lambda: _usage(ok=False, error="token_expired")),
-        _provider("openai-codex", lambda: _usage(ok=False, error="no_credentials")),
+        _provider("openai", lambda: _usage(ok=False, error="no_credentials")),
     )
     await druks_db.flush()
     assert all(r["status"] == "recorded" for r in results)
@@ -142,7 +142,7 @@ async def test_fetch_crash_writes_crash_snapshot(druks_db) -> None:
     def boom() -> ParsedUsage:
         raise RuntimeError("boom")
 
-    results = await _poll(_provider("anthropic", boom), _provider("openai-codex", boom))
+    results = await _poll(_provider("anthropic", boom), _provider("openai", boom))
     await druks_db.flush()
     assert all(r["status"] == "errored" and r["error"] == "crashed" for r in results)
 
@@ -154,7 +154,7 @@ async def test_fetch_crash_writes_crash_snapshot(druks_db) -> None:
 async def test_snapshot_persists_unlimited_flag(druks_db) -> None:
     await _poll(
         _provider(
-            "openai-codex",
+            "openai",
             lambda: _usage(
                 plan_tier="business",
                 five=_metric(100),
@@ -165,7 +165,7 @@ async def test_snapshot_persists_unlimited_flag(druks_db) -> None:
     )
     await druks_db.flush()
 
-    row = await UsageScrape.latest_for("openai-codex", (await _connection()).account_id)
+    row = await UsageScrape.latest_for("openai", (await _connection()).account_id)
     assert row is not None
     assert row.unlimited is True
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -264,13 +264,19 @@ optional. It reports pending setup if the selected tracker lacks a connection.
 
 ## Harnesses
 
-Anthropic and ChatGPT subscription credentials connect from **Settings → Providers**.
-The connection flow stores each credential in Postgres. Druks refreshes the
-credential on a schedule. It creates the CLI credential file inside each
-sandbox. It does not copy a host login. This is a capability connection for
+Druks registers two providers, `anthropic` and `openai`. Each accepts a
+subscription login (Claude or ChatGPT) and an API key. Both connect from
+**Settings → Providers**. The connection flow stores each credential in
+Postgres. Druks refreshes a subscription token on a schedule. It creates the
+CLI credential file inside each sandbox, or passes the key in the CLI
+environment. It does not copy a host login. This is a capability connection for
 the requesting account — in a fresh `none`-mode install the first completed
-connection also creates the operator account (see
+subscription connection also creates the operator account (see
 [access control](#public-urls-and-access-control)).
+
+The `claude` and `codex` CLIs run on either login kind of their own vendor.
+`opencode` and `pi` run on an API key only. A model id is `provider/model`
+on either kind, for example `openai/gpt-5.5`.
 
 Process settings such as `DRUKS_CLAUDE_CONFIG_DIR` and
 `DRUKS_CODEX_CONFIG_DIR` point at optional non-auth CLI configuration to carry

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -134,9 +134,9 @@ Examine the MCP path:
 
 ### Harness not connected or expired
 
-Open **Settings → Providers** and reconnect the selected Anthropic or ChatGPT
-harness. Host CLI logins do not count. Druks validates the database credential
-before provisioning a sandbox.
+Open **Settings → Providers** and reconnect the Anthropic or OpenAI login the
+model's provider needs, a subscription or an API key. Host CLI logins do not
+count. Druks validates the database credential before provisioning a sandbox.
 
 ### Model has no harness
 

--- a/frontend/src/components/Onboarding.test.tsx
+++ b/frontend/src/components/Onboarding.test.tsx
@@ -6,7 +6,7 @@ import { Onboarding } from './Onboarding'
 
 const REGISTERED_PROVIDERS: Provider[] = [
   { id: 'anthropic', label: 'Anthropic', loginKinds: ['api_key', 'oauth'] },
-  { id: 'openai-codex', label: 'ChatGPT', loginKinds: ['oauth'] },
+  { id: 'openai', label: 'OpenAI', loginKinds: ['api_key', 'oauth'] },
 ]
 
 afterEach(() => {
@@ -49,7 +49,7 @@ describe('Onboarding', () => {
       vi.fn(async (url: string | URL | Request) => {
         const path = String(url)
         if (path === '/api/providers') return providerListResponse(REGISTERED_PROVIDERS)
-        expect(path).toBe('/api/providers/openai-codex/connection/start')
+        expect(path).toBe('/api/providers/openai/connection/start')
         return new Response(
           JSON.stringify({ authorizeUrl: 'https://x/auth', connectionId: 'C1' }),
           { status: 200 },
@@ -58,7 +58,7 @@ describe('Onboarding', () => {
     )
 
     render(<Onboarding onConnected={() => undefined} />)
-    fireEvent.click(await screen.findByText('Connect ChatGPT'))
+    fireEvent.click(await screen.findByText('Connect OpenAI'))
     await flush()
 
     // The challenge panel replaces both cards, not just its own.
@@ -71,15 +71,12 @@ describe('Onboarding', () => {
   })
 
   it('renders one card per subscription provider; a key-only provider waits for Settings', async () => {
-    stubProviderList([
-      ...REGISTERED_PROVIDERS,
-      { id: 'openai', label: 'OpenAI', loginKinds: ['api_key'] },
-    ])
+    stubProviderList([...REGISTERED_PROVIDERS, { id: 'xai', label: 'xAI', loginKinds: ['api_key'] }])
 
     render(<Onboarding onConnected={() => undefined} />)
 
-    await screen.findByText('Connect ChatGPT')
-    expect(screen.queryByText('Connect OpenAI')).toBeNull()
+    await screen.findByText('Connect OpenAI')
+    expect(screen.queryByText('Connect xAI')).toBeNull()
     expect(screen.getAllByRole('button')).toHaveLength(2)
   })
 })

--- a/frontend/src/components/ProviderConnect.test.tsx
+++ b/frontend/src/components/ProviderConnect.test.tsx
@@ -64,8 +64,8 @@ describe('ProviderConnect', () => {
       providerEmail: 'claude-seat@corp.com',
       expiresAt: null,
     })
-    renderCard(provider({ id: 'openai-codex', label: 'ChatGPT' }), {
-      provider: 'openai-codex',
+    renderCard(provider({ id: 'openai', label: 'OpenAI' }), {
+      provider: 'openai',
       kind: 'oauth',
       connected: true,
       providerEmail: 'codex-seat@corp.com',

--- a/frontend/src/components/UsagePill.tsx
+++ b/frontend/src/components/UsagePill.tsx
@@ -27,7 +27,7 @@ import type { UsageProviderSummary } from '../api/types'
  */
 
 // One-letter pill labels; unknown providers fall back to their first letter.
-const SHORT_LABELS: Record<string, string> = { anthropic: 'a', 'openai-codex': 'x', openai: 'o' }
+const SHORT_LABELS: Record<string, string> = { anthropic: 'a', openai: 'o' }
 
 export function UsagePill() {
   const { data, isLoading, isError } = useUsage()


### PR DESCRIPTION
PR 1 of 3 in the Providers/Agents redesign. Base: `main`. Linear: [DRU-414](https://linear.app/fellaworks/issue/DRU-414/one-openai-provider-claude-and-codex-accept-api-key-logins).

## What

- `openai-codex` folds into `openai` as its `oauth` login kind. `OpenAiCodexProvider` is deleted; its ChatGPT connect, refresh, usage, and catalog hooks move onto `OpenAiProvider`, which now declares `{oauth, api_key}`. Model ids are `openai/<model>` on either billing. `is_metered` stays `kind == "oauth"`.
- `fetch_catalog` reads the ChatGPT models endpoint over a subscription login and models.dev over a key. `Provider.refresh_catalog()` now chooses the login itself, a subscription before a key, so there is one `provider_catalogs` row per provider and one place that says which login fills it. The daily task and both connect routes call it with no argument.
- `claude` and `codex` accept both login kinds. A codex key login renders `auth.json` as `{"OPENAI_API_KEY": key}`. A claude key login ships `ANTHROPIC_API_KEY` in the run environment and writes no credentials file. `opencode` and `pi` stay key-only.
- `pi` renders its own `openai-codex` provider name for an OpenAI subscription login from `login.kind`, not the druks provider id, in both `auth.json` and `--provider`.
- Migration `4b8d2f6e9a13` (data only, new head after `c9d1e3f5a7b2`): renames `openai-codex` to `openai` in `provider_logins`, `usage_scrapes`, `provider_catalogs` (the subscription catalog wins when both exist), `user_settings.default_model`, and `settings_overrides` values under `agent_model:*`. It fails naming the account when one holds both an `openai-codex` and an `openai` row, and fails on any other unknown provider id.
- SPA: the usage pill's short labels drop the `openai-codex` entry; the Providers pane shows two cards by itself. Test fixtures use the new id.
- Docs: `configuration.md` names the two providers and which CLIs run on which kind; `troubleshooting.md` login wording.

## Why

OpenAI is one vendor. The ChatGPT backend is a detail of the subscription login, the same shape `AnthropicProvider` already has. Only the vendor's own CLI ever runs on a subscription, and it should also run on the vendor's key.

## Tests

Provider registry (two entries, kinds), codex and claude invocation on a key login (argv, env, files), pi render on both kinds, catalog preference, and the migration on seeded rows including the conflict and unknown-provider cases.

## Gates

- `uv run ruff check backend && uv run ruff format --check backend`: pass
- Touched backend test files (19 files, 210 tests): pass. The full suite runs in CI.
- `npm --prefix frontend run lint && npm --prefix frontend test && npm --prefix frontend run build`: pass (255 tests)

## Left out

Nothing from the ticket. Shared API key is PR 2; Agents page, billing per agent, HarnessSettings removal are PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
