### PR TITLE
DRU-446: Put app settings beside app pages

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,12 +42,20 @@ navigation button opens a modal drawer. Escape closes the drawer and returns
 focus to the button.
 
 Shared settings use `/settings/<section>` routes. Search matches section names
-and field labels. General, Agent defaults, and app settings retain separate
+and field labels. General and Agent defaults retain separate
 drafts across settings pages. Save changes applies only the current page.
 Leaving Settings offers Save, Discard, and Stay. Save applies each dirty page;
 a failed request keeps the operator on that page with its draft. Resource
 actions, such as connecting a provider or minting an API token, apply at once.
 Back to Druks restores the previous work URL and keeps the work page mounted.
+
+App settings use `/apps/<name>/settings` in the work context. The app's page
+navigation and the central App settings index link to this same route.
+Options and Agents appear only when the app declares those controls. Both
+sections share one app draft. Leaving the app form offers Save, Discard, and
+Stay. An app without controls has no Settings destination. Backend app schemas
+supply these forms without a frontend module. Schedule controls use the
+existing workflow overrides.
 
 Normal interface text uses IBM Plex Sans at 15 px. Technical values use
 IBM Plex Mono. Phone inputs use at least 16 px.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -9,7 +9,9 @@ import type { App as InstalledApp } from './api/types'
 import { registerAppUI } from './apps/registry'
 
 vi.mock('./apps', () => ({}))
-vi.mock('./api/client', () => ({ api: { listApps: vi.fn(), systemHealth: vi.fn() } }))
+vi.mock('./api/client', () => ({
+  api: { listApps: vi.fn(), systemHealth: vi.fn(), getAppSettings: vi.fn() },
+}))
 vi.mock('./components/SettingsPages', () => ({ SettingsPages: () => <h1>Settings form</h1> }))
 vi.mock('./pages/EventsPage', () => ({ EventsPage: () => <h1>Events feed</h1> }))
 vi.mock('./pages/UsagePage', () => ({ UsagePage: () => <h1>Usage report</h1> }))
