### PR TITLE
DRU-418: Use one config root for every harness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Host-run Druks development environment. Copy to `.env`; copy
-# `druks.toml.example` to `druks.toml` for authored application configuration.
+# `druks.toml.example` to `druks.toml` for authored deployment configuration.
 
 # Durable application and DBOS state. deploy/compose.dev.yaml creates druks_dev
 # for the app and a separate druks database rebuilt by pytest.
@@ -24,14 +24,13 @@ SLACK_SIGNING_SECRET=
 
 DRUKS_SANDBOX_KEYS_DIR=~/.druks/sandbox-keys
 
-# Optional non-auth CLI configuration copied into sandboxes. Subscription
-# credentials are connected in the dashboard and stored in Postgres.
-DRUKS_CLAUDE_CONFIG_DIR=~/.claude
-DRUKS_CODEX_CONFIG_DIR=~/.codex
+# Optional harness configuration copied into sandboxes. Provider credentials
+# are connected in the dashboard and stored in Postgres.
+DRUKS_HARNESS_CONFIG_ROOT=~/.config/druks/harnesses
 
 # Optional shared skills root. Omit to use DRUKS_DATA_DIR/skills.
 # DRUKS_SKILLS_DIR=~/.druks/skills
 
-# Optional deployment-owned MCP catalog. Omit to use the packaged catalog
-# (Linear OAuth declared but disabled); do not set this to a blank path.
+# Optional deployment-owned MCP catalog. Omit to use the empty packaged catalog.
+# Do not set this to a blank path.
 # DRUKS_MCP_CATALOG=/path/to/catalog.json

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,7 +27,7 @@ curl -fsSL https://druks.ai/install.sh | bash
 
 Verification: the command exits with status 0. Its final output includes
 `docker compose up -d` and a message that the stack is up. `~/druks` contains
-`druks.toml`, `.env`, and `compose.yaml`.
+`druks.toml`, `.env`, and `compose.yaml`. The configured harness root exists.
 
 ## 3. Services are up
 
@@ -59,8 +59,8 @@ the error.
 
 Report that the installation succeeded. Tell the operator to open
 <http://127.0.0.1:8001>. Connect a provider under **Settings → Providers**.
