### PR TITLE
Separate provider connection methods and remove catalog status

### DIFF
--- a/frontend/src/components/ProviderConnect.test.tsx
+++ b/frontend/src/components/ProviderConnect.test.tsx
@@ -163,7 +163,7 @@ describe('ProviderConnect', () => {
     })
 
     expect(screen.getAllByText('Weekly')).toHaveLength(1)
-    expect(screen.getByLabelText('83% remaining').textContent).toBe('83%')
+    expect(screen.getByLabelText('83% remaining').textContent).toBe('83% left')
     expect(screen.queryByLabelText('69% remaining')).toBeNull()
     expect(screen.queryByLabelText('50% remaining')).toBeNull()
     expect(screen.queryByText('Fable')).toBeNull()

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -569,26 +569,6 @@ describe('SettingsModal agents', () => {
     expect(within(card).getByRole('button', { name: 'Add API key' })).toBeTruthy()
   })
 
-  it('keeps catalog freshness without model counts or a model navigation action', async () => {
-    stubFetch()
-    renderModal()
-    fireEvent.click(await screen.findByRole('button', { name: 'Providers' }))
-
-    const card = await screen.findByRole('article', { name: 'Groq' })
-    expect(within(card).queryByText(/Catalog/)).toBeNull()
-    const catalogButton = screen.getByRole('button', { name: 'Catalog status' })
-    expect(catalogButton.closest('header')?.contains(screen.getByRole('heading', { name: 'Providers' }))).toBe(true)
-    expect(catalogButton.getAttribute('aria-expanded')).toBe('false')
-    expect(screen.queryByText(/^(Updated |Stale · )/)).toBeNull()
-    fireEvent.click(catalogButton)
-    expect(catalogButton.getAttribute('aria-expanded')).toBe('true')
-    expect(screen.getAllByText(/^(Updated |Stale · )/)).toHaveLength(2)
-    fireEvent.click(catalogButton)
-    expect(screen.queryByText(/^(Updated |Stale · )/)).toBeNull()
-    expect(within(card).queryByText(/\d+ models/)).toBeNull()
-    expect(screen.queryByRole('button', { name: 'View models in Agents' })).toBeNull()
-  })
-
   it('shows the source, endpoint, and documentation before a directory key is entered', async () => {
     stubFetch()
     renderModal()

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type FormEvent, type ReactNode } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Plus } from 'lucide-react'
 
 import { ApiError, api } from '../api/client'
 import { BrowserSessionsPane } from './BrowserSessionsPane'
@@ -1779,7 +1780,7 @@ export function ConnectionsPane() {
   )
 }
 
