### PR TITLE
A provider or harness declares its billing options; the last login word goes

### DIFF
--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -34,10 +34,9 @@ MANIFEST_SCHEMA_VERSION = 2
 class Harness(ABC):
     name: str
     command: ClassVar[str]
-    # The subscription kinds this CLI consumes: "oauth" for a subscription CLI,
-    # "api_key" for one that runs on a pasted key.
-    login_kinds: ClassVar[frozenset[str]]
-    # The one provider a subscription CLI is bound to. None for a key CLI,
+    # What this CLI runs on: "subscription", "api_key", or both.
+    billing_options: ClassVar[frozenset[str]]
+    # The one provider a vendor's CLI is bound to. None for a key-only CLI,
     # which runs whichever provider the model names.
     provider: ClassVar[str | None] = None
     # The seed for this harness's settings row, ``provider/model``.
@@ -94,14 +93,14 @@ class Harness(ABC):
     def accepts(cls, subscription: ProviderSubscription) -> bool:
         """Whether this CLI runs on the subscription ``subscription``."""
         bound = not cls.provider or cls.provider == subscription.provider
-        return bound and "oauth" in cls.login_kinds
+        return bound and "subscription" in cls.billing_options
 
     @classmethod
     def has_provider(cls, provider: Provider) -> bool:
         """The one this CLI is bound to, or any that issues a subscription kind it consumes."""
         if cls.provider:
             return cls.provider == provider.id
-        return bool(cls.login_kinds & provider.login_kinds)
+        return bool(cls.billing_options & provider.billing_options)
 
     @property
     def model_id(self) -> str:

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -32,7 +32,7 @@ class ClaudeHarness(Harness):
     # (``--output-format stream-json``), so the transcript is the stdout.
     name = "claude"
     provider = AnthropicProvider.id
-    login_kinds = frozenset({"oauth", "api_key"})
+    billing_options = frozenset({"subscription", "api_key"})
     default_model = "anthropic/claude-opus-4-7"
     command = "claude"
 

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -264,7 +264,7 @@ class CodexHarness(Harness):
     # symmetric with claude. session.jsonl is still snapshotted for cost.
     name = "codex"
     provider = OpenAiProvider.id
-    login_kinds = frozenset({"oauth", "api_key"})
+    billing_options = frozenset({"subscription", "api_key"})
     default_model = "openai/gpt-5.5"
     command = "codex"
 

--- a/backend/druks/harnesses/datastructures.py
+++ b/backend/druks/harnesses/datastructures.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Self
+from typing import Literal, Self
 
 # Execution-side types live with the executor; re-exported here
 # because the harness API speaks them.
@@ -11,6 +11,8 @@ from druks.sandbox.datastructures import (  # noqa: F401
     HarnessRunResult,
 )
 from druks.settings import Settings
+
+Billing = Literal["subscription", "api_key"]
 
 
 @dataclass(frozen=True)

--- a/backend/druks/harnesses/execution.py
+++ b/backend/druks/harnesses/execution.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 from druks.accounts.constants import SYSTEM_ACCOUNT_ID
 from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
-from druks.user_settings.constants import BILLING_LOGIN_KINDS
 from druks.user_settings.models import SettingsOverride, UserSettings
 
 from .base import Harness
@@ -41,7 +40,7 @@ def check_execution(harness_name: str, model: str, billing: str) -> type[Harness
         ) from error
     if not harness.has_provider(provider):
         raise ExecutionSettingsError(f"{harness_name} does not run {provider.label} models.")
-    if BILLING_LOGIN_KINDS[billing] not in harness.login_kinds:
+    if billing not in harness.billing_options:
         raise ExecutionSettingsError(
             f"{harness_name} runs on an API key only; set billing to api_key."
         )