-Agent runs do not start with a disconnected harness. Then connect the GitHub
-App that Druks uses. Run `docker compose exec web druks doctor --sandbox` to
+Agent runs require the selected provider credential. Then connect the GitHub
+App under **Settings → Services**. Run `docker compose exec web druks doctor --sandbox` to
 prove the full sandbox path with a real container.
 
 ## Local customizations

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -215,35 +215,29 @@ async def _get_credentials(
     credentials file, plus any local config, plugins, and skills.
     ``include_plugins=False`` skips the operator's plugin state, for prompts
     that use no MCP server and would otherwise die on a misconfigured plugin."""
-    config_dir = sandbox.claude_config_dir
+    config_dir = sandbox.harness_config_root / ClaudeHarness.name
     home: list[HomeFile | HomeCopy] = []
     if subscription:
         home.append(ClaudeHarness.auth_file(subscription))
-    if config_dir:
+    home += [
+        HomeCopy(".claude.json", config_dir / ".claude.json"),
+        HomeCopy(".claude/settings.json", config_dir / "settings.json"),
+        HomeCopy(".claude/CLAUDE.md", config_dir / "CLAUDE.md"),
+    ]
+    if include_plugins:
+        plugins = config_dir / "plugins"
         home += [
-            HomeCopy(".claude.json", config_dir.parent / ".claude.json"),
-            HomeCopy(".claude/settings.json", config_dir / "settings.json"),
-            HomeCopy(".claude/CLAUDE.md", config_dir / "CLAUDE.md"),
+            HomeCopy(".claude/plugins/installed_plugins.json", plugins / "installed_plugins.json"),
+            HomeCopy(
+                ".claude/plugins/known_marketplaces.json", plugins / "known_marketplaces.json"
+            ),
+            HomeCopy(".claude/plugins/marketplaces", plugins / "marketplaces"),
+            HomeCopy(".claude/plugins/cache", plugins / "cache"),
         ]
-        if include_plugins:
-            plugins = config_dir / "plugins"
-            home += [
-                HomeCopy(
-                    ".claude/plugins/installed_plugins.json", plugins / "installed_plugins.json"
-                ),
-                HomeCopy(
-                    ".claude/plugins/known_marketplaces.json", plugins / "known_marketplaces.json"
-                ),
-                HomeCopy(".claude/plugins/marketplaces", plugins / "marketplaces"),
-                HomeCopy(".claude/plugins/cache", plugins / "cache"),
-            ]
-    # Skills come from the canonical shared dir (DRUKS_SKILLS_DIR) when set;
-    # otherwise fall back to the per-CLI skills subdir.
-    skills_src = sandbox.skills_dir or (config_dir / "skills" if config_dir else None)
-    if skills_src:
-        home.append(
-            HomeCopy(".claude/skills", skills_src, excludes=await Skill.delivery_excludes(skills))
-        )
+    skills_dir = sandbox.skills_dir or config_dir / "skills"
+    home.append(
+        HomeCopy(".claude/skills", skills_dir, excludes=await Skill.delivery_excludes(skills))
+    )
     return Credentials(home=tuple(home), github_token=github_token)
 
 

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -22,6 +22,7 @@ from druks.skills.models import Skill
 
 from .artifacts import write_cost
 from .base import Harness
+from .datastructures import SandboxSettings
 from .exceptions import (
     HarnessAuthError,
     HarnessError,
@@ -174,8 +175,6 @@ def _parse_token_count_events(
             if not isinstance(usage_raw, dict):
                 continue
             usage = _normalize_usage(usage_raw)
-            if usage is None:
-                continue
             model = info.get("model") or info.get("model_name")
             yield {
                 "timestamp": ts,
@@ -184,7 +183,7 @@ def _parse_token_count_events(
             }
 
 
-def _normalize_usage(raw: dict[str, Any]) -> _Usage | None:
+def _normalize_usage(raw: dict[str, Any]) -> _Usage:
     def _num(value: Any) -> int:
         # ``bool`` is a subclass of ``int`` in Python; exclude it explicitly so
         # a stray ``true`` in the JSONL doesn't coerce to 1.
@@ -371,7 +370,8 @@ class CodexHarness(Harness):
         key: str | None = None,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
-        if not self.sandbox:
+        sandbox = self.sandbox
+        if not sandbox:
             raise HarnessError(
                 f"{self.name} harness requires sandbox settings — set "
                 "sandbox.service_url and related TOML settings.",
@@ -395,6 +395,7 @@ class CodexHarness(Harness):
             args=tuple(cmd),
             stdin=_with_final_message_note(prompt).encode("utf-8"),
             credentials=await self._get_credentials(
+                sandbox,
                 github_token=github_token,
                 skills=skills,
                 subscription=subscription,
@@ -475,31 +476,24 @@ class CodexHarness(Harness):
 
     async def _get_credentials(
         self,
+        sandbox: SandboxSettings,
         *,
         github_token: str | None,
         skills: tuple[str, ...] = (),
         subscription: ProviderSubscription | None,
         key: str | None,
     ) -> Credentials:
-        assert self.sandbox is not None  # callers guard
-        config_dir = self.sandbox.codex_config_dir
-        home: list[HomeFile | HomeCopy] = [self.auth_file(subscription, key=key)]
-        if config_dir:
-            home += [
-                HomeCopy(".codex/config.toml", config_dir / "config.toml"),
-                HomeCopy(".codex/.credentials.json", config_dir / ".credentials.json"),
-                HomeCopy(".codex/AGENTS.md", config_dir / "AGENTS.md"),
-            ]
-        # Skills from the canonical shared dir (DRUKS_SKILLS_DIR) when set — the
-        # same set pushed to ~/.claude/skills — else the per-CLI fallback. Must
-        # be real dirs (tar follows symlinks).
-        skills_src = self.sandbox.skills_dir or (config_dir / "skills" if config_dir else None)
-        if skills_src:
-            home.append(
-                HomeCopy(
-                    ".codex/skills", skills_src, excludes=await Skill.delivery_excludes(skills)
-                )
-            )
+        config_dir = sandbox.harness_config_root / self.name
+        home: list[HomeFile | HomeCopy] = [
+            self.auth_file(subscription, key=key),
+            HomeCopy(".codex/config.toml", config_dir / "config.toml"),
+            HomeCopy(".codex/.credentials.json", config_dir / ".credentials.json"),
+            HomeCopy(".codex/AGENTS.md", config_dir / "AGENTS.md"),
+        ]
+        skills_dir = sandbox.skills_dir or config_dir / "skills"
+        home.append(
+            HomeCopy(".codex/skills", skills_dir, excludes=await Skill.delivery_excludes(skills))
+        )
         return Credentials(home=tuple(home), github_token=github_token)
 
     @classmethod

--- a/backend/druks/harnesses/datastructures.py
+++ b/backend/druks/harnesses/datastructures.py
@@ -102,13 +102,9 @@ class SandboxSettings:
     service_token: str
     service_timeout: float
     image: str
-    # Local CLI config dirs the push anchors config/plugin/skills paths on; the
-    # subscription's token set itself is synthesized from the DB at push time, never
-    # read from under these. None — no local config for that CLI on this host —
-    # carries nothing, so a CLI's local config never sprays into a sandbox
-    # uninvited.
-    claude_config_dir: Path | None
-    codex_config_dir: Path | None
+    # Each harness owns one directory under this root. Missing files are not
+    # copied into the sandbox.
+    harness_config_root: Path
     # Canonical shared-skills dir pushed into both ~/.claude/skills and
     # ~/.codex/skills in the VM. ``None`` => per-CLI fallback (the skills
     # subdir of each home).
@@ -121,13 +117,11 @@ class SandboxSettings:
             service_token=settings.sandbox.service_token,
             service_timeout=settings.sandbox.timeout,
             image=settings.sandbox.image,
-            claude_config_dir=settings.claude_config_dir,
-            codex_config_dir=settings.codex_config_dir,
+            harness_config_root=settings.harness_config_root,
             skills_dir=settings.skills_dir,
         )
 
     @classmethod
     def maybe_from_settings(cls, settings: Settings) -> Self | None:
-        if not settings.sandbox.service_url:
-            return None
-        return cls.from_settings(settings)
+        if settings.sandbox.service_url:
+            return cls.from_settings(settings)

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -217,20 +217,11 @@ class Settings(BaseSettings):
         default=DEFAULT_DATA_DIR / "sandbox-keys",
         alias="DRUKS_SANDBOX_KEYS_DIR",
     )
-    # Local CLI config each harness carries into a VM at push time: Claude's
-    # ``settings.json`` / ``CLAUDE.md`` + plugin state (plus ``.claude.json`` beside the dir),
-    # Codex's ``config.toml`` / ``AGENTS.md`` / MCP ``.credentials.json``, and
-    # each CLI's ``skills`` subdir when DRUKS_SKILLS_DIR is unset. Subscription
-    # auth never reads these — logins live in the DB, written by the
-    # connect flow (Settings → Providers). Empty => carry no local config for
-    # that CLI.
-    claude_config_dir: OptionalExpandedPath = Field(  # type: ignore[assignment]
-        default=Path("~/.claude"),
-        alias="DRUKS_CLAUDE_CONFIG_DIR",
-    )
-    codex_config_dir: OptionalExpandedPath = Field(  # type: ignore[assignment]
-        default=Path("~/.codex"),
-        alias="DRUKS_CODEX_CONFIG_DIR",
+    # Each harness owns one directory under this root. Druks copies only the
+    # files that harness declares. Provider credentials come from the database.
+    harness_config_root: ExpandedPath = Field(
+        default=Path("~/.config/druks/harnesses"),
+        alias="DRUKS_HARNESS_CONFIG_ROOT",
     )
     # Canonical shared-skills directory Druks pushes into every VM, at both
     # ``~/.claude/skills`` and ``~/.codex/skills`` (the CLIs read their own

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -31,9 +31,7 @@ _OWNED_ENV_KEYS = frozenset(
         "DRUKS_POSTGRES_PASSWORD",
         "DRUKS_DATA_DIR",
         "DRUKS_UPSTREAM",
-        "DRUKS_CLAUDE_HOME",
-        "DRUKS_CODEX_HOME",
-        "DRUKS_CLAUDE_JSON",
+        "DRUKS_HARNESS_CONFIG_ROOT",
         "DRUKS_WEBHOOK_HOST",
         "DATABASE_URL",
         "REDIS_URL",
@@ -66,7 +64,7 @@ _KNOWN_TOML_KEYS = {
         "postgres_password",
         "secrets_key",
     ),
-    "paths": ("data_dir", "claude_home", "codex_home", "claude_json"),
+    "paths": ("data_dir", "harness_config_root"),
     "sandbox": (
         "provider",
         "service_url",
@@ -174,9 +172,7 @@ secrets_key = ""
 # Host paths.
 [paths]
 data_dir = ""
-claude_home = ""
-codex_home = ""
-claude_json = ""
+harness_config_root = ""
 
 # Any drukbox provider name; docker and exe select install shapes.
 [sandbox]
@@ -249,9 +245,7 @@ def _fresh_values(*, provider: str, home: str) -> tuple[tuple[tuple[str, ...], s
         (("secrets", "postgres_password"), _hex_secret()),
         (("secrets", "secrets_key"), _secrets_key()),
         (("paths", "data_dir"), f"{home.rstrip('/')}/druks-data"),
-        (("paths", "claude_home"), f"{home.rstrip('/')}/.claude"),
-        (("paths", "codex_home"), f"{home.rstrip('/')}/.codex"),
-        (("paths", "claude_json"), f"{home.rstrip('/')}/.claude.json"),
+        (("paths", "harness_config_root"), f"{home.rstrip('/')}/.config/druks/harnesses"),
         *shape,
     )
 
@@ -373,10 +367,11 @@ def _render_env(
             "DEPLOYMENT DEFAULTS",
             (
                 ("DRUKS_DATA_DIR", _get_string(config, ("paths", "data_dir"))),
+                (
+                    "DRUKS_HARNESS_CONFIG_ROOT",
+                    _get_string(config, ("paths", "harness_config_root")),
+                ),
                 ("DRUKS_UPSTREAM", "127.0.0.1:8001"),
-                ("DRUKS_CLAUDE_HOME", _get_string(config, ("paths", "claude_home"))),
-                ("DRUKS_CODEX_HOME", _get_string(config, ("paths", "codex_home"))),
-                ("DRUKS_CLAUDE_JSON", _get_string(config, ("paths", "claude_json"))),
                 ("DRUKS_WEBHOOK_HOST", _get_string(config, ("urls", "webhook_host"))),
                 ("DATABASE_URL", "sqlite+aiosqlite:////data/drukbox.db"),
                 ("REDIS_URL", "redis://127.0.0.1:6379/2"),

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -1,75 +1,34 @@
 import base64
 import json
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import AsyncMock
 
-import httpx
 import pytest
 from conftest import connect_provider
 from druks.accounts.models import Account
-from druks.harnesses import base as hbase
 from druks.harnesses.claude import ClaudeHarness, _get_credentials
 from druks.harnesses.codex import CodexHarness
-from druks.harnesses.datastructures import (
-    SandboxSettings,
-)
+from druks.harnesses.datastructures import SandboxSettings
 from druks.harnesses.exceptions import HarnessNotConnectedError
 from druks.harnesses.models import ProviderSubscription
 from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
 from druks.sandbox.datastructures import HomeCopy
 
 
-def _jwt(exp: int) -> str:
-    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
-    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=").decode()
-    return f"{header}.{payload}.sig"
-
-
-def _claude_payload(*, access="A0", refresh="R0", expires_at=None) -> dict:
-    block = {"accessToken": access, "scopes": ["user:profile"], "subscriptionType": "max"}
-    if refresh is not None:
-        block["refreshToken"] = refresh
-    if expires_at is not None:
-        block["expiresAt"] = int(expires_at.timestamp() * 1000)
-    return {"claudeAiOauth": block}
-
-
-async def _seed_claude(*, provider_email="op@example.com", **kwargs) -> ProviderSubscription:
-    return await connect_provider(
-        AnthropicProvider, _claude_payload(**kwargs), provider_email=provider_email
-    )
-
-
-async def _seed_codex(
-    *, provider_email="op@example.com", account_id="acc-1"
+async def _seed_claude(
+    *,
+    provider_email="op@example.com",
+    access="A0",
+    refresh="R0",
 ) -> ProviderSubscription:
-    access = _jwt(int((datetime.now(UTC) + timedelta(days=9)).timestamp()))
-    tokens = {"access_token": access, "refresh_token": "R0", "account_id": account_id}
+    block = {"accessToken": access, "scopes": ["user:profile"], "subscriptionType": "max"}
+    if refresh:
+        block["refreshToken"] = refresh
     return await connect_provider(
-        OpenAiProvider,
-        {"auth_mode": "chatgpt", "OPENAI_API_KEY": None, "tokens": tokens},
+        AnthropicProvider,
+        {"claudeAiOauth": block},
         provider_email=provider_email,
     )
-
-
-def _resp(status: int, body: object) -> httpx.Response:
-    text = body if isinstance(body, str) else json.dumps(body)
-    return httpx.Response(status, text=text, request=httpx.Request("GET", "https://x"))
-
-
-def _mock_get(monkeypatch, response):
-    calls = []
-
-    async def fake_get(self, url, *, headers=None, **_kwargs):
-        calls.append({"url": url, "headers": headers})
-        return response
-
-    monkeypatch.setattr(hbase.httpx.AsyncClient, "get", fake_get)
-    return calls
-
-
-def _harness() -> ClaudeHarness:
-    return ClaudeHarness(model=ClaudeHarness.default_model, fast_mode=False, effort=None)
 
 
 async def test_claude_builder_puts_db_credentials_on_the_bundle(druks_db):
@@ -79,8 +38,7 @@ async def test_claude_builder_puts_db_credentials_on_the_bundle(druks_db):
         service_token="x",
         service_timeout=30.0,
         image="x",
-        claude_config_dir=Path("/home/agent/.claude"),
-        codex_config_dir=Path("/home/agent/.codex"),
+        harness_config_root=Path("/harnesses"),
     )
     bundle = await _get_credentials(sandbox, github_token=None, subscription=subscription)
     auth = bundle.home[0]
@@ -88,51 +46,160 @@ async def test_claude_builder_puts_db_credentials_on_the_bundle(druks_db):
     assert json.loads(auth.content)["claudeAiOauth"]["accessToken"] == "live"
 
 
-async def test_credentials_builders_carry_global_instructions(druks_db):
-    claude_login = await _seed_claude()
-    codex_login = await _seed_codex()
-    claude_config_dir = Path("/home/agent/.claude")
-    codex_config_dir = Path("/home/agent/.codex")
+async def test_credentials_builders_read_their_harness_config_directories(druks_db):
+    claude_subscription = await _seed_claude()
+    far_future_expiration = 4_102_444_800
+    jwt_header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
+    jwt_payload = (
+        base64.urlsafe_b64encode(json.dumps({"exp": far_future_expiration}).encode())
+        .rstrip(b"=")
+        .decode()
+    )
+    codex_subscription = await connect_provider(
+        OpenAiProvider,
+        {
+            "auth_mode": "chatgpt",
+            "OPENAI_API_KEY": None,
+            "tokens": {
+                "access_token": f"{jwt_header}.{jwt_payload}.sig",
+                "refresh_token": "R0",
+                "account_id": "acc-1",
+            },
+        },
+    )
+    config_root = Path("/harnesses")
     sandbox = SandboxSettings(
         service_url="x",
         service_token="x",
         service_timeout=30.0,
         image="x",
-        claude_config_dir=claude_config_dir,
-        codex_config_dir=codex_config_dir,
+        harness_config_root=config_root,
     )
 
-    claude_bundle = await _get_credentials(sandbox, github_token=None, subscription=claude_login)
+    claude_bundle = await _get_credentials(
+        sandbox,
+        github_token=None,
+        subscription=claude_subscription,
+    )
     codex_bundle = await CodexHarness(
         model=CodexHarness.default_model,
         fast_mode=False,
         effort=None,
         sandbox=sandbox,
-    )._get_credentials(github_token=None, subscription=codex_login, key=None)
+    )._get_credentials(
+        sandbox,
+        github_token=None,
+        subscription=codex_subscription,
+        key=None,
+    )
 
     assert claude_bundle.home[0].path == ".claude/.credentials.json"
     assert codex_bundle.home[0].path == ".codex/auth.json"
-    assert HomeCopy(".claude/CLAUDE.md", claude_config_dir / "CLAUDE.md") in claude_bundle.home
-    assert HomeCopy(".codex/AGENTS.md", codex_config_dir / "AGENTS.md") in codex_bundle.home
+    assert HomeCopy(".claude/settings.json", config_root / "claude/settings.json") in (
+        claude_bundle.home
+    )
+    assert HomeCopy(".claude/CLAUDE.md", config_root / "claude/CLAUDE.md") in claude_bundle.home
+    assert HomeCopy(".claude.json", config_root / "claude/.claude.json") in claude_bundle.home
+    assert (
+        HomeCopy(
+            ".claude/plugins/installed_plugins.json",
+            config_root / "claude/plugins/installed_plugins.json",
+        )
+        in claude_bundle.home
+    )
+    assert (
+        HomeCopy(
+            ".claude/plugins/known_marketplaces.json",
+            config_root / "claude/plugins/known_marketplaces.json",
+        )
+        in claude_bundle.home
+    )
+    assert (
+        HomeCopy(".claude/plugins/marketplaces", config_root / "claude/plugins/marketplaces")
+        in claude_bundle.home
+    )
+    assert HomeCopy(".claude/plugins/cache", config_root / "claude/plugins/cache") in (
+        claude_bundle.home
+    )
+    assert claude_bundle.home[-1].source == config_root / "claude/skills"
+    assert HomeCopy(".codex/config.toml", config_root / "codex/config.toml") in codex_bundle.home
+    assert (
+        HomeCopy(".codex/.credentials.json", config_root / "codex/.credentials.json")
+        in codex_bundle.home
+    )
+    assert HomeCopy(".codex/AGENTS.md", config_root / "codex/AGENTS.md") in codex_bundle.home
+    assert codex_bundle.home[-1].source == config_root / "codex/skills"
 
 
-async def test_no_config_dir_ships_credential_only(druks_db):
-    # No local config dir for the CLI => nothing of the host's config/plugins
-    # reaches the sandbox — but the DB subscription still ships: the subscription
-    # row alone decides whether a harness can run.
+async def test_missing_config_root_keeps_the_db_credential(druks_db, tmp_path):
     subscription = await _seed_claude(access="live")
     sandbox = SandboxSettings(
         service_url="x",
         service_token="x",
         service_timeout=30.0,
         image="x",
-        claude_config_dir=None,
-        codex_config_dir=None,
+        harness_config_root=tmp_path / "missing",
     )
     bundle = await _get_credentials(sandbox, github_token="gh", subscription=subscription)
-    [auth] = bundle.home
+    auth = bundle.home[0]
     assert json.loads(auth.content)["claudeAiOauth"]["accessToken"] == "live"
     assert bundle.github_token == "gh"
+
+
+@pytest.mark.parametrize(
+    ("harness", "config_name", "auth_name"),
+    [
+        (ClaudeHarness, "settings.json", ".credentials.json"),
+        (CodexHarness, "config.toml", "auth.json"),
+    ],
+)
+@pytest.mark.parametrize("config_exists", [False, True])
+async def test_config_delivery_does_not_copy_host_provider_credentials(
+    druks_db, tmp_path, harness, config_name, auth_name, config_exists
+):
+    config_root = tmp_path / "harnesses"
+    config_dir = config_root / harness.name
+    if config_exists:
+        config_dir.mkdir(parents=True)
+        (config_dir / config_name).write_text("")
+        (config_dir / auth_name).write_text('{"token": "host-token"}')
+    sandbox = SandboxSettings(
+        service_url="x",
+        service_token="x",
+        service_timeout=30.0,
+        image="x",
+        harness_config_root=config_root,
+    )
+
+    invocation = await harness(
+        model=harness.default_model, fast_mode=False, effort=None, sandbox=sandbox
+    ).build_invocation(
+        prompt="hello",
+        schema={"type": "object"},
+        run_id="run-1",
+        ssh_username="druks",
+        key="selected-key",
+    )
+    host = AsyncMock()
+    for file in invocation.credentials.home:
+        await file.push(host, "/home/druks")
+
+    if config_exists:
+        host.upload_file.assert_awaited_once_with(
+            local=config_dir / config_name,
+            remote=f"/home/druks/.{harness.name}/{config_name}",
+        )
+    else:
+        host.upload_file.assert_not_awaited()
+    host.upload_dir.assert_not_awaited()
+    if harness.name == "codex":
+        host.write_secret.assert_awaited_once_with(
+            secret=json.dumps({"OPENAI_API_KEY": "selected-key"}),
+            remote="/home/druks/.codex/auth.json",
+        )
+    else:
+        host.write_secret.assert_not_awaited()
+        assert invocation.env["ANTHROPIC_API_KEY"] == "selected-key"
 
 
 async def test_credential_without_a_selection_reads_the_accounts_row(druks_db):

--- a/backend/tests/test_harness_reasoning_flags.py
+++ b/backend/tests/test_harness_reasoning_flags.py
@@ -1,11 +1,15 @@
 import json
+import shlex
+from pathlib import Path
 
 import pytest
 from conftest import connect_provider
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
+from druks.harnesses.datastructures import SandboxSettings
 from druks.harnesses.models import ProviderSubscription
 from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
+from druks.sandbox.datastructures import McpServer
 
 _CODEX_MODEL = CodexHarness.default_model
 
@@ -19,27 +23,17 @@ async def _connected_harnesses(druks_db):
 
 
 def _sandbox_config():
-    from pathlib import Path
-
-    from druks.harnesses.datastructures import SandboxSettings
-
     return SandboxSettings(
         service_url="https://sb.test",
         service_token="t",
         service_timeout=30.0,
         image="img",
-        claude_config_dir=Path("/home/agent/.claude"),
-        codex_config_dir=Path("/home/agent/.codex"),
+        harness_config_root=Path("/harnesses"),
     )
 
 
 async def test_claude_build_invocation_carries_every_flag():
-    """Flag-drop guard: moving argv construction is exactly how
-    CLI flags got silently lost before — assert the full surface."""
-    import shlex
-
-    from druks.sandbox.datastructures import McpServer
-
+    """The Claude invocation carries the complete supported flag set."""
     schema = {"type": "object"}
     server = McpServer(name="github", url="https://api.example/mcp/", bearer_token_env_var="TOK")
     inv = await ClaudeHarness(
@@ -71,7 +65,7 @@ async def test_claude_build_invocation_carries_every_flag():
         "--output-format stream-json",
         "--verbose",
         "--json-schema",
-        shlex.quote(__import__("json").dumps(schema)),
+        shlex.quote(json.dumps(schema)),
         "--permission-mode bypassPermissions",
         "--debug-file",
         "/work/runs/run-1/debug.log",
@@ -96,9 +90,7 @@ async def test_claude_build_invocation_carries_every_flag():
 
 
 async def test_codex_build_invocation_carries_every_flag():
-    """Flag-drop guard, codex side."""
-    from druks.sandbox.datastructures import McpServer
-
+    """The Codex invocation carries the complete supported flag set."""
     server = McpServer(name="github", url="https://api.example/mcp/", bearer_token_env_var="TOK")
     inv = await CodexHarness(
         model=_CODEX_MODEL,
@@ -131,9 +123,7 @@ async def test_codex_build_invocation_carries_every_flag():
         "--output-schema",
         "--output-last-message",
         "/home/exedev/work/runs/run-1/output.json",
-        # MCP registration + marker-based session capture. No CODEX_HOME
-        # override: codex runs against its real ~/.codex (auth, config,
-        # skills all live there), and the session is found by marker.
+        # Codex uses its sandbox home for auth, config, skills, and session data.
         "mcp_servers.github.url",
         "mcp_servers.github.bearer_token_env_var",
         "touch /home/exedev/work/runs/run-1/session.marker",
@@ -149,8 +139,6 @@ async def test_codex_build_invocation_carries_every_flag():
     stdin = (inv.stdin or b"").decode()
     assert stdin.startswith("hello")
     assert "Do not send interim assistant messages" in stdin
-    # The per-run home override must never come back silently — it re-homed
-    # every piece of codex state (auth, then skills) one regression at a time.
     assert "CODEX_HOME" not in wrapper
     assert inv.env == {"TOK": "secret"}
     assert inv.extra_artifact_filenames == ("output.json", "session.jsonl")
@@ -214,8 +202,6 @@ def test_codex_emits_summary_effort_and_json_stream():
 
 
 def test_codex_mcp_flags_register_server_with_env_var_token():
-    from druks.sandbox.datastructures import McpServer
-
     server = McpServer(name="github", url="https://api.example/mcp/", bearer_token_env_var="GH_TOK")
     flags = CodexHarness(model=_CODEX_MODEL, fast_mode=False, effort=None)._mcp_flags((server,))
     assert 'mcp_servers.github.url="https://api.example/mcp/"' in flags
@@ -225,10 +211,6 @@ def test_codex_mcp_flags_register_server_with_env_var_token():
 
 
 def test_claude_mcp_flags_emit_env_ref_header_not_literal_token():
-    import json
-
-    from druks.sandbox.datastructures import McpServer
-
     server = McpServer(name="github", url="https://api.example/mcp/", bearer_token_env_var="GH_TOK")
     flags = ClaudeHarness(model="anthropic/claude-x", fast_mode=False, effort=None)._mcp_flags(
         (server,)
@@ -242,7 +224,3 @@ def test_claude_mcp_flags_emit_env_ref_header_not_literal_token():
     # No servers → no flags, on both harnesses.
     assert ClaudeHarness(model="x", fast_mode=False, effort=None)._mcp_flags(()) == ()
     assert CodexHarness(model=_CODEX_MODEL, fast_mode=False, effort=None)._mcp_flags(()) == ()
-
-
-# Workspace scaffolding tests (add_dirs dedup, GitHub MCP injection) live in
-# test_build_workspace.py — that behavior is BuildWorkspace's, not the base sandbox's.

--- a/backend/tests/test_mcp_servers.py
+++ b/backend/tests/test_mcp_servers.py
@@ -34,8 +34,7 @@ def _sandbox_config() -> SandboxSettings:
         service_token="t",
         service_timeout=30.0,
         image="img",
-        claude_config_dir=Path("/home/agent/.claude"),
-        codex_config_dir=Path("/home/agent/.codex"),
+        harness_config_root=Path("/harnesses"),
     )
 
 

--- a/backend/tests/test_opencode.py
+++ b/backend/tests/test_opencode.py
@@ -31,8 +31,7 @@ def _sandbox_config() -> SandboxSettings:
         service_token="token",
         service_timeout=30.0,
         image="image",
-        claude_config_dir=None,
-        codex_config_dir=None,
+        harness_config_root=Path("/harnesses"),
     )
 
 

--- a/backend/tests/test_pi.py
+++ b/backend/tests/test_pi.py
@@ -41,8 +41,7 @@ def _harness(*, effort: str | None = "high") -> PiHarness:
             service_token="token",
             service_timeout=30.0,
             image="image",
-            claude_config_dir=None,
-            codex_config_dir=None,
+            harness_config_root=Path("/harnesses"),
         ),
     )
 

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 import pytest
 from druks.settings import Settings, ensure_data_dirs
@@ -120,6 +121,20 @@ secrets_key = "{_SECRETS_KEY}"
     settings = Settings()
 
     assert settings.identity.jwt_identity_claim == "email"
+
+
+def test_harness_config_root_expands_the_environment_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("DRUKS_HARNESS_CONFIG_ROOT", "~/harness-config")
+
+    settings = make_settings(tmp_path)
+
+    assert settings.harness_config_root == Path.home() / "harness-config"
+
+
+def test_harness_config_root_defaults_to_the_druks_config_directory(tmp_path):
+    settings = make_settings(tmp_path)
+
+    assert settings.harness_config_root == Path.home() / ".config/druks/harnesses"
 
 
 def test_missing_explicit_config_refuses_construction(tmp_path, monkeypatch):

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -49,6 +49,8 @@ def test_fresh_exe_render_matches_the_deployment_contract(tmp_path):
     assert values["DRUKS_AUTH_HEADER"] == "X-ExeDev-Email"
     assert values["SERVICE_TOKENS"] == config["sandbox"]["service_token"]
     assert values["DRUKS_DATA_DIR"] == "/home/op/druks-data"
+    assert values["DRUKS_HARNESS_CONFIG_ROOT"] == "/home/op/.config/druks/harnesses"
+    assert config["paths"]["harness_config_root"] == values["DRUKS_HARNESS_CONFIG_ROOT"]
     assert "EXE_API_TOKEN" not in values
     assert "TAILSCALE_TAILNET" not in values
     for key in ("EXE_IMAGE_REGISTRY", "EXE_REGISTRY_USERNAME", "EXE_REGISTRY_PASSWORD"):
@@ -72,6 +74,24 @@ def test_fresh_docker_run_is_boot_ready(tmp_path):
 
     assert rc == 0
     assert "is complete" in "\n".join(printed)
+
+
+def test_custom_harness_config_root_survives_rerender(tmp_path):
+    env_path = tmp_path / ".env"
+    config_root = "/srv/druks/harness config"
+
+    assert (
+        _run(
+            env_path,
+            provider="docker",
+            set_values=(f"paths.harness_config_root={config_root}",),
+        )
+        == 0
+    )
+    assert _run(env_path) == 0
+
+    assert read_env(env_path)["DRUKS_HARNESS_CONFIG_ROOT"] == config_root
+    assert _read_toml(tmp_path / "druks.toml")["paths"]["harness_config_root"] == config_root
 
 
 @pytest.mark.parametrize(

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -8,10 +8,8 @@
 
 x-druks: &druks
   image: ghcr.io/czpython/druks:${DRUKS_TAG:-latest}
-  # Run as the deploy user (who owns the mounted ~/.claude, ~/.codex, and data
-  # dir), not root, so everything written under the data mount stays owned by
-  # (and writable to) the deploy user. install.sh writes DRUKS_UID/DRUKS_GID
-  # into .env from `id -u` / `id -g`.
+  # Run as the deploy user, not root. This user owns the data and harness-config
+  # roots. install.sh writes DRUKS_UID/DRUKS_GID into .env from `id -u` / `id -g`.
   user: "${DRUKS_UID:?set DRUKS_UID in .env — run install.sh}:${DRUKS_GID:?set DRUKS_GID in .env — run install.sh}"
   restart: unless-stopped
   network_mode: host
@@ -22,10 +20,7 @@ x-druks: &druks
     DRUKS_REDIS_URL: ${DRUKS_REDIS_URL:-redis://127.0.0.1:6379/0}
     DRUKS_DATABASE_URL: ${DRUKS_DATABASE_URL:-postgresql+psycopg://${DRUKS_POSTGRES_USER:-druks}:${DRUKS_POSTGRES_PASSWORD}@127.0.0.1:5432/${DRUKS_POSTGRES_DB:-druks}}
     DRUKS_DATA_DIR: /app/data
-    # Container view of the CLI config mounts below. Subscription credentials
-    # live in the DB (dashboard connect flow) — these carry config only.
-    DRUKS_CLAUDE_CONFIG_DIR: /harnesses/claude
-    DRUKS_CODEX_CONFIG_DIR: /harnesses/codex
+    DRUKS_HARNESS_CONFIG_ROOT: /harnesses
     # Operator-installed skills live in the (writable) data volume — the
     # settings UI installs collections here and druks pushes them into every
     # VM at both ~/.claude/skills and ~/.codex/skills.
@@ -34,12 +29,8 @@ x-druks: &druks
   volumes:
     - ./druks.toml:/app/druks.toml:ro
     - ${DRUKS_DATA_HOST_DIR:-${DRUKS_DATA_DIR:-${HOME}/druks-data}}:/app/data
-    # claude/codex config dirs (settings.json/plugins, config.toml/AGENTS.md),
-    # carried into each sandbox at push time. Auth never reads them — tokens
-    # live in the DB and rotate there — so the mounts are read-only.
-    - ${DRUKS_CLAUDE_HOME:-${HOME}/.claude}:/harnesses/claude:ro
-    - ${DRUKS_CODEX_HOME:-${HOME}/.codex}:/harnesses/codex:ro
-    - ${DRUKS_CLAUDE_JSON:-${HOME}/.claude.json}:/harnesses/.claude.json:ro
+    # Each harness owns one directory here. Provider credentials stay in the DB.
+    - ${DRUKS_HARNESS_CONFIG_ROOT:-${HOME}/.config/druks/harnesses}:/harnesses:ro
     # Shared so a reattaching worker reads the key the acquirer wrote.
     - druks_sandbox_keys:/app/sandbox-keys
   depends_on:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,7 @@ recover an installation, preserve `[secrets]`. Use repeatable
 | `DRUKS_TEST_REDIS_URL` | `redis://127.0.0.1:6379/15` | What the shipped pytest fixtures flush |
 | `DRUKS_REDIS_URL` | `redis://127.0.0.1:6379/0` | Short-lived coordination and caches |
 | `DRUKS_DATA_DIR` | `/var/lib/druks` | Logs, artifacts, installed skills |
+| `DRUKS_HARNESS_CONFIG_ROOT` | `~/.config/druks/harnesses` | Optional harness configuration copied into sandboxes |
 | `DRUKS_LOG_LEVEL` | `INFO` | Python and DBOS log level |
 
 Postgres stores durable state. Redis does not store workflow state. It supports
@@ -299,14 +300,31 @@ The `claude` and `codex` CLIs run on their own vendor's subscription or key.
 Models.dev provider after its key is stored. A model ID is `provider/model`
 for each harness, for example `openai/gpt-5.5`.
 
-Process settings such as `DRUKS_CLAUDE_CONFIG_DIR` and
-`DRUKS_CODEX_CONFIG_DIR` point at optional non-auth CLI configuration to carry
-into sandboxes. The Compose deployment mounts these read-only. The default
-harness, model, billing, effort, and timeout live in **Settings → Agents**;
-each agent can override any of them on its app's page. **Unattended runs
+`paths.harness_config_root` points at optional CLI configuration that Druks
+carries into sandboxes. The installer creates the root. Compose mounts it
+read-only at `/harnesses`. Claude and Codex each read their named directory:
+
+```text
+~/.config/druks/harnesses/
+├── claude/
+│   ├── .claude.json
+│   ├── CLAUDE.md
+│   ├── settings.json
+│   └── plugins/
+└── codex/
+    ├── .credentials.json
+    ├── AGENTS.md
+    └── config.toml
+```
+
+Missing files are optional. Codex uses `.credentials.json` for MCP credentials.
+Provider credentials do not belong in this root. OpenCode and Pi do not read it.
+The default harness, model, billing, effort, and timeout live in
+**Settings → Agents**. Each agent can override any of them on its app's page.
+**Unattended runs
 (webhooks, schedules) run as** names the account whose subscription an
-unattended run bills. A call refuses before provisioning a VM if the
-credential it bills is missing.
+unattended run bills. A call refuses before provisioning a VM if its selected
+credential is missing.
 
 ## Sandboxes
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -75,6 +75,8 @@ It creates `~/druks/.env` and exits if required values are missing.
 The output identifies each missing value. Edit `druks.toml`. For a generic
 remote shape, fill `[sandbox.<provider>]` from the Drukbox
 [configuration reference](https://github.com/czpython/drukbox).
+The installer also creates `paths.harness_config_root`. Put optional CLI
+configuration in the harness directory under that root.
 
 After boot, connect the GitHub App that Druks uses from **Settings → Services**.
 Use the permission table in [Configuration](configuration.md#github).

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -40,9 +40,10 @@ The local shape needs no authored values, so the first run goes all the way:
 
 - The installer writes `~/druks/druks.toml` with `[sandbox].provider = "docker"`.
 - It creates `~/druks/.env` with `DEFAULT_HOST_PROVIDER=docker`.
+- It creates `~/.config/druks/harnesses` for optional harness configuration.
 - It generates the database password and the stored-secret key.
 - It pulls images and applies migrations.
-- It starts Druks, Postgres, Redis, and Drukbox on `127.0.0.1:8780`.
+- It starts Druks, Postgres, Redis, and Drukbox. Drukbox listens on `127.0.0.1:8780`.
 - It uses `COMPOSE_FILE=compose.yaml:compose.override.yaml` without Caddy or the
   janitor profiles.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -116,7 +116,11 @@ main() {
   if [ -z "$DATA_HOST_DIR" ]; then
     DATA_HOST_DIR=$(sed -n 's/^DRUKS_DATA_DIR=//p' .env)
   fi
-  mkdir -p "$DATA_HOST_DIR"
+  HARNESS_CONFIG_ROOT=$(sed -n 's/^DRUKS_HARNESS_CONFIG_ROOT=//p' .env)
+  if [ -z "$HARNESS_CONFIG_ROOT" ]; then
+    HARNESS_CONFIG_ROOT="$HOME/.config/druks/harnesses"
+  fi
+  mkdir -p "$DATA_HOST_DIR" "$HARNESS_CONFIG_ROOT"
 
   # Pin the deploy user's uid/gid → the backend containers run as them, not
   # root, so everything written under the mounted data dir stays owned by
@@ -238,9 +242,9 @@ Stack is up. Verify with:
   docker compose ps
   docker compose exec web druks doctor
 
-Then finish in the dashboard. Connect a harness under
-Settings → Harnesses. Agent runs refuse to start on a harness
-that is not connected. Connect the GitHub App that druks uses.
+Then finish in the dashboard. Connect a provider under
+Settings → Providers. Agent runs require the selected provider credential.
+Connect the GitHub App that Druks uses under Settings → Services.
 MSG
 
   if [ "$PROVIDER" = "docker" ]; then
@@ -256,7 +260,7 @@ MSG
     cat <<MSG
 
 Public URLs (once exe.dev port-share is configured):
-  https://<your-host>/webhooks/{github,linear}
+  https://<your-host>/_external/{github,linear,jira}/events/
   https://<your-host>/
 ------------------------------------------------------------
 MSG


### PR DESCRIPTION
## Change

DRU-418 uses one `harness_config_root` and one read-only `/harnesses` mount. Claude and Codex read their named subdirectories. The installer creates the root.

The branch is rebased onto `main` at `7583bdb3`. The resolution preserves subscription and API-key billing, dynamic providers, and the current setup contract.

The review corrected the provider page name, webhook URLs, and a local port description. New tests cover custom roots, absent files, and host credential isolation.

Linear: https://linear.app/fellaworks/issue/DRU-418/use-one-managed-config-root-for-every-harness

## Verification

- `uv pip install -e backend/tests/druks-field_notes` succeeded.
- `uv run pytest backend/` passed: 1,591 tests, with 19 warnings.
- `uv run ruff check backend` passed.
- `uv run ruff format --check backend` passed.
- `bash -n scripts/install.sh` passed.
- GitHub backend CI, frontend CI, and the Mintlify deployment passed on `4e2c6538`.
- Compose interpolation passed for the default root and a custom absolute path with spaces. Both produce one read-only mount and `/harnesses` inside the container.
- Pyright on the five changed production Python files reports two `build_invocation` override errors. The same checks on a clean `7583bdb3` checkout report the same two errors.
- No live installation, provider login, or sandbox CLI run was done. Frontend checks were not run locally.

## Review limits

No blocking regression was found in the config-root change. The review covered each changed file and the checklist patterns.

Existing checklist exceptions remain in the touched files. These include settings submodels, provider and cost DTOs, and error fields on `ParsedUsage` and `RotationResult`. One-caller helpers and narrative comments also remain. This PR does not claim full checklist compliance or rewrite those contracts.

## Deployment

Run the installer on each host to refresh Compose. Put the selected CLI configuration in `<root>/claude` and `<root>/codex`. The removed per-harness variables have no compatibility aliases.

Provider credentials remain in Postgres. Codex `.credentials.json` holds MCP credentials. OpenCode and Pi do not read this root.
