### PR TITLE
DRU-421: Finish Providers and add OpenCode catalog

### DIFF
--- a/backend/druks/api/server.py
+++ b/backend/druks/api/server.py
@@ -33,7 +33,7 @@ from druks.durable.engine import init_dbos, launch, shutdown
 from druks.durable.exceptions import AgentCallNotFound
 from druks.events.routes import router as events_router
 from druks.files.routes import router as files_router
-from druks.harnesses.exceptions import ExecutionSettingsError
+from druks.harnesses.exceptions import CatalogError, ExecutionSettingsError
 from druks.harnesses.routes import router as providers_router
 from druks.mcp.catalog import load_mcp_catalog
 from druks.mcp.gateway import exceptions as gate_errors
@@ -216,6 +216,12 @@ async def _service_not_connected_handler(
 @app.exception_handler(OauthPageError)
 async def _oauth_page_error_handler(request: Request, exc: OauthPageError) -> HTMLResponse:
     return render_page("service_oauth_error.html", message=str(exc), status_code=exc.status_code)
+
+
+@app.exception_handler(CatalogError)
+async def _catalog_error_handler(request: Request, exc: CatalogError) -> JSONResponse:
+    detail = f"The provider directory is unreachable: {exc.tag}."
+    return JSONResponse(status_code=503, content={"error": "HTTP_503", "detail": detail})
 
 
 @app.exception_handler(ExecutionSettingsError)

--- a/backend/druks/core/tasks.py
+++ b/backend/druks/core/tasks.py
@@ -2,6 +2,7 @@ import logging
 
 from druks.files.storage import reap_deleted_file_bytes
 from druks.harnesses.datastructures import RotationResult
+from druks.harnesses.directory import refresh_added_catalogs
 from druks.harnesses.models import ProviderSubscription
 from druks.harnesses.providers import get_provider, get_providers
 from druks.sandbox import gate
@@ -29,6 +30,7 @@ async def refresh_tokens() -> None:
 async def refresh_catalogs() -> None:
     for provider in get_providers():
         await provider.refresh_catalog()
+    await refresh_added_catalogs()
 
 
 async def _refresh() -> dict[str, object]:

--- a/backend/druks/harnesses/constants.py
+++ b/backend/druks/harnesses/constants.py
@@ -2,6 +2,9 @@
 # operator completes it, and the per-subscription SET NX lock that serializes refresh.
 CONNECT_PENDING_PREFIX = "druks:harness:connect:pending:"
 REFRESH_LOCK_PREFIX = "druks:harness:refresh:"
+# The models.dev directory, read when someone searches for a provider to add.
+DIRECTORY_CACHE_KEY = "druks:harness:directory"
+DIRECTORY_CACHE_TTL_SECONDS = 24 * 3600
 
 CLAUDE_DISALLOWED_TOOLS = (
     "CronCreate",

--- a/backend/druks/harnesses/directory.py
+++ b/backend/druks/harnesses/directory.py
@@ -1,0 +1,88 @@
+import json
+import logging
+
+import httpx
+
+from druks.redis import get_client
+
+from . import exceptions
+from .constants import DIRECTORY_CACHE_KEY, DIRECTORY_CACHE_TTL_SECONDS
+from .models import ProviderCatalog, ProviderKey
+from .providers import error_tag, is_registered
+
+logger = logging.getLogger(__name__)
+
+_MODELS_DEV_URL = "https://models.dev/api.json"
+_TIMEOUT_SECONDS = 20.0
+
+
+async def list_providers() -> list[dict]:
+    """Every models.dev provider that runs on one API key, ``{"provider",
+    "label", "models"}`` each. Held in Redis for a day."""
+    redis = get_client()
+    cached = await redis.get(DIRECTORY_CACHE_KEY)
+    if cached:
+        return json.loads(cached)
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+            response = await client.get(_MODELS_DEV_URL)
+    except httpx.TimeoutException as exc:
+        raise exceptions.CatalogError("timeout") from exc
+    except httpx.HTTPError as exc:
+        raise exceptions.CatalogError("network") from exc
+    if response.status_code != 200:
+        raise exceptions.CatalogError(error_tag(response.status_code))
+    providers = parse_providers(response.text)
+    await redis.set(DIRECTORY_CACHE_KEY, json.dumps(providers), ex=DIRECTORY_CACHE_TTL_SECONDS)
+    return providers
+
+
+def parse_providers(raw: str) -> list[dict]:
+    """The models.dev providers a key can reach: the key form holds one
+    environment variable, so a provider that needs more has no place in it."""
+    try:
+        providers = []
+        for provider_id, provider in json.loads(raw).items():
+            if len(provider.get("env") or []) != 1:
+                continue
+            models = [
+                {"id": f"{provider_id}/{model_id}", "label": model.get("name") or model_id}
+                for model_id, model in provider.get("models", {}).items()
+            ]
+            if models:
+                providers.append(
+                    {
+                        "provider": provider_id,
+                        "label": provider.get("name") or provider_id,
+                        "models": sorted(models, key=lambda model: model["label"]),
+                    }
+                )
+    except json.JSONDecodeError as exc:
+        raise exceptions.CatalogError("unparseable") from exc
+    except (AttributeError, TypeError) as exc:
+        raise exceptions.CatalogError("unexpected_payload") from exc
+    if providers:
+        return sorted(providers, key=lambda provider: provider["label"])
+    raise exceptions.CatalogError("empty_list")
+
+
+async def add_provider(provider_id: str) -> ProviderCatalog:
+    """Make a directory provider one of the installation's, with the model
+    list it publishes. A provider the directory does not list raises ``KeyError``."""
+    for provider in await list_providers():
+        if provider["provider"] == provider_id:
+            return await ProviderCatalog.create(
+                provider_id, provider["models"], label=provider["label"]
+            )
+    raise KeyError(provider_id)
+
+
+async def refresh_added_catalogs() -> None:
+    """Re-read the directory for every provider the operator added by key."""
+    keys = await ProviderKey.list_all()
+    added = [row.provider for row in keys if not is_registered(row.provider)]
+    for provider_id in added:
+        try:
+            await add_provider(provider_id)
+        except (exceptions.CatalogError, KeyError) as exc:
+            logger.warning("directory refresh of %s failed: %s", provider_id, exc)

--- a/backend/druks/harnesses/execution.py
+++ b/backend/druks/harnesses/execution.py
@@ -6,8 +6,8 @@ from druks.user_settings.models import SettingsOverride, UserSettings
 
 from .base import Harness
 from .exceptions import ExecutionSettingsError, HarnessNotConnectedError
-from .models import ProviderKey, ProviderSubscription
-from .providers import get_provider
+from .models import ProviderCatalog, ProviderKey, ProviderSubscription
+from .providers import get_provider, is_registered, provider_label
 from .registry import get_harness
 
 
@@ -26,20 +26,26 @@ class Execution:
         return self.subscription.account_id if self.subscription else SYSTEM_ACCOUNT_ID
 
 
-def check_execution(harness_name: str, model: str, billing: str) -> type[Harness]:
+async def check_execution(harness_name: str, model: str, billing: str) -> type[Harness]:
     """The harness that runs the triple; a triple no harness runs raises."""
     harness = get_harness(harness_name)
     if not harness:
         raise ExecutionSettingsError(f"no installed harness is named {harness_name!r}.")
     provider_id = model.partition("/")[0]
-    try:
+    if is_registered(provider_id):
         provider = get_provider(provider_id)
-    except KeyError as error:
-        raise ExecutionSettingsError(
-            f"model {model!r} names no provider; a model id is 'provider/model'."
-        ) from error
-    if not harness.has_provider(provider):
-        raise ExecutionSettingsError(f"{harness_name} does not run {provider.label} models.")
+        if not harness.has_provider(provider):
+            raise ExecutionSettingsError(f"{harness_name} does not run {provider.label} models.")
+    else:
+        catalog = await ProviderCatalog.get(provider_id)
+        if not catalog:
+            raise ExecutionSettingsError(
+                f"model {model!r} names no provider; add one in Settings → Providers."
+            )
+        if harness.provider:
+            raise ExecutionSettingsError(f"{harness_name} does not run {catalog.label} models.")
+        if model not in {entry["id"] for entry in catalog.models}:
+            raise ExecutionSettingsError(f"{catalog.label} lists no model {model!r}.")
     if billing not in harness.billing_options:
         raise ExecutionSettingsError(
             f"{harness_name} runs on an API key only; set billing to api_key."
@@ -59,15 +65,15 @@ async def resolve_execution(agent_name: str, account_id: str | None) -> Executio
     harness_name = (await SettingsOverride.agent_harness(agent_name)).value
     model = (await SettingsOverride.agent_model(agent_name)).value
     billing = (await SettingsOverride.agent_billing(agent_name)).value
-    harness_class = check_execution(harness_name, model, billing)
+    harness_class = await check_execution(harness_name, model, billing)
     provider_id = model.partition("/")[0]
     subscription = None
     key = None
     if billing == "api_key":
         provider_key = await ProviderKey.get(provider_id)
         if not provider_key:
-            label = get_provider(provider_id).label
-            raise HarnessNotConnectedError(f"add an {label} API key in Settings → Providers.")
+            label = await provider_label(provider_id)
+            raise HarnessNotConnectedError(f"add the {label} API key in Settings → Providers.")
         key = provider_key.value.decrypt()
     else:
         subscription = await ProviderSubscription.lookup(

--- a/backend/druks/harnesses/models.py
+++ b/backend/druks/harnesses/models.py
@@ -179,25 +179,37 @@ class ProviderKey(Base):
 
 class ProviderCatalog(Base):
     """The models a provider offers, ``{"id", "label"}`` each with ids
-    namespaced ``provider/model``. Fetched over a subscription or the key."""
+    namespaced ``provider/model``; ``label`` names the provider."""
 
     __tablename__ = "provider_catalogs"
 
     provider: Mapped[str] = mapped_column(String, primary_key=True)
+    label: Mapped[str]
     models: Mapped[Any] = mapped_column(JSONB)
     fetched_at: Mapped[datetime] = mapped_column(default=Base.utc_now, onupdate=Base.utc_now)
+
+    @classmethod
+    async def get(cls, provider: str) -> "ProviderCatalog | None":
+        return await db_session().get(cls, provider)
 
     @classmethod
     async def list_all(cls) -> list["ProviderCatalog"]:
         return list(await db_session().scalars(select(cls).order_by(cls.provider)))
 
     @classmethod
-    async def create(cls, provider: str, models: list[dict]) -> None:
+    async def create(cls, provider: str, models: list[dict], *, label: str) -> "ProviderCatalog":
         session = db_session()
         row = await session.get(cls, provider)
-        if row:
-            row.models = models
-            row.fetched_at = Base.utc_now()
-        else:
-            session.add(cls(provider=provider, models=models))
+        if not row:
+            row = cls(provider=provider)
+            session.add(row)
+        row.models = models
+        row.label = label
+        row.fetched_at = Base.utc_now()
+        await session.flush()
+        return row
+
+    async def delete(self) -> None:
+        session = db_session()
+        await session.delete(self)
         await session.flush()

--- a/backend/druks/harnesses/providers.py
+++ b/backend/druks/harnesses/providers.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import json
 import logging
+import re
 import secrets
 import urllib.parse
 from datetime import UTC, datetime, timedelta
@@ -35,7 +36,19 @@ logger = logging.getLogger(__name__)
 _GRANT_TIMEOUT_SECONDS = 30.0
 _USAGE_TIMEOUT_SECONDS = 20.0
 _CATALOG_TIMEOUT_SECONDS = 20.0
-_MODELS_DEV_URL = "https://models.dev/api.json"
+_OPENAI_MODELS_URL = "https://api.openai.com/v1/models"
+# The platform lists every model on the account; only these run a coding agent.
+_OPENAI_CHAT_MODEL = re.compile(r"^(gpt-|o\d)")
+_OPENAI_NON_CHAT_MARKERS = (
+    "-realtime",
+    "-audio",
+    "-tts",
+    "-transcribe",
+    "-image",
+    "-search",
+    "-instruct",
+    "-embedding",
+)
 # The connect-flow pending state (PKCE verifier + state) lives in Redis this
 # long — enough to authorize and paste, short enough that an abandoned attempt
 # clears.
@@ -413,7 +426,7 @@ class Provider:
         except (exceptions.CatalogError, exceptions.OAuthTokenError) as exc:
             logger.warning("catalog refresh for %s failed: %s", cls.id, exc.tag)
         else:
-            await ProviderCatalog.create(cls.id, list(models))
+            await ProviderCatalog.create(cls.id, list(models), label=cls.label)
 
     @classmethod
     def _catalog_request(
@@ -443,6 +456,18 @@ def get_provider(provider_id: str) -> Provider:
         if provider.id == provider_id:
             return provider
     raise KeyError(provider_id)
+
+
+def is_registered(provider_id: str) -> bool:
+    return any(provider.id == provider_id for provider in get_providers())
+
+
+async def provider_label(provider_id: str) -> str:
+    """What to call a provider: the registry's name, or the one its catalog
+    carries for a provider the operator added by key."""
+    if is_registered(provider_id):
+        return get_provider(provider_id).label
+    return (await ProviderCatalog.get(provider_id)).label
 
 
 def _utc_now() -> datetime:
@@ -958,7 +983,7 @@ class OpenAiProvider(Provider):
         cls, subscription: ProviderSubscription | None, key: str | None
     ) -> ProviderRequest:
         if not subscription:
-            return ProviderRequest(_MODELS_DEV_URL, {})
+            return ProviderRequest(_OPENAI_MODELS_URL, {"Authorization": f"Bearer {key}"})
         # ``client_version`` is required and lower-bounds the list (the server
         # returns models with ``minimal_client_version <= client_version``); the
         # high constant asks for the full catalog, and the empty-list guard
@@ -973,8 +998,10 @@ class OpenAiProvider(Provider):
         try:
             if billing == "api_key":
                 models = tuple(
-                    {"id": f"{cls.id}/{model['id']}", "label": model["name"]}
-                    for model in json.loads(raw)[cls.id]["models"].values()
+                    {"id": f"{cls.id}/{model['id']}", "label": model["id"]}
+                    for model in json.loads(raw)["data"]
+                    if _OPENAI_CHAT_MODEL.match(model["id"])
+                    and not any(marker in model["id"] for marker in _OPENAI_NON_CHAT_MARKERS)
                 )
             else:
                 models = tuple(

--- a/backend/druks/harnesses/routes.py
+++ b/backend/druks/harnesses/routes.py
@@ -9,11 +9,13 @@ from druks.accounts.schemas import AccountResponse
 from druks.database import db_session
 from druks.user_settings.models import UserSettings
 
+from . import directory
 from .exceptions import ConnectError
 from .models import ProviderCatalog, ProviderKey, ProviderSubscription
-from .providers import Provider, get_provider, get_providers
+from .providers import Provider, get_provider, get_providers, is_registered
 from .schemas import (
     ProviderCatalogResponse,
+    ProviderDirectoryResponse,
     ProviderKeyResponse,
     ProviderResponse,
     ProviderSubscriptionResponse,
@@ -61,6 +63,18 @@ async def list_keys() -> list[ProviderKey]:
 )
 async def list_catalogs() -> list[ProviderCatalog]:
     return await ProviderCatalog.list_all()
+
+
+@router.get(
+    "/directory",
+    response_model=list[ProviderDirectoryResponse],
+    response_model_by_alias=True,
+    dependencies=[Depends(current_session_account)],
+)
+async def list_directory() -> list[dict]:
+    """The providers an operator can add by key: the directory minus the registered ones."""
+    providers = await directory.list_providers()
+    return [provider for provider in providers if not is_registered(provider["provider"])]
 
 
 def _resolve_provider(provider_id: str) -> Provider:
@@ -154,27 +168,40 @@ async def create_key(
     account: Account = Depends(current_session_account),
     key: str = Body(..., embed=True),
 ) -> ProviderKey:
-    provider = _resolve_provider(provider_id)
-    if "api_key" not in provider.billing_options:
-        raise HTTPException(
-            status_code=422,
-            detail=f"{provider.label} does not accept API keys.",
-        )
-    if key := key.strip():
-        row = await ProviderKey.create(provider=provider.id, key=key, account=account)
+    """The installation's key at a provider. A provider from the directory
+    becomes one of the installation's when its key lands."""
+    if not (key := key.strip()):
+        raise HTTPException(status_code=422, detail="The API key is empty. Paste a key.")
+    if is_registered(provider_id):
+        provider = get_provider(provider_id)
+        if "api_key" not in provider.billing_options:
+            raise HTTPException(
+                status_code=422, detail=f"{provider.label} does not accept API keys."
+            )
+        stored = await ProviderKey.create(provider=provider.id, key=key, account=account)
         await provider.refresh_catalog()
-        return row
-    raise HTTPException(status_code=422, detail="The API key is empty. Paste a key.")
+        return stored
+    try:
+        await directory.add_provider(provider_id)
+    except KeyError as error:
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {provider_id!r}") from error
+    return await ProviderKey.create(provider=provider_id, key=key, account=account)
 
 
 @router.delete(
     "/{provider_id}/key", status_code=204, dependencies=[Depends(current_session_account)]
 )
 async def remove_key(provider_id: str) -> None:
-    provider = _resolve_provider(provider_id)
-    row = await ProviderKey.get(provider.id)
-    if row:
-        await row.delete()
+    """A provider the operator added from the directory is gone with its key."""
+    stored = await ProviderKey.get(provider_id)
+    if stored:
+        await stored.delete()
+    if is_registered(provider_id):
+        return
+    catalog = await ProviderCatalog.get(provider_id)
+    if not catalog:
+        raise HTTPException(status_code=404, detail=f"Unknown provider: {provider_id!r}")
+    await catalog.delete()
 
 
 @router.delete("/{provider_id}/connection", status_code=204)

--- a/backend/druks/harnesses/schemas.py
+++ b/backend/druks/harnesses/schemas.py
@@ -47,5 +47,12 @@ class ProviderCatalogResponse(Schema):
     model_config = ConfigDict(from_attributes=True)
 
     provider: str
+    label: str
     models: list[CatalogModel]
     fetched_at: datetime
+
+
+class ProviderDirectoryResponse(Schema):
+    provider: str
+    label: str
+    models: list[CatalogModel]

--- a/backend/druks/user_settings/routes.py
+++ b/backend/druks/user_settings/routes.py
@@ -89,12 +89,19 @@ async def update_user_settings(
         if field in _EXECUTION_DEFAULTS
     }
     if defaults:
-        check_execution(
+        await check_execution(
             defaults.get("default_harness", row.default_harness),
             defaults.get("default_model", row.default_model),
             defaults.get("default_billing", row.default_billing),
         )
         await row.update_profile(**defaults)
+        for agent in agents.all():
+            name = agent.id
+            await check_execution(
+                (await SettingsOverride.agent_harness(name)).value,
+                (await SettingsOverride.agent_model(name)).value,
+                (await SettingsOverride.agent_billing(name)).value,
+            )
     if body.fallback_account_id:
         if not await Account.get(body.fallback_account_id, exclude_system=True):
             raise HTTPException(
@@ -136,7 +143,7 @@ async def update_app_settings(body: AppsSettingsUpdate) -> AppsSettingsResponse:
     for name in {*body.agent_harnesses, *body.agent_models, *body.agent_billings}:
         if name not in agents:
             raise HTTPException(status_code=422, detail=f"Unknown agent {name!r}")
-        check_execution(
+        await check_execution(
             (await SettingsOverride.agent_harness(name)).value,
             (await SettingsOverride.agent_model(name)).value,
             (await SettingsOverride.agent_billing(name)).value,

--- a/backend/migrations/versions/c8b1f4d2a963_provider_catalog_label.py
+++ b/backend/migrations/versions/c8b1f4d2a963_provider_catalog_label.py
@@ -1,0 +1,33 @@
+"""A provider catalog names its provider.
+
+Revision ID: c8b1f4d2a963
+Revises: 7e1c4b9d2a58
+Create Date: 2026-09-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c8b1f4d2a963"
+down_revision: str | Sequence[str] | None = "7e1c4b9d2a58"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("provider_catalogs", sa.Column("label", sa.String(), nullable=True))
+    # Only registered providers have rows so far; the next refresh rewrites these.
+    op.execute(
+        sa.text(
+            "UPDATE provider_catalogs SET label = CASE provider "
+            "WHEN 'anthropic' THEN 'Anthropic' WHEN 'openai' THEN 'OpenAI' "
+            "ELSE initcap(provider) END"
+        )
+    )
+    op.alter_column("provider_catalogs", "label", nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("provider_catalogs", "label")

--- a/backend/tests/test_api_providers.py
+++ b/backend/tests/test_api_providers.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from conftest import connect_provider
 from druks.accounts.models import Account
+from druks.harnesses import directory
 from druks.harnesses.models import ProviderCatalog, ProviderKey, ProviderSubscription
 from druks.harnesses.providers import AnthropicProvider
 from druks.testing import configure_app_for_test, make_settings
@@ -121,6 +122,42 @@ async def test_removing_the_key_leaves_every_subscription(tmp_path: Path, druks_
     assert await ProviderSubscription.reload(mine_id)
 
 
+_GROQ = {
+    "provider": "groq",
+    "label": "Groq",
+    "models": [{"id": "groq/llama-4", "label": "Llama 4"}],
+}
+
+
+def _stub_directory(monkeypatch, providers: list[dict]) -> None:
+    async def list_providers():
+        return providers
+
+    monkeypatch.setattr(directory, "list_providers", list_providers)
+
+
+async def test_a_key_for_a_directory_provider_adds_it(tmp_path: Path, druks_db, monkeypatch):
+    _stub_directory(monkeypatch, [_GROQ])
+    with _build_client(tmp_path) as client:
+        response = client.post("/api/providers/groq/key", json={"key": "gsk-secret"})
+        assert response.status_code == 200
+        assert response.json()["provider"] == "groq"
+        [catalog] = client.get("/api/providers/catalogs").json()
+        assert (catalog["provider"], catalog["label"]) == ("groq", "Groq")
+        assert client.post("/api/providers/nobody/key", json={"key": "x"}).status_code == 404
+
+        # Removing the key removes the provider with it.
+        assert client.delete("/api/providers/groq/key").status_code == 204
+        assert client.get("/api/providers/catalogs").json() == []
+    assert await ProviderKey.list_all() == []
+
+
+def test_directory_lists_only_providers_one_can_add(tmp_path: Path, monkeypatch):
+    _stub_directory(monkeypatch, [_GROQ, {"provider": "openai", "label": "OpenAI", "models": []}])
+    with _build_client(tmp_path) as client:
+        assert client.get("/api/providers/directory").json() == [_GROQ]
+
+
 def test_disconnect_without_a_login_is_a_no_op(tmp_path: Path):
     with _build_client(tmp_path) as client:
         response = client.delete("/api/providers/anthropic/connection")
@@ -135,11 +172,14 @@ def test_unknown_provider_is_404(tmp_path: Path):
 
 async def test_catalogs_list_what_each_provider_offers(tmp_path: Path, druks_db):
     await ProviderCatalog.create(
-        "anthropic", [{"id": "anthropic/claude-fable-5", "label": "Claude Fable 5", "efforts": []}]
+        "anthropic",
+        [{"id": "anthropic/claude-fable-5", "label": "Claude Fable 5", "efforts": []}],
+        label="Anthropic",
     )
     await druks_db.commit()
     with _build_client(tmp_path) as client:
         [catalog] = client.get("/api/providers/catalogs").json()
     assert catalog["provider"] == "anthropic"
+    assert catalog["label"] == "Anthropic"
     assert catalog["models"] == [{"id": "anthropic/claude-fable-5", "label": "Claude Fable 5"}]
     assert catalog["fetchedAt"]

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -147,6 +147,24 @@ def test_patch_settings_updates_the_defaults_every_agent_inherits(tmp_path: Path
     assert agents["implement"]["source"] == "default"
 
 
+def test_patch_settings_rejects_defaults_that_break_an_agent_override(tmp_path: Path):
+    with _build_client(tmp_path) as client:
+        override = client.patch(
+            "/api/settings/apps",
+            json={"agentModels": {"generate_plan": "anthropic/claude-opus-4-7"}},
+        )
+        assert override.status_code == 200
+
+        response = client.patch(
+            "/api/settings",
+            json={"defaultHarness": "codex", "defaultModel": "openai/gpt-5.5"},
+        )
+
+        assert response.status_code == 422
+        assert "does not run Anthropic" in response.json()["detail"]
+        assert client.get("/api/settings").json()["defaultHarness"] == "claude"
+
+
 def test_patch_settings_rejects_a_model_no_harness_runs(tmp_path: Path):
     with _build_client(tmp_path) as client:
         response = client.patch("/api/settings", json={"defaultModel": "gpt-5.5"})

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -31,6 +31,7 @@ SESSION_ONLY_API_ROUTES = {
     ("POST", "/api/auth/personal-tokens"),
     ("DELETE", "/api/auth/personal-tokens/{pat_id}"),
     ("GET", "/api/providers/catalogs"),
+    ("GET", "/api/providers/directory"),
     ("GET", "/api/providers/subscriptions"),
     ("GET", "/api/providers/keys"),
     ("POST", "/api/providers/{provider_id}/key"),

--- a/backend/tests/test_execution.py
+++ b/backend/tests/test_execution.py
@@ -6,7 +6,7 @@ from druks.accounts.models import Account
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.exceptions import ExecutionSettingsError, HarnessNotConnectedError
 from druks.harnesses.execution import check_execution, resolve_execution
-from druks.harnesses.models import ProviderKey, ProviderSubscription
+from druks.harnesses.models import ProviderCatalog, ProviderKey, ProviderSubscription
 from druks.harnesses.opencode import OpenCodeHarness
 from druks.harnesses.providers import AnthropicProvider
 from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
@@ -27,18 +27,23 @@ OVERSIZED = agents.Agent(
 )
 
 
-def test_check_judges_the_triple_together():
-    assert check_execution("claude", "anthropic/claude-opus-4-7", "subscription") is ClaudeHarness
-    assert check_execution("claude", "anthropic/claude-opus-4-7", "api_key") is ClaudeHarness
-    assert check_execution("opencode", "anthropic/claude-opus-4-7", "api_key") is OpenCodeHarness
+async def test_check_judges_the_triple_together(druks_db):
+    assert (
+        await check_execution("claude", "anthropic/claude-opus-4-7", "subscription")
+        is ClaudeHarness
+    )
+    assert await check_execution("claude", "anthropic/claude-opus-4-7", "api_key") is ClaudeHarness
+    assert (
+        await check_execution("opencode", "anthropic/claude-opus-4-7", "api_key") is OpenCodeHarness
+    )
     with pytest.raises(ExecutionSettingsError, match="claude does not run OpenAI models"):
-        check_execution("claude", "openai/gpt-5.5", "subscription")
+        await check_execution("claude", "openai/gpt-5.5", "subscription")
     with pytest.raises(ExecutionSettingsError, match="opencode runs on an API key only"):
-        check_execution("opencode", "anthropic/claude-opus-4-7", "subscription")
+        await check_execution("opencode", "anthropic/claude-opus-4-7", "subscription")
     with pytest.raises(ExecutionSettingsError, match="no installed harness is named 'grok'"):
-        check_execution("grok", "anthropic/claude-opus-4-7", "subscription")
-    with pytest.raises(ExecutionSettingsError, match="a model id is 'provider/model'"):
-        check_execution("claude", "claude-opus-4-7", "subscription")
+        await check_execution("grok", "anthropic/claude-opus-4-7", "subscription")
+    with pytest.raises(ExecutionSettingsError, match="names no provider"):
+        await check_execution("claude", "claude-opus-4-7", "subscription")
 
 
 async def _subscription(email: str) -> ProviderSubscription:
@@ -99,8 +104,52 @@ async def test_a_key_agent_refuses_without_the_key(druks_db):
     actor = await _subscription("a@example.com")
     await SettingsOverride.set_agent_billing(PROBE.id, "api_key")
 
-    with pytest.raises(HarnessNotConnectedError, match="add an Anthropic API key"):
+    with pytest.raises(HarnessNotConnectedError, match="add the Anthropic API key"):
         await resolve_execution(PROBE.id, actor.account_id)
+
+
+async def test_opencode_runs_an_added_provider_with_its_key_and_model(druks_db):
+    await ProviderCatalog.create(
+        "openrouter",
+        [{"id": "openrouter/anthropic/claude-sonnet-4", "label": "Claude Sonnet 4"}],
+        label="OpenRouter",
+    )
+    await ProviderKey.create(
+        provider="openrouter",
+        key="sk-openrouter",
+        account=await Account.get_or_create("ops@example.com"),
+    )
+    await SettingsOverride.set_agent_harness(PROBE.id, "opencode")
+    await SettingsOverride.set_agent_model(PROBE.id, "openrouter/anthropic/claude-sonnet-4")
+    await SettingsOverride.set_agent_billing(PROBE.id, "api_key")
+
+    execution = await resolve_execution(PROBE.id, None)
+
+    assert execution.harness_class is OpenCodeHarness
+    assert execution.model == "openrouter/anthropic/claude-sonnet-4"
+    assert execution.key == "sk-openrouter"
+
+
+async def test_an_added_provider_without_a_key_names_it(druks_db):
+    await ProviderCatalog.create("groq", [{"id": "groq/llama-4", "label": "Llama 4"}], label="Groq")
+    await SettingsOverride.set_agent_harness(PROBE.id, "opencode")
+    await SettingsOverride.set_agent_model(PROBE.id, "groq/llama-4")
+    await SettingsOverride.set_agent_billing(PROBE.id, "api_key")
+
+    with pytest.raises(HarnessNotConnectedError, match="add the Groq API key in Settings"):
+        await resolve_execution(PROBE.id, None)
+
+
+async def test_an_added_provider_runs_only_on_an_unbound_cli_and_its_own_models(druks_db):
+    await ProviderCatalog.create("groq", [{"id": "groq/llama-4", "label": "Llama 4"}], label="Groq")
+
+    with pytest.raises(ExecutionSettingsError, match="claude does not run Groq models"):
+        await check_execution("claude", "groq/llama-4", "api_key")
+    with pytest.raises(ExecutionSettingsError, match="Groq lists no model 'groq/llama-9'"):
+        await check_execution("opencode", "groq/llama-9", "api_key")
+    with pytest.raises(ExecutionSettingsError, match="names no provider; add one"):
+        await check_execution("opencode", "nobody/model", "api_key")
+    assert await check_execution("opencode", "groq/llama-4", "api_key") is OpenCodeHarness
 
 
 async def test_a_key_only_harness_bills_the_key(druks_db):

--- a/backend/tests/test_migration_one_openai_provider.py
+++ b/backend/tests/test_migration_one_openai_provider.py
@@ -55,8 +55,12 @@ async def test_openai_codex_rows_become_openai_everywhere(druks_db):
     codex = await _login("openai-codex", "seat@example.com")
     await _login("openai", "key@example.com")
     await UsageScrape(provider="openai-codex", account_id=codex.account_id, raw_output=None).save()
-    await ProviderCatalog.create("openai-codex", [{"id": "openai-codex/gpt-5.5", "label": "sub"}])
-    await ProviderCatalog.create("openai", [{"id": "openai/gpt-5.5", "label": "key"}])
+    await ProviderCatalog.create(
+        "openai-codex", [{"id": "openai-codex/gpt-5.5", "label": "sub"}], label="OpenAI"
+    )
+    await ProviderCatalog.create(
+        "openai", [{"id": "openai/gpt-5.5", "label": "key"}], label="OpenAI"
+    )
     await (await UserSettings.get()).update_profile(default_model="openai-codex/gpt-5.5")
     await SettingsOverride.set_agent_model("implement", "openai-codex/gpt-5-mini")
     await SettingsOverride.set_agent_effort("implement", "openai-codex/keep")

--- a/backend/tests/test_opencode.py
+++ b/backend/tests/test_opencode.py
@@ -156,6 +156,30 @@ def test_auth_json_keys_the_provider() -> None:
     assert json.loads(rendered) == {"openai": {"type": "api", "key": _API_KEY}}
 
 
+async def test_third_party_invocation_keeps_provider_key_and_model_namespace() -> None:
+    harness = OpenCodeHarness(
+        model="openrouter/anthropic/claude-sonnet-4",
+        fast_mode=False,
+        effort=None,
+        sandbox=_sandbox_config(),
+    )
+
+    invocation = await harness.build_invocation(
+        key="sk-openrouter",
+        prompt="Run it.",
+        schema={"type": "object"},
+        run_id="run-openrouter",
+        ssh_username="exedev",
+    )
+
+    assert invocation.env is not None
+    assert json.loads(invocation.env["OPENCODE_AUTH_CONTENT"]) == {
+        "openrouter": {"type": "api", "key": "sk-openrouter"}
+    }
+    assert invocation.env["DRUKS_PROVIDER"] == "openrouter"
+    assert invocation.env["DRUKS_MODEL"] == "anthropic/claude-sonnet-4"
+
+
 def test_parse_returns_contract_and_writes_cost_sidecars(tmp_path: Path) -> None:
     structured = {"answer": "done", "count": 3}
 

--- a/backend/tests/test_provider_catalogs.py
+++ b/backend/tests/test_provider_catalogs.py
@@ -6,9 +6,20 @@ import pytest
 from conftest import connect_provider
 from druks.accounts.models import Account
 from druks.harnesses import providers as pbase
+from druks.harnesses.constants import DIRECTORY_CACHE_KEY
+from druks.harnesses.directory import (
+    add_provider,
+    list_providers,
+    parse_providers,
+    refresh_added_catalogs,
+)
 from druks.harnesses.exceptions import CatalogError
 from druks.harnesses.models import ProviderCatalog, ProviderKey
 from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
+from druks.redis import get_client
+
+_LLAMA = {"id": "groq/llama-4", "label": "Llama 4"}
+_GROQ = {"name": "Groq", "env": ["GROQ_API_KEY"], "models": {"llama-4": {"name": "Llama 4"}}}
 
 
 def _resp(status: int, body: object) -> httpx.Response:
@@ -103,21 +114,66 @@ def test_codex_parse_empty_catalog_is_an_error() -> None:
         OpenAiProvider._parse_catalog(json.dumps({"models": []}), billing="subscription")
 
 
-def test_openai_parse_reads_its_models_dev_section() -> None:
+def test_openai_parse_keeps_the_chat_models_of_its_own_list() -> None:
     raw = json.dumps(
         {
-            "openai": {"id": "openai", "models": {"gpt-5.5": {"id": "gpt-5.5", "name": "GPT-5.5"}}},
-            "anthropic": {"id": "anthropic", "models": {}},
+            "data": [
+                {"id": "gpt-5.5", "object": "model"},
+                {"id": "o3-mini", "object": "model"},
+                {"id": "gpt-4o-realtime-preview", "object": "model"},
+                {"id": "whisper-1", "object": "model"},
+                {"id": "text-embedding-3-small", "object": "model"},
+            ]
         }
     )
 
     assert OpenAiProvider._parse_catalog(raw, billing="api_key") == (
-        {"id": "openai/gpt-5.5", "label": "GPT-5.5"},
+        {"id": "openai/gpt-5.5", "label": "gpt-5.5"},
+        {"id": "openai/o3-mini", "label": "o3-mini"},
     )
     with pytest.raises(CatalogError, match="unexpected_payload"):
-        OpenAiProvider._parse_catalog(json.dumps({"anthropic": {}}), billing="api_key")
+        OpenAiProvider._parse_catalog(json.dumps({"models": []}), billing="api_key")
     with pytest.raises(CatalogError, match="empty_list"):
-        OpenAiProvider._parse_catalog(json.dumps({"openai": {"models": {}}}), billing="api_key")
+        OpenAiProvider._parse_catalog(
+            json.dumps({"data": [{"id": "whisper-1"}]}), billing="api_key"
+        )
+
+
+def test_directory_keeps_one_key_providers_with_exact_ids() -> None:
+    providers = parse_providers(
+        json.dumps(
+            {
+                "openrouter": {
+                    "id": "different-nested-id",
+                    "name": "OpenRouter",
+                    "env": ["OPENROUTER_API_KEY"],
+                    "models": {
+                        "anthropic/claude-sonnet-4": {
+                            "id": "different-model-id",
+                            "name": "Claude Sonnet 4",
+                        }
+                    },
+                },
+                "amazon-bedrock": {
+                    "name": "Amazon Bedrock",
+                    "env": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+                    "models": {"nova": {"name": "Nova"}},
+                },
+            }
+        )
+    )
+
+    assert providers == [
+        {
+            "provider": "openrouter",
+            "label": "OpenRouter",
+            "models": [{"id": "openrouter/anthropic/claude-sonnet-4", "label": "Claude Sonnet 4"}],
+        }
+    ]
+    with pytest.raises(CatalogError, match="unparseable"):
+        parse_providers("<!doctype html>")
+    with pytest.raises(CatalogError, match="empty_list"):
+        parse_providers(json.dumps({"amazon-bedrock": {"env": ["A", "B"], "models": {}}}))
 
 
 async def test_anthropic_fetch_uses_the_oauth_token(monkeypatch, druks_db):
@@ -181,20 +237,18 @@ async def test_refresh_without_a_login_stores_nothing(monkeypatch, druks_db):
     assert await ProviderCatalog.list_all() == []
 
 
-async def test_openai_refresh_reads_the_subscription_over_the_key(monkeypatch, druks_db):
-    # A key alone reads models.dev; once a subscription exists its endpoint
-    # lists what the codex CLI runs, and that catalog wins.
+async def test_openai_refresh_reads_its_own_list_over_the_key(monkeypatch, druks_db):
     account = await Account.get_or_create("op@example.com")
     await ProviderKey.create(provider="openai", key="sk-openai", account=account)
-    calls = _mock_get(
-        monkeypatch,
-        _resp(200, {"openai": {"models": {"gpt-5.5": {"id": "gpt-5.5", "name": "GPT-5.5"}}}}),
-    )
+    calls = _mock_get(monkeypatch, _resp(200, {"data": [{"id": "gpt-5.5"}, {"id": "whisper-1"}]}))
     await OpenAiProvider.refresh_catalog()
-    assert calls[0]["url"] == "https://models.dev/api.json"
+    assert calls[0]["url"] == "https://api.openai.com/v1/models"
+    assert calls[0]["headers"] == {"Authorization": "Bearer sk-openai"}
     [stored] = await ProviderCatalog.list_all()
-    assert stored.models == [{"id": "openai/gpt-5.5", "label": "GPT-5.5"}]
+    assert stored.label == "OpenAI"
+    assert stored.models == [{"id": "openai/gpt-5.5", "label": "gpt-5.5"}]
 
+    # A subscription's endpoint wins once one exists.
     await connect_provider(
         OpenAiProvider,
         {"tokens": {"access_token": "a.b.c", "account_id": "acc-7"}},
@@ -208,3 +262,42 @@ async def test_openai_refresh_reads_the_subscription_over_the_key(monkeypatch, d
     assert calls[0]["url"].startswith("https://chatgpt.com/backend-api/codex/models")
     [stored] = await ProviderCatalog.list_all()
     assert [model["id"] for model in stored.models] == ["openai/gpt-5.6"]
+
+
+async def test_directory_is_fetched_once_and_read_from_redis(monkeypatch, druks_redis):
+    calls = _mock_get(monkeypatch, _resp(200, {"groq": _GROQ}))
+
+    first = await list_providers()
+    second = await list_providers()
+
+    assert first == second == [{"provider": "groq", "label": "Groq", "models": [_LLAMA]}]
+    assert [call["url"] for call in calls] == ["https://models.dev/api.json"]
+
+    _mock_get(monkeypatch, _resp(503, "down"))
+    await get_client().delete(DIRECTORY_CACHE_KEY)
+    with pytest.raises(CatalogError, match="http_503"):
+        await list_providers()
+
+
+async def test_adding_a_directory_provider_creates_its_catalog(monkeypatch, druks_db, druks_redis):
+    _mock_get(monkeypatch, _resp(200, {"groq": _GROQ}))
+
+    added = await add_provider("groq")
+
+    assert (added.provider, added.label, added.models) == ("groq", "Groq", [_LLAMA])
+    with pytest.raises(KeyError):
+        await add_provider("nobody")
+
+
+async def test_added_catalogs_refresh_from_the_directory(monkeypatch, druks_db, druks_redis):
+    account = await Account.get_or_create("op@example.com")
+    await ProviderKey.create(provider="groq", key="gsk", account=account)
+    await ProviderKey.create(provider="anthropic", key="sk-ant", account=account)
+    calls = _mock_get(monkeypatch, _resp(200, {"groq": _GROQ}))
+
+    await refresh_added_catalogs()
+
+    # Only the added provider reads the directory; anthropic is registered.
+    assert [call["url"] for call in calls] == ["https://models.dev/api.json"]
+    [stored] = await ProviderCatalog.list_all()
+    assert (stored.provider, stored.label) == ("groq", "Groq")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -269,19 +269,25 @@ optional. It reports pending setup if the selected tracker lacks a connection.
 
 ## Harnesses
 
-Druks registers two providers, `anthropic` and `openai`. Each accepts a
-subscription (Claude or ChatGPT) and an API key. Both connect from
-**Settings → Providers**. The connection flow stores each credential in
-Postgres. Druks refreshes a subscription token on a schedule. It creates the
-CLI credential file inside each sandbox, or passes the key in the CLI
-environment. It does not copy a host login. This is a capability connection for
-the requesting account — in a fresh `none`-mode install the first completed
-subscription connection also creates the operator account (see
-[access control](#public-urls-and-access-control)).
+Druks registers two subscription providers, `anthropic` and `openai`. Each
+also accepts an API key. Both connect from **Settings → Providers**. The
+connection flow stores each credential in Postgres. Druks refreshes a
+subscription token on a schedule. It creates the CLI credential file inside
+each sandbox, or passes the key in the CLI environment. It does not copy a
+host login. This is a capability connection for the requesting account. In a
+fresh `none`-mode install, the first completed subscription connection also
+creates the operator account. See [access control](#public-urls-and-access-control).
+
+**Add provider** searches the Models.dev directory for a vendor that runs on
+one API key. Druks reads the directory when you open the search, keeps it in
+Redis for a day, and stores nothing until you paste a key. The key makes the
+vendor one of the installation's providers with its model list. Removing the
+key removes the vendor.
 
 The `claude` and `codex` CLIs run on their own vendor's subscription or key.
-`opencode` and `pi` run on an API key only. A model id is `provider/model`
-on either kind, for example `openai/gpt-5.5`.
+`opencode` and `pi` run on an API key only. OpenCode can run a supported
+Models.dev provider after its key is stored. A model ID is `provider/model`
+for each harness, for example `openai/gpt-5.5`.
 
 Process settings such as `DRUKS_CLAUDE_CONFIG_DIR` and
 `DRUKS_CODEX_CONFIG_DIR` point at optional non-auth CLI configuration to carry
@@ -289,8 +295,8 @@ into sandboxes. The Compose deployment mounts these read-only. The default
 harness, model, billing, effort, and timeout live in **Settings → Agents**;
 each agent can override any of them on its app's page. **Unattended runs
 (webhooks, schedules) run as** names the account whose subscription an
-unattended run bills. A call refuses before provisioning a VM if the login it
-bills is missing.
+unattended run bills. A call refuses before provisioning a VM if the
+credential it bills is missing.
 
 ## Sandboxes
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -29,6 +29,7 @@ import type {
   Service,
   Provider,
   ProviderCatalog,
+  ProviderDirectoryEntry,
   ProviderKey,
   ProviderSubscription,
   Skill,
@@ -272,6 +273,7 @@ export const api = {
   providerSubscriptions: () => getJSON<ProviderSubscription[]>('/api/providers/subscriptions'),
   providerKeys: () => getJSON<ProviderKey[]>('/api/providers/keys'),
   providerCatalogs: () => getJSON<ProviderCatalog[]>('/api/providers/catalogs'),
+  providerDirectory: () => getJSON<ProviderDirectoryEntry[]>('/api/providers/directory'),
   startProviderConnect: (id: string) =>
     postJSON<ConnectChallenge>(`/api/providers/${encodeURIComponent(id)}/connection/start`, {}),
   completeProviderConnect: (id: string, code: string, connectionId: string) =>

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -515,11 +515,19 @@ export interface Provider {
   billingOptions: string[]
 }
 
-/** The models one provider offers, fetched over a subscription. */
+/** One provider's model list; `label` names the provider. */
 export interface ProviderCatalog {
   provider: string
+  label: string
   models: CatalogModel[]
   fetchedAt: string
+}
+
+/** One Models.dev provider that runs on a single API key. */
+export interface ProviderDirectoryEntry {
+  provider: string
+  label: string
+  models: CatalogModel[]
 }
 
 /** One account's subscription at one provider. */

--- a/frontend/src/components/ProviderConnect.test.tsx
+++ b/frontend/src/components/ProviderConnect.test.tsx
@@ -74,25 +74,28 @@ async function flush() {
 }
 
 describe('ProviderConnect', () => {
-  it('a card with nothing connected offers a sign-in above the key field', () => {
+  it('keeps the API-key input collapsed until the user asks for it', () => {
     renderCard(provider())
 
     expect(screen.getByRole('button', { name: 'Sign in with Anthropic' })).toBeTruthy()
+    expect(screen.queryByLabelText('API key')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Add API key' }))
     expect(screen.getByLabelText('API key')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Add key' })).toBeTruthy()
-    expect(screen.queryByText('Disconnect')).toBeNull()
-    expect(screen.queryByText('Remove')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Save API key' })).toBeTruthy()
+    expect(screen.queryByText('Disconnect subscription')).toBeNull()
+    expect(screen.queryByText('Remove API key')).toBeNull()
   })
 
   it('a key-only vendor shows only the key block', () => {
     renderCard(provider({ id: 'xai', label: 'xAI', billingOptions: ['api_key'] }))
 
-    expect(screen.getByLabelText('API key')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Add API key' })).toBeTruthy()
+    expect(screen.queryByLabelText('API key')).toBeNull()
     expect(screen.queryByText('Subscription')).toBeNull()
     expect(screen.queryByRole('button', { name: /Sign in/ })).toBeNull()
   })
 
-  it('a subscription shows its plan, identity, quota, and expiry with Reconnect and Disconnect', () => {
+  it('a healthy subscription has no expired state or reconnect action', () => {
     renderCard(provider(), {
       subscription: subscription({ expiresAt: '2099-01-01T00:00:00Z' }),
       usage: {
@@ -115,15 +118,17 @@ describe('ProviderConnect', () => {
 
     expect(screen.getByText('Connected')).toBeTruthy()
     expect(screen.getByText('Claude Max · claude-seat@corp.com')).toBeTruthy()
-    expect(screen.getByText('82%')).toBeTruthy()
-    expect(screen.getByText('41%')).toBeTruthy()
-    expect(screen.getByText(/token expires/)).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Reconnect' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Disconnect' })).toBeTruthy()
+    expect(screen.getByText('82% remaining')).toBeTruthy()
+    expect(screen.getByText('41% remaining')).toBeTruthy()
+    expect(screen.getByText('5-hour')).toBeTruthy()
+    expect(screen.getByText('Weekly')).toBeTruthy()
+    expect(screen.getByText(/Token expires/)).toBeTruthy()
+    expect(screen.queryByText('Expired')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Disconnect subscription' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: /Sign in/ })).toBeNull()
-    // No key yet: the field is there, the key facts are not.
-    expect(screen.getByLabelText('API key')).toBeTruthy()
-    expect(screen.queryByText('Remove')).toBeNull()
+    expect(screen.queryByLabelText('API key')).toBeNull()
+    expect(screen.queryByText('Remove API key')).toBeNull()
   })
 
   it('a shared key shows its tail, who set it, spend today, Replace and Remove', () => {
@@ -132,7 +137,8 @@ describe('ProviderConnect', () => {
     expect(screen.getByText('…4f2a')).toBeTruthy()
     expect(screen.getByText(/set by ops@corp.com/)).toBeTruthy()
     expect(screen.getByText(/\$12\.40 today/)).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Remove' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Remove API key' })).toBeTruthy()
+    expect(screen.getByLabelText('More Anthropic API key actions')).toBeTruthy()
     expect(screen.queryByLabelText('API key')).toBeNull()
     // The subscription block still invites a sign-in.
     expect(screen.getByRole('button', { name: 'Sign in with Anthropic' })).toBeTruthy()
@@ -147,8 +153,8 @@ describe('ProviderConnect', () => {
 
     expect(screen.getByText('claude-seat@corp.com')).toBeTruthy()
     expect(screen.getByText('…4f2a')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Disconnect' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Remove' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Disconnect subscription' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Remove API key' })).toBeTruthy()
     expect(screen.queryByText('op@example.com')).toBeNull()
   })
 
@@ -159,9 +165,9 @@ describe('ProviderConnect', () => {
 
     expect(screen.getByText('Expired')).toBeTruthy()
     expect(screen.getByText('claude-seat@corp.com')).toBeTruthy()
-    expect(screen.getByText(/token expired/)).toBeTruthy()
+    expect(screen.getByText(/Token expired/)).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Reconnect' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Disconnect' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Disconnect subscription' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: /Sign in/ })).toBeNull()
   })
 
@@ -215,10 +221,11 @@ describe('ProviderConnect', () => {
     vi.stubGlobal('fetch', fetchMock)
 
     const { invalidate } = renderCard(provider({ billingOptions: ['api_key'] }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add API key' }))
     fireEvent.change(screen.getByLabelText('API key'), {
       target: { value: 'the-api-key' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Add key' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Save API key' }))
     await flush()
 
     const storeCall = fetchMock.mock.calls.find(
@@ -236,7 +243,7 @@ describe('ProviderConnect', () => {
     vi.stubGlobal('confirm', () => true)
 
     renderCard(provider(), { subscription: subscription(), apiKey: sharedKey })
-    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove API key' }))
     await flush()
 
     const [url, init] = fetchMock.mock.calls[0]!

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -60,6 +60,29 @@ const resolvedAgents = {
   ],
 }
 
+const providerCatalogs = [
+  {
+    provider: 'anthropic',
+    label: 'Anthropic',
+    models: [{ id: 'anthropic/claude-opus-4-7', label: 'Claude Opus 4.7' }],
+    fetchedAt: '2026-09-05T08:00:00Z',
+  },
+  {
+    provider: 'groq',
+    label: 'Groq',
+    models: [{ id: 'groq/llama-4', label: 'Llama 4' }],
+    fetchedAt: '2026-09-05T08:00:00Z',
+  },
+]
+
+const providerDirectory = [
+  {
+    provider: 'cerebras',
+    label: 'Cerebras',
+    models: [{ id: 'cerebras/gpt-oss-120b', label: 'GPT OSS 120B' }],
+  },
+]
+
 // PATCH /api/settings bodies, in order.
 const patched: Record<string, unknown>[] = []
 
@@ -222,13 +245,37 @@ function stubFetch(
         return new Response(JSON.stringify({ ...userSettings, ...JSON.parse(String(init.body)) }), { status: 200 })
       }
       if (path === '/api/providers/catalogs') {
-        return new Response('[]', { status: 200 })
+        return new Response(JSON.stringify(providerCatalogs), { status: 200 })
+      }
+      if (path === '/api/providers/directory') {
+        return new Response(JSON.stringify(providerDirectory), { status: 200 })
       }
       if (path === '/api/providers/subscriptions') {
-        return new Response('[]', { status: 200 })
+        return new Response(JSON.stringify([
+          {
+            provider: 'anthropic',
+            providerEmail: 'seat@example.com',
+            expiresAt: null,
+            updatedAt: '2026-09-05T08:00:00Z',
+            connected: true,
+          },
+        ]), { status: 200 })
+      }
+      if (path === '/api/providers/keys') {
+        return new Response(JSON.stringify([
+          {
+            provider: 'groq',
+            keyTail: '4f2a',
+            updatedBy: { id: 'acc-1', username: 'paulo@example.com' },
+            updatedAt: '2026-09-05T08:00:00Z',
+          },
+        ]), { status: 200 })
       }
       if (path === '/api/providers') {
-        return new Response('[]', { status: 200 })
+        return new Response(JSON.stringify([
+          { id: 'anthropic', label: 'Anthropic', billingOptions: ['api_key', 'subscription'] },
+          { id: 'openai', label: 'OpenAI', billingOptions: ['api_key', 'subscription'] },
+        ]), { status: 200 })
       }
       if (path === '/api/browser-sessions') {
         return new Response('[]', { status: 200 })
@@ -421,7 +468,12 @@ describe('SettingsModal agents', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'save' }))
     await waitFor(() => expect(patched).toHaveLength(1))
-    expect(patched[0]).toEqual({ defaultHarness: 'opencode', defaultBilling: 'api_key', defaultEffort: 'low' })
+    expect(patched[0]).toEqual({
+      defaultHarness: 'opencode',
+      defaultModel: 'groq/llama-4',
+      defaultBilling: 'api_key',
+      defaultEffort: 'low',
+    })
   })
 
   it('the app page carries harness and billing cells that follow the chosen harness', async () => {
@@ -439,5 +491,63 @@ describe('SettingsModal agents', () => {
     // A key-only harness locks billing to API key on the row.
     expect(screen.getByText('API key ⚬')).toBeTruthy()
     expect(screen.getByText('API key ⚬').closest('button')!.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('searches the Models.dev directory for an unconfigured provider', async () => {
+    stubFetch()
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: 'Providers' }))
+
+    expect(await screen.findByText('Anthropic')).toBeTruthy()
+    expect(screen.getByText('Groq')).toBeTruthy()
+    expect(screen.queryByText('OpenAI')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Add provider' }))
+    fireEvent.change(screen.getByLabelText('Add provider'), { target: { value: 'gpt oss' } })
+
+    expect(await screen.findByText('Cerebras')).toBeTruthy()
+    expect(screen.queryByText('OpenAI')).toBeNull()
+  })
+
+  it('selects a configured third-party OpenCode model', async () => {
+    stubFetch()
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: 'Agents' }))
+
+    fireEvent.change(screen.getByLabelText('Harness'), { target: { value: 'opencode' } })
+    fireEvent.click(await screen.findByRole('button', { name: 'Model' }))
+    const search = screen.getByLabelText('Search models')
+    fireEvent.change(search, { target: { value: 'groq' } })
+    expect(screen.getByRole('listbox', { name: 'Model choices' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('option', { name: /Llama 4/ }))
+    expect(screen.getByRole('button', { name: 'Model' }).textContent).toContain('Llama 4')
+  })
+
+  it('opens a configured provider catalog from the Providers pane', async () => {
+    stubFetch()
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: 'Providers' }))
+
+    const groqCard = (await screen.findByText('Groq')).closest('article')
+    fireEvent.click(groqCard!.querySelector<HTMLButtonElement>('.provider-models-row button')!)
+
+    expect(await screen.findByRole('heading', { name: 'Agents' })).toBeTruthy()
+    expect((screen.getByLabelText('Search models') as HTMLInputElement).value).toBe('groq')
+    const llama = screen.getByRole('option', { name: /Llama 4/ }) as HTMLButtonElement
+    expect(llama.disabled).toBe(true)
+    expect(llama.textContent).toContain('Select a compatible harness and billing method')
+  })
+
+  it('closes the model chooser with Escape without closing settings', async () => {
+    const onClose = vi.fn()
+    stubFetch()
+    renderModal(onClose)
+    fireEvent.click(await screen.findByRole('button', { name: 'Agents' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Model' }))
+
+    const search = screen.getByLabelText('Search models')
+    fireEvent.keyDown(search, { key: 'Escape' })
+
+    expect(screen.queryByLabelText('Search models')).toBeNull()
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -35,24 +35,69 @@ import {
   type WorkflowSettingField,
 } from '../api/types'
 import { appLabel } from '../apps/registry'
-import { absTime, money, relTimeFromIso, timeAway } from '../lib/format'
+import { absTime, money, relTimeFromIso } from '../lib/format'
 import { useUsageToday } from '../lib/useUsage'
 import { Bar } from './UsagePanel'
 import { harnessColors } from '../lib/harnessColors'
 
-interface Catalog {
-  modelsOf: (harness: string) => CatalogModel[]
+interface CatalogChoice extends CatalogModel {
+  provider: string
+  providerLabel: string
+  enabled: boolean
+  unavailableReason?: string
 }
 
-function buildCatalog(harnesses: Harness[], providers: Provider[], catalogs: ProviderCatalog[]): Catalog {
-  const hasProvider = (harness: Harness, provider: Provider) =>
-    harness.provider ? harness.provider === provider.id : harness.billingOptions.some((k) => provider.billingOptions.includes(k))
-  const modelsByProvider = Object.fromEntries(catalogs.map((c) => [c.provider, c.models]))
+interface Catalog {
+  modelsOf: (harness: string, billing: Billing) => CatalogChoice[]
+  modelsForProvider: (provider: string) => CatalogChoice[]
+}
+
+const addedProvider = (id: string, label: string): Provider => ({ id, label, billingOptions: ['api_key'] })
+
+function knownProviders(providers: Provider[], catalogs: ProviderCatalog[]): Provider[] {
+  const added = catalogs
+    .filter((catalog) => !providers.some((provider) => provider.id === catalog.provider))
+    .map((catalog) => addedProvider(catalog.provider, catalog.label))
+  return [...providers, ...added].sort((left, right) => left.label.localeCompare(right.label))
+}
+
+function buildCatalog(
+  harnesses: Harness[],
+  providers: Provider[],
+  catalogs: ProviderCatalog[],
+  subscriptions: ProviderSubscription[],
+  keys: ProviderKey[],
+): Catalog {
+  const providersById = new Map(providers.map((provider) => [provider.id, provider]))
+  const connected = new Set(subscriptions.filter((row) => row.connected).map((row) => row.provider))
+  const keyed = new Set(keys.map((row) => row.provider))
+  const choicesFor = (catalog: ProviderCatalog, billing: Billing): CatalogChoice[] => {
+    const enabled = billing === 'api_key' ? keyed.has(catalog.provider) : connected.has(catalog.provider)
+    const unavailableReason = billing === 'api_key'
+      ? `Add ${catalog.label} API key`
+      : `Connect ${catalog.label} subscription`
+    return catalog.models.map((model) => ({
+      ...model,
+      provider: catalog.provider,
+      providerLabel: catalog.label,
+      enabled,
+      unavailableReason: enabled ? undefined : unavailableReason,
+    }))
+  }
   return {
-    modelsOf: (name) => {
-      const harness = harnesses.find((h) => h.name === name)
+    modelsOf: (name, billing) => {
+      const harness = harnesses.find((entry) => entry.name === name)
       if (!harness) return []
-      return providers.filter((p) => hasProvider(harness, p)).flatMap((p) => modelsByProvider[p.id] ?? [])
+      return catalogs
+        .filter((catalog) => !harness.provider || harness.provider === catalog.provider)
+        .filter((catalog) => providersById.get(catalog.provider)?.billingOptions.includes(billing))
+        .flatMap((catalog) => choicesFor(catalog, billing))
+    },
+    modelsForProvider: (provider) => {
+      const billing: Billing = connected.has(provider) && !keyed.has(provider) ? 'subscription' : 'api_key'
+      return catalogs
+        .filter((catalog) => catalog.provider === provider)
+        .flatMap((catalog) => choicesFor(catalog, billing))
     },
   }
 }
@@ -203,6 +248,7 @@ export function SettingsModal({ open, onClose }: Props) {
     queryFn: () => api.providerCatalogs(),
     enabled: open,
     staleTime: 60_000,
+    retry: 1,
   })
   const [timezone, setTimezone] = useState<string>('UTC')
   const [defaults, setDefaults] = useState<Defaults | null>(null)
@@ -214,6 +260,7 @@ export function SettingsModal({ open, onClose }: Props) {
   // 'general' | 'providers' | 'agents' | 'browser-sessions' | 'skills' | 'mcp' |
   // 'agent-access' | <app name>
   const [section, setSection] = useState<string>('general')
+  const [modelBrowseProvider, setModelBrowseProvider] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [appProblems, setAppProblems] = useState<AppSettingsProblems>({})
@@ -350,10 +397,32 @@ export function SettingsModal({ open, onClose }: Props) {
   const allApps = data?.apps ?? []
   const allowedEfforts = data?.allowedEfforts ?? []
   const harnesses = harnessesQuery.data ?? []
-  const providers = providersQuery.data ?? []
+  const providerCatalogs = providerCatalogsQuery.data ?? []
+  const providers = knownProviders(providersQuery.data ?? [], providerCatalogs)
   const providerSubscriptions = providerSubscriptionsQuery.data ?? []
   const providerKeys = providerKeysQuery.data ?? []
-  const catalog = buildCatalog(harnesses, providers, providerCatalogsQuery.data ?? [])
+  const catalog = buildCatalog(
+    harnesses,
+    providers,
+    providerCatalogs,
+    providerSubscriptions,
+    providerKeys,
+  )
+  const savedDefaults = settingsQuery.data ? defaultsOf(settingsQuery.data) : null
+  const executionDefaultsDirty = Boolean(
+    defaults &&
+      savedDefaults &&
+      (defaults.defaultHarness !== savedDefaults.defaultHarness ||
+        defaults.defaultModel !== savedDefaults.defaultModel ||
+        defaults.defaultBilling !== savedDefaults.defaultBilling),
+  )
+  const defaultsExecutionInvalid = Boolean(
+    executionDefaultsDirty &&
+      defaults &&
+      !catalog
+        .modelsOf(defaults.defaultHarness, defaults.defaultBilling)
+        .some((model) => model.id === defaults.defaultModel && model.enabled),
+  )
   const harnessByName: Record<string, Harness> = Object.fromEntries(
     harnesses.map((h) => [h.name, h]),
   )
@@ -481,7 +550,29 @@ export function SettingsModal({ open, onClose }: Props) {
                 busy={busy}
               />
             )}
-            {section === 'providers' && <ProvidersPane providers={providers} subscriptions={providerSubscriptions} keys={providerKeys} />}
+            {section === 'providers' && (
+              <ProvidersPane
+                providers={providers}
+                subscriptions={providerSubscriptions}
+                keys={providerKeys}
+                catalogs={providerCatalogs}
+                loading={
+                  providersQuery.isLoading ||
+                  providerSubscriptionsQuery.isLoading ||
+                  providerKeysQuery.isLoading ||
+                  providerCatalogsQuery.isLoading
+                }
+                requestError={
+                  providerCatalogsQuery.error instanceof Error
+                    ? providerCatalogsQuery.error.message
+                    : null
+                }
+                onViewModels={(providerId) => {
+                  setModelBrowseProvider(providerId)
+                  setSection('agents')
+                }}
+              />
+            )}
             {section === 'agents' &&
               (defaults ? (
                 <AgentsPane
@@ -494,6 +585,9 @@ export function SettingsModal({ open, onClose }: Props) {
                   catalog={catalog}
                   allowedEfforts={allowedEfforts}
                   onOpenApp={setSection}
+                  onAddProvider={() => setSection('providers')}
+                  browseProvider={modelBrowseProvider}
+                  onBrowseOpened={() => setModelBrowseProvider(null)}
                   busy={busy}
                 />
               ) : (
@@ -522,6 +616,7 @@ export function SettingsModal({ open, onClose }: Props) {
                 onAgentBilling={setAgentBilling}
                 onAgentEffort={setAgentEffort}
                 onAgentTimeout={setAgentTimeout}
+                onAddProvider={() => setSection('providers')}
                 onWorkflowField={setWorkflowField}
                 onAppSetting={setAppSetting}
                 busy={busy}
@@ -533,13 +628,19 @@ export function SettingsModal({ open, onClose }: Props) {
         <div className="set-foot">
           <div className={'set-status ' + (dirty ? 'dirty' : 'saved')}>
             <span className="sd" />
-            {error ? error : dirty ? 'unsaved changes' : 'saved'}
+            {error
+              ? error
+              : defaultsExecutionInvalid
+                ? 'choose a connected model'
+                : dirty
+                  ? 'unsaved changes'
+                  : 'saved'}
           </div>
           <div className="set-foot-actions">
             <button className="set-btn ghost" onClick={onClose} disabled={busy}>
               cancel
             </button>
-            <button className="set-btn primary" onClick={() => void submit()} disabled={busy || !dirty}>
+            <button className="set-btn primary" onClick={() => void submit()} disabled={busy || !dirty || defaultsExecutionInvalid}>
               {busy ? 'saving…' : 'save'}
             </button>
           </div>
@@ -682,7 +783,11 @@ function Menu({ anchor, children, onClose }: { anchor: HTMLElement | null; child
       if (ref.current && !ref.current.contains(e.target as Node) && anchor && !anchor.contains(e.target as Node)) onClose()
     }
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        onClose()
+      }
     }
     document.addEventListener('mousedown', onDown)
     document.addEventListener('keydown', onKey)
@@ -711,6 +816,152 @@ function Opt({ sel, famColor, main, sub, onClick }: { sel: boolean; famColor?: s
   )
 }
 
+function ModelChooser({
+  id,
+  value,
+  displayValue,
+  choices,
+  onPick,
+  disabled,
+  label,
+  inheritLabel,
+  isOverride = false,
+  onAddProvider,
+  browseProvider,
+  onBrowseOpened,
+  onBrowseClosed,
+}: {
+  id?: string
+  value: string | null
+  displayValue: string
+  choices: CatalogChoice[]
+  onPick: (value: string | null) => void
+  disabled: boolean
+  label: string
+  inheritLabel?: string
+  isOverride?: boolean
+  onAddProvider: () => void
+  browseProvider?: string | null
+  onBrowseOpened?: () => void
+  onBrowseClosed?: () => void
+}) {
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const [anchor, setAnchor] = useState<HTMLButtonElement | null>(null)
+  const [search, setSearch] = useState('')
+  const selected = choices.find((choice) => choice.id === value)
+
+  useEffect(() => {
+    if (!browseProvider || !buttonRef.current) return
+    setSearch(browseProvider)
+    setAnchor(buttonRef.current)
+    onBrowseOpened?.()
+  }, [browseProvider, onBrowseOpened])
+
+  const query = search.trim().toLocaleLowerCase()
+  const visible = choices.filter((choice) =>
+    [choice.label, choice.id, choice.providerLabel, choice.provider].some((term) =>
+      term.toLocaleLowerCase().includes(query),
+    ),
+  )
+  const grouped = visible.reduce((groups, choice) => {
+    const models = groups.get(choice.provider) ?? []
+    models.push(choice)
+    groups.set(choice.provider, models)
+    return groups
+  }, new Map<string, CatalogChoice[]>())
+  const hasRunnable = choices.some((choice) => choice.enabled)
+  const close = () => {
+    setAnchor(null)
+    setSearch('')
+    onBrowseClosed?.()
+  }
+  const pick = (next: string | null) => {
+    onPick(next)
+    close()
+  }
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        id={id}
+        type="button"
+        className={
+          inheritLabel
+            ? `set-cell ${isOverride ? 'override' : 'inherit'}`
+            : 'set-select model-chooser-trigger'
+        }
+        aria-label={label}
+        aria-haspopup="listbox"
+        aria-expanded={Boolean(anchor)}
+        disabled={disabled}
+        onClick={(event) => setAnchor((current) => (current ? null : event.currentTarget))}
+      >
+        {inheritLabel &&
+          (isOverride ? <span className="ov-dot" /> : <span className="inh-glyph">↳</span>)}
+        <span className="cell-val">{selected?.label ?? displayValue}</span>
+        <span className="cell-arrow" aria-hidden="true">▾</span>
+      </button>
+      {anchor && (
+        <Menu anchor={anchor} onClose={close}>
+          <div className="model-chooser" role="listbox" aria-label={`${label} choices`}>
+            <input
+              autoFocus
+              className="model-chooser-search"
+              aria-label="Search models"
+              placeholder="Search models or providers"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+            {inheritLabel && (
+              <button
+                type="button"
+                role="option"
+                aria-selected={!isOverride}
+                className="model-chooser-option"
+                onClick={() => pick(null)}
+              >
+                <span>Inherit</span>
+                <small>{inheritLabel}</small>
+              </button>
+            )}
+            {[...grouped.entries()].map(([providerId, models]) => (
+              <div className="model-chooser-group" key={providerId}>
+                <div className="model-chooser-provider">
+                  <span>{models[0]?.providerLabel}</span>
+                  <code>{providerId}</code>
+                </div>
+                {models.map((model) => (
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={value === model.id}
+                    aria-disabled={!model.enabled}
+                    className="model-chooser-option"
+                    disabled={!model.enabled}
+                    key={model.id}
+                    onClick={() => pick(model.id)}
+                  >
+                    <span>{model.label}</span>
+                    <small>{model.enabled ? model.id : model.unavailableReason}</small>
+                  </button>
+                ))}
+              </div>
+            ))}
+            {visible.length === 0 && (
+              <p className="model-chooser-empty">No model matches this search.</p>
+            )}
+            {!hasRunnable && choices.some((choice) => choice.unavailableReason?.startsWith('Add ')) && (
+              <button type="button" className="model-chooser-setup" onClick={onAddProvider}>
+                Add a provider key
+              </button>
+            )}
+          </div>
+        </Menu>
+      )}
+    </>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // InheritCell — inherited (ghosted ↳) vs override (bright ● + reset)
 // ---------------------------------------------------------------------------
@@ -723,11 +974,13 @@ function InheritCell({
   resolvedLabel,
   inheritLabel,
   harness,
+  billing,
   harnesses,
   harnessColor,
   catalog,
   allowedEfforts,
   onPick,
+  onAddProvider,
   disabled,
 }: {
   kind: 'harness' | 'model' | 'billing' | 'effort' | 'timeout'
@@ -735,11 +988,13 @@ function InheritCell({
   resolvedLabel: string
   inheritLabel: string
   harness: string
+  billing: Billing
   harnesses: Harness[]
   harnessColor: Record<string, string>
   catalog: Catalog
   allowedEfforts: string[]
   onPick: (v: CellValue) => void
+  onAddProvider: () => void
   disabled: boolean
 }) {
   // Anchor the menu off the clicked element (state, not a ref) so nothing reads
@@ -750,6 +1005,21 @@ function InheritCell({
     onPick(v)
     setAnchor(null)
   }
+  if (kind === 'model') {
+    return (
+      <ModelChooser
+        value={typeof value === 'string' ? value : null}
+        displayValue={resolvedLabel}
+        choices={catalog.modelsOf(harness, billing)}
+        onPick={onPick}
+        disabled={disabled}
+        label={`Model for ${harness}`}
+        inheritLabel={inheritLabel}
+        isOverride={isOverride}
+        onAddProvider={onAddProvider}
+      />
+    )
+  }
   const menu = () => {
     if (kind === 'harness') {
       return (
@@ -758,18 +1028,6 @@ function InheritCell({
           <div className="menu-div" />
           {harnesses.map((h) => (
             <Opt key={h.name} sel={value === h.name} famColor={harnessColor[h.name]} main={h.name} onClick={() => pick(h.name)} />
-          ))}
-        </>
-      )
-    }
-    if (kind === 'model') {
-      return (
-        <>
-          <Opt sel={!isOverride} main="inherit" sub={'· ' + inheritLabel} onClick={() => pick(null)} />
-          <div className="menu-inherit-note">the models {harness} runs</div>
-          <div className="menu-div" />
-          {catalog.modelsOf(harness).map((m) => (
-            <Opt key={m.id} sel={value === m.id} famColor={harnessColor[harness]} main={m.label} onClick={() => pick(m.id)} />
           ))}
         </>
       )
@@ -895,6 +1153,9 @@ export function AgentsPane({
   catalog,
   allowedEfforts,
   onOpenApp,
+  onAddProvider,
+  browseProvider,
+  onBrowseOpened,
   busy,
 }: {
   defaults: Defaults
@@ -906,19 +1167,53 @@ export function AgentsPane({
   catalog: Catalog
   allowedEfforts: string[]
   onOpenApp: (app: string) => void
+  onAddProvider: () => void
+  browseProvider: string | null
+  onBrowseOpened: () => void
   busy: boolean
 }) {
   const fieldId = useId()
   const id = (field: string) => `${fieldId}-${field}`
   const harnesses = Object.values(harnessByName)
-  const models = catalog.modelsOf(defaults.defaultHarness)
+  const executionModels = catalog.modelsOf(defaults.defaultHarness, defaults.defaultBilling)
+  const [browsingProvider, setBrowsingProvider] = useState<string | null>(null)
+  const providerToBrowse = browseProvider ?? browsingProvider
+  const models = providerToBrowse
+    ? catalog.modelsForProvider(providerToBrowse).map((choice) => {
+        const compatible = executionModels.find(
+          (candidate) => candidate.id === choice.id && candidate.provider === choice.provider,
+        )
+        return {
+          ...choice,
+          enabled: Boolean(compatible?.enabled),
+          unavailableReason: compatible
+            ? compatible.unavailableReason
+            : choice.enabled
+              ? 'Select a compatible harness and billing method'
+              : choice.unavailableReason,
+        }
+      })
+    : executionModels
   const defaultKeyOnly = keyOnly(harnessByName[defaults.defaultHarness])
   const timeouts = TIMEOUTS.includes(defaults.defaultTimeout)
     ? TIMEOUTS
     : [...TIMEOUTS, defaults.defaultTimeout].sort((a, b) => a - b)
   const set = (patch: Partial<Defaults>) => onDefaults({ ...defaults, ...patch })
+  const setTriple = (harness: string, billing: Billing) => {
+    const choices = catalog.modelsOf(harness, billing)
+    const currentIsRunnable = choices.some(
+      (choice) => choice.id === defaults.defaultModel && choice.enabled,
+    )
+    set({
+      defaultHarness: harness,
+      defaultBilling: billing,
+      defaultModel: currentIsRunnable
+        ? defaults.defaultModel
+        : (choices.find((choice) => choice.enabled)?.id ?? defaults.defaultModel),
+    })
+  }
   const setHarness = (name: string) =>
-    set({ defaultHarness: name, ...(keyOnly(harnessByName[name]) ? { defaultBilling: 'api_key' } : {}) })
+    setTriple(name, keyOnly(harnessByName[name]) ? 'api_key' : defaults.defaultBilling)
 
   return (
     <div className="set-pane mcp-pane">
@@ -949,16 +1244,22 @@ export function AgentsPane({
             <label className="mcp-label" htmlFor={id('model')}>
               Model
             </label>
-            <select id={id('model')} className="set-select" value={defaults.defaultModel} onChange={(e) => set({ defaultModel: e.target.value })} disabled={busy}>
-              {!models.some((m) => m.id === defaults.defaultModel) && (
-                <option value={defaults.defaultModel}>{defaults.defaultModel}</option>
-              )}
-              {models.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.label}
-                </option>
-              ))}
-            </select>
+            <ModelChooser
+              id={id('model')}
+              value={defaults.defaultModel}
+              displayValue={defaults.defaultModel}
+              choices={models}
+              onPick={(model) => model && set({ defaultModel: model })}
+              disabled={busy}
+              label="Model"
+              onAddProvider={onAddProvider}
+              browseProvider={browseProvider}
+              onBrowseOpened={() => {
+                setBrowsingProvider(browseProvider)
+                onBrowseOpened()
+              }}
+              onBrowseClosed={() => setBrowsingProvider(null)}
+            />
           </div>
           <div className="mcp-field">
             <label className="mcp-label" htmlFor={id('billing')}>
@@ -968,7 +1269,7 @@ export function AgentsPane({
               id={id('billing')}
               className="set-select"
               value={defaults.defaultBilling}
-              onChange={(e) => set({ defaultBilling: e.target.value as Billing })}
+              onChange={(e) => setTriple(defaults.defaultHarness, e.target.value as Billing)}
               disabled={busy || defaultKeyOnly}
             >
               {BILLINGS.map((b) => (
@@ -1011,6 +1312,11 @@ export function AgentsPane({
             </select>
           </div>
         </div>
+        {!models.some((model) => model.id === defaults.defaultModel && model.enabled) && (
+          <div className="model-chooser-warning" role="status">
+            Choose a model with a connected credential before you save these defaults.
+          </div>
+        )}
       </div>
 
       <div className="set-group">
@@ -1535,41 +1841,185 @@ function ProvidersPane({
   providers,
   subscriptions,
   keys,
+  catalogs,
+  loading,
+  requestError,
+  onViewModels,
 }: {
   providers: Provider[]
   subscriptions: ProviderSubscription[]
   keys: ProviderKey[]
+  catalogs: ProviderCatalog[]
+  loading: boolean
+  requestError: string | null
+  onViewModels: (providerId: string) => void
 }) {
-  const providerColor = harnessColors(providers.map((p) => p.id))
+  const [adding, setAdding] = useState(false)
+  const [search, setSearch] = useState('')
+  const [pendingProviders, setPendingProviders] = useState<Provider[]>([])
+  const [openedAt] = useState(() => Date.now())
+  // The directory is only the search box's source, read when it opens.
+  const directoryQuery = useQuery({
+    queryKey: ['providerDirectory'],
+    queryFn: () => api.providerDirectory(),
+    enabled: adding,
+    staleTime: 60_000,
+    retry: 1,
+  })
   // The quota bars read the same snapshot the appbar pill polls; this pane
   // only reads it, so the pill stays the one nudging scrapes.
   const usageQuery = useQuery<UsageResponse>({ queryKey: ['usage'], queryFn: () => api.usage(), retry: 1 })
   const todayQuery = useUsageToday()
+  const configuredIds = new Set([
+    ...subscriptions.map((row) => row.provider),
+    ...keys.map((row) => row.provider),
+    ...pendingProviders.map((provider) => provider.id),
+  ])
+  const configured = [
+    ...providers,
+    ...pendingProviders.filter((pending) => !providers.some((known) => known.id === pending.id)),
+  ].filter((provider) => configuredIds.has(provider.id))
+  const providerColor = harnessColors(configured.map((provider) => provider.id))
+  const query = search.trim().toLocaleLowerCase()
+  const candidates = [
+    ...providers.map((provider) => ({
+      provider: provider.id,
+      label: provider.label,
+      models: catalogs.find((catalog) => catalog.provider === provider.id)?.models ?? [],
+    })),
+    ...(directoryQuery.data ?? []),
+  ]
+    .filter((entry) => !configuredIds.has(entry.provider))
+    .filter((entry) =>
+      [entry.label, entry.provider, ...entry.models.flatMap((model) => [model.label, model.id])].some(
+        (text) => text.toLocaleLowerCase().includes(query),
+      ),
+    )
   return (
     <div className="set-pane mcp-pane hrs-pane">
       <header className="mcp-pane-head">
         <h2 className="mcp-pane-title">Providers</h2>
         <p className="mcp-pane-sub">
-          Your subscription at each model provider, and the installation&apos;s API key.
+          Manage credentials and billing methods. Credential changes save immediately.
         </p>
       </header>
+      {loading && <div className="provider-state" role="status">Loading providers…</div>}
+      {requestError && <div className="mcp-error" role="alert">{requestError}</div>}
+      {!loading && configured.length === 0 && (
+        <div className="provider-empty">
+          <strong>No provider is configured.</strong>
+          <span>Add one to make models available to agents.</span>
+        </div>
+      )}
       <div className="hrs-list">
-        {providers.map((provider) => (
-          <div key={provider.id} className="set-card hr-card" style={{ '--fam': providerColor[provider.id] } as CSSProperties}>
-            <div className="hr-ident">
-              <span className="hr-ident-dot" />
-              <span className="hr-name">{provider.label}</span>
-              <span className="hr-provider">{provider.id}</span>
+        {configured.map((provider) => {
+          const subscription = subscriptions.find((row) => row.provider === provider.id) ?? null
+          const apiKey = keys.find((row) => row.provider === provider.id) ?? null
+          const catalog = catalogs.find((entry) => entry.provider === provider.id)
+          const modelCount = catalog?.models.length ?? 0
+          const catalogIsStale = Boolean(
+            catalog && openedAt - new Date(catalog.fetchedAt).getTime() > 24 * 60 * 60 * 1000,
+          )
+          const connection = subscription?.connected
+            ? apiKey
+              ? 'Subscription and API key configured'
+              : 'Subscription connected'
+            : subscription
+              ? 'Subscription needs reconnect'
+              : apiKey
+                ? 'API key configured'
+                : 'Not configured'
+          return (
+            <article key={provider.id} className="set-card hr-card" style={{ '--fam': providerColor[provider.id] } as CSSProperties}>
+              <header className="hr-ident">
+                <span className="hr-ident-dot" aria-hidden="true" />
+                <span className="hr-identity-copy">
+                  <span className="hr-name">{provider.label}</span>
+                  <code className="hr-provider">{provider.id}</code>
+                </span>
+                <span className="hr-card-state" role="status">{connection}</span>
+                <span className="hr-count"><b>{modelCount}</b> models</span>
+              </header>
+              <ProviderConnect
+                provider={provider}
+                subscription={subscription}
+                apiKey={apiKey}
+                usage={usageQuery.data?.providers.find((row) => row.id === provider.id) ?? null}
+                keySpendToday={todayQuery.data?.providers.find((row) => row.id === provider.id)?.keySpendUsd ?? null}
+              />
+              <div className="provider-models-row">
+                <span>
+                  <strong>{modelCount} models available</strong>
+                  {catalog ? (
+                    <small>
+                      {catalogIsStale ? 'Catalog is stale' : 'Catalog updated'}{' '}
+                      {relTimeFromIso(catalog.fetchedAt)}
+                    </small>
+                  ) : (
+                    <small>No catalog is available yet.</small>
+                  )}
+                </span>
+                <button type="button" className="set-btn ghost" onClick={() => onViewModels(provider.id)}>
+                  View models in Agents
+                </button>
+              </div>
+            </article>
+          )
+        })}
+      </div>
+      <div className="provider-add">
+        {!adding ? (
+          <button type="button" className="set-btn ghost" onClick={() => setAdding(true)}>Add provider</button>
+        ) : (
+          <div className="set-card provider-add-panel">
+            <div className="provider-add-head">
+              <label htmlFor="provider-search">Add provider</label>
+              <button type="button" className="set-btn quiet" onClick={() => { setAdding(false); setSearch('') }}>Close</button>
             </div>
-            <ProviderConnect
-              provider={provider}
-              subscription={subscriptions.find((l) => l.provider === provider.id) ?? null}
-              apiKey={keys.find((k) => k.provider === provider.id) ?? null}
-              usage={usageQuery.data?.providers.find((u) => u.id === provider.id) ?? null}
-              keySpendToday={todayQuery.data?.providers.find((t) => t.id === provider.id)?.keySpendUsd ?? null}
+            <input
+              autoFocus
+              id="provider-search"
+              className="set-select"
+              type="search"
+              placeholder="Search providers or models"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
             />
+            <div className="provider-results" role="list" aria-label="Provider search results">
+              {candidates.slice(0, 30).map((entry) => {
+                const provider =
+                  providers.find((registered) => registered.id === entry.provider) ??
+                  addedProvider(entry.provider, entry.label)
+                return (
+                  <button
+                    type="button"
+                    className="provider-result"
+                    key={provider.id}
+                    onClick={() => {
+                      setPendingProviders((current) => [...current, provider])
+                      setAdding(false)
+                      setSearch('')
+                    }}
+                  >
+                    <span><strong>{provider.label}</strong><code>{provider.id}</code></span>
+                    <span><b>{entry.models.length}</b> models</span>
+                    <span>{provider.billingOptions.map(billingLabel).join(' or ')}</span>
+                    <span>Not configured</span>
+                  </button>
+                )
+              })}
+              {directoryQuery.isLoading && (
+                <p className="provider-state" role="status">Reading the Models.dev directory…</p>
+              )}
+              {directoryQuery.error instanceof Error && (
+                <p className="mcp-error" role="alert">{directoryQuery.error.message}</p>
+              )}
+              {!directoryQuery.isLoading && candidates.length === 0 && (
+                <p className="provider-state">No supported provider matches this search.</p>
+              )}
+            </div>
           </div>
-        ))}
+        )}
       </div>
     </div>
   )
@@ -1593,6 +2043,7 @@ export function ProviderConnect({
   const [error, setError] = useState<string | null>(null)
   const [key, setKey] = useState('')
   const [replacing, setReplacing] = useState(false)
+  const [keyFormOpen, setKeyFormOpen] = useState(false)
 
   const refresh = () => queryClient.invalidateQueries({ queryKey: ['providerSubscriptions'] })
   const refreshKeys = () => queryClient.invalidateQueries({ queryKey: ['providerKeys'] })
@@ -1629,6 +2080,7 @@ export function ProviderConnect({
       await api.createProviderKey(provider.id, key)
       setKey('')
       setReplacing(false)
+      setKeyFormOpen(false)
     }, refreshKeys)
   }
 
@@ -1636,9 +2088,14 @@ export function ProviderConnect({
   // An expired subscription is still a subscription: keep its identity and Disconnect
   // visible and ask for a Reconnect, not a first-time sign-in.
   const expired = Boolean(subscription) && !connected
-  const showKeyForm = acceptsApiKey && (!apiKey || replacing)
+  const showKeyForm = acceptsApiKey && (keyFormOpen || replacing)
   return (
     <div className="hr-connect">
+      {acceptsSubscription && acceptsApiKey && (
+        <p className="hr-billing-note">
+          Use either your provider subscription or the installation API key as the billing method.
+        </p>
+      )}
       {acceptsSubscription && (
         <section className="hr-block">
           <div className="hr-block-title">Subscription</div>
@@ -1651,23 +2108,30 @@ export function ProviderConnect({
                   {subscription.providerEmail}
                 </span>
                 <span className="hr-conn-actions">
-                  {!flow.challenge && (
-                    <button className="set-btn ghost" onClick={() => void flow.start()} disabled={busy || flow.busy}>
+                  {expired && !flow.challenge && (
+                    <button className="set-btn primary" onClick={() => void flow.start()} disabled={busy || flow.busy}>
                       Reconnect
                     </button>
                   )}
-                  <button className="set-btn danger quiet" onClick={disconnect} disabled={busy || flow.busy}>
-                    Disconnect
-                  </button>
+                  <details className="hr-more">
+                    <summary aria-label={`More ${provider.label} subscription actions`}>More</summary>
+                    <button className="set-btn danger quiet" onClick={disconnect} disabled={busy || flow.busy}>
+                      Disconnect subscription
+                    </button>
+                  </details>
                 </span>
               </div>
-              {usage?.fiveHour && <QuotaRow label="5h" metric={usage.fiveHour} />}
+              {usage?.fiveHour && <QuotaRow label="5-hour" metric={usage.fiveHour} />}
               {usage?.weeks.map((week, index) => (
-                <QuotaRow key={index} label="week" metric={week} />
+                <QuotaRow key={index} label="Weekly" metric={week} />
               ))}
               {subscription.expiresAt && (
                 <span className="hr-conn-exp">
-                  token {expired ? 'expired' : 'expires'} {timeAway(subscription.expiresAt)}
+                  Token {expired ? 'expired' : 'expires'}{' '}
+                  {new Date(subscription.expiresAt).toLocaleString([], {
+                    dateStyle: 'medium',
+                    timeStyle: 'long',
+                  })}
                 </span>
               )}
             </>
@@ -1697,11 +2161,19 @@ export function ProviderConnect({
                 <button className="set-btn ghost" onClick={() => setReplacing((value) => !value)} disabled={busy}>
                   {replacing ? 'Keep' : 'Replace'}
                 </button>
-                <button className="set-btn danger quiet" onClick={removeKey} disabled={busy}>
-                  Remove
-                </button>
+                <details className="hr-more">
+                  <summary aria-label={`More ${provider.label} API key actions`}>More</summary>
+                  <button className="set-btn danger quiet" onClick={removeKey} disabled={busy}>
+                    Remove API key
+                  </button>
+                </details>
               </span>
             </div>
+          )}
+          {!apiKey && !showKeyForm && (
+            <button className="set-btn ghost provider-key-add" type="button" onClick={() => setKeyFormOpen(true)}>
+              Add API key
+            </button>
           )}
           {showKeyForm && (
             <form className="hr-conn-flow" onSubmit={createKey}>
@@ -1718,8 +2190,13 @@ export function ProviderConnect({
                   value={key}
                 />
                 <button className="hr-conn-btn" disabled={busy || flow.busy || !key.trim()} type="submit">
-                  {apiKey ? 'Replace key' : 'Add key'}
+                  {apiKey ? 'Replace key' : 'Save API key'}
                 </button>
+                {!apiKey && (
+                  <button className="set-btn quiet" type="button" onClick={() => { setKey(''); setKeyFormOpen(false) }}>
+                    Cancel
+                  </button>
+                )}
               </div>
             </form>
           )}
@@ -1737,16 +2214,14 @@ export function ProviderConnect({
 function QuotaRow({ label, metric }: { label: string; metric: UsageMetric }) {
   if (metric.percentLeft === null) return null
   const resets = metric.resetsAt
-    ? new Date(metric.resetsAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    ? new Date(metric.resetsAt).toLocaleString([], { dateStyle: 'medium', timeStyle: 'long' })
     : null
   return (
     <div className="hr-quota">
-      <span className="hr-quota-label mono">
-        {label}
-        {metric.model ? ` · ${metric.model}` : ''}
-      </span>
+      <span className="hr-quota-label">{label}</span>
+      <span className="hr-quota-model mono">{metric.model ?? ''}</span>
       <Bar pctLeft={metric.percentLeft} />
-      <span className="hr-quota-pct mono">{metric.percentLeft}%</span>
+      <span className="hr-quota-pct mono">{metric.percentLeft}% remaining</span>
       <span className="hr-conn-exp">{resets ? `resets ${resets}` : ''}</span>
     </div>
   )
@@ -2683,6 +3158,7 @@ function AppPane({
   onAgentBilling,
   onAgentEffort,
   onAgentTimeout,
+  onAddProvider,
   onWorkflowField,
   onAppSetting,
   busy,
@@ -2700,6 +3176,7 @@ function AppPane({
   onAgentBilling: (name: string, billing: Billing | null) => void
   onAgentEffort: (name: string, effort: string | null) => void
   onAgentTimeout: (name: string, timeout: number | null) => void
+  onAddProvider: () => void
   onWorkflowField: (kind: string, field: string, value: unknown) => void
   onAppSetting: (app: string, field: string, value: unknown) => void
   busy: boolean
@@ -2856,6 +3333,7 @@ function AppPane({
             onAgentBilling={onAgentBilling}
             onAgentEffort={onAgentEffort}
             onAgentTimeout={onAgentTimeout}
+            onAddProvider={onAddProvider}
             busy={busy}
           />
         </div>
@@ -2877,6 +3355,7 @@ function AgentTable({
   onAgentBilling,
   onAgentEffort,
   onAgentTimeout,
+  onAddProvider,
   busy,
 }: {
   app: AppSettings
@@ -2891,6 +3370,7 @@ function AgentTable({
   onAgentBilling: (name: string, billing: Billing | null) => void
   onAgentEffort: (name: string, effort: string | null) => void
   onAgentTimeout: (name: string, timeout: number | null) => void
+  onAddProvider: () => void
   busy: boolean
 }) {
   const harnesses = Object.values(harnessByName)
@@ -2921,10 +3401,26 @@ function AgentTable({
         const timeoutInherit = a.timeoutSource === 'declared' ? 'declared · ' + a.timeout + 's' : 'default · ' + defaults.defaultTimeout + 's'
         const pickHarness = (v: CellValue) => {
           const name = (v as string | null) ?? null
+          const nextHarness = name ?? defaults.defaultHarness
+          const nextBilling = keyOnly(harnessByName[nextHarness]) ? 'api_key' : billing
           onAgentHarness(a.name, name)
-          if (name && keyOnly(harnessByName[name])) onAgentBilling(a.name, 'api_key')
+          if (nextBilling !== billing) onAgentBilling(a.name, nextBilling)
+          const choices = catalog.modelsOf(nextHarness, nextBilling)
+          if (!choices.some((choice) => choice.id === model && choice.enabled)) {
+            const first = choices.find((choice) => choice.enabled)
+            if (first) onAgentModel(a.name, first.id)
+          }
         }
-        const shared = { harness, harnesses, harnessColor, catalog, allowedEfforts, disabled: busy }
+        const pickBilling = (v: CellValue) => {
+          const nextBilling = ((v as Billing | null) ?? defaults.defaultBilling) as Billing
+          onAgentBilling(a.name, (v as Billing | null) ?? null)
+          const choices = catalog.modelsOf(harness, nextBilling)
+          if (!choices.some((choice) => choice.id === model && choice.enabled)) {
+            const first = choices.find((choice) => choice.enabled)
+            if (first) onAgentModel(a.name, first.id)
+          }
+        }
+        const shared = { harness, billing, harnesses, harnessColor, catalog, allowedEfforts, onAddProvider, disabled: busy }
         return (
           <div key={a.name} className="set-trow">
             <div className="agent-cell">
@@ -2943,7 +3439,7 @@ function AgentTable({
                 value={locked ? null : billingOver}
                 resolvedLabel={billingLabel(billing) + (locked ? ' ⚬' : '')}
                 inheritLabel={'default · ' + billingLabel(defaults.defaultBilling)}
-                onPick={(v) => onAgentBilling(a.name, (v as Billing | null) ?? null)}
+                onPick={pickBilling}
                 {...shared}
                 disabled={busy || locked}
               />

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1002,12 +1002,15 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 /* Harnesses — the MCP pane's measure and scale; each card separates identity,
    defaults, and connection into three bands. Provider color survives only as
    the identity dot and the guided connect-flow accent. */
-.hrs-list { display: flex; flex-direction: column; gap: 12px; }
-.hr-card { display: flex; flex-direction: column; gap: 13px; padding: 14px; }
-.hr-ident { display: flex; align-items: center; gap: 9px; }
+.hrs-list { display: flex; flex-direction: column; gap: 10px; }
+.hrs-pane :is(.set-btn, .hr-conn-btn, .mcp-conn, .hr-more summary) { font-family: var(--font-sans); letter-spacing: 0; }
+.hr-card { display: flex; flex-direction: column; gap: 12px; padding: 13px 14px; }
+.hr-ident { display: grid; grid-template-columns: auto minmax(120px, 1fr) auto auto; align-items: center; gap: 9px 14px; }
 .hr-ident-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fam, var(--border-loud)); flex-shrink: 0; }
-.hr-name { font-family: var(--font-mono); font-size: 13px; color: var(--text); }
-.hr-provider { font-size: 12px; color: var(--text-faint); }
+.hr-identity-copy { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
+.hr-name { font-size: 13.5px; font-weight: 600; color: var(--text); }
+.hr-provider { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-faint); }
+.hr-card-state { font-size: 11.5px; color: var(--text-mid); }
 .hr-count { margin-left: auto; font-size: 12px; color: var(--text-dim); white-space: nowrap; }
 .hr-count b { color: var(--text-mid); font-weight: 500; }
 .hr-controls { display: grid; grid-template-columns: minmax(180px, 1fr) 110px 110px auto; gap: 12px 14px; align-items: end; }
@@ -1017,14 +1020,14 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 @media (max-width: 720px) { .hr-controls { grid-template-columns: 1fr 1fr; } }
 @media (max-width: 460px) { .hr-controls { grid-template-columns: 1fr; } }
 
-/* Subscription connection — status chip + connect/paste/disconnect flow. */
+/* Provider credentials — one compact alternative-billing surface. */
 .hr-connect { border-top: 1px solid var(--border); padding-top: 12px; display: flex; flex-direction: column; gap: 10px; }
 .hr-conn-status { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .hr-chip { display: inline-flex; align-items: center; padding: 2px 9px; border-radius: 3px; font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.04em; }
 .hr-chip-on { color: var(--fam, var(--text-mid)); border: 1px solid color-mix(in oklch, var(--fam, var(--border-loud)) 42%, transparent); background: color-mix(in oklch, var(--fam, var(--border-loud)) 10%, transparent); }
 .hr-chip-off { color: var(--text-faint); border: 1px solid var(--border); }
 .hr-conn-exp { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-faint); }
-.hr-conn-actions { margin-left: auto; display: flex; gap: 8px; }
+.hr-conn-actions { margin-left: auto; display: flex; align-items: center; gap: 8px; }
 .hr-conn-btn { padding: 5px 13px; border-radius: 4px; font-family: var(--font-mono); font-size: 11.5px; cursor: pointer; background: color-mix(in oklch, var(--fam, var(--accent)) 16%, var(--surface)); color: var(--fam, var(--accent)); border: 1px solid color-mix(in oklch, var(--fam, var(--accent)) 45%, transparent); transition: all 120ms; }
 .hr-conn-btn:hover:not(:disabled) { background: color-mix(in oklch, var(--fam, var(--accent)) 26%, var(--surface)); }
 .hr-conn-btn:disabled { opacity: 0.45; cursor: default; }
@@ -1037,14 +1040,72 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .hr-conn-paste { flex-wrap: wrap; }
 .hr-conn-input { flex: 1; min-width: 200px; padding: 6px 10px; border-radius: 4px; background: var(--surface-2); border: 1px solid var(--border); color: var(--text); font-family: var(--font-mono); font-size: 12px; }
 .hr-conn-input:focus { outline: none; border-color: color-mix(in oklch, var(--fam, var(--accent)) 55%, transparent); }
-.hr-conn-error { font-size: 11.5px; color: var(--outcome-failed); font-family: var(--font-mono); }
+.hr-conn-error { font-size: 11.5px; color: var(--outcome-failed); }
 .hr-block { display: flex; flex-direction: column; gap: 9px; }
 .hr-block + .hr-block { border-top: 1px solid var(--border); padding-top: 12px; }
-.hr-block-title { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-faint); }
-.hr-quota { display: grid; grid-template-columns: 36px 1fr 40px auto; align-items: center; gap: 10px; font-size: 11.5px; }
+.hr-block-title { font-size: 11px; font-weight: 600; color: var(--text-dim); }
+.hr-billing-note { margin: 0; font-size: 11.5px; line-height: 1.45; color: var(--text-dim); }
+.hr-quota { display: grid; grid-template-columns: 70px minmax(0, 100px) minmax(120px, 1fr) 106px minmax(190px, auto); align-items: center; gap: 10px; font-size: 11.5px; }
 .hr-quota .us-bar { margin: 0; }
-.hr-quota-label { color: var(--text-dim); }
-.hr-quota-pct { text-align: right; color: var(--text-mid); }
+.hr-quota-label { color: var(--text-mid); }
+.hr-quota-model { color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.hr-quota-pct { text-align: right; color: var(--text-mid); white-space: nowrap; }
+.provider-key-add { align-self: flex-start; }
+.hr-more { position: relative; }
+.hr-more summary { list-style: none; cursor: pointer; color: var(--text-dim); font-size: 11.5px; padding: 6px 8px; border-radius: 4px; }
+.hr-more summary::-webkit-details-marker { display: none; }
+.hr-more summary:hover { color: var(--text); background: var(--surface-3); }
+.hr-more[open] > .set-btn { position: absolute; z-index: 4; top: calc(100% + 4px); right: 0; background: var(--surface-3); box-shadow: 0 12px 28px -10px rgba(0, 0, 0, 0.8); }
+.provider-models-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; border-top: 1px solid var(--border); padding-top: 11px; }
+.provider-models-row > span { display: flex; flex-direction: column; gap: 3px; font-size: 11.5px; color: var(--text-mid); }
+.provider-models-row strong { color: var(--text); font-weight: 500; }
+.provider-models-row small { font-family: var(--font-mono); font-size: 10px; color: var(--text-faint); }
+.provider-state { font-size: 12px; color: var(--text-dim); }
+.provider-empty { display: flex; flex-direction: column; gap: 4px; padding: 18px 0 4px; color: var(--text-dim); font-size: 12px; }
+.provider-empty strong { color: var(--text); font-size: 13px; }
+.provider-add { display: flex; flex-direction: column; align-items: flex-start; }
+.provider-add-panel { width: min(100%, 720px); padding: 14px; display: grid; gap: 10px; }
+.provider-add-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.provider-add-head label { font-size: 13px; font-weight: 600; color: var(--text); }
+.provider-results { display: flex; flex-direction: column; max-height: 260px; overflow: auto; border-top: 1px solid var(--border); }
+.provider-result { display: grid; grid-template-columns: minmax(150px, 1.5fr) 90px minmax(140px, 1fr) 120px; align-items: center; gap: 12px; width: 100%; padding: 10px 4px; border-bottom: 1px solid var(--border-soft); color: var(--text-mid); text-align: left; font-size: 11.5px; }
+.provider-result:hover { background: var(--surface-3); color: var(--text); }
+.provider-result > span:first-child { display: flex; flex-direction: column; gap: 2px; }
+.provider-result strong { font-size: 12.5px; color: var(--text); }
+.provider-result code, .provider-result b { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); font-weight: 400; }
+
+@media (max-width: 600px) {
+  .set-backdrop { padding: 0; }
+  .set-modal { width: 100vw; height: 100dvh; max-height: none; border-radius: 0; border: 0; }
+  .set-head { height: 46px; padding: 0 12px; }
+  .set-head-r > span { display: none; }
+  .set-grid { grid-template-columns: 1fr; grid-template-rows: auto minmax(0, 1fr); }
+  .set-rail { flex-direction: row; gap: 4px; padding: 6px 8px; border-right: 0; border-bottom: 1px solid var(--border); overflow-x: auto; }
+  .set-rail-label { display: none; }
+  .set-navitem { width: auto; flex: 0 0 auto; padding: 7px 9px; white-space: nowrap; }
+  .set-pane { padding: 16px 14px 24px; gap: 18px; }
+  .set-foot { height: 52px; padding: 0 12px; }
+  .set-foot-actions { gap: 6px; }
+  .set-btn { padding: 7px 11px; }
+  .hr-ident { grid-template-columns: auto minmax(0, 1fr) auto; gap: 7px 9px; }
+  .hr-card-state { grid-column: 2 / -1; }
+  .hr-count { grid-column: 3; grid-row: 1; }
+  .hr-identity-copy { flex-direction: column; align-items: flex-start; gap: 2px; }
+  .hr-conn-status { align-items: flex-start; }
+  .hr-conn-id { width: calc(100% - 90px); }
+  .hr-conn-actions { width: 100%; margin-left: 0; }
+  .hr-quota { grid-template-columns: minmax(70px, auto) minmax(0, 1fr) auto; grid-template-areas: 'label model pct' 'bar bar bar' 'reset reset reset'; gap: 5px 8px; padding: 5px 0; }
+  .hr-quota-label { grid-area: label; }
+  .hr-quota-model { grid-area: model; }
+  .hr-quota .us-bar { grid-area: bar; }
+  .hr-quota-pct { grid-area: pct; }
+  .hr-quota .hr-conn-exp { grid-area: reset; }
+  .provider-models-row { align-items: flex-start; flex-direction: column; }
+  .provider-result { grid-template-columns: 1fr auto; gap: 5px 12px; }
+  .provider-result > span:nth-child(3), .provider-result > span:nth-child(4) { grid-column: 1 / -1; }
+  .provider-add-panel { padding: 12px; }
+  .model-chooser-option { align-items: flex-start; flex-direction: column; gap: 2px; }
+}
 
 .set-switch { position: relative; width: 34px; height: 18px; border-radius: 10px; flex-shrink: 0; background: var(--surface-3); border: 1px solid var(--border-loud); transition: all 140ms; cursor: pointer; }
 .set-switch::after { content: ''; position: absolute; top: 1.5px; left: 1.5px; width: 12px; height: 12px; border-radius: 50%; background: var(--text-dim); transition: all 140ms; }
@@ -1107,6 +1168,24 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .menu-opt .mo-fam { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
 .menu-div { height: 1px; background: var(--border); margin: 5px 4px; }
 .menu-inherit-note { font-size: 10px; color: var(--text-faint); padding: 0 9px 6px; line-height: 1.4; }
+.model-chooser-trigger { display: flex; align-items: center; text-align: left; background-image: none; }
+.model-chooser-trigger .cell-arrow { margin-left: auto; color: var(--text-faint); font-size: 9px; }
+.model-chooser { width: min(520px, calc(100vw - 24px)); display: flex; flex-direction: column; gap: 4px; }
+.model-chooser-search { width: 100%; padding: 9px 10px; color: var(--text); background: var(--bg); border: 1px solid var(--border); border-radius: 4px; font-size: 12px; }
+.model-chooser-search:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.model-chooser-group { display: flex; flex-direction: column; border-top: 1px solid var(--border-soft); padding-top: 4px; }
+.model-chooser-provider { display: flex; justify-content: space-between; gap: 16px; padding: 6px 9px 4px; font-size: 11.5px; font-weight: 600; color: var(--text-mid); }
+.model-chooser-provider code { font-family: var(--font-mono); font-size: 10px; font-weight: 400; color: var(--text-faint); }
+.model-chooser-option { display: flex; align-items: baseline; justify-content: space-between; gap: 18px; width: 100%; padding: 7px 9px; border-radius: 4px; color: var(--text-mid); text-align: left; font-size: 12px; }
+.model-chooser-option:hover:not(:disabled) { background: var(--surface-2); color: var(--text); }
+.model-chooser-option[aria-selected='true'] { background: color-mix(in oklch, var(--accent) 14%, transparent); color: var(--text); }
+.model-chooser-option:disabled { opacity: 0.5; cursor: not-allowed; }
+.model-chooser-option small { font-family: var(--font-mono); font-size: 9.5px; color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.model-chooser-empty { margin: 8px 9px; font-size: 11.5px; color: var(--text-dim); }
+.model-chooser-setup { align-self: flex-start; margin: 5px 9px 8px; color: var(--accent); font-size: 11.5px; }
+.model-chooser-setup:hover { text-decoration: underline; text-underline-offset: 3px; }
+.model-chooser-warning { font-size: 11.5px; color: var(--decision-request-revision); }
+.model-chooser-option:focus-visible, .model-chooser-setup:focus-visible, .model-chooser-trigger:focus-visible, .set-cell:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .set-foot { display: flex; align-items: center; justify-content: space-between; padding: 0 18px; height: 56px; flex-shrink: 0; border-top: 1px solid var(--border); background: var(--surface-2); }
 .set-status { display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 12px; color: var(--text-dim); }


### PR DESCRIPTION
## Summary

- Finish the compact and responsive Settings Providers screen and the searchable model chooser under Agents and app overrides.
- A third-party provider comes into being when its key is added. `POST /api/providers/{provider}/key` for a provider not registered in Druks reads Models.dev, creates the provider's catalog row (label and models), and stores the key. Removing the key removes the provider.
- The Models.dev directory is only the search box behind **Add provider**: `GET /api/providers/directory` reads it on demand, cached in Redis for a day. It is never stored as a table and never refreshed by the cron.
- The cron refreshes catalogs only for providers with a subscription or a key. A registered provider reads its own endpoint; an added provider re-reads the directory.
- OpenAI over a key reads `GET https://api.openai.com/v1/models`, filtered to the models that run a coding agent. Anthropic keeps `/v1/models`.
- `check_execution` reads `ProviderCatalog` only for an unregistered provider: the model must be one the provider lists, and a CLI bound to its vendor refuses it.
- Migration `c8b1f4d2a963` adds a non-null `label` column to `provider_catalogs`. Every row names its provider, so the SPA reads provider labels from catalogs alone.
- An unreachable directory is one 503 named in one place: a `CatalogError` handler beside the existing `ExecutionSettingsError` one, so no route hand-maps it.

## Verification

- `uv run ruff check backend` and `uv run ruff format --check backend`
- `uv run pytest` over the touched files: `test_provider_catalogs.py`, `test_execution.py`, `test_api_providers.py`, `test_migration_one_openai_provider.py`
- `npm --prefix frontend run lint`, `SettingsModal.test.tsx`, `ProviderConnect.test.tsx`, `Onboarding.test.tsx`, `npm --prefix frontend run build`
- The full suites run in CI.

## Tracking

- https://linear.app/fellaworks/issue/DRU-421/finish-the-providers-pane-and-expose-the-modelsdev-opencode-catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
