### PR TITLE
DRU-423: Simplify provider settings and fix provider search

### DIFF
--- a/frontend/src/components/ProviderConnect.test.tsx
+++ b/frontend/src/components/ProviderConnect.test.tsx
@@ -86,6 +86,18 @@ describe('ProviderConnect', () => {
     expect(screen.queryByText('Remove API key')).toBeNull()
   })
 
+  it('clears a canceled API key before the form opens again', () => {
+    renderCard(provider())
+    fireEvent.click(screen.getByRole('button', { name: 'Add API key' }))
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'discarded-key' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    expect(screen.queryByLabelText('API key')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Add API key' }))
+    expect((screen.getByLabelText('API key') as HTMLInputElement).value).toBe('')
+    expect((screen.getByRole('button', { name: 'Save API key' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
   it('a key-only vendor shows only the key block', () => {
     renderCard(provider({ id: 'xai', label: 'xAI', billingOptions: ['api_key'] }))
 

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { SettingsModal } from './SettingsModal'
@@ -76,6 +76,26 @@ const providerCatalogs = [
 ]
 
 const providerDirectory = [
+  ...Array.from({ length: 35 }, (_, index) => ({
+    provider: `gateway-${index}`,
+    label: `Gateway ${index}`,
+    models: [{ id: `gateway-${index}/moonshotai/kimi-k2`, label: 'Kimi K2' }],
+  })),
+  {
+    provider: 'kimi-for-coding',
+    label: 'Kimi For Coding',
+    models: [{ id: 'kimi-for-coding/kimi-k2', label: 'Kimi K2' }],
+  },
+  {
+    provider: 'moonshotai',
+    label: 'Moonshot AI',
+    models: [{ id: 'moonshotai/kimi-k2', label: 'Kimi K2' }],
+  },
+  {
+    provider: 'moonshotai-cn',
+    label: 'Moonshot AI (China)',
+    models: [{ id: 'moonshotai-cn/kimi-k2', label: 'Kimi K2' }],
+  },
   {
     provider: 'cerebras',
     label: 'Cerebras',
@@ -522,19 +542,38 @@ describe('SettingsModal agents', () => {
     expect(screen.getByRole('button', { name: 'Model' }).textContent).toContain('Llama 4')
   })
 
-  it('opens a configured provider catalog from the Providers pane', async () => {
+  it.each([
+    [' KIMI ', 'Kimi For Coding'],
+    ['moonshot', 'Moonshot AI'],
+  ])('prioritizes provider names and keeps all matches for %s', async (query, label) => {
+    stubFetch()
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: 'Providers' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Add provider' }))
+    fireEvent.change(screen.getByLabelText('Add provider'), { target: { value: query } })
+
+    const results = screen.getByRole('list', { name: 'Provider search results' })
+    await within(results).findByText(label)
+    const buttons = within(results).getAllByRole('button')
+    expect(buttons[0]!.textContent).toContain(label)
+    expect(buttons.length).toBeGreaterThan(30)
+    expect(within(results).getByText('Moonshot AI (China)')).toBeTruthy()
+    expect(within(results).queryByText(/\d+ models/)).toBeNull()
+
+    fireEvent.click(buttons[0]!)
+    const card = screen.getByText(label).closest('article')!
+    expect(within(card).getByRole('button', { name: 'Add API key' })).toBeTruthy()
+  })
+
+  it('keeps catalog freshness without model counts or a model navigation action', async () => {
     stubFetch()
     renderModal()
     fireEvent.click(await screen.findByRole('button', { name: 'Providers' }))
 
-    const groqCard = (await screen.findByText('Groq')).closest('article')
-    fireEvent.click(groqCard!.querySelector<HTMLButtonElement>('.provider-models-row button')!)
-
-    expect(await screen.findByRole('heading', { name: 'Agents' })).toBeTruthy()
-    expect((screen.getByLabelText('Search models') as HTMLInputElement).value).toBe('groq')
-    const llama = screen.getByRole('option', { name: /Llama 4/ }) as HTMLButtonElement
-    expect(llama.disabled).toBe(true)
-    expect(llama.textContent).toContain('Select a compatible harness and billing method')
+    const card = (await screen.findByText('Groq')).closest('article')!
+    expect(within(card).getByText(/Catalog (updated|is stale)/)).toBeTruthy()
+    expect(within(card).queryByText(/\d+ models/)).toBeNull()
+    expect(screen.queryByRole('button', { name: 'View models in Agents' })).toBeNull()
   })
 
   it('closes the model chooser with Escape without closing settings', async () => {

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -49,7 +49,6 @@ interface CatalogChoice extends CatalogModel {
 
 interface Catalog {
   modelsOf: (harness: string, billing: Billing) => CatalogChoice[]
-  modelsForProvider: (provider: string) => CatalogChoice[]
 }
 
 const addedProvider = (id: string, label: string): Provider => ({ id, label, billingOptions: ['api_key'] })
@@ -91,12 +90,6 @@ function buildCatalog(
       return catalogs
         .filter((catalog) => !harness.provider || harness.provider === catalog.provider)
         .filter((catalog) => providersById.get(catalog.provider)?.billingOptions.includes(billing))
-        .flatMap((catalog) => choicesFor(catalog, billing))
-    },
-    modelsForProvider: (provider) => {
-      const billing: Billing = connected.has(provider) && !keyed.has(provider) ? 'subscription' : 'api_key'
-      return catalogs
-        .filter((catalog) => catalog.provider === provider)
         .flatMap((catalog) => choicesFor(catalog, billing))
     },
   }
@@ -260,7 +253,6 @@ export function SettingsModal({ open, onClose }: Props) {
   // 'general' | 'providers' | 'agents' | 'browser-sessions' | 'skills' | 'mcp' |
   // 'agent-access' | <app name>
   const [section, setSection] = useState<string>('general')
-  const [modelBrowseProvider, setModelBrowseProvider] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [appProblems, setAppProblems] = useState<AppSettingsProblems>({})
@@ -567,10 +559,6 @@ export function SettingsModal({ open, onClose }: Props) {
                     ? providerCatalogsQuery.error.message
                     : null
                 }
-                onViewModels={(providerId) => {
-                  setModelBrowseProvider(providerId)
-                  setSection('agents')
-                }}
               />
             )}
             {section === 'agents' &&
@@ -586,8 +574,6 @@ export function SettingsModal({ open, onClose }: Props) {
                   allowedEfforts={allowedEfforts}
                   onOpenApp={setSection}
                   onAddProvider={() => setSection('providers')}
-                  browseProvider={modelBrowseProvider}
-                  onBrowseOpened={() => setModelBrowseProvider(null)}
                   busy={busy}
                 />
               ) : (
@@ -827,9 +813,6 @@ function ModelChooser({
   inheritLabel,
   isOverride = false,
   onAddProvider,
-  browseProvider,
-  onBrowseOpened,
-  onBrowseClosed,
 }: {
   id?: string
   value: string | null
@@ -841,21 +824,10 @@ function ModelChooser({
   inheritLabel?: string
   isOverride?: boolean
   onAddProvider: () => void
-  browseProvider?: string | null
-  onBrowseOpened?: () => void
-  onBrowseClosed?: () => void
 }) {
-  const buttonRef = useRef<HTMLButtonElement>(null)
   const [anchor, setAnchor] = useState<HTMLButtonElement | null>(null)
   const [search, setSearch] = useState('')
   const selected = choices.find((choice) => choice.id === value)
-
-  useEffect(() => {
-    if (!browseProvider || !buttonRef.current) return
-    setSearch(browseProvider)
-    setAnchor(buttonRef.current)
-    onBrowseOpened?.()
-  }, [browseProvider, onBrowseOpened])
 
   const query = search.trim().toLocaleLowerCase()
   const visible = choices.filter((choice) =>
@@ -873,7 +845,6 @@ function ModelChooser({
   const close = () => {
     setAnchor(null)
     setSearch('')
-    onBrowseClosed?.()
   }
   const pick = (next: string | null) => {
     onPick(next)
@@ -882,7 +853,6 @@ function ModelChooser({
   return (
     <>
       <button
-        ref={buttonRef}
         id={id}
         type="button"
         className={
@@ -1154,8 +1124,6 @@ export function AgentsPane({
   allowedEfforts,
   onOpenApp,
   onAddProvider,
-  browseProvider,
-  onBrowseOpened,
   busy,
 }: {
   defaults: Defaults
@@ -1168,32 +1136,12 @@ export function AgentsPane({
   allowedEfforts: string[]
   onOpenApp: (app: string) => void
   onAddProvider: () => void
-  browseProvider: string | null
-  onBrowseOpened: () => void
   busy: boolean
 }) {
   const fieldId = useId()
   const id = (field: string) => `${fieldId}-${field}`
   const harnesses = Object.values(harnessByName)
-  const executionModels = catalog.modelsOf(defaults.defaultHarness, defaults.defaultBilling)
-  const [browsingProvider, setBrowsingProvider] = useState<string | null>(null)
-  const providerToBrowse = browseProvider ?? browsingProvider
-  const models = providerToBrowse
-    ? catalog.modelsForProvider(providerToBrowse).map((choice) => {
-        const compatible = executionModels.find(
-          (candidate) => candidate.id === choice.id && candidate.provider === choice.provider,
-        )
-        return {
-          ...choice,
-          enabled: Boolean(compatible?.enabled),
-          unavailableReason: compatible
-            ? compatible.unavailableReason
-            : choice.enabled
-              ? 'Select a compatible harness and billing method'
-              : choice.unavailableReason,
-        }
-      })
-    : executionModels
+  const models = catalog.modelsOf(defaults.defaultHarness, defaults.defaultBilling)
   const defaultKeyOnly = keyOnly(harnessByName[defaults.defaultHarness])
   const timeouts = TIMEOUTS.includes(defaults.defaultTimeout)
     ? TIMEOUTS
@@ -1253,12 +1201,6 @@ export function AgentsPane({
               disabled={busy}
               label="Model"
               onAddProvider={onAddProvider}
-              browseProvider={browseProvider}
-              onBrowseOpened={() => {
-                setBrowsingProvider(browseProvider)
-                onBrowseOpened()
-              }}
-              onBrowseClosed={() => setBrowsingProvider(null)}
             />
           </div>
           <div className="mcp-field">
@@ -1844,7 +1786,6 @@ function ProvidersPane({
   catalogs,
   loading,
   requestError,
-  onViewModels,
 }: {
   providers: Provider[]
   subscriptions: ProviderSubscription[]
@@ -1852,7 +1793,6 @@ function ProvidersPane({
   catalogs: ProviderCatalog[]
   loading: boolean
   requestError: string | null
-  onViewModels: (providerId: string) => void
 }) {
   const [adding, setAdding] = useState(false)
   const [search, setSearch] = useState('')
@@ -1890,10 +1830,17 @@ function ProvidersPane({
     ...(directoryQuery.data ?? []),
   ]
     .filter((entry) => !configuredIds.has(entry.provider))
+    .map((entry) => ({
+      ...entry,
+      nameMatches: [entry.label, entry.provider].some((text) => text.toLocaleLowerCase().includes(query)),
+    }))
     .filter((entry) =>
-      [entry.label, entry.provider, ...entry.models.flatMap((model) => [model.label, model.id])].some(
-        (text) => text.toLocaleLowerCase().includes(query),
+      entry.nameMatches || entry.models.some((model) =>
+        [model.label, model.id].some((text) => text.toLocaleLowerCase().includes(query)),
       ),
+    )
+    .sort((left, right) =>
+      Number(right.nameMatches) - Number(left.nameMatches) || left.label.localeCompare(right.label),
     )
   return (
     <div className="set-pane mcp-pane hrs-pane">
@@ -1916,29 +1863,21 @@ function ProvidersPane({
           const subscription = subscriptions.find((row) => row.provider === provider.id) ?? null
           const apiKey = keys.find((row) => row.provider === provider.id) ?? null
           const catalog = catalogs.find((entry) => entry.provider === provider.id)
-          const modelCount = catalog?.models.length ?? 0
           const catalogIsStale = Boolean(
             catalog && openedAt - new Date(catalog.fetchedAt).getTime() > 24 * 60 * 60 * 1000,
           )
-          const connection = subscription?.connected
-            ? apiKey
-              ? 'Subscription and API key configured'
-              : 'Subscription connected'
-            : subscription
-              ? 'Subscription needs reconnect'
-              : apiKey
-                ? 'API key configured'
-                : 'Not configured'
           return (
             <article key={provider.id} className="set-card hr-card" style={{ '--fam': providerColor[provider.id] } as CSSProperties}>
               <header className="hr-ident">
                 <span className="hr-ident-dot" aria-hidden="true" />
                 <span className="hr-identity-copy">
                   <span className="hr-name">{provider.label}</span>
-                  <code className="hr-provider">{provider.id}</code>
                 </span>
-                <span className="hr-card-state" role="status">{connection}</span>
-                <span className="hr-count"><b>{modelCount}</b> models</span>
+                <span className="provider-catalog" title={catalog ? new Date(catalog.fetchedAt).toLocaleString() : undefined}>
+                  {catalog
+                    ? `${catalogIsStale ? 'Catalog is stale' : 'Catalog updated'} ${relTimeFromIso(catalog.fetchedAt)}`
+                    : 'No catalog yet'}
+                </span>
               </header>
               <ProviderConnect
                 provider={provider}
@@ -1947,22 +1886,6 @@ function ProvidersPane({
                 usage={usageQuery.data?.providers.find((row) => row.id === provider.id) ?? null}
                 keySpendToday={todayQuery.data?.providers.find((row) => row.id === provider.id)?.keySpendUsd ?? null}
               />
-              <div className="provider-models-row">
-                <span>
-                  <strong>{modelCount} models available</strong>
-                  {catalog ? (
-                    <small>
-                      {catalogIsStale ? 'Catalog is stale' : 'Catalog updated'}{' '}
-                      {relTimeFromIso(catalog.fetchedAt)}
-                    </small>
-                  ) : (
-                    <small>No catalog is available yet.</small>
-                  )}
-                </span>
-                <button type="button" className="set-btn ghost" onClick={() => onViewModels(provider.id)}>
-                  View models in Agents
-                </button>
-              </div>
             </article>
           )
         })}
@@ -1986,7 +1909,7 @@ function ProvidersPane({
               onChange={(event) => setSearch(event.target.value)}
             />
             <div className="provider-results" role="list" aria-label="Provider search results">
-              {candidates.slice(0, 30).map((entry) => {
+              {candidates.map((entry) => {
                 const provider =
                   providers.find((registered) => registered.id === entry.provider) ??
                   addedProvider(entry.provider, entry.label)
@@ -2002,9 +1925,7 @@ function ProvidersPane({
                     }}
                   >
                     <span><strong>{provider.label}</strong><code>{provider.id}</code></span>
-                    <span><b>{entry.models.length}</b> models</span>
                     <span>{provider.billingOptions.map(billingLabel).join(' or ')}</span>
-                    <span>Not configured</span>
                   </button>
                 )
               })}
@@ -2091,11 +2012,6 @@ export function ProviderConnect({
   const showKeyForm = acceptsApiKey && (keyFormOpen || replacing)
   return (
     <div className="hr-connect">
-      {acceptsSubscription && acceptsApiKey && (
-        <p className="hr-billing-note">
-          Use either your provider subscription or the installation API key as the billing method.
-        </p>
-      )}
       {acceptsSubscription && (
         <section className="hr-block">
           <div className="hr-block-title">Subscription</div>
@@ -2149,7 +2065,7 @@ export function ProviderConnect({
       )}
       {acceptsApiKey && (
         <section className="hr-block">
-          <div className="hr-block-title">API key</div>
+          {(apiKey || showKeyForm) && <div className="hr-block-title">API key</div>}
           {apiKey && (
             <div className="hr-conn-status">
               <span className="hr-conn-id">…{apiKey.keyTail}</span>
@@ -2171,33 +2087,31 @@ export function ProviderConnect({
             </div>
           )}
           {!apiKey && !showKeyForm && (
-            <button className="set-btn ghost provider-key-add" type="button" onClick={() => setKeyFormOpen(true)}>
+            <button className="set-btn quiet provider-key-add" type="button" onClick={() => setKeyFormOpen(true)}>
               Add API key
             </button>
           )}
           {showKeyForm && (
-            <form className="hr-conn-flow" onSubmit={createKey}>
-              <div className="hr-conn-step hr-conn-paste">
-                <input
-                  aria-label="API key"
-                  autoComplete="off"
-                  className="hr-conn-input"
-                  disabled={busy || flow.busy}
-                  onChange={(event) => setKey(event.target.value)}
-                  placeholder="Paste API key"
-                  spellCheck={false}
-                  type="password"
-                  value={key}
-                />
-                <button className="hr-conn-btn" disabled={busy || flow.busy || !key.trim()} type="submit">
-                  {apiKey ? 'Replace key' : 'Save API key'}
+            <form className="provider-key-form" onSubmit={createKey}>
+              <input
+                aria-label="API key"
+                autoComplete="off"
+                className="hr-conn-input"
+                disabled={busy || flow.busy}
+                onChange={(event) => setKey(event.target.value)}
+                placeholder="Paste API key"
+                spellCheck={false}
+                type="password"
+                value={key}
+              />
+              <button className="hr-conn-btn" disabled={busy || flow.busy || !key.trim()} type="submit">
+                {apiKey ? 'Replace key' : 'Save API key'}
+              </button>
+              {!apiKey && (
+                <button className="set-btn quiet" type="button" onClick={() => { setKey(''); setKeyFormOpen(false) }}>
+                  Cancel
                 </button>
-                {!apiKey && (
-                  <button className="set-btn quiet" type="button" onClick={() => { setKey(''); setKeyFormOpen(false) }}>
-                    Cancel
-                  </button>
-                )}
-              </div>
+              )}
             </form>
           )}
         </section>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1005,14 +1005,10 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .hrs-list { display: flex; flex-direction: column; gap: 10px; }
 .hrs-pane :is(.set-btn, .hr-conn-btn, .mcp-conn, .hr-more summary) { font-family: var(--font-sans); letter-spacing: 0; }
 .hr-card { display: flex; flex-direction: column; gap: 12px; padding: 13px 14px; }
-.hr-ident { display: grid; grid-template-columns: auto minmax(120px, 1fr) auto auto; align-items: center; gap: 9px 14px; }
+.hr-ident { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 9px 14px; }
 .hr-ident-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fam, var(--border-loud)); flex-shrink: 0; }
 .hr-identity-copy { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
 .hr-name { font-size: 13.5px; font-weight: 600; color: var(--text); }
-.hr-provider { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-faint); }
-.hr-card-state { font-size: 11.5px; color: var(--text-mid); }
-.hr-count { margin-left: auto; font-size: 12px; color: var(--text-dim); white-space: nowrap; }
-.hr-count b { color: var(--text-mid); font-weight: 500; }
 .hr-controls { display: grid; grid-template-columns: minmax(180px, 1fr) 110px 110px auto; gap: 12px 14px; align-items: end; }
 .hr-fast { height: 34px; display: flex; align-items: center; padding: 0 1px; }
 .hr-conn-id { font-family: var(--font-mono); font-size: 12px; color: var(--text-mid); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -1044,22 +1040,21 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .hr-block { display: flex; flex-direction: column; gap: 9px; }
 .hr-block + .hr-block { border-top: 1px solid var(--border); padding-top: 12px; }
 .hr-block-title { font-size: 11px; font-weight: 600; color: var(--text-dim); }
-.hr-billing-note { margin: 0; font-size: 11.5px; line-height: 1.45; color: var(--text-dim); }
 .hr-quota { display: grid; grid-template-columns: 70px minmax(0, 100px) minmax(120px, 1fr) 106px minmax(190px, auto); align-items: center; gap: 10px; font-size: 11.5px; }
 .hr-quota .us-bar { margin: 0; }
 .hr-quota-label { color: var(--text-mid); }
 .hr-quota-model { color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .hr-quota-pct { text-align: right; color: var(--text-mid); white-space: nowrap; }
-.provider-key-add { align-self: flex-start; }
+.provider-key-add { align-self: flex-start; padding-left: 0; }
+.provider-key-form { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+.provider-key-form .hr-conn-input { min-width: 0; flex: 1 1 240px; }
+.provider-key-form .hr-conn-input:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.provider-catalog { font-size: 10.5px; color: var(--text-dim); }
 .hr-more { position: relative; }
 .hr-more summary { list-style: none; cursor: pointer; color: var(--text-dim); font-size: 11.5px; padding: 6px 8px; border-radius: 4px; }
 .hr-more summary::-webkit-details-marker { display: none; }
 .hr-more summary:hover { color: var(--text); background: var(--surface-3); }
 .hr-more[open] > .set-btn { position: absolute; z-index: 4; top: calc(100% + 4px); right: 0; background: var(--surface-3); box-shadow: 0 12px 28px -10px rgba(0, 0, 0, 0.8); }
-.provider-models-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; border-top: 1px solid var(--border); padding-top: 11px; }
-.provider-models-row > span { display: flex; flex-direction: column; gap: 3px; font-size: 11.5px; color: var(--text-mid); }
-.provider-models-row strong { color: var(--text); font-weight: 500; }
-.provider-models-row small { font-family: var(--font-mono); font-size: 10px; color: var(--text-faint); }
 .provider-state { font-size: 12px; color: var(--text-dim); }
 .provider-empty { display: flex; flex-direction: column; gap: 4px; padding: 18px 0 4px; color: var(--text-dim); font-size: 12px; }
 .provider-empty strong { color: var(--text); font-size: 13px; }
@@ -1068,11 +1063,11 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .provider-add-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .provider-add-head label { font-size: 13px; font-weight: 600; color: var(--text); }
 .provider-results { display: flex; flex-direction: column; max-height: 260px; overflow: auto; border-top: 1px solid var(--border); }
-.provider-result { display: grid; grid-template-columns: minmax(150px, 1.5fr) 90px minmax(140px, 1fr) 120px; align-items: center; gap: 12px; width: 100%; padding: 10px 4px; border-bottom: 1px solid var(--border-soft); color: var(--text-mid); text-align: left; font-size: 11.5px; }
+.provider-result { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; width: 100%; padding: 10px 4px; border-bottom: 1px solid var(--border-soft); color: var(--text-mid); text-align: left; font-size: 11.5px; }
 .provider-result:hover { background: var(--surface-3); color: var(--text); }
 .provider-result > span:first-child { display: flex; flex-direction: column; gap: 2px; }
 .provider-result strong { font-size: 12.5px; color: var(--text); }
-.provider-result code, .provider-result b { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); font-weight: 400; }
+.provider-result code { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); font-weight: 400; }
 
 @media (max-width: 600px) {
   .set-backdrop { padding: 0; }
@@ -1088,8 +1083,7 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
   .set-foot-actions { gap: 6px; }
   .set-btn { padding: 7px 11px; }
   .hr-ident { grid-template-columns: auto minmax(0, 1fr) auto; gap: 7px 9px; }
-  .hr-card-state { grid-column: 2 / -1; }
-  .hr-count { grid-column: 3; grid-row: 1; }
+  .provider-catalog { grid-column: 2 / -1; }
   .hr-identity-copy { flex-direction: column; align-items: flex-start; gap: 2px; }
   .hr-conn-status { align-items: flex-start; }
   .hr-conn-id { width: calc(100% - 90px); }
@@ -1100,9 +1094,7 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
   .hr-quota .us-bar { grid-area: bar; }
   .hr-quota-pct { grid-area: pct; }
   .hr-quota .hr-conn-exp { grid-area: reset; }
-  .provider-models-row { align-items: flex-start; flex-direction: column; }
   .provider-result { grid-template-columns: 1fr auto; gap: 5px 12px; }
-  .provider-result > span:nth-child(3), .provider-result > span:nth-child(4) { grid-column: 1 / -1; }
   .provider-add-panel { padding: 12px; }
   .model-chooser-option { align-items: flex-start; flex-direction: column; gap: 2px; }
 }


### PR DESCRIPTION
## What changed

Provider settings show credentials, usage, and catalog freshness with less repeated content. Remove model counts, the “View models in Agents” action, repeated connection status, and billing instructions. Move catalog freshness to the card header and remove the extra box around the API key form.

Provider search shows all matches and puts provider-name matches first. The previous 30-result limit hid direct providers among model resellers. Regression tests cover Kimi and Moonshot searches with more than 30 matches.

Tracks [DRU-423](https://linear.app/fellaworks/issue/DRU-423).

## Risk

Frontend changes only. No migrations or backend contract changes. Live provider authentication was not tested.

## Verification

- `npm --prefix frontend run lint` — passed.
- `npm --prefix frontend test` — all 270 tests passed.
- `npm --prefix frontend run build` — passed.
- `git diff --check` — passed.
- Browser inspection with local test data covered desktop and 390 px layouts, the API key form, and provider search. No horizontal overflow at 390 px; Moonshot appeared first.
- Backend tests were not run because no backend files changed.
