### PR TITLE
DRU-366: Stop naming two harnesses in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@
 > before version 1.0. `main` and `latest` contain edge builds. They are not
 > stable releases.
 
-Druks is a self-hosted **home for durable agent apps**. It runs agents with the
-Claude and Codex subscriptions that you already use. Druks includes Software
-Factory. This app automates software delivery from a ticket to a reviewed pull
-request.
+Druks is a self-hosted **home for durable agent apps**. It runs agents through
+connected harnesses. The included Software Factory app automates software
+delivery from a ticket to a reviewed pull request.
 
 An ordinary agent script loses its place when the process dies. A Druks
 workflow records the result of each completed durable operation in Postgres.
@@ -79,7 +78,7 @@ prerequisites, access control, verification, and rollback.
 ```text
 trigger ──> app workflow ──> durable step ──> agent ──> sandbox
                  │                     │              │
-                 │                     │              └─ Claude or Codex harness
+                 │                     │              └─ harness CLI
                  │                     └─ result checkpointed in Postgres
                  ├─ event ──> feed / app reaction
                  └─ gate  ──> wait for human or external system ──> resume
@@ -91,7 +90,7 @@ Druks owns the execution and operating substrate:
 
 - DBOS workflows and queues that use Postgres
 - Typed human gates, cancellation, schedules, and observable run state
-- Claude and Codex harness dispatch through isolated Drukbox sandboxes
+- Agent harness dispatch through isolated Drukbox sandboxes
 - Append-only events, live feeds, webhooks, notifications, MCP servers, and skills
 - Validated operator settings, encrypted MCP and OAuth secrets, and the dashboard shell
 - App discovery, API namespaces, and independent migration histories.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -39,7 +39,7 @@ name must match `App.name`. The same name scopes:
 ### Druks owns
 
 - Durable execution, queues, schedules, run state, cancellation, and gates
-- Agent descriptors, Claude and Codex harness dispatch, and sandbox access
+- Agent descriptors, harness dispatch, and sandbox access
 - Subject timelines, the event feed, signals, webhook dispatch, and notifications
 - MCP and skill delivery, settings, MCP secret encryption, and diagnostics
 - The FastAPI server, shared dashboard shell, and app loading.
@@ -143,7 +143,7 @@ These terms describe different ownership layers:
 | Layer | Responsibility |
 | --- | --- |
 | Agent | App-owned prompt, output contract, and run timeout |
-| Harness | Platform adapter that invokes the Claude or Codex CLI for a model |
+| Harness | Platform adapter that invokes an agent CLI for a model |
 | Workspace | App customization of what a call receives, such as a cloned repository |
 | Sandbox | Drukbox-provisioned isolated host where the harness process runs |
 | Provider | A Drukbox backend name that supplies the host. `docker` and `exe` select install shapes |
@@ -197,9 +197,9 @@ Harness subscription payloads and notification webhook URLs do not use that
 encryption envelope. They are standard Postgres fields. The API withholds or
 masks their values. Thus, database and backup access is credential access.
 
-Druks injects enabled MCP servers through both harnesses. A call receives the
-enabled skills it requests, or every enabled skill when it requests none. A
-workspace can also require an MCP server and supply its credentials.
+Druks injects enabled MCP servers through the selected harness. A call receives
+the enabled skills it requests, or every enabled skill when it requests none.
+A workspace can also require an MCP server and supply its credentials.
 Each agent call records its declarations and delivery so later evaluation can
 distinguish capability sets without storing the tokens.
 
@@ -228,7 +228,7 @@ webhooks and the token-authenticated notification response.
 
 The PAT-authenticated
 `/mcp` endpoint also stays outside the gate. Each route keeps its own
-authentication. A Claude or Codex connection adds a capability to the current
+authentication. A harness connection adds a capability to the current
 account. It is not a login. See
 [configuration](configuration.md#public-urls-and-access-control) for the
 trust requirements. The edge must remove client-supplied copies of the identity

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -394,9 +394,9 @@ is one of:
 - A token from a named process environment variable
 - An OAuth connection, which requires `urls.endpoint`.
 
-Druks delivers enabled servers to both harnesses unless an app workspace
-owns a required server with the same name. Tokens enter the agent environment
-under a derived variable and are never returned by the API.
+Druks delivers enabled servers through the selected harness unless an app
+workspace owns a required server with the same name. Tokens enter the agent
+environment under a derived variable and are never returned by the API.
 
 ## Skills
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -110,19 +110,21 @@ docker compose ps
 curl -fsS http://127.0.0.1:8001/health
 ```
 
-Then connect Anthropic and ChatGPT from **Settings → Providers → Connect**. Each card
-opens the provider authorization page. Paste the returned code into the card.
-Subscription tokens live in the database, not in a host CLI login. Agent runs
-do not start with a disconnected harness.
+Then connect the providers for your selected harnesses from
+**Settings → Providers**. Use a subscription or API key, as each provider
+supports. A subscription connection opens the provider authorization page.
+Paste the returned code into the card. Credentials live in the database, not
+in a host CLI login. Agent runs do not start when the selected harness has no
+connected provider.
 
