### PR TITLE
Trust a provider 401 over the stored token expiry

### DIFF
--- a/backend/druks/harnesses/providers.py
+++ b/backend/druks/harnesses/providers.py
@@ -270,8 +270,27 @@ class Provider:
     async def fetch_usage(
         cls, subscription: ProviderSubscription, *, now: datetime | None = None
     ) -> ParsedUsage:
-        """Fetch + parse the subscription's remaining-quota snapshot from its
-        subscription endpoint. Auth/HTTP failures collapse to a
+        """Fetch + parse the subscription's remaining-quota snapshot, refreshing
+        the token once on a 401. A provider can revoke an access token
+        server-side while its JWT ``exp`` is still days out (a subscription
+        change does exactly this), so the 401 — not the stored expiry — is what
+        says the token is dead."""
+        parsed = await cls._usage_snapshot(subscription, now=now)
+        if parsed.error != "unauthorized":
+            return parsed
+        # rotate_token drops the row when the refresh lineage is also revoked,
+        # so the account then reads disconnected and the card asks for a Reconnect.
+        result = await cls.rotate_token(subscription.id, margin=timedelta.max)
+        refreshed = await ProviderSubscription.reload(subscription.id)
+        if result.action != "refreshed" or not refreshed:
+            return ParsedUsage(ok=False, error="auth_required")
+        return await cls._usage_snapshot(refreshed, now=now)
+
+    @classmethod
+    async def _usage_snapshot(
+        cls, subscription: ProviderSubscription, *, now: datetime | None = None
+    ) -> ParsedUsage:
+        """One fetch of the usage endpoint. Auth/HTTP failures collapse to a
         ``ParsedUsage(ok=False, error=<tag>)`` so they never look like
         '0 metrics'."""
         try:

--- a/backend/tests/test_provider_auth.py
+++ b/backend/tests/test_provider_auth.py
@@ -431,6 +431,46 @@ async def test_codex_fetch_usage_success(monkeypatch, druks_db):
     assert calls[0]["headers"]["ChatGPT-Account-Id"] == "acc-7"
 
 
+async def test_codex_usage_forces_a_refresh_on_401_then_retries(monkeypatch, druks_db):
+    # The stored access token's JWT ``exp`` is days out, so the refresh loop
+    # never touches it — but the provider 401s it server-side. fetch_usage must
+    # trust the 401, refresh, and retry once.
+    connection = await _seed_codex(account_id="acc-7")
+    fresh = _jwt(int((_NOW + timedelta(days=9)).timestamp()))
+    _mock_post(monkeypatch, _resp(200, {"access_token": fresh, "refresh_token": "R1"}))
+    body = {
+        "plan_type": "pro",
+        "rate_limit": {
+            "primary_window": {"used_percent": 39, "limit_window_seconds": 18000, "reset_at": 1},
+            "secondary_window": {"used_percent": 39, "limit_window_seconds": 604800, "reset_at": 2},
+        },
+    }
+    responses = [_resp(401, {"detail": {"code": "token_expired"}}), _resp(200, body)]
+    gets = []
+
+    async def fake_get(self, url, *, headers=None, **_kwargs):
+        gets.append(headers)
+        return responses[min(len(gets) - 1, len(responses) - 1)]
+
+    monkeypatch.setattr(pbase.httpx.AsyncClient, "get", fake_get)
+    parsed = await OpenAiProvider.fetch_usage(connection, now=_NOW)
+    assert parsed.ok is True
+    assert parsed.plan_tier == "pro"
+    assert len(gets) == 2  # 401, then the post-refresh retry
+
+
+async def test_codex_usage_reports_auth_required_when_the_refresh_is_revoked(monkeypatch, druks_db):
+    # The subscription changed: both the access token and its refresh lineage
+    # are revoked. The forced refresh gets invalid_grant, so we surface
+    # auth_required rather than looping on the dead token.
+    connection = await _seed_codex(account_id="acc-7")
+    _mock_post(monkeypatch, _resp(400, {"error": "invalid_grant"}))
+    _mock_get(monkeypatch, _resp(401, {"detail": {"code": "token_expired"}}))
+    parsed = await OpenAiProvider.fetch_usage(connection, now=_NOW)
+    assert parsed.ok is False
+    assert parsed.error == "auth_required"
+
+
 async def test_lookup_reads_only_the_accounts_own_subscription(druks_db):
     own = await _seed_claude(provider_email="a@example.com")
     other = await _seed_claude(provider_email="b@example.com")

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -35,7 +35,7 @@ import {
   type WorkflowSettingField,
 } from '../api/types'
 import { appLabel } from '../apps/registry'
-import { absTime, money, relTimeFromIso } from '../lib/format'
+import { absTime, money, relTimeFromIso, timeAway } from '../lib/format'
 import { useUsageToday } from '../lib/useUsage'
 import { Bar } from './UsagePanel'
 import { harnessColors } from '../lib/harnessColors'
@@ -1667,7 +1667,7 @@ export function ProviderConnect({
               ))}
               {subscription.expiresAt && (
                 <span className="hr-conn-exp">
-                  token {expired ? 'expired' : 'expires'} {relTimeFromIso(subscription.expiresAt)}
+                  token {expired ? 'expired' : 'expires'} {timeAway(subscription.expiresAt)}
                 </span>
               )}
             </>


### PR DESCRIPTION
Two independent fixes surfaced while debugging codex "unauthorized" on the box.

## codex 401 never recovers
A ChatGPT/OAuth access token can be revoked server-side (a subscription change does exactly this) while its JWT `exp` is still days out. `needs_refresh` only rotates within 24h of that `exp`, so the dead token silently 401s for days while the Providers card still reads "connected".

`fetch_usage` now treats a **401 as authority over the stored expiry**: it forces a refresh past the usual margin (`margin=timedelta.max`) and retries the request once.

- Access token dead, refresh token valid → rotate mints a fresh token → retry succeeds. Self-heal.
- Whole grant revoked → the forced refresh gets `invalid_grant`; `rotate_token` already drops the row → the account reads disconnected and the card shows **Reconnect** within one poll cycle → `fetch_usage` returns `auth_required` (no loop on the dead token).

## "token expires 0s ago"
The subscription line rendered `relTimeFromIso(expiresAt)`, and `secondsSince` clamps any **future** time to `0` (`Math.max(0, now - t)`) — so every live token read "token expires 0s ago". Swapped to the existing `timeAway` helper, which reads both directions ("in 7h" / "5m ago"). The wire was already correct.

## Tests
- Two new cases in `test_provider_auth.py`: 401 → forced refresh → retry succeeds; 401 → revoked refresh → `auth_required`.
- Existing `test_provider_auth`, `test_usage_poll`, `test_api_usage`, and `ProviderConnect.test.tsx` pass; frontend builds.

Does not revive an already-revoked credential — that still needs a Reconnect. It stops the stale "connected · 0s ago" state and makes the card self-correct.