@@ -95,6 +97,7 @@ afterEach(cleanup)
 
 beforeEach(() => {
   vi.mocked(api.listApps).mockResolvedValue(roster)
+  vi.mocked(api.getAppSettings).mockResolvedValue({ allowedEfforts: [], apps: [] })
   vi.stubGlobal(
     'matchMedia',
     vi.fn(() => ({ matches: true, addEventListener: vi.fn(), removeEventListener: vi.fn() })),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { navigate as browserNavigate, useLocationProperty } from 'wouter/use-bro
 
 import { api } from './api/client'
 import type { Account } from './api/types'
+import type { UnsavedForm } from './components/settings'
 import { useScreenWakeLock } from './lib/useScreenWakeLock'
 import { useTimezone } from './lib/preferences'
 import { EmptyState } from './components/EmptyState'
@@ -33,7 +34,7 @@ import { appHome, appLabel, appOwning, getAppUI, registeredApps } from './apps/r
 const ROUTER_BASE = import.meta.env.BASE_URL.replace(/\/$/, '')
 
 export function App({ account }: { account: Account }) {
-  const leaveSettings = useRef<((proceed: () => void) => void) | null>(null)
+  const unsavedFormRef = useRef<UnsavedForm | null>(null)
   const position = useRef(window.history.state?.druksPosition ?? 0)
   const currentUrl = useRef(window.location.href)
   const workEntry = useRef(window.history.state?.druksWork)
@@ -57,15 +58,17 @@ export function App({ account }: { account: Account }) {
       )
         return
       const destination = event.state?.druksPosition ?? 0
-      const leavesSettings =
-        !window.location.pathname.startsWith(`${settingsPath}/`) &&
-        window.location.pathname !== settingsPath
-      if (leaveSettings.current && leavesSettings && !acceptedPop.current) {
+      const form = unsavedFormRef.current
+      const leavesForm =
+        form &&
+        window.location.pathname !== form.path &&
+        !window.location.pathname.startsWith(`${form.path}/`)
+      if (form && leavesForm && !acceptedPop.current) {
         event.stopImmediatePropagation()
         const distance = position.current - destination
         restoring.current = true
         window.history.go(distance)
-        leaveSettings.current(() => {
+        form.confirm(() => {
           acceptedPop.current = true
           window.history.go(-distance)
         })
@@ -118,8 +121,9 @@ export function App({ account }: { account: Account }) {
       })
       currentUrl.current = window.location.href
     }
-    if (leaveSettings.current && to !== settingsPath && !to.startsWith(`${settingsPath}/`)) {
-      leaveSettings.current(proceed)
+    const form = unsavedFormRef.current
+    if (form && to !== form.path && !to.startsWith(`${form.path}/`)) {
+      form.confirm(proceed)
     } else {
       proceed()
     }
@@ -127,18 +131,18 @@ export function App({ account }: { account: Account }) {
 
   return (
     <Router base={ROUTER_BASE} aroundNav={aroundNav}>
-      <AppContexts account={account} leaveSettings={leaveSettings} aroundNav={aroundNav} />
+      <AppContexts account={account} unsavedFormRef={unsavedFormRef} aroundNav={aroundNav} />
     </Router>
   )
 }
 
 function AppContexts({
   account,
-  leaveSettings,
+  unsavedFormRef,
   aroundNav,
 }: {
   account: Account
-  leaveSettings: RefObject<((proceed: () => void) => void) | null>
+  unsavedFormRef: RefObject<UnsavedForm | null>
   aroundNav: NonNullable<RouterProps['aroundNav']>
 }) {
   const [location] = useLocation()
@@ -179,25 +183,38 @@ function AppContexts({
   return (
     <>
       <Router base={ROUTER_BASE} hook={workLocation} searchHook={workQuery} aroundNav={aroundNav}>
-        <AppShell account={account} hidden={isSettings} />
+        <AppShell account={account} hidden={isSettings} unsavedFormRef={unsavedFormRef} />
       </Router>
       {isSettings && (
         <SettingsPages
           account={account}
           returnTo={`${workPath.slice(ROUTER_BASE.length)}${workSearch ? `?${workSearch}` : ''}${work.hash}`}
-          leaveSettings={leaveSettings}
+          unsavedFormRef={unsavedFormRef}
         />
       )}
     </>
   )
 }
 
-function AppShell({ account, hidden }: { account: Account; hidden: boolean }) {
+function AppShell({
+  account,
+  hidden,
+  unsavedFormRef,
+}: {
+  account: Account
+  hidden: boolean
+  unsavedFormRef: RefObject<UnsavedForm | null>
+}) {
   const [location, navigate] = useLocation()
   const timezone = useTimezone()
   const rosterQuery = useQuery({
     queryKey: ['apps'],
     queryFn: api.listApps,
+    staleTime: 60_000,
+  })
+  const settingsQuery = useQuery({
+    queryKey: ['appSettings'],
+    queryFn: api.getAppSettings,
     staleTime: 60_000,
   })
   const registered = useMemo(() => {
@@ -265,8 +282,25 @@ function AppShell({ account, hidden }: { account: Account; hidden: boolean }) {
     return () => window.removeEventListener('keydown', onKey)
   }, [location, app, navigate, defaultApp, hidden])
 
-  const navigation =
+  const declaredNavigation =
     ui?.navigation ?? rosterQuery.data?.find((entry) => entry.name === app)?.navigation
+  const appSettings = settingsQuery.data?.apps.find((entry) => entry.name === app)
+  const hasSettings = Boolean(
+    appSettings &&
+      (appSettings.settings.length ||
+        appSettings.agents.length ||
+        appSettings.workflows.some((workflow) => workflow.fields.length)),
+  )
+  const navigation: [string, string][] = urlApp
+    ? [
+        ...(declaredNavigation?.length
+          ? declaredNavigation
+          : hasSettings
+            ? [[appHome(urlApp), 'Home'] as [string, string]]
+            : []),
+        ...(hasSettings ? [[`/apps/${urlApp}/settings`, 'Settings'] as [string, string]] : []),
+      ]
+    : []
   const activeTab = navigation
     ?.map(([url]) => url)
     .filter((url) => location === url || location.startsWith(`${url}/`))
@@ -401,6 +435,17 @@ function AppShell({ account, hidden }: { account: Account; hidden: boolean }) {
           </p>
         )}
         <Switch>
+          <Route path="/apps/:name/settings/:tab?">
+            {(params) => (
+              <SettingsPages
+                account={account}
+                returnTo={appHome(params.name)}
+                unsavedFormRef={unsavedFormRef}
+                appName={params.name}
+                active={!hidden}
+              />
+            )}
+          </Route>
           <Route path="/usage">
             <UsagePage />
           </Route>

--- a/frontend/src/apps/registry.tsx
+++ b/frontend/src/apps/registry.tsx
@@ -1,26 +1,14 @@
 import type { ReactNode } from 'react'
 
-// The client-side app-UI registry: how an app contributes frontend.
-// An app calls ``registerAppUI`` once at import time with the routes
-// its pages live at; the shell mounts them. An app whose pages are its own
-// JavaScript declares its subnav tabs here too, because only it knows those
-// URLs; an app whose pages are Python declarations gets its tabs from the
-// roster. An app that registers nothing still gets feed, settings, and usage
-// from the shell for free — those are platform surfaces, not per-app
-// contributions.
-
-// One route an app mounts. ``path`` is a wouter pattern under the router base
-// (e.g. ``/software_factory`` or ``/software_factory/work-items/:slug``); ``render`` receives the matched
-// params.
 export interface AppRoute {
+  /** A wouter pattern under the router base, such as /notes/:id. */
   path: string
   render: (params: Record<string, string>) => ReactNode
 }
 
 export interface AppUI {
-  // The app's name — the same identifier the backend registry keys it by.
   name: string
-  // The path the brand + dropdown land on (defaults to ``/<name>``).
+  /** The app's default destination. Defaults to /<name>. */
   home?: string
   routes: AppRoute[]
   // Subnav tabs as (url, label) pairs, for an app whose pages are its own
@@ -36,8 +24,6 @@ export interface AppUI {
   systemStrip?: boolean
 }
 
-// The switcher/display label for an app — derived from its name, never
-// declared: underscores become spaces, the lowercase house style stays.
 export function appLabel(name: string): string {
   return name.replace(/_/g, ' ')
 }
@@ -52,37 +38,21 @@ export function getAppUI(name: string): AppUI | undefined {
   return REGISTRY.get(name)
 }
 
-// Every UI-contributing app, in registration order. Available synchronously at
-// import, so the shell mounts routes from this — direct URLs work on a cold load, not
-// only once the async settings response arrives.
 export function registeredApps(): AppUI[] {
   return [...REGISTRY.values()]
 }
 
-// The home path the shell navigates to for an app — its declared ``home`` or
-// the conventional ``/<name>``. Apps with no UI contribution still resolve to a
-// home so the dropdown and Esc have somewhere to land.
 export function appHome(name: string): string {
   return REGISTRY.get(name)?.home ?? `/${name}`
 }
 
-// A wouter-style pattern (``/software_factory/work-items/:slug``) as a regex anchored to the
-// whole path — for deciding which app owns the current URL (its dropdown +
-// accent).
-function patternRegex(pattern: string): RegExp {
-  const source = pattern.replace(/:[^/]+/g, '[^/]+')
-  return new RegExp(`^${source}$`)
-}
-
-// The registered app that owns a location: the one whose home the path sits
-// under, or whose routes match it. Reads the local registry (synchronous), so a direct
-// load resolves the app for its dropdown + accent without waiting on the settings
-// fetch. Null on shell-owned paths (/usage, /events, /).
 export function appOwning(location: string): string | null {
+  const settingsApp = /^\/apps\/([^/]+)\/settings(?:\/|$)/.exec(location)?.[1]
+  if (settingsApp && REGISTRY.has(settingsApp)) return settingsApp
   for (const ui of REGISTRY.values()) {
     const home = ui.home ?? `/${ui.name}`
     if (location === home || location.startsWith(`${home}/`)) return ui.name
-    if (ui.routes.some((route) => patternRegex(route.path).test(location))) return ui.name
+    if (ui.routes.some((route) => new RegExp(`^${route.path.replace(/:[^/]+/g, '[^/]+')}$`).test(location))) return ui.name
   }
   return null
 }

--- a/frontend/src/components/CronField.test.tsx
+++ b/frontend/src/components/CronField.test.tsx
@@ -8,22 +8,38 @@ afterEach(cleanup)
 describe('CronField', () => {
   it('keeps the preset select visible in custom mode, so custom is not a one-way door', () => {
     const onChange = vi.fn()
-    render(<CronField value="0 * * * *" onChange={onChange} disabled={false} />)
+    render(<CronField label="Schedule" value="0 * * * *" onChange={onChange} disabled={false} />)
 
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'custom' } })
     expect(screen.getByPlaceholderText(/cron, e.g./)).toBeTruthy()
     expect(screen.getByRole('combobox')).toBeTruthy()
 
-    // Picking a preset again leaves custom mode and reports the cadence.
     fireEvent.change(screen.getByRole('combobox'), { target: { value: '*/15 * * * *' } })
     expect(onChange).toHaveBeenCalledWith('*/15 * * * *')
     expect(screen.queryByPlaceholderText(/cron, e.g./)).toBeNull()
   })
 
   it('opens directly in custom mode for a value outside the presets', () => {
-    render(<CronField value="7 3 * * 1" onChange={() => {}} disabled={false} />)
+    render(<CronField label="Schedule" value="7 3 * * 1" onChange={() => {}} disabled={false} />)
     const input = screen.getByPlaceholderText(/cron, e.g./) as HTMLInputElement
     expect(input.value).toBe('7 3 * * 1')
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('custom')
+  })
+
+  it('shows the saved custom cadence when an unsaved preset is discarded', () => {
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <CronField label="Schedule" value="7 3 * * 1" onChange={onChange} disabled={false} />,
+    )
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '*/15 * * * *' } })
+    rerender(
+      <CronField label="Schedule" value="*/15 * * * *" onChange={onChange} disabled={false} />,
+    )
+    expect(screen.queryByRole('textbox')).toBeNull()
+    rerender(<CronField label="Schedule" value="7 3 * * 1" onChange={onChange} disabled={false} />)
+    expect(
+      (screen.getByRole('textbox', { name: 'Schedule (cron)' }) as HTMLInputElement).value,
+    ).toBe('7 3 * * 1')
     expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('custom')
   })
 })

--- a/frontend/src/components/CronField.tsx
+++ b/frontend/src/components/CronField.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 
 import { Select, TextInput } from './Control'
 
-// The cadences an operator actually picks from; anything else is "custom".
 const CRON_PRESETS: [cron: string, label: string][] = [
   ['*/5 * * * *', 'Every 5 minutes'],
   ['*/15 * * * *', 'Every 15 minutes'],
@@ -13,28 +12,29 @@ const CRON_PRESETS: [cron: string, label: string][] = [
 ]
 
 export function CronField({
+  label,
   value,
   onChange,
   disabled,
 }: {
+  label: string
   value: string
-  onChange: (v: string) => void
+  onChange: (value: string) => void
   disabled: boolean
 }) {
-  // A value outside the presets opens in the raw-cron input, so nothing an
-  // operator (or the API) stored is ever hidden or clobbered. The select
-  // stays visible as the mode switcher, so custom is never a one-way door.
-  const [custom, setCustom] = useState(() => !CRON_PRESETS.some(([cron]) => cron === value))
+  const [custom, setCustom] = useState(false)
+  const showCustom = custom || !CRON_PRESETS.some(([cron]) => cron === value)
   return (
     <>
       <Select
-        value={custom ? 'custom' : value}
-        onChange={(e) => {
-          if (e.target.value === 'custom') {
+        aria-label={label}
+        value={showCustom ? 'custom' : value}
+        onChange={(event) => {
+          if (event.target.value === 'custom') {
             setCustom(true)
           } else {
             setCustom(false)
-            onChange(e.target.value)
+            onChange(event.target.value)
           }
         }}
         disabled={disabled}
@@ -46,12 +46,13 @@ export function CronField({
         ))}
         <option value="custom">Custom cron…</option>
       </Select>
-      {custom && (
+      {showCustom && (
         <TextInput
           type="text"
+          aria-label={`${label} (cron)`}
           value={value}
           placeholder="cron, e.g. */15 * * * *"
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(event) => onChange(event.target.value)}
           disabled={disabled}
         />
       )}

--- a/frontend/src/components/SettingField.tsx
+++ b/frontend/src/components/SettingField.tsx
@@ -1,13 +1,10 @@
 import { CronField } from './CronField'
 import { Field, Select, Textarea, TextInput } from './Control'
 
-// One declared field, rendered from its kind — the settings panes and a
-// service's connect form both draw through here.
 interface SettingFieldProps {
   label: string
   help?: string
-  // str | int | bool | enum | secret | cron. ``bool`` is not drawn here: a
-  // toggle is a row, not a labelled control, so the panes pull those out.
+  /** A field kind. The pane renders boolean fields as toggle rows. */
   type: string
   choices?: string[] | null
   multiline?: boolean
@@ -40,12 +37,16 @@ function FieldControl({
   disabled,
 }: ControlProps) {
   if (type === 'enum') {
-    // A broken declaration, not a text field: say so rather than accept anything.
     if (!choices?.length) {
       return <span className="set-field-error">{label} declares no choices</span>
     }
     return (
-      <Select value={value} onChange={(e) => onChange(e.target.value)} disabled={disabled}>
+      <Select
+        aria-label={label}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        disabled={disabled}
+      >
         {choices.map((choice) => (
           <option key={choice} value={choice}>
             {choice}
@@ -56,7 +57,9 @@ function FieldControl({
   }
 
   if (type === 'cron') {
-    return <CronField value={value} onChange={onChange} disabled={disabled ?? false} />
+    return (
+      <CronField label={label} value={value} onChange={onChange} disabled={disabled ?? false} />
+    )
   }
 
   // The stored secret never reaches the client, so the box shows only whether
@@ -64,16 +67,13 @@ function FieldControl({
   const secret = type === 'secret'
   const placeholder = secret ? (secretSet ? '•••••••• (set)' : 'not set') : undefined
 
-  // multiline is declared independent of type (field_multiline in the backend
-  // reads a separate json_schema_extra key), so it governs textarea-vs-input
-  // for any kind, not only secrets — a pasted PEM and a pasted long
-  // description both need their newlines kept.
+  // Multiline is independent of the field kind; descriptions and secrets both need newlines.
   if (multiline) {
     return (
       <Textarea
         value={value}
         placeholder={placeholder}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(event) => onChange(event.target.value)}
         disabled={disabled}
         aria-label={label}
       />
@@ -85,7 +85,7 @@ function FieldControl({
       type={secret ? 'password' : type === 'int' ? 'number' : 'text'}
       value={value}
       placeholder={placeholder}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={(event) => onChange(event.target.value)}
       disabled={disabled}
       aria-label={label}
     />

--- a/frontend/src/components/SettingsPages.test.tsx
+++ b/frontend/src/components/SettingsPages.test.tsx
@@ -2,11 +2,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { Router } from 'wouter'
-import { SettingsPages } from './SettingsPages'
 import { App } from '../App'
 import { api } from '../api/client'
-import type { UserSettings } from '../api/types'
+import type {
+  AgentSetting,
+  AppsSettingsResponse,
+  UpdateAppsSettingsRequest,
+  UserSettings,
+} from '../api/types'
 
 vi.mock('../apps', () => ({}))
 vi.mock('../pages/EventsPage', () => ({
@@ -40,7 +43,7 @@ const userSettings = {
   updatedAt: '2026-08-01T00:00:00Z',
 }
 
-const coder = {
+const coder: AgentSetting = {
   name: 'coder',
   description: 'writes the change',
   harness: 'codex',
@@ -55,7 +58,7 @@ const coder = {
   timeoutSource: 'default',
 }
 
-const critic = {
+const critic: AgentSetting = {
   name: 'critic',
   description: 'reviews the change',
   harness: 'opencode',
@@ -138,7 +141,7 @@ const providerDirectory = [
 
 const patched: Record<string, unknown>[] = []
 
-const appSettings = {
+const appSettings: AppsSettingsResponse = {
   allowedEfforts: ['low', 'medium', 'high'],
   apps: [
     {
@@ -161,6 +164,7 @@ const appSettings = {
           visibleWhenField: '',
           visibleWhenValue: null,
           secretSet: null,
+          multiline: false,
           overridden: false,
         },
         {
@@ -175,6 +179,7 @@ const appSettings = {
           visibleWhenField: 'tracker',
           visibleWhenValue: 'linear',
           secretSet: null,
+          multiline: false,
           overridden: false,
         },
         {
@@ -189,6 +194,7 @@ const appSettings = {
           visibleWhenField: 'tracker',
           visibleWhenValue: 'jira',
           secretSet: null,
+          multiline: false,
           overridden: false,
         },
       ],
@@ -253,6 +259,7 @@ const appSettings = {
           visibleWhenField: '',
           visibleWhenValue: null,
           secretSet: null,
+          multiline: false,
           overridden: false,
         },
       ],
@@ -270,20 +277,57 @@ function stubFetch(
   },
 ) {
   let savedSettings = { ...userSettings }
+  const savedApps = structuredClone(appSettings)
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const path = String(input)
-      if (path === '/api/apps') return new Response('[]', { status: 200 })
+      if (path === '/api/apps')
+        return new Response(
+          JSON.stringify(
+            appSettings.apps.map((app) => ({
+              name: app.name,
+              description: app.description,
+              icon: app.icon,
+              builtin: false,
+              subjectTypes: [],
+              hasFrontend: false,
+              navigation: [],
+              pages: [],
+              operations: [],
+            })),
+          ),
+          { status: 200 },
+        )
       if (path === '/api/settings/apps' && init?.method === 'PATCH') {
-        if (!shouldRejectPatch) return new Response('{}', { status: 200 })
+        if (!shouldRejectPatch) {
+          const edits: UpdateAppsSettingsRequest = JSON.parse(String(init.body))
+          for (const app of savedApps.apps) {
+            for (const field of app.settings) {
+              const value = edits.appSettings?.[app.name]?.[field.name]
+              if (value !== undefined) {
+                if (field.type === 'secret') field.secretSet = Boolean(value)
+                else field.value = value
+                field.overridden = true
+              }
+            }
+            for (const agent of app.agents) {
+              const effort = edits.agentEfforts?.[agent.name]
+              if (effort !== undefined) {
+                agent.effort = effort ?? savedSettings.defaultEffort
+                agent.effortSource = effort === null ? 'default' : 'agent'
+              }
+            }
+          }
+          return new Response(JSON.stringify(savedApps), { status: 200 })
+        }
         return new Response(JSON.stringify({ detail }), {
           status: 422,
           statusText: 'Unprocessable Entity',
         })
       }
       if (path === '/api/settings/apps') {
-        return new Response(JSON.stringify(appSettings), { status: 200 })
+        return new Response(JSON.stringify(savedApps), { status: 200 })
       }
       if (path === '/api/settings/harnesses') {
         return new Response(JSON.stringify(harnesses), { status: 200 })
@@ -352,6 +396,13 @@ function stubFetch(
       if (path === '/api/browser-sessions') {
         return new Response('[]', { status: 200 })
       }
+      if (
+        ['/api/services', '/api/oauth/connections', '/api/skills', '/api/mcp-servers'].includes(
+          path,
+        )
+      ) {
+        return new Response('[]', { status: 200 })
+      }
       if (path === '/api/settings') {
         return new Response(JSON.stringify(savedSettings), { status: 200 })
       }
@@ -369,19 +420,7 @@ function renderSettings(workPath?: string) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(
     <QueryClientProvider client={queryClient}>
-      <>
-        {workPath ? (
-          <App account={{ id: 'operator', username: 'operator@example.invalid' }} />
-        ) : (
-          <Router>
-            <SettingsPages
-              account={{ id: 'operator', username: 'operator@example.invalid' }}
-              returnTo="/work"
-              leaveSettings={{ current: null }}
-            />
-          </Router>
-        )}
-      </>
+      <App account={{ id: 'operator', username: 'operator@example.invalid' }} />
     </QueryClientProvider>,
   )
 }
@@ -430,7 +469,8 @@ describe('SettingsPages app fields', () => {
     const appIdError = await screen.findByText('The review App ID is invalid.')
     expect(pairError.closest('.set-field')?.textContent).toContain('Review App private key')
     expect(appIdError.closest('.set-field')?.textContent).toContain('Review App ID')
-    expect(window.location.pathname.startsWith('/settings/')).toBe(true)
+    expect(screen.getByRole('alert').textContent).toBe('Check the highlighted fields.')
+    expect(window.location.pathname).toBe('/apps/review/settings')
   })
 
   it('reveals the chosen section immediately and prunes edits hidden before save', async () => {
@@ -575,6 +615,7 @@ describe('SettingsPages agents', () => {
     renderSettings()
     fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
     fireEvent.click(await screen.findByRole('link', { name: 'software factory' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Agents' }))
     await screen.findByText('coder')
     const harnessCell = screen.getByText('codex').closest('button')!
     expect(harnessCell.className).toContain('override')
@@ -689,24 +730,20 @@ describe('SettingsPages agents', () => {
 })
 
 describe('settings drafts and navigation', () => {
-  it('keeps drafts across pages and saves only the current page', async () => {
+  it('keeps shared drafts across pages and saves only the current page', async () => {
     stubFetch(false)
     renderSettings()
     fireEvent.change(await screen.findByRole('combobox', { name: 'Timezone' }), {
       target: { value: 'Europe/Madrid' },
     })
-    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'field notes' }))
-    fireEvent.change(screen.getByLabelText('Notebook'), { target: { value: 'travel' } })
+    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    fireEvent.change(await screen.findByLabelText('Effort'), { target: { value: 'low' } })
     fireEvent.click(screen.getByRole('link', { name: 'General' }))
-    expect((screen.getByRole('combobox', { name: 'Timezone' }) as HTMLSelectElement).value).toBe(
-      'Europe/Madrid',
-    )
+    expect((screen.getByLabelText('Timezone') as HTMLSelectElement).value).toBe('Europe/Madrid')
     fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
     await waitFor(() => expect(patched).toEqual([{ timezone: 'Europe/Madrid' }]))
-    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(screen.getByRole('link', { name: 'field notes' }))
-    expect((screen.getByLabelText('Notebook') as HTMLInputElement).value).toBe('travel')
+    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    expect((screen.getByLabelText('Effort') as HTMLSelectElement).value).toBe('low')
     expect(
       (screen.getByRole('button', { name: 'Save changes' }) as HTMLButtonElement).disabled,
     ).toBe(false)
@@ -745,32 +782,36 @@ describe('settings drafts and navigation', () => {
     expect(patched).toEqual([])
   })
 
-  it('stays on a failed page after earlier drafts save successfully', async () => {
-    stubFetch(true)
+  it('stays on a failed page after earlier shared drafts save successfully', async () => {
+    stubFetch(false)
+    const update = vi
+      .spyOn(api, 'updateSettings')
+      .mockResolvedValueOnce({ ...userSettings, timezone: 'Europe/Madrid' } as UserSettings)
+      .mockRejectedValueOnce(new Error('Could not save the agent defaults.'))
     renderSettings('/events')
     fireEvent.click(await screen.findByRole('link', { name: 'Settings' }))
     fireEvent.click(screen.getByRole('link', { name: 'General' }))
-    fireEvent.change(await screen.findByRole('combobox', { name: 'Timezone' }), {
+    fireEvent.change(await screen.findByLabelText('Timezone'), {
       target: { value: 'Europe/Madrid' },
     })
-    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'review' }))
-    fireEvent.change(screen.getByLabelText('Review App ID'), { target: { value: 'bad-id' } })
+    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    fireEvent.change(await screen.findByLabelText('Effort'), { target: { value: 'low' } })
     fireEvent.click(screen.getByRole('link', { name: 'Back to Druks' }))
     fireEvent.click(
       within(screen.getByRole('dialog', { name: 'Save your changes?' })).getByRole('button', {
         name: 'Save',
       }),
     )
-    await screen.findByText('The review App ID is invalid.')
-    expect(window.location.pathname).toBe('/settings/apps/review')
-    expect((screen.getByLabelText('Review App ID') as HTMLInputElement).value).toBe('bad-id')
-    expect(patched).toEqual([{ timezone: 'Europe/Madrid' }])
+    await screen.findByText('Could not save the agent defaults.')
+    expect(window.location.pathname).toBe('/settings/agents')
+    expect((screen.getByLabelText('Effort') as HTMLSelectElement).value).toBe('low')
+    expect(update.mock.calls.map(([body]) => body)).toEqual([
+      { timezone: 'Europe/Madrid' },
+      { defaultEffort: 'low' },
+    ])
     expect(screen.queryByRole('dialog', { name: 'Save your changes?' })).toBeNull()
     fireEvent.click(screen.getByRole('link', { name: 'General' }))
-    expect((screen.getByRole('combobox', { name: 'Timezone' }) as HTMLSelectElement).value).toBe(
-      'Europe/Madrid',
-    )
+    expect((screen.getByLabelText('Timezone') as HTMLSelectElement).value).toBe('Europe/Madrid')
     expect(
       (screen.getByRole('button', { name: 'Save changes' }) as HTMLButtonElement).disabled,
     ).toBe(true)
@@ -897,5 +938,195 @@ it('restores the work return URL when a settings fragment route reloads', async 
   expect(window.location.pathname + window.location.hash).toBe('/settings/general#settings-content')
   expect(screen.getByRole('link', { name: 'Back to Druks' }).getAttribute('href')).toBe(
     '/events?app=field_notes#recent',
+  )
+})
+
+describe('canonical app settings', () => {
+  it('shows a load failure with Retry on a direct app settings link', async () => {
+    stubFetch(false)
+    vi.spyOn(api, 'getAppSettings')
+      .mockRejectedValueOnce(new Error('Offline'))
+      .mockResolvedValue(appSettings)
+    renderSettings('/apps/field_notes/settings')
+    expect(await screen.findByRole('alert')).toHaveProperty(
+      'textContent',
+      'Could not load settings. Try again',
+    )
+    expect(screen.queryByText('No settings page matches this address.')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    await screen.findByLabelText('Notebook')
+  })
+
+  it('keeps the loading state until the app settings lookup completes', async () => {
+    stubFetch(false)
+    let resolveSettings!: (value: typeof appSettings) => void
+    vi.spyOn(api, 'getAppSettings').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSettings = resolve
+        }),
+    )
+    renderSettings('/apps/field_notes/settings')
+    expect(await screen.findByText('Loading app settings…')).toBeTruthy()
+    expect(screen.queryByText('No settings page matches this address.')).toBeNull()
+    await act(async () => resolveSettings(appSettings))
+    await screen.findByLabelText('Notebook')
+  })
+
+  it('does not create settings destinations for apps without controls', async () => {
+    stubFetch(false)
+    vi.spyOn(api, 'getAppSettings').mockResolvedValue({
+      ...appSettings,
+      apps: [{ ...appSettings.apps[0]!, agents: [], settings: [], workflows: [] }],
+    })
+    renderSettings('/settings/apps')
+    expect(await screen.findByText('No installed app declares settings.')).toBeTruthy()
+    expect(screen.queryByRole('link', { name: 'software factory' })).toBeNull()
+    fireEvent.click(screen.getByRole('link', { name: 'Back to Druks' }))
+    const appLink = await screen.findByRole('link', { name: 'software factory' })
+    fireEvent.click(appLink)
+    await waitFor(() => expect(window.location.pathname).toBe('/software_factory'))
+    expect(screen.queryByRole('navigation', { name: 'software factory pages' })).toBeNull()
+  })
+
+  it('does not show an empty Agents page for an app that only declares options', async () => {
+    stubFetch(false)
+    renderSettings('/apps/field_notes/settings/agents')
+    expect(await screen.findByText('No settings page matches this address.')).toBeTruthy()
+    expect(screen.queryByLabelText('Notebook')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Save changes' })).toBeNull()
+  })
+
+  it('keeps Options and Agents drafts together and sends only that app', async () => {
+    stubFetch(false)
+    renderSettings('/apps/software_factory/settings')
+    await screen.findByLabelText('Tracker')
+    fireEvent.change(screen.getByLabelText('Linear trigger status'), {
+      target: { value: 'Agent Queue' },
+    })
+    fireEvent.click(screen.getByRole('link', { name: 'Agents' }))
+    fireEvent.click(await screen.findByText('high'))
+    fireEvent.click(await screen.findByText('low'))
+    fireEvent.click(screen.getByRole('link', { name: 'Options' }))
+    expect((screen.getByLabelText('Linear trigger status') as HTMLInputElement).value).toBe(
+      'Agent Queue',
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('button', { name: 'Save changes' }) as HTMLButtonElement).disabled,
+      ).toBe(true),
+    )
+    const patch = vi
+      .mocked(fetch)
+      .mock.calls.find(
+        ([path, init]) => String(path) === '/api/settings/apps' && init?.method === 'PATCH',
+      )
+    expect(JSON.parse(String(patch?.[1]?.body))).toEqual({
+      agentEfforts: { coder: 'low' },
+      appSettings: { software_factory: { linear_trigger_status: 'Agent Queue' } },
+      workflowSettings: {},
+    })
+    expect(patched).toEqual([])
+    expect(screen.getByRole('status').textContent).toBe('Saved')
+    expect((screen.getByLabelText('Linear trigger status') as HTMLInputElement).value).toBe(
+      'Agent Queue',
+    )
+    fireEvent.click(screen.getByRole('link', { name: 'Agents' }))
+    const savedEffort = await screen.findByText('low')
+    expect(savedEffort.closest('button')?.classList.contains('override')).toBe(true)
+  })
+
+  it('asks before leaving a dirty app and keeps its draft after Stay', async () => {
+    stubFetch(false)
+    renderSettings('/apps/field_notes/settings')
+    fireEvent.change(await screen.findByLabelText('Notebook'), { target: { value: 'travel' } })
+    fireEvent.click(screen.getByRole('link', { name: 'Events' }))
+    const dialog = screen.getByRole('dialog', { name: 'Save your changes?' })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Stay' }))
+    expect(window.location.pathname).toBe('/apps/field_notes/settings')
+    expect((screen.getByLabelText('Notebook') as HTMLInputElement).value).toBe('travel')
+    fireEvent.click(screen.getByRole('link', { name: 'Events' }))
+    fireEvent.click(
+      within(screen.getByRole('dialog', { name: 'Save your changes?' })).getByRole('button', {
+        name: 'Discard',
+      }),
+    )
+    await screen.findByRole('heading', { name: 'Current work' })
+    expect(window.location.pathname).toBe('/events')
+    expect(vi.mocked(fetch).mock.calls.some(([, init]) => init?.method === 'PATCH')).toBe(false)
+  })
+
+  it('guards the shared-to-app context change and opens the canonical page after Save', async () => {
+    stubFetch(false)
+    renderSettings()
+    fireEvent.change(await screen.findByLabelText('Timezone'), {
+      target: { value: 'Europe/Madrid' },
+    })
+    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
+    const destination = await screen.findByRole('link', { name: 'field notes' })
+    expect(destination.getAttribute('href')).toBe('/apps/field_notes/settings')
+    fireEvent.click(destination)
+    expect(window.location.pathname).toBe('/settings/apps')
+    fireEvent.click(
+      within(screen.getByRole('dialog', { name: 'Save your changes?' })).getByRole('button', {
+        name: 'Save',
+      }),
+    )
+    await screen.findByLabelText('Notebook')
+    expect(window.location.pathname).toBe('/apps/field_notes/settings')
+    expect(patched).toEqual([{ timezone: 'Europe/Madrid' }])
+    expect(screen.queryByRole('navigation', { name: 'App settings sections' })).toBeNull()
+  })
+
+  it('restores app settings from shared settings and guards new edits after return', async () => {
+    stubFetch(false)
+    renderSettings('/apps/software_factory/settings/agents')
+    const pages = await screen.findByRole('navigation', { name: 'software factory pages' })
+    expect(within(pages).getByRole('link', { name: 'Settings' }).getAttribute('aria-current')).toBe(
+      'page',
+    )
+    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    await screen.findByRole('heading', { name: 'Agent defaults' })
+    fireEvent.click(screen.getByRole('link', { name: 'Back to Druks' }))
+    await screen.findByText('coder')
+    expect(window.location.pathname).toBe('/apps/software_factory/settings/agents')
+    fireEvent.click(screen.getByRole('link', { name: 'Options' }))
+    fireEvent.change(screen.getByLabelText('Linear trigger status'), {
+      target: { value: 'Agent Queue' },
+    })
+    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    expect(screen.getByRole('dialog', { name: 'Save your changes?' })).toBeTruthy()
+  })
+})
+
+describe('settings resource read failures', () => {
+  it.each([
+    ['connections', 'services', 'services'],
+    ['connections', 'listConnections', 'connections'],
+    ['skills', 'skillCollections', 'skill collections'],
+    ['mcp', 'mcpServers', 'MCP servers'],
+    ['api-tokens', 'pats', 'API tokens'],
+  ] as const)(
+    'retries a failed %s read from %s without claiming an empty result',
+    async (section, method, label) => {
+      stubFetch(false)
+      const request = vi
+        .spyOn(api, method)
+        .mockRejectedValueOnce(new Error('Offline'))
+        .mockResolvedValue([])
+      renderSettings(`/settings/${section}`)
+      if (method === 'listConnections') {
+        fireEvent.click(await screen.findByRole('button', { name: 'Accounts' }))
+      }
+      const alert = await screen.findByRole('alert')
+      expect(alert.textContent).toContain(`Could not load ${label}.`)
+      if (method === 'listConnections') expect(screen.queryByText('No connections yet.')).toBeNull()
+      if (method === 'skillCollections')
+        expect(screen.queryByText('No collections yet — import one above.')).toBeNull()
+      fireEvent.click(within(alert).getByRole('button', { name: 'Try again' }))
+      await waitFor(() => expect(screen.queryByRole('alert')).toBeNull())
+      expect(request).toHaveBeenCalledTimes(2)
+    },
   )
 })

--- a/frontend/src/components/SettingsPages.tsx
+++ b/frontend/src/components/SettingsPages.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type RefObject } from 'react'
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Search } from 'lucide-react'
+import { ArrowLeft, ArrowUpRight, Search } from 'lucide-react'
 import { Link, useLocation } from 'wouter'
 
 import { ApiError, api } from '../api/client'
@@ -27,7 +27,14 @@ import {
   ServicesPane,
   SkillsPane,
 } from './SettingsPanes'
-import { buildCatalog, defaultsOf, isFieldVisible, knownProviders, type Defaults } from './settings'
+import {
+  buildCatalog,
+  defaultsOf,
+  isFieldVisible,
+  knownProviders,
+  type Defaults,
+  type UnsavedForm,
+} from './settings'
 
 const SECTIONS = [
   {
@@ -93,14 +100,19 @@ function withField(
 export function SettingsPages({
   account,
   returnTo,
-  leaveSettings,
+  unsavedFormRef,
+  appName,
+  active = true,
 }: {
   account: Account
   returnTo: string
-  leaveSettings: RefObject<((proceed: () => void) => void) | null>
+  unsavedFormRef: RefObject<UnsavedForm | null>
+  appName?: string
+  active?: boolean
 }) {
   const [location, navigate] = useLocation()
-  const section = location.slice('/settings/'.length) || 'providers'
+  const section = appName ? `apps/${appName}` : location.slice('/settings/'.length) || 'providers'
+  const formPath = `${import.meta.env.BASE_URL.replace(/\/$/, '')}${appName ? `/apps/${appName}/settings` : '/settings'}`
   const queryClient = useQueryClient()
   const settingsQuery = useQuery({ queryKey: ['settings'], queryFn: api.getSettings })
   const appsQuery = useQuery({ queryKey: ['appSettings'], queryFn: api.getAppSettings })
@@ -114,7 +126,12 @@ export function SettingsPages({
   })
   const keysQuery = useQuery({ queryKey: ['providerKeys'], queryFn: api.providerKeys })
   const catalogsQuery = useQuery({ queryKey: ['providerCatalogs'], queryFn: api.providerCatalogs })
-  const apps = appsQuery.data?.apps ?? []
+  const apps = (appsQuery.data?.apps ?? []).filter(
+    (entry) =>
+      entry.settings.length > 0 ||
+      entry.agents.length > 0 ||
+      entry.workflows.some((workflow) => workflow.fields.length > 0),
+  )
   const harnesses = harnessesQuery.data ?? []
   const catalogs = catalogsQuery.data ?? []
   const providers = knownProviders(providersQuery.data ?? [], catalogs)
@@ -140,6 +157,7 @@ export function SettingsPages({
   if (!visited.includes(section)) setVisited([...visited, section])
   const tick = useTicker()
   const confirmation = useRef<HTMLDialogElement>(null)
+  const confirmationTitle = useId()
   const pending = useRef<(() => void) | null>(null)
   const leaving = useRef(false)
   const heading = useRef<HTMLHeadingElement>(null)
@@ -172,10 +190,20 @@ export function SettingsPages({
       .map(([name]) => `apps/${name}`),
   ]
   const dirty = dirtyPages.includes(section)
-  const app = apps.find((entry) => section === `apps/${entry.name}`)
+  const app = appName ? apps.find((entry) => entry.name === appName) : undefined
+  const appTab = location.endsWith('/agents') ? 'agents' : 'options'
+  const validAppPage =
+    !appName ||
+    location === `/apps/${appName}/settings` ||
+    Boolean(app?.agents.length && location === `/apps/${appName}/settings/agents`)
+  const hasOptions = Boolean(
+    app && (app.settings.length || app.workflows.some((workflow) => workflow.fields.length)),
+  )
+  const paneSection = app?.agents.length && !hasOptions ? 'agents' : appTab
+  const Content = appName ? 'section' : 'main'
   const title =
     SECTIONS.find((entry) => entry.id === section)?.label ?? (app ? appLabel(app.name) : 'Settings')
-  const formPage = section === 'general' || section === 'agents' || Boolean(app)
+  const formPage = section === 'general' || section === 'agents' || Boolean(app && validAppPage)
   const executionChanged =
     defaults &&
     savedDefaults &&
@@ -195,21 +223,25 @@ export function SettingsPages({
   }, [location, navigate])
 
   useLayoutEffect(() => {
-    heading.current?.focus()
-  }, [section])
+    if (active) heading.current?.focus({ preventScroll: true })
+  }, [section, active])
 
   useLayoutEffect(() => {
-    leaveSettings.current =
-      dirtyPages.length > 0
-        ? (proceed) => {
-            pending.current = proceed
-            confirmation.current?.showModal()
-          }
-        : null
-    return () => {
-      leaveSettings.current = null
+    const form: UnsavedForm = {
+      path: formPath,
+      confirm: (proceed) => {
+        pending.current = proceed
+        confirmation.current?.showModal()
+      },
     }
-  }, [dirtyPages.length, leaveSettings])
+    if (active && dirtyPages.length > 0) {
+      leaving.current = false
+      unsavedFormRef.current = form
+    }
+    return () => {
+      if (unsavedFormRef.current === form) unsavedFormRef.current = null
+    }
+  }, [dirtyPages.length, unsavedFormRef, formPath, active])
 
   useEffect(() => {
     function beforeUnload(event: BeforeUnloadEvent) {
@@ -245,7 +277,7 @@ export function SettingsPages({
 
   function finishLeaving() {
     leaving.current = true
-    leaveSettings.current = null
+    unsavedFormRef.current = null
     confirmation.current?.close()
     pending.current?.()
   }
@@ -321,6 +353,7 @@ export function SettingsPages({
       }
       proceed?.()
     } catch (caught) {
+      let message = caught instanceof Error ? caught.message : 'Could not save settings. Try again.'
       if (
         caught instanceof ApiError &&
         caught.status === 422 &&
@@ -329,14 +362,15 @@ export function SettingsPages({
         !Array.isArray(caught.detail)
       ) {
         setAppProblems(caught.detail as AppSettingsProblems)
+        message = 'Check the highlighted fields.'
       }
       setErrors((current) => ({
         ...current,
-        [page]: caught instanceof Error ? caught.message : 'Could not save settings. Try again.',
+        [page]: message,
       }))
       confirmation.current?.close()
       pending.current = null
-      navigate(`/settings/${page}`)
+      navigate(appName ? `/apps/${appName}/settings` : `/settings/${page}`)
       window.requestAnimationFrame(() => errorNotice.current?.focus())
     } finally {
       setSaving(false)
@@ -366,7 +400,7 @@ export function SettingsPages({
         ].map((label) => ({
           label,
           owner: appLabel(entry.name),
-          path: `/settings/apps/${entry.name}`,
+          path: `/apps/${entry.name}/settings`,
         })),
       ),
     )
@@ -376,7 +410,7 @@ export function SettingsPages({
 
   return (
     <div
-      className="command-center settings-context"
+      className={appName ? 'settings-context app-settings' : 'command-center settings-context'}
       onKeyDown={(event) => {
         if (
           (event.metaKey || event.ctrlKey) &&
@@ -400,10 +434,10 @@ export function SettingsPages({
           !event.shiftKey &&
           !event.altKey &&
           event.button === 0 &&
-          leaveSettings.current
+          unsavedFormRef.current
         ) {
           const target = new URL(anchor.href)
-          const settingsRoot = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/settings`
+          const settingsRoot = formPath
           if (
             target.origin !== window.location.origin ||
             (target.pathname !== settingsRoot && !target.pathname.startsWith(`${settingsRoot}/`))
@@ -411,7 +445,7 @@ export function SettingsPages({
             event.preventDefault()
             event.stopPropagation()
             anchor.closest('dialog')?.close('navigation')
-            leaveSettings.current(() => {
+            unsavedFormRef.current.confirm(() => {
               if (target.origin === window.location.origin)
                 navigate(`~${target.pathname}${target.search}${target.hash}`)
               else window.location.assign(target.href)
@@ -420,64 +454,97 @@ export function SettingsPages({
         }
       }}
     >
-      <a className="skip-navigation" href="#settings-content">
-        Skip to content
-      </a>
-      <header className="command-header">
-        <Sidebar account={account} home={returnTo}>
-          <Link className="settings-back sidebar-link" href={returnTo}>
-            <ArrowLeft size={17} aria-hidden="true" />
-            Back to Druks
-          </Link>
-          <h2 className="settings-sidebar-title">Settings</h2>
-          <nav className="settings-navigation" aria-label="Settings">
-            {['AI execution', 'Tools & access', 'Personal', 'Apps'].map((group) => (
-              <div key={group}>
-                <div className="sidebar-group-title">{group}</div>
-                {SECTIONS.filter((entry) => entry.group === group).map((entry) => (
-                  <Link
-                    key={entry.id}
-                    aria-label={entry.label}
-                    aria-description={dirtyPages.includes(entry.id) ? 'Unsaved changes' : undefined}
-                    href={`/settings/${entry.id}`}
-                    className="sidebar-link"
-                    aria-current={
-                      section === entry.id || (entry.id === 'apps' && Boolean(app))
-                        ? 'page'
-                        : undefined
-                    }
-                  >
-                    {entry.label}
-                    {dirtyPages.includes(entry.id) && <span aria-hidden="true">•</span>}
-                  </Link>
+      {!appName && (
+        <>
+          <a className="skip-navigation" href="#settings-content">
+            Skip to content
+          </a>
+          <header className="command-header">
+            <Sidebar account={account} home={returnTo}>
+              <Link className="settings-back sidebar-link" href={returnTo}>
+                <ArrowLeft size={17} aria-hidden="true" />
+                Back to Druks
+              </Link>
+              <h2 className="settings-sidebar-title">Settings</h2>
+              <nav className="settings-navigation" aria-label="Settings">
+                {['AI execution', 'Tools & access', 'Personal', 'Apps'].map((group) => (
+                  <div key={group}>
+                    <div className="sidebar-group-title">{group}</div>
+                    {SECTIONS.filter((entry) => entry.group === group).map((entry) => (
+                      <Link
+                        key={entry.id}
+                        aria-label={entry.label}
+                        aria-description={
+                          dirtyPages.includes(entry.id) ? 'Unsaved changes' : undefined
+                        }
+                        href={`/settings/${entry.id}`}
+                        className="sidebar-link"
+                        aria-current={
+                          section === entry.id || (entry.id === 'apps' && Boolean(app))
+                            ? 'page'
+                            : undefined
+                        }
+                      >
+                        {entry.label}
+                        {dirtyPages.includes(entry.id) && <span aria-hidden="true">•</span>}
+                      </Link>
+                    ))}
+                  </div>
                 ))}
-              </div>
-            ))}
-          </nav>
-        </Sidebar>
-        <div className="command-breadcrumb">
-          <span>Settings /</span>
-          <strong>{title}</strong>
-        </div>
-      </header>
-      <main className="settings-main" id="settings-content" tabIndex={-1}>
+              </nav>
+            </Sidebar>
+            <div className="command-breadcrumb">
+              <span>Settings /</span>
+              <strong>{title}</strong>
+            </div>
+          </header>
+        </>
+      )}
+      <Content
+        className="settings-main"
+        id={appName ? 'app-settings-content' : 'settings-content'}
+        tabIndex={-1}
+      >
         <div className="settings-page-head">
           <div>
             <h1 tabIndex={-1} ref={heading}>
               {title}
             </h1>
           </div>
-          <label className="settings-search">
-            <Search size={17} aria-hidden="true" />
-            <input
-              type="search"
-              aria-label="Search settings"
-              placeholder="Search settings"
-              value={search}
-              onChange={(event) => setSearch(event.target.value)}
-            />
-          </label>
+          {!appName && (
+            <label className="settings-search">
+              <Search size={17} aria-hidden="true" />
+              <input
+                type="search"
+                aria-label="Search settings"
+                placeholder="Search settings"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+              />
+            </label>
+          )}
         </div>
+        {appName && app && (
+          <>
+            <p className="app-settings-description">{app.description}</p>
+            {hasOptions && app.agents.length > 0 && (
+              <nav className="settings-tabs" aria-label="App settings sections">
+                <Link
+                  href={`/apps/${app.name}/settings`}
+                  aria-current={paneSection === 'options' ? 'page' : undefined}
+                >
+                  Options
+                </Link>
+                <Link
+                  href={`/apps/${app.name}/settings/agents`}
+                  aria-current={paneSection === 'agents' ? 'page' : undefined}
+                >
+                  Agents
+                </Link>
+              </nav>
+            )}
+          </>
+        )}
         {search.trim() && (
           <div className="settings-search-results" aria-label="Settings search results">
             {searchResults.length === 0 ? (
@@ -501,19 +568,21 @@ export function SettingsPages({
             {errors[section]}
           </p>
         )}
-        {(settingsQuery.isError || appsQuery.isError) && (formPage || section === 'apps') && (
-          <p role="alert" className="settings-error">
-            Could not load settings.{' '}
-            <button
-              onClick={() => {
-                void settingsQuery.refetch()
-                void appsQuery.refetch()
-              }}
-            >
-              Try again
-            </button>
-          </p>
-        )}
+        {appName && appsQuery.isPending && <p role="status">Loading app settings…</p>}
+        {(settingsQuery.isError || appsQuery.isError) &&
+          (appName || formPage || section === 'apps') && (
+            <p role="alert" className="settings-error">
+              Could not load settings.{' '}
+              <button
+                onClick={() => {
+                  void settingsQuery.refetch()
+                  void appsQuery.refetch()
+                }}
+              >
+                Try again
+              </button>
+            </p>
+          )}
         {visited.map((page) => (
           <div key={page} hidden={page !== section} className="settings-pane">
             {page === 'general' && (
@@ -536,7 +605,7 @@ export function SettingsPages({
                   harnessColor={harnessColor}
                   catalog={catalog}
                   allowedEfforts={appsQuery.data?.allowedEfforts ?? []}
-                  onOpenApp={(name) => navigate(`/settings/apps/${name}`)}
+                  onOpenApp={(name) => navigate(`/apps/${name}/settings`)}
                   onAddProvider={() => navigate('/settings/providers')}
                   busy={saving}
                 />
@@ -594,27 +663,33 @@ export function SettingsPages({
             {page === 'skills' && <SkillsPane />}
             {page === 'browser-sessions' && <BrowserSessionsPane />}
             {page === 'api-tokens' && <AgentAccessPane />}
-            {page === 'apps' && (
+            {page === 'apps' && !search.trim() && (
               <div className="settings-app-index">
                 {apps.map((entry) => (
                   <Link
                     key={entry.name}
                     aria-label={appLabel(entry.name)}
-                    href={`/settings/apps/${entry.name}`}
+                    href={`/apps/${entry.name}/settings`}
                   >
                     <strong>{appLabel(entry.name)}</strong>
                     <span>{entry.description}</span>
                   </Link>
                 ))}
                 {appsQuery.isPending && <p role="status">Loading app settings…</p>}
+                {!appsQuery.isPending && !appsQuery.isError && apps.length === 0 && (
+                  <p>No installed app declares settings.</p>
+                )}
               </div>
             )}
             {apps
-              .filter((entry) => page === `apps/${entry.name}`)
+              .filter(
+                (entry) => validAppPage && appName === entry.name && page === `apps/${entry.name}`,
+              )
               .map((entry) => (
-                <div key={entry.name}>
+                <div key={entry.name} className="app-settings-layout">
                   <AppPane
                     app={entry}
+                    section={paneSection}
                     edits={appEdits[entry.name] ?? {}}
                     fieldErrors={appProblems[entry.name] ?? {}}
                     harnessColor={harnessColor}
@@ -678,14 +753,23 @@ export function SettingsPages({
                     }}
                     onAddProvider={() => navigate('/settings/providers')}
                   />
+                  <aside className="app-settings-owner">
+                    <h2>Owned by this app</h2>
+                    <p>These settings affect {appLabel(entry.name)}.</p>
+                    <p>Provider credentials and shared defaults remain in Settings.</p>
+                    <Link href="/settings/agents">
+                      Agent defaults <ArrowUpRight size={15} aria-hidden="true" />
+                    </Link>
+                  </aside>
                 </div>
               ))}
           </div>
         ))}
-        {!SECTIONS.some((entry) => entry.id === section) && !app && !appsQuery.isPending && (
-          <p>No settings page matches this address.</p>
-        )}
-      </main>
+        {appsQuery.isSuccess &&
+          (!validAppPage || (!SECTIONS.some((entry) => entry.id === section) && !app)) && (
+            <p>No settings page matches this address.</p>
+          )}
+      </Content>
       {formPage && (
         <footer className="settings-save-bar">
           <span role="status">{saving ? 'Saving…' : dirty ? 'Unsaved changes' : 'Saved'}</span>
@@ -716,7 +800,7 @@ export function SettingsPages({
       <dialog
         className="settings-leave-dialog"
         ref={confirmation}
-        aria-labelledby="leave-settings-title"
+        aria-labelledby={confirmationTitle}
         onCancel={(event) => {
           event.preventDefault()
           if (!saving) {
@@ -725,7 +809,7 @@ export function SettingsPages({
           }
         }}
       >
-        <h2 id="leave-settings-title">Save your changes?</h2>
+        <h2 id={confirmationTitle}>Save your changes?</h2>
         <p>
           You have unsaved changes in {dirtyPages.length} settings{' '}
           {dirtyPages.length === 1 ? 'page' : 'pages'}.

--- a/frontend/src/components/SettingsPanes.tsx
+++ b/frontend/src/components/SettingsPanes.tsx
@@ -828,6 +828,15 @@ export function ServicesPane() {
 
   return (
     <div className="set-pane mcp-pane svc-pane">
+      {query.isPending && <p role="status">Loading services…</p>}
+      {query.isError && (
+        <p className="mcp-error" role="alert">
+          Could not load services.{' '}
+          <button className="set-btn ghost" onClick={() => void query.refetch()}>
+            Try again
+          </button>
+        </p>
+      )}
       {selected ? (
         <ServiceDetail service={selected} onBack={() => setSelectedSlug(null)} />
       ) : (
@@ -1184,6 +1193,15 @@ export function ConnectionsPane() {
 
   return (
     <div className="set-pane mcp-pane svc-pane">
+      {query.isPending && <p role="status">Loading connections…</p>}
+      {query.isError && (
+        <p className="mcp-error" role="alert">
+          Could not load connections.{' '}
+          <button className="set-btn ghost" onClick={() => void query.refetch()}>
+            Try again
+          </button>
+        </p>
+      )}
       <header className="mcp-pane-head">
         <h2 className="mcp-pane-title">Connections</h2>
         <p className="mcp-pane-sub">
@@ -1195,7 +1213,9 @@ export function ConnectionsPane() {
           {error}
         </div>
       )}
-      {connections.length === 0 && <p className="mcp-pane-sub">No connections yet.</p>}
+      {query.isSuccess && connections.length === 0 && (
+        <p className="mcp-pane-sub">No connections yet.</p>
+      )}
       {connections.length > 0 && (
         <div className="set-card svc-facts">
           {live.map((connection) => (
@@ -1401,7 +1421,7 @@ export function ProvidersPane({
                 {directoryQuery.error.message}
               </p>
             )}
-            {!directoryQuery.isLoading && candidates.length === 0 && (
+            {directoryQuery.isSuccess && candidates.length === 0 && (
               <p className="provider-state">No supported provider matches this search.</p>
             )}
           </div>
@@ -1417,7 +1437,7 @@ export function ProvidersPane({
           {requestError}
         </div>
       )}
-      {!loading && configured.length === 0 && (
+      {!loading && !requestError && configured.length === 0 && (
         <div className="provider-empty">
           <strong>No provider is configured.</strong>
           <span>Add one to make models available to agents.</span>
@@ -1838,6 +1858,15 @@ export function SkillsPane() {
 
   return (
     <div className="set-pane mcp-pane skills-pane">
+      {collectionsQuery.isPending && <p role="status">Loading skill collections…</p>}
+      {collectionsQuery.isError && (
+        <p className="mcp-error" role="alert">
+          Could not load skill collections.{' '}
+          <button className="set-btn ghost" onClick={() => void collectionsQuery.refetch()}>
+            Try again
+          </button>
+        </p>
+      )}
       <header className="mcp-pane-head">
         <p className="mcp-pane-sub">
           Import skill collections from GitHub. Enabled skills are available to agents in every
@@ -1891,7 +1920,7 @@ export function SkillsPane() {
         <h3 className="mcp-h">
           Collections <span className="gl-count">{collections.length}</span>
         </h3>
-        {collections.length === 0 && (
+        {collectionsQuery.isSuccess && collections.length === 0 && (
           <p className="mcp-help">No collections yet — import one above.</p>
         )}
         {collections.length > 0 && (
@@ -1992,7 +2021,7 @@ function CollectionCard({
                   on={skill.enabled}
                   onClick={() => void onToggle(collection.id, skill.name, !skill.enabled)}
                   disabled={busy}
-                  label={`Enable ${skill.name} skill`}
+                  label={`Enabled: ${skill.name} skill`}
                 />
                 <label htmlFor={`${switchId}-${skill.name}`}>Enabled</label>
               </span>
@@ -2162,6 +2191,15 @@ export function McpServersPane() {
 
   return (
     <div className="set-pane mcp-pane">
+      {serversQuery.isPending && <p role="status">Loading MCP servers…</p>}
+      {serversQuery.isError && (
+        <p className="mcp-error" role="alert">
+          Could not load MCP servers.{' '}
+          <button className="set-btn ghost" onClick={() => void serversQuery.refetch()}>
+            Try again
+          </button>
+        </p>
+      )}
       <header className="mcp-pane-head">
         <p className="mcp-pane-sub">
           Tools your agents can call. Enabled servers are carried into every sandbox VM; secrets
@@ -2561,6 +2599,15 @@ export function AgentAccessPane() {
 
   return (
     <div className="set-pane">
+      {patsQuery.isPending && <p role="status">Loading API tokens…</p>}
+      {patsQuery.isError && (
+        <p className="mcp-error" role="alert">
+          Could not load API tokens.{' '}
+          <button className="set-btn ghost" onClick={() => void patsQuery.refetch()}>
+            Try again
+          </button>
+        </p>
+      )}
       <div className="set-pane-head">
         <div className="set-pane-sub">
           Give an agent, script, or CLI a token to call druks as you — same account and permissions,
@@ -2674,6 +2721,7 @@ function PatRow({
 
 export function AppPane({
   app,
+  section,
   edits,
   fieldErrors,
   harnessByName,
@@ -2692,6 +2740,7 @@ export function AppPane({
   busy,
 }: {
   app: AppSettings
+  section: string
   edits: UpdateAppsSettingsRequest
   fieldErrors: Record<string, string>
   harnessByName: Record<string, Harness>
@@ -2757,9 +2806,7 @@ export function AppPane({
       ? onWorkflowField(option.kind, option.field.name, value)
       : onAppSetting(option.kind, option.field.name, value)
   // The control speaks strings; the override store keeps the declared type.
-  // Clearing a secret's box records no edit, so the stored secret stays. An integer
-  // mid-edit that does not parse records nothing, so the box can be emptied and
-  // retyped without writing a bad value.
+  // Clearing a secret's box leaves its stored value unchanged.
   const setTypedOption = (option: (typeof optionFields)[number], next: string) => {
     if (option.field.type === 'secret') return setOption(option, next || undefined)
     if (option.field.type !== 'int') return setOption(option, next)
@@ -2768,14 +2815,7 @@ export function AppPane({
   }
   return (
     <div className="set-pane">
-      <div className="set-pane-head">
-        <div className="set-pane-sub">
-          {app.description ||
-            'Each stage runs as its own agent — set the defaults once under Agents, override only where it matters.'}
-        </div>
-      </div>
-
-      {optionFields.length > 0 && (
+      {section === 'options' && optionFields.length > 0 && (
         <div className="set-group">
           <div className="set-group-label">{appLabel(app.name)} options</div>
           {sectionLabels
@@ -2820,7 +2860,7 @@ export function AppPane({
                     </div>
                   )}
                   {otherFields.length > 0 && (
-                    <div className="set-field-row" style={{ maxWidth: 440 }}>
+                    <div className="set-field-row">
                       {otherFields.map((option) => {
                         const override = optionEdit(option)
                         const currentValue = optionValue(option)
@@ -2859,7 +2899,7 @@ export function AppPane({
         </div>
       )}
 
-      {app.agents.length > 0 && defaults && (
+      {section === 'agents' && app.agents.length > 0 && defaults && (
         <div className="set-group">
           <div className="set-group-label">agents</div>
           <AgentTable

--- a/frontend/src/components/settings.ts
+++ b/frontend/src/components/settings.ts
@@ -103,3 +103,8 @@ export function isFieldVisible(
   const current = edit !== undefined ? edit : controller.value
   return String(current) === String(field.visibleWhenValue)
 }
+
+export interface UnsavedForm {
+  path: string
+  confirm: (proceed: () => void) => void
+}

--- a/frontend/src/settings.css
+++ b/frontend/src/settings.css
@@ -20,7 +20,7 @@
 .settings-pane .mcp-pane > * { max-width: none; }
 .settings-pane .set-pane-sub { font-size: 15px; }
 .settings-pane .mcp-pane-title { font-size: 18px; }
-.settings-pane .mcp-pane-sub, .settings-pane .set-field-help { font-size: 13px; }
+.settings-pane .set-field-help { font-size: 13px; }
 .settings-pane :is(.set-group-label, .set-field-label, .set-thead, .agents-app, .agents-legend, .agent-name, .menu-group, .menu-opt) { font-family: var(--font-sans); letter-spacing: 0; text-transform: none; }
 .settings-pane :is(.set-group-label, .set-field-label, .agents-app, .agent-name, .menu-opt) { font-size: 15px; }
 .settings-pane :is(.set-thead, .agents-legend, .menu-group, .set-field-error) { font-size: 13px; }
@@ -99,4 +99,30 @@
   .settings-default-execution { padding: 20px; }
   .settings-default-execution .set-defaults { grid-template-columns: minmax(0, 1fr); gap: 20px; }
   .settings-pane .model-chooser-search { font-size: 16px; }
+}
+
+.app-settings { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+.app-settings .settings-page-head { margin-bottom: 8px; }
+.app-settings-description { margin: 0 0 24px; color: var(--text-mid); }
+.settings-tabs a { display: flex; align-items: center; min-height: 44px; color: var(--text-dim); text-decoration: none; border-bottom: 2px solid transparent; }
+.settings-tabs a[aria-current="page"] { color: var(--text); border-color: var(--bucket-run); }
+.app-settings-layout { display: grid; grid-template-columns: minmax(0, 880px) 220px; gap: 28px; }
+.app-settings-layout > .set-pane { min-width: 0; padding: 0; }
+.app-settings-layout .set-group { padding: 24px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); }
+.app-settings-layout .set-group-label { font-size: 18px; margin-bottom: 20px; }
+.app-settings-layout .set-field-row { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 24px; }
+.app-settings-layout .set-field { min-width: 0; }
+.app-settings-owner { padding-left: 20px; border-left: 1px solid var(--border); color: var(--text-mid); font-size: 13px; line-height: 1.5; }
+.app-settings-owner h2 { margin: 0 0 8px; color: var(--text); font-size: 15px; font-weight: 500; }
+.app-settings-owner p { margin: 0 0 16px; }
+.app-settings-owner a { display: inline-flex; align-items: center; gap: 6px; color: var(--text); font-size: 15px; text-decoration: none; }
+.app-settings-owner a:hover { text-decoration: underline; }
+.app-settings .set-app-toggles { margin-bottom: 24px; }
+@media (max-width: 1100px) {
+  .app-settings-layout { grid-template-columns: minmax(0, 1fr); }
+  .app-settings-owner { padding: 0; border: 0; }
+}
+@media (max-width: 649px) {
+  .app-settings-layout .set-group { padding: 20px; }
+  .app-settings-layout .set-field-row { grid-template-columns: minmax(0, 1fr); gap: 20px; }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,19 +3,10 @@ import react from '@vitejs/plugin-react'
 import { fileURLToPath } from 'node:url'
 
 // Repo-root dist/, where the backend serves the SPA from (app.frontend).
-const repoDist = fileURLToPath(
-  new URL('../dist/', import.meta.url),
-)
+const repoDist = fileURLToPath(new URL('../dist/', import.meta.url))
 
-// The modules the shell shares with installed dist apps, mapped to the
-// /src/runtime/* re-export shim that serves each. An app's bundle externalizes
-// these bare specifiers; this import map resolves them to the shims, so one
-// React instance — and one copy of the shell's components — serves the whole
-// document. In a build the shims are extra entries — hashed like any asset,
-// with their shared code in the common chunks — and the import map (regenerated
-// into index.html per build) carries the hashed names. In dev the Vite server
-// serves the shim sources directly. Values carry their extension: the React
-// shims are .js, @druks/ui is .ts because it re-exports .tsx.
+// Installed app bundles share the shell's React instance and UI components.
+// Production import maps resolve to fingerprinted entries.
 const SHARED_MODULES: Record<string, string> = {
   react: 'react.js',
   'react-dom': 'react-dom.js',
@@ -25,11 +16,9 @@ const SHARED_MODULES: Record<string, string> = {
 }
 
 const shimUrl = (file: string) => new URL(`./src/runtime/${file}`, import.meta.url)
-// The rollup entry name for a shim, and what transformIndexHtml matches on.
 const shimEntry = (file: string) => `runtime-${file.replace(/\.[jt]s$/, '')}`
 
-// Bundled apps import '@druks/ui' as an installed app does, so breaking
-// the lent surface reddens the shell's own build first. Exported for vitest.
+// Bundled apps exercise the same UI contract as separately installed apps.
 export const shellAlias = {
   '@druks/ui': fileURLToPath(shimUrl(SHARED_MODULES['@druks/ui']!)),
 }
@@ -37,11 +26,11 @@ export const shellAlias = {
 function shellImportMap(): Plugin {
   return {
     name: 'druks-shell-import-map',
-    transformIndexHtml(_html, ctx) {
+    transformIndexHtml(_html, context) {
       const entryFile = (file: string): string => {
-        if (!ctx.bundle) return `/src/runtime/${file}`
-        const chunk = Object.values(ctx.bundle).find(
-          (out) => out.type === 'chunk' && out.isEntry && out.name === shimEntry(file),
+        if (!context.bundle) return `/src/runtime/${file}`
+        const chunk = Object.values(context.bundle).find(
+          (output) => output.type === 'chunk' && output.isEntry && output.name === shimEntry(file),
         )
         if (!chunk) throw new Error(`runtime shim ${file} missing from the bundle`)
         return `/${chunk.fileName}`
@@ -61,20 +50,18 @@ function shellImportMap(): Plugin {
   }
 }
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), shellImportMap()],
   resolve: { alias: shellAlias },
   server: {
     port: 5173,
     proxy: {
-      // FastAPI serves the API (and installed app dists under /app);
-      // Vite proxies during dev so the SPA can hit both same-origin.
       '/api': {
         target: 'http://127.0.0.1:8001',
         changeOrigin: true,
       },
-      '/app': {
+      // Match /app/ exactly so shared routes under /apps/ stay in Vite.
+      '/app/': {
         target: 'http://127.0.0.1:8001',
         changeOrigin: true,
       },
@@ -84,8 +71,7 @@ export default defineConfig({
     outDir: repoDist,
     emptyOutDir: true,
     rollupOptions: {
-      // The runtime shims are entries whose exports ARE the product — without
-      // this, tree-shaking strips them down to bare side-effect imports.
+      // Installed apps import these exports, so tree-shaking must retain them.
       preserveEntrySignatures: 'exports-only',
       input: {
         main: fileURLToPath(new URL('./index.html', import.meta.url)),
@@ -97,32 +83,23 @@ export default defineConfig({
         ),
       },
       output: {
-        // Split rarely-changing vendor code out of the main app chunk
-        // so re-deploys (which mostly touch app code) don't bust the
-        // operator's cache for these. Also keeps the main bundle
-        // under the 500 KB warning threshold without raising the
-        // limit, which would just hide the signal.
-        //
-        // Markdown rendering is its own chunk because react-markdown
-        // + remark-gfm + their micromark deps pull in a sizable
-        // tokenizer that only a few detail pages actually need.
-        //
-        // Vite 8 / rolldown took the static-map form of ``manualChunks``
-        // away; the function form below is the supported equivalent.
+        // Vendor chunks retain their cache when app code changes.
+        // Markdown loads only on detail pages that need its tokenizer.
         manualChunks(id: string): string | undefined {
-          if (id.includes('node_modules/react-markdown') ||
-              id.includes('node_modules/remark-') ||
-              id.includes('node_modules/micromark') ||
-              id.includes('node_modules/mdast-') ||
-              id.includes('node_modules/unist-') ||
-              id.includes('node_modules/hast-')) {
+          if (
+            id.includes('node_modules/react-markdown') ||
+            id.includes('node_modules/remark-') ||
+            id.includes('node_modules/micromark') ||
+            id.includes('node_modules/mdast-') ||
+            id.includes('node_modules/unist-') ||
+            id.includes('node_modules/hast-')
+          ) {
             return 'markdown-vendor'
           }
           if (id.includes('node_modules/@tanstack/react-query')) {
             return 'query-vendor'
           }
-          if (id.includes('node_modules/react') ||
-              id.includes('node_modules/scheduler')) {
+          if (id.includes('node_modules/react') || id.includes('node_modules/scheduler')) {
             return 'react-vendor'
           }
           return undefined


### PR DESCRIPTION
App settings now open beside the app's pages at one canonical URL, shared by app navigation and the searchable settings index. Options and Agents retain one app draft with Save, Discard, and Stay; schema validation, secret redaction, inheritance, and schedule overrides remain intact.

Validation: frontend lint, 314 tests, and build passed. Browser checks covered 1440/1024/390 px, direct links, native Back, app drafts, Software Factory inheritance, proof-app validation and secrets, and a local schedule's pause, cadence, resume, and real ticks. Read-error retries and custom-cron Discard have regression tests.
Stack: based on https://github.com/czpython/druks/pull/442.
External provider login and service authorization were not exercised.