-After both connections:
+After you connect the required providers:
 
 ```bash
 docker compose exec web druks doctor
 ```
 
 Each configured check must pass. You can run the command before you connect the
-harnesses. In that state, both harness credential checks report errors.
+harnesses. In that state, each disconnected harness reports a credential error.
 
 ### 4. Expose the public surfaces
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,7 +74,7 @@ contains the built SPA and serves it from FastAPI.
 | `backend/druks/ui/` | Page declarations, the block/value/field catalog, the page API |
 | `backend/druks/events/`, `signals.py` | Event log, feed, and reactions |
 | `backend/druks/webhooks/` | Authenticated delivery framework and deduplication |
-| `backend/druks/harnesses/` | Claude/Codex invocation, auth, usage, capability manifests |
+| `backend/druks/harnesses/` | Harness invocation, authentication, usage, and capability manifests |
 | `backend/druks/sandbox/` | Drukbox lifecycle, SSH execution, workspace delivery |
 | `backend/druks/api/` | FastAPI composition and platform routes |
 | `backend/druks/{mcp,skills,notifications,user_settings}/` | Shared operator services |

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -76,14 +76,15 @@ Success means the Compose services are up and the health endpoint returns
 
 ## 3. Connect agent harnesses
 
-Open **Settings → Providers** in the dashboard and connect Anthropic and ChatGPT.
-Druks stores those subscription credentials in Postgres and writes a fresh
-credential file into each sandbox. It does not use host CLI login files.
+Open **Settings → Providers** in the dashboard. Connect the providers for your
+selected harnesses with a subscription or API key, as each provider supports.
+Druks stores the credentials in Postgres and sends fresh credentials to each
+sandbox. It does not use host CLI login files.
 The local profile uses `[identity].mode = "none"`. It has no browser
 authentication and exactly one operator account.
 
 A new installation shows its
-setup page until the first provider connection completes. That connection
+setup page until the first subscription connection completes. That connection
 creates the operator account from the provider-verified email. Protect database
 access and backups as credential data. Harness payloads do not use the
 `[secrets].secrets_key` envelope that protects MCP tokens and OAuth grants.
@@ -100,7 +101,8 @@ docker compose exec web druks doctor
 ```
 
 Each configured check must be green. You can run this command before you connect
-the harnesses. The Claude and Codex credential checks will fail in that state.
+the harnesses. In that state, each disconnected harness reports a credential
+error.
 
 To prove the full sandbox path rather than only Drukbox's control-plane health:
 
@@ -152,7 +154,7 @@ development Druks environment and invoke its documented trigger or
 
 `[sandbox].image` selects the image Drukbox starts. The shipped
 `ghcr.io/czpython/druks/sandbox:latest` image contains the non-root `druks`
-user plus Git, GitHub CLI, Node, Claude, and Codex.
+user plus Git, GitHub CLI, Node, and the supported agent CLIs.
 
 If you change the sandbox, build the image from the repository:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,7 +12,7 @@ not require public ingress.
 
 - Docker with the Compose plugin
 - Sufficient Docker capacity for the stack and short-lived sandbox containers
-- A Claude or Codex subscription to run an agent.
+- A subscription or API key for a supported agent harness.
 
 ## Install
 
@@ -24,7 +24,7 @@ curl -fsSL https://druks.ai/install.sh | bash
 
 The installer creates `~/druks` and generates the local secrets. Then it applies
 database migrations, pulls the images, and starts the stack. It does not read
-or reuse Claude or Codex credentials from your host.
+or reuse agent harness credentials from your host.
 
 Make sure that the services and API operate:
 
@@ -44,9 +44,10 @@ Open the dashboard at [http://127.0.0.1:8001](http://127.0.0.1:8001).
 
 ## Connect a provider
 
-Open **Settings → Providers** and connect Anthropic or ChatGPT. The provider validates
-the subscription. Druks stores the connection in Postgres. The first harness
-connection completes the setup of a new local installation.
+Open **Settings → Providers** and connect a provider for your selected harness.
+Use a subscription or API key, as the provider supports. Druks stores the
+connection in Postgres. The first subscription connection completes the setup
+of a new local installation.
 
 Run the platform preflight:
 


### PR DESCRIPTION
## Summary

- Replace stale Claude-and-Codex pair wording with registry-driven harness language.
- Document subscription and API-key connections without fixing the general guidance to named harnesses.
- Remove other two-harness assumptions from the public docs and sandbox image description.

Linear: [DRU-366](https://linear.app/fellaworks/issue/DRU-366/onboarding-and-docs-stop-naming-two-harnesses)

## Verification

- `PYTHONPATH=backend uv run python -c ...` returned `claude`, `codex`, `opencode`, and `pi` with their login kinds.
- `rg -n -i "claude (and|or) codex" README.md docs/` returned no matches.
- The broader two-harness wording scan returned no matches.
- `git diff --check` passed.
- `mint validate` and `mint broken-links --check-anchors --check-redirects` were not run because the `mint` command is not installed.
- Backend and frontend tests were not run because this change updates documentation only.