-// Providers — who answers and bills a model request. One card per vendor: the
+// Providers — who answers and bills a model request. One section per vendor: the
 // requester's own subscription and the installation's one API key.
 // Connection state persists immediately, outside the modal's Save.
 function ProvidersPane({
@@ -1800,10 +1801,8 @@ function ProvidersPane({
   requestError: string | null
 }) {
   const [adding, setAdding] = useState(false)
-  const [catalogsOpen, setCatalogsOpen] = useState(false)
   const [search, setSearch] = useState('')
   const [pendingProviders, setPendingProviders] = useState<Provider[]>([])
-  const [openedAt] = useState(() => Date.now())
   const directoryQuery = useQuery({
     queryKey: ['providerDirectory'],
     queryFn: () => api.providerDirectory(),
@@ -1850,41 +1849,85 @@ function ProvidersPane({
       Number(right.nameMatches) - Number(left.nameMatches) || left.label.localeCompare(right.label),
     )
   return (
-    <div className="set-pane mcp-pane hrs-pane">
+    <div className="set-pane mcp-pane hrs-pane providers-pane">
       <header className="mcp-pane-head">
         <div className="provider-heading">
-          <h2 className="mcp-pane-title">Providers</h2>
-          {catalogs.length > 0 && (
-            <button
-              type="button"
-              className="set-btn ghost"
-              aria-expanded={catalogsOpen}
-              aria-controls="provider-catalog-status"
-              onClick={() => setCatalogsOpen((open) => !open)}
-            >
-              Catalog status
-            </button>
-          )}
-        </div>
-        <p className="mcp-pane-sub">
-          Manage credentials and billing methods. Credential changes save immediately.
-        </p>
-        {catalogsOpen && (
-          <div id="provider-catalog-status" className="provider-catalogs">
-            <dl>
-              {catalogs.map((catalog) => (
-                <div key={catalog.provider}>
-                  <dt>{catalog.label}</dt>
-                  <dd title={new Date(catalog.fetchedAt).toLocaleString()}>
-                    {openedAt - new Date(catalog.fetchedAt).getTime() > 24 * 60 * 60 * 1000 ? 'Stale · ' : 'Updated '}
-                    {relTimeFromIso(catalog.fetchedAt)}
-                  </dd>
-                </div>
-              ))}
-            </dl>
+          <div>
+            <h2 className="mcp-pane-title">Providers</h2>
+            <p className="mcp-pane-sub">Connect the accounts your agents use.</p>
           </div>
-        )}
+          <button
+            type="button"
+            className="set-btn provider-add-button"
+            aria-expanded={adding}
+            aria-controls="provider-add-panel"
+            onClick={() => setAdding((open) => !open)}
+          >
+            <Plus size={14} aria-hidden="true" />
+            Add provider
+          </button>
+        </div>
       </header>
+      {adding && (
+        <div id="provider-add-panel" className="set-card provider-add-panel">
+          <div className="provider-add-head">
+            <label htmlFor="provider-search">Add provider</label>
+            <button type="button" className="set-btn ghost" onClick={() => { setAdding(false); setSearch('') }}>Close</button>
+          </div>
+          <input
+            autoFocus
+            id="provider-search"
+            className="set-select"
+            type="search"
+            placeholder="Search providers or models"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+          <p className="provider-directory-note">
+            Listings from <a href="https://models.dev" target="_blank" rel="noopener noreferrer">Models.dev</a>.
+            {' '}Druks does not verify these providers. Check the endpoint and documentation before adding a key.
+          </p>
+          <div className="provider-results" role="list" aria-label="Provider search results">
+            {candidates.map((entry) => {
+              const provider =
+                providers.find((registered) => registered.id === entry.provider) ??
+                addedProvider(entry.provider, entry.label)
+              const endpoint = providerWebUrl(entry.apiUrl)
+              const documentation = providerWebUrl(entry.documentationUrl)
+              return (
+                <div className="provider-result" role="listitem" key={provider.id}>
+                  <button
+                    type="button"
+                    className="provider-result-select"
+                    onClick={() => {
+                      setPendingProviders((current) => [...current, provider])
+                      setAdding(false)
+                      setSearch('')
+                    }}
+                  >
+                    <strong>{provider.label}</strong>
+                    <code>{endpoint?.host ?? provider.id}</code>
+                  </button>
+                  {documentation && (
+                    <a href={documentation.href} target="_blank" rel="noopener noreferrer" aria-label={`Documentation for ${provider.label}`}>
+                      Docs
+                    </a>
+                  )}
+                </div>
+              )
+            })}
+            {directoryQuery.isLoading && (
+              <p className="provider-state" role="status">Reading the Models.dev directory…</p>
+            )}
+            {directoryQuery.error instanceof Error && (
+              <p className="mcp-error" role="alert">{directoryQuery.error.message}</p>
+            )}
+            {!directoryQuery.isLoading && candidates.length === 0 && (
+              <p className="provider-state">No supported provider matches this search.</p>
+            )}
+          </div>
+        </div>
+      )}
       {loading && <div className="provider-state" role="status">Loading providers…</div>}
       {requestError && <div className="mcp-error" role="alert">{requestError}</div>}
       {!loading && configured.length === 0 && (
@@ -1900,12 +1943,10 @@ function ProvidersPane({
           const isDirectoryProvider = !registeredProviders.some((entry) => entry.id === provider.id)
           const directoryEntry = directoryQuery.data?.find((entry) => entry.provider === provider.id)
           return (
-            <article key={provider.id} aria-label={provider.label} className="set-card hr-card" style={{ '--fam': providerColor[provider.id] } as CSSProperties}>
+            <article key={provider.id} aria-label={provider.label} className="provider-section" style={{ '--fam': providerColor[provider.id] } as CSSProperties}>
               <header className="hr-ident">
                 <span className="hr-ident-dot" aria-hidden="true" />
-                <span className="hr-identity-copy">
-                  <span className="hr-name">{provider.label}</span>
-                </span>
+                <h3 className="hr-name">{provider.label}</h3>
               </header>
               {isDirectoryProvider && (
                 <div className="provider-source">
@@ -1927,70 +1968,7 @@ function ProvidersPane({
           )
         })}
       </div>
-      <div className="provider-add">
-        {!adding ? (
-          <button type="button" className="set-btn ghost" onClick={() => setAdding(true)}>Add provider</button>
-        ) : (
-          <div className="set-card provider-add-panel">
-            <div className="provider-add-head">
-              <label htmlFor="provider-search">Add provider</label>
-              <button type="button" className="set-btn ghost" onClick={() => { setAdding(false); setSearch('') }}>Close</button>
-            </div>
-            <input
-              autoFocus
-              id="provider-search"
-              className="set-select"
-              type="search"
-              placeholder="Search providers or models"
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-            />
-            <p className="provider-directory-note">
-              Listings from <a href="https://models.dev" target="_blank" rel="noopener noreferrer">Models.dev</a>.
-              {' '}Druks does not verify these providers. Check the endpoint and documentation before adding a key.
-            </p>
-            <div className="provider-results" role="list" aria-label="Provider search results">
-              {candidates.map((entry) => {
-                const provider =
-                  providers.find((registered) => registered.id === entry.provider) ??
-                  addedProvider(entry.provider, entry.label)
-                const endpoint = providerWebUrl(entry.apiUrl)
-                const documentation = providerWebUrl(entry.documentationUrl)
-                return (
-                  <div className="provider-result" role="listitem" key={provider.id}>
-                    <button
-                      type="button"
-                      className="provider-result-select"
-                      onClick={() => {
-                        setPendingProviders((current) => [...current, provider])
-                        setAdding(false)
-                        setSearch('')
-                      }}
-                    >
-                      <strong>{provider.label}</strong>
-                      <code>{endpoint?.host ?? provider.id}</code>
-                    </button>
-                    {documentation && (
-                      <a href={documentation.href} target="_blank" rel="noopener noreferrer" aria-label={`Documentation for ${provider.label}`}>
-                        Docs
-                      </a>
-                    )}
-                  </div>
-                )
-              })}
-              {directoryQuery.isLoading && (
-                <p className="provider-state" role="status">Reading the Models.dev directory…</p>
-              )}
-              {directoryQuery.error instanceof Error && (
-                <p className="mcp-error" role="alert">{directoryQuery.error.message}</p>
-              )}
-              {!directoryQuery.isLoading && candidates.length === 0 && (
-                <p className="provider-state">No supported provider matches this search.</p>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
+      <p className="provider-save-note">Changes save automatically.</p>
     </div>
   )
 }
@@ -2063,67 +2041,74 @@ export function ProviderConnect({
   return (
     <div className="hr-connect">
       {acceptsSubscription && (
-        <section className="hr-block">
-          {subscription ? (
-            <>
-              <div className="hr-conn-status">
-                <ServiceStatus connected={connected} label={expired ? 'Expired' : undefined} />
-                <span className="hr-conn-id">
-                  {usage?.planTier ? `${usage.planTier} · ` : ''}
-                  {subscription.providerEmail}
-                  <span className="hr-subscription"> · Subscription</span>
-                </span>
-                <span className="hr-conn-actions">
+        <section className="hr-block" aria-label={`${provider.label} subscription`}>
+          <div className="provider-method-head">
+            <h4 className="hr-block-title">Subscription</h4>
+            {subscription && <ServiceStatus connected={connected} label={expired ? 'Expired' : undefined} />}
+            <div className="hr-conn-actions">
+              {subscription ? (
+                <>
                   {expired && !flow.challenge && (
                     <button className="set-btn primary" onClick={() => void flow.start()} disabled={busy || flow.busy}>
                       Reconnect
                     </button>
                   )}
-                  <button className="set-btn danger" aria-label={`Disconnect ${provider.label} subscription`} onClick={disconnect} disabled={busy || flow.busy}>
+                  <button className="set-btn ghost" aria-label={`Disconnect ${provider.label} subscription`} onClick={disconnect} disabled={busy || flow.busy}>
                     Disconnect
                   </button>
-                </span>
-              </div>
-              {usage?.fiveHour && <QuotaRow label="5-hour" metric={usage.fiveHour} />}
-              {weekly && <QuotaRow label="Weekly" metric={weekly} />}
-            </>
-          ) : (
-            !flow.challenge && (
-              <div>
+                </>
+              ) : !flow.challenge && (
                 <button className="set-btn primary" onClick={() => void flow.start()} disabled={busy || flow.busy}>
                   Sign in with {provider.label}
                 </button>
+              )}
+            </div>
+          </div>
+          {subscription ? (
+            <>
+              <p className="provider-account">
+                {usage?.planTier ? `${usage.planTier} · ` : ''}
+                {subscription.providerEmail}
+              </p>
+              <div className="provider-quotas">
+                {usage?.fiveHour && <QuotaRow label="5-hour" metric={usage.fiveHour} />}
+                {weekly && <QuotaRow label="Weekly" metric={weekly} />}
               </div>
-            )
-          )}
+            </>
+          ) : <p className="provider-account">Not connected</p>}
           <ConnectSteps flow={flow} />
         </section>
       )}
       {acceptsApiKey && (
-        <section className="hr-block">
-          {(apiKey || showKeyForm) && <div className="hr-block-title">API key</div>}
-          {apiKey && (
-            <div className="hr-conn-status">
-              <span className="hr-conn-id">…{apiKey.keyTail}</span>
-              <span className="hr-conn-exp">
+        <section className="hr-block" aria-label={`${provider.label} API key`}>
+          <div className="provider-method-head">
+            <h4 className="hr-block-title">API key</h4>
+            <div className="hr-conn-actions">
+              {apiKey ? (
+                <>
+                  <button className="set-btn ghost" onClick={() => setReplacing((value) => !value)} disabled={busy}>
+                    {replacing ? 'Keep' : 'Replace'}
+                  </button>
+                  <button className="set-btn danger" aria-label={`Remove ${provider.label} API key`} onClick={removeKey} disabled={busy}>
+                    Remove
+                  </button>
+                </>
+              ) : !showKeyForm && (
+                <button className="set-btn ghost" type="button" aria-label="Add API key" onClick={() => setKeyFormOpen(true)}>
+                  Add key
+                </button>
+              )}
+            </div>
+          </div>
+          {apiKey ? (
+            <div className="provider-key-details">
+              <code>…{apiKey.keyTail}</code>
+              <span>
                 set by {apiKey.updatedBy.username} · {relTimeFromIso(apiKey.updatedAt)}
                 {keySpendToday !== null && ` · ${money(keySpendToday)} today`}
               </span>
-              <span className="hr-conn-actions">
-                <button className="set-btn ghost" onClick={() => setReplacing((value) => !value)} disabled={busy}>
-                  {replacing ? 'Keep' : 'Replace'}
-                </button>
-                <button className="set-btn danger" aria-label={`Remove ${provider.label} API key`} onClick={removeKey} disabled={busy}>
-                  Remove
-                </button>
-              </span>
             </div>
-          )}
-          {!apiKey && !showKeyForm && (
-            <button className="set-btn ghost provider-key-add" type="button" onClick={() => setKeyFormOpen(true)}>
-              Add API key
-            </button>
-          )}
+          ) : !showKeyForm && <p className="provider-account">Not configured</p>}
           {showKeyForm && (
             <form className="provider-key-form" aria-label={`${provider.label} API key`} onSubmit={createKey}>
               <input
@@ -2172,7 +2157,7 @@ function QuotaRow({ label, metric }: { label: string; metric: UsageMetric }) {
     <div className="hr-quota">
       <span className="hr-quota-label">{label}</span>
       <Bar pctLeft={metric.percentLeft} />
-      <span className="hr-quota-pct mono" aria-label={`${metric.percentLeft}% remaining`} title="Remaining">{metric.percentLeft}%</span>
+      <span className="hr-quota-pct mono" aria-label={`${metric.percentLeft}% remaining`} title="Remaining">{metric.percentLeft}% left</span>
       {resets && (
         <time className="hr-quota-reset" dateTime={resets} title={new Date(resets).toLocaleString()}>
           {minutes > 0 ? `Resets in ${remaining}` : 'Reset due'}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1040,25 +1040,22 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .hr-block { display: flex; flex-direction: column; gap: 9px; }
 .hr-block + .hr-block { border-top: 1px solid var(--border); padding-top: 12px; }
 .hr-block-title { font-size: 11px; font-weight: 600; color: var(--text-dim); }
-.hr-quota { display: grid; grid-template-columns: 55px minmax(80px, 1fr) 40px 100px; align-items: center; gap: 10px; font-size: 11.5px; }
+.hr-quota { display: grid; grid-template-columns: 55px minmax(80px, 1fr) 64px 110px; align-items: center; gap: 10px; font-size: 11.5px; }
 .hr-quota .us-bar { margin: 0; }
 .hr-quota-label { color: var(--text-mid); }
 .hr-quota-pct { text-align: right; color: var(--text-mid); white-space: nowrap; }
-.provider-key-add { align-self: flex-start; }
 .provider-key-form { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
 .provider-key-form .hr-conn-input { min-width: 0; flex: 1 1 240px; }
 .provider-key-form .hr-conn-input:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .provider-state { font-size: 12px; color: var(--text-dim); }
 .provider-empty { display: flex; flex-direction: column; gap: 4px; padding: 18px 0 4px; color: var(--text-dim); font-size: 12px; }
 .provider-empty strong { color: var(--text); font-size: 13px; }
-.provider-add { display: flex; flex-direction: column; align-items: flex-start; }
 .provider-add-panel { width: min(100%, 720px); padding: 14px; display: grid; gap: 10px; }
 .provider-add-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .provider-add-head label { font-size: 13px; font-weight: 600; color: var(--text); }
 .provider-results { display: flex; flex-direction: column; max-height: 260px; overflow: auto; border-top: 1px solid var(--border); }
 .provider-result { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; width: 100%; padding: 0 4px; border-bottom: 1px solid var(--border-soft); color: var(--text-mid); text-align: left; font-size: 11.5px; }
 
-.hr-subscription { font-family: var(--font-sans); color: var(--text-dim); font-size: 11.5px; }
 .hr-quota-reset { color: var(--text-dim); font-size: 11px; }
 .provider-source { display: grid; gap: 5px; font-size: 11.5px; color: var(--text-dim); overflow-wrap: anywhere; }
 .provider-source p, .provider-directory-note { margin: 0; font-size: 11px; color: var(--text-dim); line-height: 1.5; }
@@ -1068,13 +1065,32 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .provider-result-select:hover { background: var(--surface-3); }
 .provider-result-select strong { font-size: 12.5px; }
 .provider-result-select code { font-size: 10.5px; color: var(--text-dim); overflow-wrap: anywhere; }
-.provider-heading { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 8px 16px; }
-.provider-catalogs { align-self: flex-end; width: min(100%, 320px); padding: 10px 0; font-size: 11px; color: var(--text-dim); }
-.provider-catalogs dl { display: grid; gap: 6px; margin: 0; }
-.provider-catalogs dl > div { display: flex; justify-content: space-between; gap: 12px; }
-.provider-catalogs dd { margin: 0; white-space: nowrap; }
+.provider-heading { display: flex; align-items: flex-start; justify-content: space-between; flex-wrap: wrap; gap: 16px; }
+.provider-heading .mcp-pane-sub { margin-top: 6px; }
+.providers-pane { gap: 24px; }
+.providers-pane .hrs-list { gap: 0; }
+.provider-section { display: flex; flex-direction: column; gap: 20px; padding: 24px 0; border-bottom: 1px solid var(--border); }
+.provider-section:first-child { padding-top: 0; }
+.provider-section .hr-name { margin: 0; font-size: 18px; }
+.provider-section .hr-connect { border: 0; padding: 0; gap: 18px; }
+.provider-section .hr-block { gap: 6px; }
+.provider-section .hr-block + .hr-block { padding-top: 18px; }
+.provider-method-head { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 8px 16px; }
+.provider-method-head .hr-block-title { margin: 0; font-size: 14px; font-weight: 600; color: var(--text); }
+.provider-method-head .hr-conn-actions { grid-column: 3; margin: 0; }
+.provider-account { margin: 0; color: var(--text-mid); font-size: 12.5px; overflow-wrap: anywhere; }
+.provider-quotas { display: grid; gap: 12px; margin-top: 14px; }
+.provider-quotas:empty { display: none; }
+.provider-quotas .us-bar { height: 5px; border: 0; }
+.provider-quotas .hr-quota-pct { font-family: var(--font-sans); font-variant-numeric: tabular-nums; }
+.provider-key-details { display: flex; flex-wrap: wrap; gap: 6px 12px; color: var(--text-mid); font-size: 12px; overflow-wrap: anywhere; }
+.provider-save-note { margin: 0; color: var(--text-dim); font-size: 12px; }
+.providers-pane .provider-add-button { display: inline-flex; align-items: center; gap: 6px; flex-shrink: 0; min-height: 32px; background: var(--text); color: var(--bg); border-color: var(--text); }
+.providers-pane .provider-add-button:hover { background: var(--text-mid); border-color: var(--text-mid); }
+.providers-pane .set-btn { min-height: 30px; }
 .hrs-pane .set-btn.ghost { border-color: var(--border-loud); background: var(--surface-2); }
 .hrs-pane .set-btn.ghost:hover:not(:disabled) { background: var(--surface-3); }
+.providers-pane .set-btn.ghost { background: transparent; }
 .hr-connect .set-btn:disabled { opacity: 0.45; cursor: default; }
 .hrs-pane :is(a, summary, .provider-result-select):focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
@@ -1101,6 +1117,11 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
   .hr-quota .us-bar { grid-area: bar; }
   .hr-quota-pct { grid-area: pct; }
   .hr-quota-reset { grid-area: reset; }
+  .provider-method-head { grid-template-columns: minmax(0, 1fr) auto; gap: 6px 12px; }
+  .provider-method-head .hr-block-title { grid-column: 1; grid-row: 1; }
+  .provider-method-head .mcp-conn { grid-column: 1; grid-row: 2; }
+  .provider-method-head .hr-conn-actions { grid-column: 2; grid-row: 1 / span 2; max-width: 170px; justify-content: flex-end; }
+  .provider-section { padding: 22px 0; }
   .provider-result { grid-template-columns: 1fr auto; gap: 5px 12px; }
   .provider-add-panel { padding: 12px; }
   .provider-key-form .hr-conn-input { flex-basis: 100%; }


### PR DESCRIPTION
Providers now separates each subscription from its API key. Subscription status and Disconnect sit beside the Subscription heading, with identity and usage below. API key has its own Add, Replace, and Remove actions. The provider list uses flat sections, Add provider moves to the header, and quota labels state the percentage left.

Remove Catalog status from the page while retaining catalog data for model discovery. Existing confirmation and credential request behavior remains in place.

Validation: frontend lint and production build passed. Browser checks at 1440px and 390px used a read-only production API proxy: no horizontal overflow; Add key, Cancel, Add provider, and search worked. No credentials were submitted. The design detector only reported existing styles outside the changed surface.

No tests added or run locally. Removed the obsolete test that required the deleted catalog disclosure and updated one existing quota text assertion. No backend or configuration changes.

Fixes DRU-441.

