### PR TITLE
DRU-436: Use red buttons for provider credential removal

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -2079,7 +2079,7 @@ export function ProviderConnect({
                       Reconnect
                     </button>
                   )}
-                  <button className="set-btn ghost" aria-label={`Disconnect ${provider.label} subscription`} onClick={disconnect} disabled={busy || flow.busy}>
+                  <button className="set-btn danger" aria-label={`Disconnect ${provider.label} subscription`} onClick={disconnect} disabled={busy || flow.busy}>
                     Disconnect
                   </button>
                 </span>
@@ -2113,7 +2113,7 @@ export function ProviderConnect({
                 <button className="set-btn ghost" onClick={() => setReplacing((value) => !value)} disabled={busy}>
                   {replacing ? 'Keep' : 'Replace'}
                 </button>
-                <button className="set-btn ghost" aria-label={`Remove ${provider.label} API key`} onClick={removeKey} disabled={busy}>
+                <button className="set-btn danger" aria-label={`Remove ${provider.label} API key`} onClick={removeKey} disabled={busy}>
                   Remove
                 </button>
               </span>


### PR DESCRIPTION
Disconnect and Remove use the existing red danger button style. Cancel stays neutral because it closes the unsaved form.