--- a/backend/druks/harnesses/opencode.py
+++ b/backend/druks/harnesses/opencode.py
@@ -30,7 +30,7 @@ _ERROR_TYPES = {
 
 class OpenCodeHarness(Harness):
     name = "opencode"
-    login_kinds = frozenset({"api_key"})
+    billing_options = frozenset({"api_key"})
     default_model = "anthropic/claude-sonnet-4-5"
     command = "opencode"
     # The server writes nothing until the message POST completes; the wrapper

--- a/backend/druks/harnesses/pi.py
+++ b/backend/druks/harnesses/pi.py
@@ -35,7 +35,7 @@ _STATUS_ERRORS = {
 class PiHarness(Harness):
     name = "pi"
     command = "pi"
-    login_kinds = frozenset({"api_key"})
+    billing_options = frozenset({"api_key"})
     default_model = "openai/gpt-5.5"
 
     @classmethod

--- a/backend/druks/harnesses/providers.py
+++ b/backend/druks/harnesses/providers.py
@@ -55,9 +55,9 @@ class Provider:
 
     id: ClassVar[str]
     label: ClassVar[str]
-    # "oauth" for a subscription subscription, "api_key" for a pasted key.
-    login_kinds: ClassVar[frozenset[str]]
-    # OAuth refresh config (set by providers with an "oauth" subscription kind).
+    # What this provider bills: "subscription", "api_key", or both.
+    billing_options: ClassVar[frozenset[str]]
+    # OAuth refresh config (set by providers that offer a subscription).
     REFRESH_MARGIN: ClassVar[timedelta]
     _TOKEN_URL: ClassVar[str]
     _CLIENT_ID: ClassVar[str]
@@ -392,7 +392,9 @@ class Provider:
             raise exceptions.CatalogError("network") from exc
         if response.status_code != 200:
             raise exceptions.CatalogError(error_tag(response.status_code))
-        return cls._parse_catalog(response.text, kind="oauth" if subscription else "api_key")
+        return cls._parse_catalog(
+            response.text, billing="subscription" if subscription else "api_key"
+        )
 
     @classmethod
     async def refresh_catalog(cls) -> None:
@@ -422,10 +424,10 @@ class Provider:
         raise NotImplementedError
 
     @classmethod
-    def _parse_catalog(cls, raw: str, *, kind: str) -> tuple[dict, ...]:
+    def _parse_catalog(cls, raw: str, *, billing: str) -> tuple[dict, ...]:
         """Namespaced ``{"id", "label"}`` entries from the model-list body
-        fetched over a ``kind`` subscription; raises :class:`CatalogError` on a body
-        offering nothing."""
+        fetched on ``billing``; raises :class:`CatalogError` on a body offering
+        nothing."""
         raise NotImplementedError
 
 
@@ -573,7 +575,7 @@ _CLAUDE_CODE_USER_AGENT = "claude-code/2.1.0"
 class AnthropicProvider(Provider):
     id = "anthropic"
     label = "Anthropic"
-    login_kinds = frozenset({"oauth", "api_key"})
+    billing_options = frozenset({"subscription", "api_key"})
 
     REFRESH_MARGIN = timedelta(hours=2)
     _TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
@@ -708,7 +710,7 @@ class AnthropicProvider(Provider):
         return ProviderRequest("https://api.anthropic.com/v1/models?limit=100", headers)
 
     @classmethod
-    def _parse_catalog(cls, raw: str, *, kind: str) -> tuple[dict, ...]:
+    def _parse_catalog(cls, raw: str, *, billing: str) -> tuple[dict, ...]:
         try:
             models = tuple(
                 {"id": f"{cls.id}/{model['id']}", "label": model.get("display_name") or model["id"]}
@@ -798,7 +800,7 @@ class OpenAiProvider(Provider):
 
     id = "openai"
     label = "OpenAI"
-    login_kinds = frozenset({"oauth", "api_key"})
+    billing_options = frozenset({"subscription", "api_key"})
 
     REFRESH_MARGIN = timedelta(hours=24)
     _TOKEN_URL = "https://auth.openai.com/oauth/token"
@@ -967,9 +969,9 @@ class OpenAiProvider(Provider):
         )
 
     @classmethod
-    def _parse_catalog(cls, raw: str, *, kind: str) -> tuple[dict, ...]:
+    def _parse_catalog(cls, raw: str, *, billing: str) -> tuple[dict, ...]:
         try:
-            if kind == "api_key":
+            if billing == "api_key":
                 models = tuple(
                     {"id": f"{cls.id}/{model['id']}", "label": model["name"]}
                     for model in json.loads(raw)[cls.id]["models"].values()

--- a/backend/druks/harnesses/routes.py
+++ b/backend/druks/harnesses/routes.py
@@ -155,7 +155,7 @@ async def create_key(
     key: str = Body(..., embed=True),
 ) -> ProviderKey:
     provider = _resolve_provider(provider_id)
-    if "api_key" not in provider.login_kinds:
+    if "api_key" not in provider.billing_options:
         raise HTTPException(
             status_code=422,
             detail=f"{provider.label} does not accept API keys.",

--- a/backend/druks/harnesses/schemas.py
+++ b/backend/druks/harnesses/schemas.py
@@ -15,7 +15,7 @@ class ProviderResponse(Schema):
 
     id: str
     label: str
-    login_kinds: SortedNames
+    billing_options: SortedNames
 
 
 class ProviderSubscriptionResponse(Schema):

--- a/backend/druks/user_settings/constants.py
+++ b/backend/druks/user_settings/constants.py
@@ -3,4 +3,3 @@ DEFAULT_HARNESS = "claude"
 DEFAULT_BILLING = "subscription"
 DEFAULT_EFFORT = "high"
 DEFAULT_TIMEOUT = 1800
-BILLING_LOGIN_KINDS = {"subscription": "oauth", "api_key": "api_key"}

--- a/backend/druks/user_settings/datastructures.py
+++ b/backend/druks/user_settings/datastructures.py
@@ -2,7 +2,6 @@ from typing import Literal, NamedTuple, get_args
 
 Effort = Literal["low", "medium", "high"]
 ALLOWED_EFFORTS: tuple[str, ...] = get_args(Effort)
-Billing = Literal["subscription", "api_key"]
 
 
 class ResolvedChoice(NamedTuple):

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -11,10 +11,11 @@ from druks.apps.settings import (
     field_section,
     field_visibility,
 )
+from druks.harnesses.datastructures import Billing
 from druks.harnesses.schemas import SortedNames
 from druks.schemas import Schema
 
-from .datastructures import Billing, Effort
+from .datastructures import Effort
 
 
 class HarnessResponse(Schema):
@@ -22,7 +23,7 @@ class HarnessResponse(Schema):
 
     name: str
     provider: str | None
-    login_kinds: SortedNames
+    billing_options: SortedNames
 
 
 class UserSettingsResponse(Schema):

--- a/backend/tests/test_api_providers.py
+++ b/backend/tests/test_api_providers.py
@@ -17,13 +17,13 @@ def _providers(client: TestClient) -> dict[str, dict]:
     return {p["id"]: p for p in client.get("/api/providers").json()}
 
 
-def test_list_carries_login_kinds_and_no_connection(tmp_path: Path):
+def test_list_carries_billing_options_and_no_connection(tmp_path: Path):
     # One card per vendor; each takes a subscription and an API key.
     with _build_client(tmp_path) as client:
         providers = _providers(client)
     assert list(providers) == ["anthropic", "openai"]
-    assert providers["anthropic"]["loginKinds"] == ["api_key", "oauth"]
-    assert providers["openai"]["loginKinds"] == ["api_key", "oauth"]
+    assert providers["anthropic"]["billingOptions"] == ["api_key", "subscription"]
+    assert providers["openai"]["billingOptions"] == ["api_key", "subscription"]
     assert providers["openai"]["label"] == "OpenAI"
 
 

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -30,10 +30,10 @@ def test_get_harnesses_lists_the_registry(tmp_path: Path):
     assert harnesses["claude"] == {
         "name": "claude",
         "provider": "anthropic",
-        "loginKinds": ["api_key", "oauth"],
+        "billingOptions": ["api_key", "subscription"],
     }
     assert harnesses["codex"]["provider"] == "openai"
-    assert harnesses["pi"] == {"name": "pi", "provider": None, "loginKinds": ["api_key"]}
+    assert harnesses["pi"] == {"name": "pi", "provider": None, "billingOptions": ["api_key"]}
 
 
 def test_get_settings_carries_the_execution_defaults(tmp_path: Path):

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -143,8 +143,8 @@ async def test_provider_list_answers_before_an_account_exists(druks_client):
     body = response.json()
     assert [item["id"] for item in body] == [provider.id for provider in get_providers()]
     by_id = {item["id"]: item for item in body}
-    assert by_id["anthropic"]["loginKinds"] == ["api_key", "oauth"]
-    assert by_id["openai"]["loginKinds"] == ["api_key", "oauth"]
+    assert by_id["anthropic"]["billingOptions"] == ["api_key", "subscription"]
+    assert by_id["openai"]["billingOptions"] == ["api_key", "subscription"]
     assert not await Account.list_non_system()
 
 

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -261,7 +261,7 @@ async def test_a_second_pasted_key_replaces_the_first(tmp_path, druks_db):
 
 
 async def test_api_key_connect_requires_a_declared_kind(tmp_path, druks_db, monkeypatch):
-    monkeypatch.setattr(OpenAiProvider, "login_kinds", frozenset({"oauth"}))
+    monkeypatch.setattr(OpenAiProvider, "billing_options", frozenset({"subscription"}))
     with _header_client(tmp_path) as client:
         response = client.post(
             "/api/providers/openai/key",

--- a/backend/tests/test_opencode.py
+++ b/backend/tests/test_opencode.py
@@ -49,7 +49,7 @@ def test_class_facts_and_registration() -> None:
     assert get_harness("opencode") is OpenCodeHarness
     assert OpenCodeHarness.command == "opencode"
     assert OpenCodeHarness.provider is None
-    assert OpenCodeHarness.login_kinds == {"api_key"}
+    assert OpenCodeHarness.billing_options == {"api_key"}
     assert OpenCodeHarness.first_byte_seconds is None
     assert OpenCodeHarness.failure_markers == {}
     assert "_model_discovery_request" not in OpenCodeHarness.__dict__

--- a/backend/tests/test_pi.py
+++ b/backend/tests/test_pi.py
@@ -71,7 +71,7 @@ def test_class_facts_and_registration() -> None:
     assert get_harness("pi") is PiHarness
     assert PiHarness.command == "pi"
     assert PiHarness.provider is None
-    assert PiHarness.login_kinds == {"api_key"}
+    assert PiHarness.billing_options == {"api_key"}
 
 
 def test_auth_file_renders_a_key_under_the_vendor() -> None:

--- a/backend/tests/test_provider_auth.py
+++ b/backend/tests/test_provider_auth.py
@@ -510,7 +510,7 @@ async def test_minimal_provider_reports_unsupported_usage(monkeypatch):
     class MinimalProvider(pbase.Provider):
         id = "minimal"
         label = "Minimal"
-        login_kinds = frozenset({"api_key"})
+        billing_options = frozenset({"api_key"})
 
     subscription = SimpleNamespace(payload={})
     calls = _mock_get(monkeypatch, _resp(200, {}))

--- a/backend/tests/test_provider_catalogs.py
+++ b/backend/tests/test_provider_catalogs.py
@@ -46,7 +46,7 @@ def test_anthropic_parse_namespaces_ids_and_keeps_labels() -> None:
         }
     )
 
-    assert AnthropicProvider._parse_catalog(payload, kind="oauth") == (
+    assert AnthropicProvider._parse_catalog(payload, billing="subscription") == (
         {"id": "anthropic/claude-fable-5", "label": "Claude Fable 5"},
         {"id": "anthropic/claude-opus-4-8", "label": "claude-opus-4-8"},
     )
@@ -62,7 +62,7 @@ def test_anthropic_parse_namespaces_ids_and_keeps_labels() -> None:
 )
 def test_anthropic_parse_names_why_a_body_offers_nothing(body, tag) -> None:
     with pytest.raises(CatalogError) as error:
-        AnthropicProvider._parse_catalog(body, kind="oauth")
+        AnthropicProvider._parse_catalog(body, billing="subscription")
     assert error.value.tag == tag
 
 
@@ -86,7 +86,7 @@ def test_codex_parse_keeps_only_listed_models() -> None:
         }
     )
 
-    assert OpenAiProvider._parse_catalog(payload, kind="oauth") == (
+    assert OpenAiProvider._parse_catalog(payload, billing="subscription") == (
         {
             "id": "openai/gpt-5.6-sol",
             "label": "GPT-5.6-Sol",
@@ -100,7 +100,7 @@ def test_codex_parse_empty_catalog_is_an_error() -> None:
     """A stale-low ``client_version`` yields ``200 {"models": []}`` — that must
     never read as "no models" and wipe the stored list."""
     with pytest.raises(CatalogError, match="empty_list"):
-        OpenAiProvider._parse_catalog(json.dumps({"models": []}), kind="oauth")
+        OpenAiProvider._parse_catalog(json.dumps({"models": []}), billing="subscription")
 
 
 def test_openai_parse_reads_its_models_dev_section() -> None:
@@ -111,13 +111,13 @@ def test_openai_parse_reads_its_models_dev_section() -> None:
         }
     )
 
-    assert OpenAiProvider._parse_catalog(raw, kind="api_key") == (
+    assert OpenAiProvider._parse_catalog(raw, billing="api_key") == (
         {"id": "openai/gpt-5.5", "label": "GPT-5.5"},
     )
     with pytest.raises(CatalogError, match="unexpected_payload"):
-        OpenAiProvider._parse_catalog(json.dumps({"anthropic": {}}), kind="api_key")
+        OpenAiProvider._parse_catalog(json.dumps({"anthropic": {}}), billing="api_key")
     with pytest.raises(CatalogError, match="empty_list"):
-        OpenAiProvider._parse_catalog(json.dumps({"openai": {"models": {}}}), kind="api_key")
+        OpenAiProvider._parse_catalog(json.dumps({"openai": {"models": {}}}), billing="api_key")
 
 
 async def test_anthropic_fetch_uses_the_oauth_token(monkeypatch, druks_db):

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -503,7 +503,7 @@ export interface Harness {
   name: string
   /** Null for a key-only CLI. */
   provider: string | null
-  loginKinds: string[]
+  billingOptions: string[]
 }
 
 /** One model provider — who answers and bills a request. An account holds at
@@ -512,7 +512,7 @@ export interface Harness {
 export interface Provider {
   id: string
   label: string
-  loginKinds: string[]
+  billingOptions: string[]
 }
 
 /** The models one provider offers, fetched over a subscription. */

--- a/frontend/src/components/IdentityBootstrap.test.tsx
+++ b/frontend/src/components/IdentityBootstrap.test.tsx
@@ -89,7 +89,7 @@ describe('IdentityBootstrap', () => {
           {
             id: 'anthropic',
             label: 'Anthropic',
-            loginKinds: ['oauth'],
+            billingOptions: ['subscription'],
           },
         ],
       }),

--- a/frontend/src/components/Onboarding.test.tsx
+++ b/frontend/src/components/Onboarding.test.tsx
@@ -5,8 +5,8 @@ import type { Provider } from '../api/types'
 import { Onboarding } from './Onboarding'
 
 const REGISTERED_PROVIDERS: Provider[] = [
-  { id: 'anthropic', label: 'Anthropic', loginKinds: ['api_key', 'oauth'] },
-  { id: 'openai', label: 'OpenAI', loginKinds: ['api_key', 'oauth'] },
+  { id: 'anthropic', label: 'Anthropic', billingOptions: ['api_key', 'subscription'] },
+  { id: 'openai', label: 'OpenAI', billingOptions: ['api_key', 'subscription'] },
 ]
 
 afterEach(() => {
@@ -71,7 +71,7 @@ describe('Onboarding', () => {
   })
 
   it('renders one card per subscription provider; a key-only provider waits for Settings', async () => {
-    stubProviderList([...REGISTERED_PROVIDERS, { id: 'xai', label: 'xAI', loginKinds: ['api_key'] }])
+    stubProviderList([...REGISTERED_PROVIDERS, { id: 'xai', label: 'xAI', billingOptions: ['api_key'] }])
 
     render(<Onboarding onConnected={() => undefined} />)
 

--- a/frontend/src/components/Onboarding.tsx
+++ b/frontend/src/components/Onboarding.tsx
@@ -26,7 +26,7 @@ export function Onboarding({ onConnected }: { onConnected: (account: Account) =>
     let ignore = false
     api.providers().then(
       (registered) => {
-        if (!ignore) setProviders(registered.filter((p) => p.loginKinds.includes('oauth')))
+        if (!ignore) setProviders(registered.filter((p) => p.billingOptions.includes('subscription')))
       },
       (error: unknown) => {
         if (!ignore) setLoadError(error instanceof Error ? error.message : String(error))

--- a/frontend/src/components/ProviderConnect.test.tsx
+++ b/frontend/src/components/ProviderConnect.test.tsx
@@ -9,7 +9,7 @@ function provider(overrides: Partial<Provider> = {}): Provider {
   return {
     id: 'anthropic',
     label: 'Anthropic',
-    loginKinds: ['api_key', 'oauth'],
+    billingOptions: ['api_key', 'subscription'],
     ...overrides,
   }
 }
@@ -85,7 +85,7 @@ describe('ProviderConnect', () => {
   })
 
   it('a key-only vendor shows only the key block', () => {
-    renderCard(provider({ id: 'xai', label: 'xAI', loginKinds: ['api_key'] }))
+    renderCard(provider({ id: 'xai', label: 'xAI', billingOptions: ['api_key'] }))
 
     expect(screen.getByLabelText('API key')).toBeTruthy()
     expect(screen.queryByText('Subscription')).toBeNull()
@@ -214,7 +214,7 @@ describe('ProviderConnect', () => {
     )
     vi.stubGlobal('fetch', fetchMock)
 
-    const { invalidate } = renderCard(provider({ loginKinds: ['api_key'] }))
+    const { invalidate } = renderCard(provider({ billingOptions: ['api_key'] }))
     fireEvent.change(screen.getByLabelText('API key'), {
       target: { value: 'the-api-key' },
     })

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -5,9 +5,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { SettingsModal } from './SettingsModal'
 
 const harnesses = [
-  { name: 'claude', provider: 'anthropic', loginKinds: ['api_key', 'oauth'] },
-  { name: 'codex', provider: 'openai', loginKinds: ['api_key', 'oauth'] },
-  { name: 'opencode', provider: null, loginKinds: ['api_key'] },
+  { name: 'claude', provider: 'anthropic', billingOptions: ['api_key', 'subscription'] },
+  { name: 'codex', provider: 'openai', billingOptions: ['api_key', 'subscription'] },
+  { name: 'opencode', provider: null, billingOptions: ['api_key'] },
 ]
 
 const userSettings = {

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -46,7 +46,7 @@ interface Catalog {
 
 function buildCatalog(harnesses: Harness[], providers: Provider[], catalogs: ProviderCatalog[]): Catalog {
   const hasProvider = (harness: Harness, provider: Provider) =>
-    harness.provider ? harness.provider === provider.id : harness.loginKinds.some((k) => provider.loginKinds.includes(k))
+    harness.provider ? harness.provider === provider.id : harness.billingOptions.some((k) => provider.billingOptions.includes(k))
   const modelsByProvider = Object.fromEntries(catalogs.map((c) => [c.provider, c.models]))
   return {
     modelsOf: (name) => {
@@ -58,7 +58,7 @@ function buildCatalog(harnesses: Harness[], providers: Provider[], catalogs: Pro
 }
 
 const keyOnly = (harness: Harness | undefined) =>
-  Boolean(harness) && !harness!.loginKinds.includes('oauth')
+  Boolean(harness) && !harness!.billingOptions.includes('subscription')
 
 const BILLINGS: Billing[] = ['subscription', 'api_key']
 const billingLabel = (billing: string) => (billing === 'api_key' ? 'API key' : 'subscription')
@@ -1599,8 +1599,8 @@ export function ProviderConnect({
   const flow = useProviderConnect(provider.id, async () => {
     await refresh()
   })
-  const acceptsOauth = provider.loginKinds.includes('oauth')
-  const acceptsApiKey = provider.loginKinds.includes('api_key')
+  const acceptsSubscription = provider.billingOptions.includes('subscription')
+  const acceptsApiKey = provider.billingOptions.includes('api_key')
 
   const run = (action: () => Promise<unknown>, after: () => Promise<unknown>) => {
     setBusy(true)
@@ -1639,7 +1639,7 @@ export function ProviderConnect({
   const showKeyForm = acceptsApiKey && (!apiKey || replacing)
   return (
     <div className="hr-connect">
-      {acceptsOauth && (
+      {acceptsSubscription && (
         <section className="hr-block">
           <div className="hr-block-title">Subscription</div>
           {subscription ? (


### PR DESCRIPTION
Follow-up to the Providers/Agents redesign. Base: `main`. Linear: [DRU-420](https://linear.app/fellaworks/issue/DRU-420/billing-options-replaces-login-kinds-one-billing-vocabulary-end-to-end).

## What

- `Provider.login_kinds` and `Harness.login_kinds` become `billing_options`, a frozenset of `subscription` / `api_key`. A provider declares what it offers (anthropic, openai: both); a harness declares what it runs on (claude, codex: both; opencode, pi: `api_key`).
- `Harness.accepts(subscription)` reads `"subscription" in cls.billing_options`; `check_execution` reads `billing in harness.billing_options`. `BILLING_LOGIN_KINDS` is deleted.
- `Provider._parse_catalog(raw, *, billing)`; the `Billing` literal moves to `druks.harnesses.datastructures`.
- Wire: `loginKinds` is `billingOptions` on `GET /api/providers` and `GET /api/settings/harnesses`. Onboarding filters on `subscription`; the modal's key-only check and the card's subscription block read the same.
- The two comment stutters the rename pass left in `providers.py` and `base.py` are gone.

No migration: no column stores a kind, and the override rows already hold `subscription` / `api_key`.

## Gates

- `uv run ruff check backend && uv run ruff format --check backend`: pass
- Touched backend test files: 200 passed; the full suite runs in CI
- `npm --prefix frontend run lint && npm --prefix frontend run build`: pass; the touched test files pass (27), the rest run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
