### PR TITLE
DRU-428: Simplify provider quotas and show provider source details

### DIFF
--- a/backend/druks/harnesses/constants.py
+++ b/backend/druks/harnesses/constants.py
@@ -2,7 +2,7 @@
 # operator completes it, and the per-subscription SET NX lock that serializes refresh.
 CONNECT_PENDING_PREFIX = "druks:harness:connect:pending:"
 REFRESH_LOCK_PREFIX = "druks:harness:refresh:"
-# The models.dev directory, read when someone searches for a provider to add.
+# Provider search and details share the Models.dev cache.
 DIRECTORY_CACHE_KEY = "druks:harness:directory"
 DIRECTORY_CACHE_TTL_SECONDS = 24 * 3600
 

--- a/backend/druks/harnesses/directory.py
+++ b/backend/druks/harnesses/directory.py
@@ -17,8 +17,7 @@ _TIMEOUT_SECONDS = 20.0
 
 
 async def list_providers() -> list[dict]:
-    """Every models.dev provider that runs on one API key, ``{"provider",
-    "label", "models"}`` each. Held in Redis for a day."""
+    """List Models.dev providers that use one API key. Cache the list for one day."""
     redis = get_client()
     cached = await redis.get(DIRECTORY_CACHE_KEY)
     if cached:
@@ -54,6 +53,8 @@ def parse_providers(raw: str) -> list[dict]:
                     {
                         "provider": provider_id,
                         "label": provider.get("name") or provider_id,
+                        "documentation_url": provider.get("doc"),
+                        "api_url": provider.get("api"),
                         "models": sorted(models, key=lambda model: model["label"]),
                     }
                 )

--- a/backend/druks/harnesses/schemas.py
+++ b/backend/druks/harnesses/schemas.py
@@ -55,4 +55,6 @@ class ProviderCatalogResponse(Schema):
 class ProviderDirectoryResponse(Schema):
     provider: str
     label: str
+    documentation_url: str | None
+    api_url: str | None
     models: list[CatalogModel]

