### PR TITLE
Restore standard provider button colors

### DIFF
--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1858,7 +1858,7 @@ function ProvidersPane({
           </div>
           <button
             type="button"
-            className="set-btn provider-add-button"
+            className="set-btn primary provider-add-button"
             aria-expanded={adding}
             aria-controls="provider-add-panel"
             onClick={() => setAdding((open) => !open)}
@@ -2053,7 +2053,7 @@ export function ProviderConnect({
                       Reconnect
                     </button>
                   )}
-                  <button className="set-btn ghost" aria-label={`Disconnect ${provider.label} subscription`} onClick={disconnect} disabled={busy || flow.busy}>
+                  <button className="set-btn danger" aria-label={`Disconnect ${provider.label} subscription`} onClick={disconnect} disabled={busy || flow.busy}>
                     Disconnect
                   </button>
                 </>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1085,8 +1085,7 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .provider-quotas .hr-quota-pct { font-family: var(--font-sans); font-variant-numeric: tabular-nums; }
 .provider-key-details { display: flex; flex-wrap: wrap; gap: 6px 12px; color: var(--text-mid); font-size: 12px; overflow-wrap: anywhere; }
 .provider-save-note { margin: 0; color: var(--text-dim); font-size: 12px; }
-.providers-pane .provider-add-button { display: inline-flex; align-items: center; gap: 6px; flex-shrink: 0; min-height: 32px; background: var(--text); color: var(--bg); border-color: var(--text); }
-.providers-pane .provider-add-button:hover { background: var(--text-mid); border-color: var(--text-mid); }
+.providers-pane .provider-add-button { display: inline-flex; align-items: center; gap: 6px; flex-shrink: 0; min-height: 32px; }
 .providers-pane .set-btn { min-height: 30px; }
 .hrs-pane .set-btn.ghost { border-color: var(--border-loud); background: var(--surface-2); }
 .hrs-pane .set-btn.ghost:hover:not(:disabled) { background: var(--surface-3); }


### PR DESCRIPTION
Add provider uses the shared Druks primary button style instead of a custom white fill. Disconnect uses the shared red danger style again. The layout and credential behavior are unchanged.

Validation: frontend lint and build passed. Desktop and 390px browser checks confirmed cyan Add provider and red Disconnect, no horizontal overflow, and a working provider search disclosure. No tests added or run locally.

Fixes DRU-436.