--- a/backend/tests/test_api_providers.py
+++ b/backend/tests/test_api_providers.py
@@ -125,6 +125,8 @@ async def test_removing_the_key_leaves_every_subscription(tmp_path: Path, druks_
 _GROQ = {
     "provider": "groq",
     "label": "Groq",
+    "documentation_url": "https://console.groq.com/docs",
+    "api_url": "https://api.groq.com/openai/v1",
     "models": [{"id": "groq/llama-4", "label": "Llama 4"}],
 }
 
@@ -155,7 +157,15 @@ async def test_a_key_for_a_directory_provider_adds_it(tmp_path: Path, druks_db, 
 def test_directory_lists_only_providers_one_can_add(tmp_path: Path, monkeypatch):
     _stub_directory(monkeypatch, [_GROQ, {"provider": "openai", "label": "OpenAI", "models": []}])
     with _build_client(tmp_path) as client:
-        assert client.get("/api/providers/directory").json() == [_GROQ]
+        assert client.get("/api/providers/directory").json() == [
+            {
+                "provider": "groq",
+                "label": "Groq",
+                "models": _GROQ["models"],
+                "documentationUrl": "https://console.groq.com/docs",
+                "apiUrl": "https://api.groq.com/openai/v1",
+            }
+        ]
 
 
 def test_disconnect_without_a_login_is_a_no_op(tmp_path: Path):

--- a/backend/tests/test_provider_catalogs.py
+++ b/backend/tests/test_provider_catalogs.py
@@ -146,6 +146,8 @@ def test_directory_keeps_one_key_providers_with_exact_ids() -> None:
                 "openrouter": {
                     "id": "different-nested-id",
                     "name": "OpenRouter",
+                    "doc": "https://openrouter.ai/docs",
+                    "api": "https://openrouter.ai/api/v1",
                     "env": ["OPENROUTER_API_KEY"],
                     "models": {
                         "anthropic/claude-sonnet-4": {
@@ -167,6 +169,8 @@ def test_directory_keeps_one_key_providers_with_exact_ids() -> None:
         {
             "provider": "openrouter",
             "label": "OpenRouter",
+            "documentation_url": "https://openrouter.ai/docs",
+            "api_url": "https://openrouter.ai/api/v1",
             "models": [{"id": "openrouter/anthropic/claude-sonnet-4", "label": "Claude Sonnet 4"}],
         }
     ]
@@ -270,7 +274,19 @@ async def test_directory_is_fetched_once_and_read_from_redis(monkeypatch, druks_
     first = await list_providers()
     second = await list_providers()
 
-    assert first == second == [{"provider": "groq", "label": "Groq", "models": [_LLAMA]}]
+    assert (
+        first
+        == second
+        == [
+            {
+                "provider": "groq",
+                "label": "Groq",
+                "models": [_LLAMA],
+                "documentation_url": None,
+                "api_url": None,
+            }
+        ]
+    )
     assert [call["url"] for call in calls] == ["https://models.dev/api.json"]
 
     _mock_get(monkeypatch, _resp(503, "down"))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -278,11 +278,21 @@ host login. This is a capability connection for the requesting account. In a
 fresh `none`-mode install, the first completed subscription connection also
 creates the operator account. See [access control](#public-urls-and-access-control).
 
-**Add provider** searches the Models.dev directory for a vendor that runs on
-one API key. Druks reads the directory when you open the search, keeps it in
-Redis for a day, and stores nothing until you paste a key. The key makes the
-vendor one of the installation's providers with its model list. Removing the
-key removes the vendor.
+**Add provider** searches Models.dev for providers that use one API key.
+Druks caches the directory in Redis for one day for search and provider details.
+**Save** stores the key and adds the provider and its model list.
+When you remove the key, Druks removes the provider.
+
+Provider details show documentation and API URLs from Models.dev.
+Druks does not verify provider identity or restrict requests to the listed endpoint.
+When an agent runs, OpenCode selects the endpoint.
+
+Before you save a key, check the provider documentation and domain.
+
+Cards show five-hour and general weekly limits with the time until reset.
+Tooltips show exact reset times. **Catalog status** shows each provider's last
+update. Anthropic and OpenAI fetch separate model lists. Added providers use
+the cached Models.dev directory.
 
 The `claude` and `codex` CLIs run on their own vendor's subscription or key.
 `opencode` and `pi` run on an API key only. OpenCode can run a supported

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -528,6 +528,8 @@ export interface ProviderCatalog {
 export interface ProviderDirectoryEntry {
   provider: string
   label: string
+  documentationUrl: string | null
+  apiUrl: string | null
   models: CatalogModel[]
 }
 

--- a/frontend/src/components/ProviderConnect.test.tsx
+++ b/frontend/src/components/ProviderConnect.test.tsx
@@ -65,6 +65,7 @@ function renderCard(
 afterEach(() => {
   cleanup()
   vi.unstubAllGlobals()
+  vi.useRealTimers()
 })
 
 async function flush() {
@@ -81,7 +82,7 @@ describe('ProviderConnect', () => {
     expect(screen.queryByLabelText('API key')).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'Add API key' }))
     expect(screen.getByLabelText('API key')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Save API key' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy()
     expect(screen.queryByText('Disconnect subscription')).toBeNull()
     expect(screen.queryByText('Remove API key')).toBeNull()
   })
@@ -95,7 +96,7 @@ describe('ProviderConnect', () => {
     expect(screen.queryByLabelText('API key')).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'Add API key' }))
     expect((screen.getByLabelText('API key') as HTMLInputElement).value).toBe('')
-    expect((screen.getByRole('button', { name: 'Save API key' }) as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(true)
   })
 
   it('a key-only vendor shows only the key block', () => {
@@ -134,13 +135,46 @@ describe('ProviderConnect', () => {
     expect(screen.getByText('41% remaining')).toBeTruthy()
     expect(screen.getByText('5-hour')).toBeTruthy()
     expect(screen.getByText('Weekly')).toBeTruthy()
-    expect(screen.getByText(/Token expires/)).toBeTruthy()
+    expect(screen.queryByText(/Token expires/)).toBeNull()
     expect(screen.queryByText('Expired')).toBeNull()
     expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull()
-    expect(screen.getByRole('button', { name: 'Disconnect subscription' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Disconnect Anthropic subscription' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: /Sign in/ })).toBeNull()
     expect(screen.queryByLabelText('API key')).toBeNull()
     expect(screen.queryByText('Remove API key')).toBeNull()
+  })
+
+  it('shows only the general weekly quota and keeps reset times relative', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-05T10:00:00Z'))
+    renderCard(provider(), {
+      subscription: subscription(),
+      usage: {
+        id: 'anthropic', label: 'Anthropic', available: true, connected: true,
+        providerEmail: 'seat@example.com', planTier: null,
+        fiveHour: { percentLeft: 0, resetsAt: '2026-09-05T12:00:00Z', model: null },
+        weeks: [
+          { percentLeft: 69, resetsAt: null, model: 'Fable' },
+          { percentLeft: 83, resetsAt: '2026-09-11T10:00:00Z', model: null },
+          { percentLeft: 50, resetsAt: null, model: 'GPT reserve' },
+        ],
+        unlimited: false, scrapedAt: null, ageSeconds: null, stale: false, error: null, rawOutput: null,
+      },
+    })
+
+    expect(screen.getAllByText('Weekly')).toHaveLength(1)
+    expect(screen.getByText('83% remaining')).toBeTruthy()
+    expect(screen.queryByText('69% remaining')).toBeNull()
+    expect(screen.queryByText('50% remaining')).toBeNull()
+    expect(screen.queryByText('Fable')).toBeNull()
+    expect(screen.queryByText('GPT reserve')).toBeNull()
+    expect(screen.getByText('Resets in 6d')).toBeTruthy()
+    expect(screen.getByText('Resets in 2h').getAttribute('dateTime')).toBe('2026-09-05T12:00:00Z')
+    expect(screen.getByText('Resets in 2h').getAttribute('title')).toBeTruthy()
+    act(() => { vi.advanceTimersByTime(1000) })
+    expect(screen.getByText('Resets in 2h')).toBeTruthy()
+    act(() => { vi.advanceTimersByTime(2 * 60 * 60 * 1000) })
+    expect(screen.getByText('Reset due')).toBeTruthy()
   })
 
   it('a shared key shows its tail, who set it, spend today, Replace and Remove', () => {
@@ -149,15 +183,15 @@ describe('ProviderConnect', () => {
     expect(screen.getByText('…4f2a')).toBeTruthy()
     expect(screen.getByText(/set by ops@corp.com/)).toBeTruthy()
     expect(screen.getByText(/\$12\.40 today/)).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Remove API key' })).toBeTruthy()
-    expect(screen.getByLabelText('More Anthropic API key actions')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Remove Anthropic API key' })).toBeTruthy()
+    expect(screen.queryByText('More')).toBeNull()
     expect(screen.queryByLabelText('API key')).toBeNull()
     // The subscription block still invites a sign-in.
     expect(screen.getByRole('button', { name: 'Sign in with Anthropic' })).toBeTruthy()
 
     fireEvent.click(screen.getByRole('button', { name: 'Replace' }))
     expect(screen.getByLabelText('API key')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Replace key' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy()
   })
 
   it('both connected shows both blocks and never the operator account', () => {
@@ -165,8 +199,8 @@ describe('ProviderConnect', () => {
 
     expect(screen.getByText('claude-seat@corp.com')).toBeTruthy()
     expect(screen.getByText('…4f2a')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Disconnect subscription' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Remove API key' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Disconnect Anthropic subscription' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Remove Anthropic API key' })).toBeTruthy()
     expect(screen.queryByText('op@example.com')).toBeNull()
   })
 
@@ -177,9 +211,9 @@ describe('ProviderConnect', () => {
 
     expect(screen.getByText('Expired')).toBeTruthy()
     expect(screen.getByText('claude-seat@corp.com')).toBeTruthy()
-    expect(screen.getByText(/Token expired/)).toBeTruthy()
+    expect(screen.queryByText(/Token expired/)).toBeNull()
     expect(screen.getByRole('button', { name: 'Reconnect' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Disconnect subscription' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Disconnect Anthropic subscription' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: /Sign in/ })).toBeNull()
   })
 
@@ -237,7 +271,8 @@ describe('ProviderConnect', () => {
     fireEvent.change(screen.getByLabelText('API key'), {
       target: { value: 'the-api-key' },
     })
-    fireEvent.click(screen.getByRole('button', { name: 'Save API key' }))
+    expect(fetchMock).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
     await flush()
 
     const storeCall = fetchMock.mock.calls.find(
@@ -255,7 +290,7 @@ describe('ProviderConnect', () => {
     vi.stubGlobal('confirm', () => true)
 
     renderCard(provider(), { subscription: subscription(), apiKey: sharedKey })
-    fireEvent.click(screen.getByRole('button', { name: 'Remove API key' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Anthropic API key' }))
     await flush()
 
     const [url, init] = fetchMock.mock.calls[0]!

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -76,6 +76,8 @@ const providerCatalogs = [
 ]
 
 const providerDirectory = [
+  { provider: 'untrusted', label: 'Untrusted', documentationUrl: 'javascript:alert(1)', apiUrl: 'https://trusted.example@evil.example/v1', models: [] },
+  { provider: 'groq', label: 'Groq', documentationUrl: 'https://console.groq.com/docs', apiUrl: 'https://api.groq.com/openai/v1', models: [] },
   ...Array.from({ length: 35 }, (_, index) => ({
     provider: `gateway-${index}`,
     label: `Gateway ${index}`,
@@ -84,6 +86,8 @@ const providerDirectory = [
   {
     provider: 'kimi-for-coding',
     label: 'Kimi For Coding',
+    documentationUrl: 'https://www.kimi.com/code/docs/',
+    apiUrl: 'https://api.kimi.com/coding/v1',
     models: [{ id: 'kimi-for-coding/kimi-k2', label: 'Kimi K2' }],
   },
   {
@@ -518,8 +522,8 @@ describe('SettingsModal agents', () => {
     renderModal()
     fireEvent.click(await screen.findByRole('button', { name: 'Providers' }))
 
-    expect(await screen.findByText('Anthropic')).toBeTruthy()
-    expect(screen.getByText('Groq')).toBeTruthy()
+    expect(await screen.findByRole('article', { name: 'Anthropic' })).toBeTruthy()
+    expect(screen.getByRole('article', { name: 'Groq' })).toBeTruthy()
     expect(screen.queryByText('OpenAI')).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'Add provider' }))
     fireEvent.change(screen.getByLabelText('Add provider'), { target: { value: 'gpt oss' } })
@@ -570,10 +574,46 @@ describe('SettingsModal agents', () => {
     renderModal()
     fireEvent.click(await screen.findByRole('button', { name: 'Providers' }))
 
-    const card = (await screen.findByText('Groq')).closest('article')!
-    expect(within(card).getByText(/Catalog (updated|is stale)/)).toBeTruthy()
+    const card = await screen.findByRole('article', { name: 'Groq' })
+    expect(within(card).queryByText(/Catalog/)).toBeNull()
+    fireEvent.click(screen.getByText('Catalog status'))
+    expect(screen.getAllByText(/^(Updated |Stale · )/)).toHaveLength(2)
     expect(within(card).queryByText(/\d+ models/)).toBeNull()
     expect(screen.queryByRole('button', { name: 'View models in Agents' })).toBeNull()
+  })
+
+  it('shows the source, endpoint, and documentation before a directory key is entered', async () => {
+    stubFetch()
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: 'Providers' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Add provider' }))
+    fireEvent.change(screen.getByLabelText('Add provider'), { target: { value: 'kimi-for-coding' } })
+
+    const docs = await screen.findByRole('link', { name: 'Documentation for Kimi For Coding' })
+    expect(docs.getAttribute('href')).toBe('https://www.kimi.com/code/docs/')
+    expect(screen.getByText('api.kimi.com')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: /Kimi For Coding/ }))
+    const card = screen.getByText('Kimi For Coding').closest('article')!
+    expect(within(card).getByRole('link', { name: 'Models.dev' }).getAttribute('href')).toBe('https://models.dev')
+    expect(within(card).getByText('https://api.kimi.com/coding/v1')).toBeTruthy()
+    expect(within(card).getByText(/Druks does not verify this provider/)).toBeTruthy()
+    expect(within(card).queryByLabelText('API key')).toBeNull()
+    fireEvent.click(within(card).getByRole('button', { name: 'Add API key' }))
+    expect(within(card).getByRole('form', { name: 'Kimi For Coding API key' })).toBeTruthy()
+  })
+
+  it('does not link unsafe directory URLs or endpoints with embedded credentials', async () => {
+    stubFetch()
+    renderModal()
+    fireEvent.click(await screen.findByRole('button', { name: 'Providers' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Add provider' }))
+    fireEvent.change(screen.getByLabelText('Add provider'), { target: { value: 'untrusted' } })
+    fireEvent.click(await screen.findByRole('button', { name: /Untrusted/ }))
+
+    const card = screen.getByText('Untrusted').closest('article')!
+    expect(within(card).queryByRole('link', { name: /Documentation/ })).toBeNull()
+    expect(within(card).getByText(/Documentation unavailable/)).toBeTruthy()
+    expect(within(card).getByText('Listed API endpoint: Unavailable')).toBeTruthy()
   })
 
   it('closes the model chooser with Escape without closing settings', async () => {

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -22,6 +22,7 @@ import {
   type CatalogModel,
   type Provider,
   type ProviderCatalog,
+  type ProviderDirectoryEntry,
   type ProviderKey,
   type ProviderSubscription,
   type Connection,
@@ -35,8 +36,9 @@ import {
   type WorkflowSettingField,
 } from '../api/types'
 import { appLabel } from '../apps/registry'
-import { absTime, money, relTimeFromIso } from '../lib/format'
+import { absTime, money, relTimeFromIso, secondsUntil } from '../lib/format'
 import { useUsageToday } from '../lib/useUsage'
+import { useTicker } from '../lib/useTicker'
 import { Bar } from './UsagePanel'
 import { harnessColors } from '../lib/harnessColors'
 
@@ -545,6 +547,7 @@ export function SettingsModal({ open, onClose }: Props) {
             {section === 'providers' && (
               <ProvidersPane
                 providers={providers}
+                registeredProviders={providersQuery.data ?? []}
                 subscriptions={providerSubscriptions}
                 keys={providerKeys}
                 catalogs={providerCatalogs}
@@ -1781,6 +1784,7 @@ export function ConnectionsPane() {
 // Connection state persists immediately, outside the modal's Save.
 function ProvidersPane({
   providers,
+  registeredProviders,
   subscriptions,
   keys,
   catalogs,
@@ -1788,6 +1792,7 @@ function ProvidersPane({
   requestError,
 }: {
   providers: Provider[]
+  registeredProviders: Provider[]
   subscriptions: ProviderSubscription[]
   keys: ProviderKey[]
   catalogs: ProviderCatalog[]
@@ -1798,11 +1803,10 @@ function ProvidersPane({
   const [search, setSearch] = useState('')
   const [pendingProviders, setPendingProviders] = useState<Provider[]>([])
   const [openedAt] = useState(() => Date.now())
-  // The directory is only the search box's source, read when it opens.
   const directoryQuery = useQuery({
     queryKey: ['providerDirectory'],
     queryFn: () => api.providerDirectory(),
-    enabled: adding,
+    enabled: adding || providers.some((provider) => !registeredProviders.some((entry) => entry.id === provider.id)),
     staleTime: 60_000,
     retry: 1,
   })
@@ -1822,9 +1826,11 @@ function ProvidersPane({
   const providerColor = harnessColors(configured.map((provider) => provider.id))
   const query = search.trim().toLocaleLowerCase()
   const candidates = [
-    ...providers.map((provider) => ({
+    ...registeredProviders.map((provider) => ({
       provider: provider.id,
       label: provider.label,
+      documentationUrl: null,
+      apiUrl: null,
       models: catalogs.find((catalog) => catalog.provider === provider.id)?.models ?? [],
     })),
     ...(directoryQuery.data ?? []),
@@ -1862,23 +1868,25 @@ function ProvidersPane({
         {configured.map((provider) => {
           const subscription = subscriptions.find((row) => row.provider === provider.id) ?? null
           const apiKey = keys.find((row) => row.provider === provider.id) ?? null
-          const catalog = catalogs.find((entry) => entry.provider === provider.id)
-          const catalogIsStale = Boolean(
-            catalog && openedAt - new Date(catalog.fetchedAt).getTime() > 24 * 60 * 60 * 1000,
-          )
+          const isDirectoryProvider = !registeredProviders.some((entry) => entry.id === provider.id)
+          const directoryEntry = directoryQuery.data?.find((entry) => entry.provider === provider.id)
           return (
-            <article key={provider.id} className="set-card hr-card" style={{ '--fam': providerColor[provider.id] } as CSSProperties}>
+            <article key={provider.id} aria-label={provider.label} className="set-card hr-card" style={{ '--fam': providerColor[provider.id] } as CSSProperties}>
               <header className="hr-ident">
                 <span className="hr-ident-dot" aria-hidden="true" />
                 <span className="hr-identity-copy">
                   <span className="hr-name">{provider.label}</span>
                 </span>
-                <span className="provider-catalog" title={catalog ? new Date(catalog.fetchedAt).toLocaleString() : undefined}>
-                  {catalog
-                    ? `${catalogIsStale ? 'Catalog is stale' : 'Catalog updated'} ${relTimeFromIso(catalog.fetchedAt)}`
-                    : 'No catalog yet'}
-                </span>
               </header>
+              {isDirectoryProvider && (
+                <div className="provider-source">
+                  {directoryEntry ? <ProviderSource entry={directoryEntry} /> : (
+                    <p className="provider-state" role="status">
+                      {directoryQuery.isLoading ? 'Loading provider details…' : 'Provider details are unavailable from Models.dev.'}
+                    </p>
+                  )}
+                </div>
+              )}
               <ProviderConnect
                 provider={provider}
                 subscription={subscription}
@@ -1890,6 +1898,23 @@ function ProvidersPane({
           )
         })}
       </div>
+      {catalogs.length > 0 && (
+        <details className="provider-catalogs">
+          <summary>Catalog status</summary>
+          <p>Providers update separately. Added providers use the Models.dev directory.</p>
+          <dl>
+            {catalogs.map((catalog) => (
+              <div key={catalog.provider}>
+                <dt>{catalog.label}</dt>
+                <dd title={new Date(catalog.fetchedAt).toLocaleString()}>
+                  {openedAt - new Date(catalog.fetchedAt).getTime() > 24 * 60 * 60 * 1000 ? 'Stale · ' : 'Updated '}
+                  {relTimeFromIso(catalog.fetchedAt)}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </details>
+      )}
       <div className="provider-add">
         {!adding ? (
           <button type="button" className="set-btn ghost" onClick={() => setAdding(true)}>Add provider</button>
@@ -1908,25 +1933,37 @@ function ProvidersPane({
               value={search}
               onChange={(event) => setSearch(event.target.value)}
             />
+            <p className="provider-directory-note">
+              Listings from <a href="https://models.dev" target="_blank" rel="noopener noreferrer">Models.dev</a>.
+              {' '}Druks does not verify these providers. Check the endpoint and documentation before adding a key.
+            </p>
             <div className="provider-results" role="list" aria-label="Provider search results">
               {candidates.map((entry) => {
                 const provider =
                   providers.find((registered) => registered.id === entry.provider) ??
                   addedProvider(entry.provider, entry.label)
+                const endpoint = providerWebUrl(entry.apiUrl)
+                const documentation = providerWebUrl(entry.documentationUrl)
                 return (
-                  <button
-                    type="button"
-                    className="provider-result"
-                    key={provider.id}
-                    onClick={() => {
-                      setPendingProviders((current) => [...current, provider])
-                      setAdding(false)
-                      setSearch('')
-                    }}
-                  >
-                    <span><strong>{provider.label}</strong><code>{provider.id}</code></span>
-                    <span>{provider.billingOptions.map(billingLabel).join(' or ')}</span>
-                  </button>
+                  <div className="provider-result" role="listitem" key={provider.id}>
+                    <button
+                      type="button"
+                      className="provider-result-select"
+                      onClick={() => {
+                        setPendingProviders((current) => [...current, provider])
+                        setAdding(false)
+                        setSearch('')
+                      }}
+                    >
+                      <strong>{provider.label}</strong>
+                      <code>{endpoint?.host ?? provider.id}</code>
+                    </button>
+                    {documentation && (
+                      <a href={documentation.href} target="_blank" rel="noopener noreferrer" aria-label={`Documentation for ${provider.label}`}>
+                        Docs
+                      </a>
+                    )}
+                  </div>
                 )
               })}
               {directoryQuery.isLoading && (
@@ -2010,11 +2047,11 @@ export function ProviderConnect({
   // visible and ask for a Reconnect, not a first-time sign-in.
   const expired = Boolean(subscription) && !connected
   const showKeyForm = acceptsApiKey && (keyFormOpen || replacing)
+  const weekly = usage?.weeks.find((week) => week.model === null)
   return (
     <div className="hr-connect">
       {acceptsSubscription && (
         <section className="hr-block">
-          <div className="hr-block-title">Subscription</div>
           {subscription ? (
             <>
               <div className="hr-conn-status">
@@ -2022,6 +2059,7 @@ export function ProviderConnect({
                 <span className="hr-conn-id">
                   {usage?.planTier ? `${usage.planTier} · ` : ''}
                   {subscription.providerEmail}
+                  <span className="hr-subscription"> · Subscription</span>
                 </span>
                 <span className="hr-conn-actions">
                   {expired && !flow.challenge && (
@@ -2029,27 +2067,13 @@ export function ProviderConnect({
                       Reconnect
                     </button>
                   )}
-                  <details className="hr-more">
-                    <summary aria-label={`More ${provider.label} subscription actions`}>More</summary>
-                    <button className="set-btn danger quiet" onClick={disconnect} disabled={busy || flow.busy}>
-                      Disconnect subscription
-                    </button>
-                  </details>
+                  <button className="set-btn quiet" aria-label={`Disconnect ${provider.label} subscription`} onClick={disconnect} disabled={busy || flow.busy}>
+                    Disconnect
+                  </button>
                 </span>
               </div>
               {usage?.fiveHour && <QuotaRow label="5-hour" metric={usage.fiveHour} />}
-              {usage?.weeks.map((week, index) => (
-                <QuotaRow key={index} label="Weekly" metric={week} />
-              ))}
-              {subscription.expiresAt && (
-                <span className="hr-conn-exp">
-                  Token {expired ? 'expired' : 'expires'}{' '}
-                  {new Date(subscription.expiresAt).toLocaleString([], {
-                    dateStyle: 'medium',
-                    timeStyle: 'long',
-                  })}
-                </span>
-              )}
+              {weekly && <QuotaRow label="Weekly" metric={weekly} />}
             </>
           ) : (
             !flow.challenge && (
@@ -2077,12 +2101,9 @@ export function ProviderConnect({
                 <button className="set-btn ghost" onClick={() => setReplacing((value) => !value)} disabled={busy}>
                   {replacing ? 'Keep' : 'Replace'}
                 </button>
-                <details className="hr-more">
-                  <summary aria-label={`More ${provider.label} API key actions`}>More</summary>
-                  <button className="set-btn danger quiet" onClick={removeKey} disabled={busy}>
-                    Remove API key
-                  </button>
-                </details>
+                <button className="set-btn quiet" aria-label={`Remove ${provider.label} API key`} onClick={removeKey} disabled={busy}>
+                  Remove
+                </button>
               </span>
             </div>
           )}
@@ -2092,7 +2113,7 @@ export function ProviderConnect({
             </button>
           )}
           {showKeyForm && (
-            <form className="provider-key-form" onSubmit={createKey}>
+            <form className="provider-key-form" aria-label={`${provider.label} API key`} onSubmit={createKey}>
               <input
                 aria-label="API key"
                 autoComplete="off"
@@ -2105,7 +2126,7 @@ export function ProviderConnect({
                 value={key}
               />
               <button className="hr-conn-btn" disabled={busy || flow.busy || !key.trim()} type="submit">
-                {apiKey ? 'Replace key' : 'Save API key'}
+                {busy ? 'Saving…' : 'Save'}
               </button>
               {!apiKey && (
                 <button className="set-btn quiet" type="button" onClick={() => { setKey(''); setKeyFormOpen(false) }}>
@@ -2126,18 +2147,56 @@ export function ProviderConnect({
 }
 
 function QuotaRow({ label, metric }: { label: string; metric: UsageMetric }) {
+  useTicker(Boolean(metric.resetsAt))
   if (metric.percentLeft === null) return null
   const resets = metric.resetsAt
-    ? new Date(metric.resetsAt).toLocaleString([], { dateStyle: 'medium', timeStyle: 'long' })
-    : null
+  const minutes = resets ? Math.max(0, Math.ceil(secondsUntil(resets) / 60)) : 0
+  const remaining = minutes >= 1440
+    ? `${Math.ceil(minutes / 1440)}d`
+    : minutes >= 60
+      ? `${Math.floor(minutes / 60)}h${minutes % 60 ? ` ${minutes % 60}m` : ''}`
+      : `${minutes}m`
   return (
     <div className="hr-quota">
       <span className="hr-quota-label">{label}</span>
-      <span className="hr-quota-model mono">{metric.model ?? ''}</span>
       <Bar pctLeft={metric.percentLeft} />
       <span className="hr-quota-pct mono">{metric.percentLeft}% remaining</span>
-      <span className="hr-conn-exp">{resets ? `resets ${resets}` : ''}</span>
+      {resets && (
+        <time className="hr-quota-reset" dateTime={resets} title={new Date(resets).toLocaleString()}>
+          {minutes > 0 ? `Resets in ${remaining}` : 'Reset due'}
+        </time>
+      )}
     </div>
+  )
+}
+
+function providerWebUrl(value: string | null): URL | null {
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' && !url.username && !url.password ? url : null
+  } catch {
+    return null
+  }
+}
+
+function ProviderSource({ entry }: { entry: ProviderDirectoryEntry }) {
+  const endpoint = providerWebUrl(entry.apiUrl)
+  const documentation = providerWebUrl(entry.documentationUrl)
+  return (
+    <>
+      <div>
+        Listed by <a href="https://models.dev" target="_blank" rel="noopener noreferrer">Models.dev</a>
+        {' · '}
+        {documentation ? (
+          <a href={documentation.href} target="_blank" rel="noopener noreferrer">
+            Documentation · {documentation.host}
+          </a>
+        ) : 'Documentation unavailable'}
+      </div>
+      <div>Listed API endpoint: {endpoint ? <code>{endpoint.href}</code> : 'Unavailable'}</div>
+      <p>Druks does not verify this provider.</p>
+    </>
   )
 }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1003,9 +1003,9 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
    defaults, and connection into three bands. Provider color survives only as
    the identity dot and the guided connect-flow accent. */
 .hrs-list { display: flex; flex-direction: column; gap: 10px; }
-.hrs-pane :is(.set-btn, .hr-conn-btn, .mcp-conn, .hr-more summary) { font-family: var(--font-sans); letter-spacing: 0; }
+.hrs-pane :is(.set-btn, .hr-conn-btn, .mcp-conn) { font-family: var(--font-sans); letter-spacing: 0; }
 .hr-card { display: flex; flex-direction: column; gap: 12px; padding: 13px 14px; }
-.hr-ident { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 9px 14px; }
+.hr-ident { display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 9px 14px; }
 .hr-ident-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fam, var(--border-loud)); flex-shrink: 0; }
 .hr-identity-copy { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
 .hr-name { font-size: 13.5px; font-weight: 600; color: var(--text); }
@@ -1040,21 +1040,14 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .hr-block { display: flex; flex-direction: column; gap: 9px; }
 .hr-block + .hr-block { border-top: 1px solid var(--border); padding-top: 12px; }
 .hr-block-title { font-size: 11px; font-weight: 600; color: var(--text-dim); }
-.hr-quota { display: grid; grid-template-columns: 70px minmax(0, 100px) minmax(120px, 1fr) 106px minmax(190px, auto); align-items: center; gap: 10px; font-size: 11.5px; }
+.hr-quota { display: grid; grid-template-columns: 55px minmax(80px, 1fr) 110px 100px; align-items: center; gap: 10px; font-size: 11.5px; }
 .hr-quota .us-bar { margin: 0; }
 .hr-quota-label { color: var(--text-mid); }
-.hr-quota-model { color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .hr-quota-pct { text-align: right; color: var(--text-mid); white-space: nowrap; }
 .provider-key-add { align-self: flex-start; padding-left: 0; }
 .provider-key-form { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
 .provider-key-form .hr-conn-input { min-width: 0; flex: 1 1 240px; }
 .provider-key-form .hr-conn-input:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.provider-catalog { font-size: 10.5px; color: var(--text-dim); }
-.hr-more { position: relative; }
-.hr-more summary { list-style: none; cursor: pointer; color: var(--text-dim); font-size: 11.5px; padding: 6px 8px; border-radius: 4px; }
-.hr-more summary::-webkit-details-marker { display: none; }
-.hr-more summary:hover { color: var(--text); background: var(--surface-3); }
-.hr-more[open] > .set-btn { position: absolute; z-index: 4; top: calc(100% + 4px); right: 0; background: var(--surface-3); box-shadow: 0 12px 28px -10px rgba(0, 0, 0, 0.8); }
 .provider-state { font-size: 12px; color: var(--text-dim); }
 .provider-empty { display: flex; flex-direction: column; gap: 4px; padding: 18px 0 4px; color: var(--text-dim); font-size: 12px; }
 .provider-empty strong { color: var(--text); font-size: 13px; }
@@ -1063,11 +1056,25 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .provider-add-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .provider-add-head label { font-size: 13px; font-weight: 600; color: var(--text); }
 .provider-results { display: flex; flex-direction: column; max-height: 260px; overflow: auto; border-top: 1px solid var(--border); }
-.provider-result { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; width: 100%; padding: 10px 4px; border-bottom: 1px solid var(--border-soft); color: var(--text-mid); text-align: left; font-size: 11.5px; }
-.provider-result:hover { background: var(--surface-3); color: var(--text); }
-.provider-result > span:first-child { display: flex; flex-direction: column; gap: 2px; }
-.provider-result strong { font-size: 12.5px; color: var(--text); }
-.provider-result code { font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); font-weight: 400; }
+.provider-result { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; width: 100%; padding: 0 4px; border-bottom: 1px solid var(--border-soft); color: var(--text-mid); text-align: left; font-size: 11.5px; }
+
+.hr-subscription { font-family: var(--font-sans); color: var(--text-dim); font-size: 11.5px; }
+.hr-quota-reset { color: var(--text-dim); font-size: 11px; }
+.provider-source { display: grid; gap: 5px; font-size: 11.5px; color: var(--text-dim); overflow-wrap: anywhere; }
+.provider-source p, .provider-directory-note { margin: 0; font-size: 11px; color: var(--text-dim); line-height: 1.5; }
+.provider-source a, .provider-directory-note a, .provider-result > a { color: var(--text-mid); text-decoration: underline; text-underline-offset: 3px; }
+.provider-source code { font-size: 11px; color: var(--text-mid); }
+.provider-result-select { display: flex; flex-direction: column; gap: 3px; align-items: flex-start; min-width: 0; text-align: left; padding: 11px 4px; color: var(--text); }
+.provider-result-select:hover { background: var(--surface-3); }
+.provider-result-select strong { font-size: 12.5px; }
+.provider-result-select code { font-size: 10.5px; color: var(--text-dim); overflow-wrap: anywhere; }
+.provider-catalogs { font-size: 11px; color: var(--text-dim); }
+.provider-catalogs summary { cursor: pointer; padding: 5px 0; }
+.provider-catalogs p { margin: 8px 0; }
+.provider-catalogs dl { display: grid; gap: 6px; margin: 0; }
+.provider-catalogs dl > div { display: flex; justify-content: space-between; gap: 12px; }
+.provider-catalogs dd { margin: 0; }
+.hrs-pane :is(a, summary, .provider-result-select):focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 @media (max-width: 600px) {
   .set-backdrop { padding: 0; }
@@ -1083,17 +1090,15 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
   .set-foot-actions { gap: 6px; }
   .set-btn { padding: 7px 11px; }
   .hr-ident { grid-template-columns: auto minmax(0, 1fr) auto; gap: 7px 9px; }
-  .provider-catalog { grid-column: 2 / -1; }
   .hr-identity-copy { flex-direction: column; align-items: flex-start; gap: 2px; }
   .hr-conn-status { align-items: flex-start; }
-  .hr-conn-id { width: calc(100% - 90px); }
-  .hr-conn-actions { width: 100%; margin-left: 0; }
-  .hr-quota { grid-template-columns: minmax(70px, auto) minmax(0, 1fr) auto; grid-template-areas: 'label model pct' 'bar bar bar' 'reset reset reset'; gap: 5px 8px; padding: 5px 0; }
+  .hr-conn-id { flex: 1 1 180px; white-space: normal; overflow-wrap: anywhere; }
+  .hr-conn-actions { flex-wrap: wrap; }
+  .hr-quota { grid-template-columns: minmax(70px, auto) minmax(0, 1fr) auto; grid-template-areas: 'label pct pct' 'bar bar bar' 'reset reset reset'; gap: 5px 8px; padding: 5px 0; }
   .hr-quota-label { grid-area: label; }
-  .hr-quota-model { grid-area: model; }
   .hr-quota .us-bar { grid-area: bar; }
   .hr-quota-pct { grid-area: pct; }
-  .hr-quota .hr-conn-exp { grid-area: reset; }
+  .hr-quota-reset { grid-area: reset; }
   .provider-result { grid-template-columns: 1fr auto; gap: 5px 12px; }
   .provider-add-panel { padding: 12px; }
   .model-chooser-option { align-items: flex-start; flex-direction: column; gap: 2px; }


### PR DESCRIPTION
## What changed

Provider cards show the five-hour quota and general weekly quota with relative reset times, such as “Resets in 2h.” Exact times remain in tooltips. Model-specific weekly quotas and token expiry text are removed. Subscription appears beside the account, and visible Disconnect and Remove buttons replace the overlapping More menus.

Catalog freshness moves to one Catalog status disclosure. Each provider retains its own timestamp because Anthropic and OpenAI fetch separate lists; added providers use the Models.dev directory.

Provider search shows the listed API domain and a documentation link. Added-provider cards show the directory source, full listed endpoint, and documentation domain before key entry. The API exposes Models.dev metadata. The existing Redis directory cache key stays unchanged. Key entry retains explicit submission with a short Save button.

Tracks [DRU-428](https://linear.app/fellaworks/issue/DRU-428).

## Risk

Provider metadata is directory data, not identity verification. Only HTTPS URLs without embedded credentials become links. Druks does not pin the endpoint; OpenCode resolves its provider endpoint when an agent runs. No migration or credential-routing change.

The directory is also read when the Providers pane shows added-provider details. Its existing one-day Redis cache remains. After deployment, clear the cached directory from the installation directory so the next request reads the new metadata:

```bash
docker compose exec redis redis-cli DEL druks:harness:directory
```

## Verification

- `uv run pytest backend/tests/test_provider_catalogs.py backend/tests/test_api_providers.py` — 30 passed.
- `uv run ruff check backend` — passed.
- `uv run ruff format --check backend` — passed.
- `npm --prefix frontend test` — 284 passed.
- `npm --prefix frontend run lint` — passed.
- `npm --prefix frontend run build` — passed.
- `git diff --check` — passed.
- Browser checks with local test data covered desktop and 390 px layouts, relative quotas, visible actions, provider search, source details, and key entry. No horizontal overflow at 390 px.
- Full backend suite, live authentication, and live agent execution were not run.

