### PR TITLE
DRU-447 Clarify provider access and Connections pages

### DIFF
--- a/frontend/src/components/BrowserSessionsPane.test.tsx
+++ b/frontend/src/components/BrowserSessionsPane.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { BrowserSession } from '../api/types'
+import { api } from '../api/client'
 import { BrowserSessionsPane } from './BrowserSessionsPane'
 
 function browserSession(overrides: Partial<BrowserSession> = {}): BrowserSession {
@@ -51,9 +52,19 @@ afterEach(() => {
   cleanup()
   vi.unstubAllGlobals()
   vi.unstubAllEnvs()
+  vi.restoreAllMocks()
 })
 
 describe('BrowserSessionsPane', () => {
+  it('shows a failed read without a false empty state and retries', async () => {
+    vi.spyOn(api, 'browserSessions').mockRejectedValueOnce(new Error('unavailable')).mockResolvedValueOnce([])
+    renderPane()
+    expect(screen.getByRole('status').textContent).toBe('Loading browser sessions…')
+    expect(await screen.findByRole('alert')).toHaveProperty('textContent', 'Could not load browser sessions. Try again')
+    expect(screen.queryByText('No installed app declares a browser session.')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+    expect(await screen.findByText('No installed app declares a browser session.')).toBeTruthy()
+  })
   it('lists status, base-aware login actions, and refresh timestamps', async () => {
     vi.stubEnv('BASE_URL', '/druks/')
     stubFetch([

--- a/frontend/src/components/BrowserSessionsPane.tsx
+++ b/frontend/src/components/BrowserSessionsPane.tsx
@@ -21,7 +21,6 @@ const FORMAT_LABELS: Record<BrowserSessionPayloadFormat, string> = {
   profile_dir: 'Profile directory',
 }
 
-/* An anonymous session has no login action at all. */
 const LOGIN_ACTION_LABELS: Record<Exclude<BrowserSessionStatus, 'anonymous'>, string> = {
   needs_login: 'Log in',
   ready: 'Open window',
@@ -64,9 +63,18 @@ export function BrowserSessionsPane() {
         </p>
       </header>
 
-      {(error ?? (query.error instanceof Error ? query.error.message : null)) && (
+      {query.isPending && <p role="status">Loading browser sessions…</p>}
+      {query.isError && (
+        <p className="mcp-error" role="alert">
+          Could not load browser sessions.{' '}
+          <button className="set-btn ghost" onClick={() => void query.refetch()}>
+            Try again
+          </button>
+        </p>
+      )}
+      {error && (
         <div className="mcp-error" role="alert">
-          {error ?? (query.error instanceof Error ? query.error.message : '')}
+          {error}
         </div>
       )}
 
@@ -74,7 +82,7 @@ export function BrowserSessionsPane() {
         <h3 className="mcp-h">
           Sessions <span className="gl-count">{sessions.length}</span>
         </h3>
-        {!query.isLoading && sessions.length === 0 && (
+        {query.isSuccess && sessions.length === 0 && (
           <p className="mcp-help">No installed app declares a browser session.</p>
         )}
         {sessions.length > 0 && (
@@ -104,7 +112,6 @@ export function BrowserSessionsPane() {
                 <div className="browser-session-actions">
                   {session.isDeclared ? (
                     session.status !== 'anonymous' && (
-                      /* A full load dismisses Settings before the login window mounts. */
                       <a
                         className="set-btn primary"
                         href={`${import.meta.env.BASE_URL}browser-sessions/${encodeURIComponent(session.name)}/login`}

--- a/frontend/src/components/ProviderConnect.test.tsx
+++ b/frontend/src/components/ProviderConnect.test.tsx
@@ -151,7 +151,7 @@ describe('ProviderConnect', () => {
     expect(screen.queryByText('Remove API key')).toBeNull()
   })
 
-  it('shows only the general weekly quota and keeps reset times relative', () => {
+  it('shows each quota window and keeps reset times relative', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-09-05T10:00:00Z'))
     renderCard(provider(), {
@@ -184,10 +184,10 @@ describe('ProviderConnect', () => {
 
     expect(screen.getAllByText('Weekly')).toHaveLength(1)
     expect(screen.getByLabelText('83% remaining').textContent).toBe('83% left')
-    expect(screen.queryByLabelText('69% remaining')).toBeNull()
-    expect(screen.queryByLabelText('50% remaining')).toBeNull()
-    expect(screen.queryByText('Fable')).toBeNull()
-    expect(screen.queryByText('GPT reserve')).toBeNull()
+    expect(screen.getByLabelText('69% remaining').textContent).toBe('69% left')
+    expect(screen.getByLabelText('50% remaining').textContent).toBe('50% left')
+    expect(screen.getByText('Weekly · Fable')).toBeTruthy()
+    expect(screen.getByText('Weekly · GPT reserve')).toBeTruthy()
     expect(screen.getByText('Resets in 6d')).toBeTruthy()
     expect(screen.getByText('Resets in 2h').getAttribute('dateTime')).toBe('2026-09-05T12:00:00Z')
     expect(screen.getByText('Resets in 2h').getAttribute('title')).toBeTruthy()
@@ -243,7 +243,7 @@ describe('ProviderConnect', () => {
     expect(screen.queryByRole('button', { name: /Sign in/ })).toBeNull()
   })
 
-  it('drives the connection flow end to end and refreshes only the providers query', async () => {
+  it('drives the connection flow and refreshes credentials, models, and usage', async () => {
     const responses: Record<string, unknown> = {
       '/api/providers/anthropic/connection/start': {
         authorizeUrl: 'https://x/auth',
@@ -283,10 +283,12 @@ describe('ProviderConnect', () => {
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: ['providerSubscriptions'],
     })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['providerCatalogs'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['usage'] })
     expect(fetchMock.mock.calls.some(([url]) => String(url) === '/api/auth/me')).toBe(false)
   })
 
-  it('posts a pasted API key and refreshes the keys query', async () => {
+  it('posts a pasted API key and refreshes keys and model choices', async () => {
     const fetchMock = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(
       async (url) =>
         new Response(JSON.stringify(url.endsWith('/key') ? sharedKey : {}), {
@@ -309,6 +311,7 @@ describe('ProviderConnect', () => {
       key: 'the-api-key',
     })
     expect(invalidate).toHaveBeenCalledWith({ queryKey: ['providerKeys'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['providerCatalogs'] })
   })
 
   it('removing the key deletes it, never the subscription', async () => {

--- a/frontend/src/components/ResourcePages.test.tsx
+++ b/frontend/src/components/ResourcePages.test.tsx
@@ -1,0 +1,213 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from '../api/client'
+import type { Connection, Provider, UsageProviderSummary } from '../api/types'
+import { ConnectionsPane, ProvidersPane } from './SettingsPanes'
+
+const provider: Provider = {
+  id: 'anthropic',
+  label: 'Anthropic',
+  billingOptions: ['subscription', 'api_key'],
+}
+
+const usage: UsageProviderSummary = {
+  id: 'anthropic',
+  label: 'Anthropic',
+  available: true,
+  connected: true,
+  providerEmail: 'seat@example.invalid',
+  planTier: 'Subscription plan',
+  fiveHour: { percentLeft: 82, resetsAt: null, model: null },
+  weeks: [{ percentLeft: 41, resetsAt: '2099-09-05T12:00:00Z', model: null }],
+  unlimited: false,
+  scrapedAt: '2026-09-05T08:00:00Z',
+  ageSeconds: 3600,
+  stale: true,
+  error: null,
+  rawOutput: null,
+}
+
+function renderProviders(snapshot: UsageProviderSummary = usage) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  vi.spyOn(api, 'usage').mockResolvedValue({ providers: [snapshot] })
+  vi.spyOn(api, 'usageToday').mockResolvedValue({
+    day: '2026-09-05',
+    timezone: 'UTC',
+    providers: [],
+  })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ProvidersPane
+        providers={[provider]}
+        registeredProviders={[provider]}
+        subscriptions={[
+          {
+            provider: provider.id,
+            providerEmail: 'seat@example.invalid',
+            connected: true,
+            expiresAt: null,
+            updatedAt: '2026-09-05T08:00:00Z',
+          },
+        ]}
+        keys={[]}
+        catalogs={[
+          {
+            provider: provider.id,
+            label: provider.label,
+            models: [
+              { id: 'anthropic/long-model', label: 'A long model name for a specific capability' },
+            ],
+            fetchedAt: '2026-09-05T08:00:00Z',
+          },
+        ]}
+        loading={false}
+        requestError={null}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('Provider resource rows', () => {
+  it('shows access, remaining quota, reset and freshness before Manage', async () => {
+    renderProviders()
+    expect(await screen.findByText(/Usage stale/)).toBeTruthy()
+    expect(screen.getByText('Subscription connected')).toBeTruthy()
+    expect(
+      screen.getAllByLabelText('41% remaining').filter((element) => !element.closest('[hidden]')),
+    ).toHaveLength(1)
+    expect(screen.queryByRole('button', { name: 'Add API key' })).toBeNull()
+    expect(screen.queryByRole('alert')).toBeNull()
+    const summary = screen
+      .getByRole('article', { name: 'Anthropic' })
+      .querySelector('.provider-summary')!
+    expect(summary.textContent).toContain('Resets in')
+    expect(summary.textContent).not.toContain('Not configured')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Manage Anthropic' }))
+    expect(screen.getByRole('region', { name: 'Anthropic subscription' })).toBeTruthy()
+    expect(screen.getByRole('region', { name: 'Anthropic API key' })).toBeTruthy()
+    expect(screen.getByText(/1 model · Catalog fetched/)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Add API key' })).toBeTruthy()
+  })
+
+  it('keeps unsubmitted credentials when Manage is closed and reopened', async () => {
+    renderProviders()
+    fireEvent.click(screen.getByRole('button', { name: 'Manage Anthropic' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add API key' }))
+    fireEvent.change(screen.getByLabelText('API key'), {
+      target: { value: 'local-unsubmitted-test' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Close Anthropic' }))
+    expect(screen.queryByRole('form', { name: 'Anthropic API key' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Manage Anthropic' }))
+    expect((screen.getByLabelText('API key') as HTMLInputElement).value).toBe(
+      'local-unsubmitted-test',
+    )
+    await screen.findByText(/Usage stale/)
+  })
+
+  it('shows unmetered quota without percentage bars', async () => {
+    renderProviders({ ...usage, unlimited: true })
+    await screen.findAllByText('Quota: unmetered')
+    expect(screen.queryByLabelText('41% remaining')).toBeNull()
+    expect(screen.queryByLabelText('82% remaining')).toBeNull()
+  })
+
+  it('reports unavailable quota and a failed refresh without claiming no providers', async () => {
+    renderProviders({ ...usage, weeks: [], fiveHour: null, error: 'timeout' })
+    expect(await screen.findByText('Usage refresh failed.')).toBeTruthy()
+    expect(screen.getByText('Weekly quota unavailable')).toBeTruthy()
+    expect(screen.queryByText('No provider is configured.')).toBeNull()
+  })
+})
+
+describe('Account grant groups', () => {
+  const account: Connection = {
+    id: 'account-1',
+    provider: 'gmail',
+    scopes: ['read'],
+    identity: { email: 'mailbox@example.invalid' },
+    connectedAt: '2026-09-05T08:00:00Z',
+    revokedAt: null,
+    revokedReason: '',
+  }
+
+  function renderAccounts() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={queryClient}>
+        <section aria-label="Current accounts">
+          <ConnectionsPane />
+        </section>
+        <section aria-label="Grant history">
+          <ConnectionsPane revokedOnly />
+        </section>
+      </QueryClientProvider>,
+    )
+  }
+
+  it('keeps live grants and revoked history separate and names the confirmed account', async () => {
+    let accounts = [
+      account,
+      {
+        ...account,
+        id: 'account-2',
+        identity: { email: 'old@example.invalid' },
+        revokedAt: '2026-09-05T09:00:00Z',
+        revokedReason: 'user',
+      },
+    ]
+    vi.spyOn(api, 'listConnections').mockImplementation(async () => accounts)
+    const disconnect = vi.spyOn(api, 'disconnectConnection').mockImplementation(async (id) => {
+      accounts = accounts.map((entry) =>
+        entry.id === id
+          ? { ...entry, revokedAt: '2026-09-05T10:00:00Z', revokedReason: 'user' }
+          : entry,
+      )
+    })
+    const confirm = vi.fn(() => false)
+    vi.stubGlobal('confirm', confirm)
+    renderAccounts()
+    const current = within(screen.getByRole('region', { name: 'Current accounts' }))
+    const history = within(screen.getByRole('region', { name: 'Grant history' }))
+    await current.findByText(/mailbox@example.invalid/)
+    expect(current.queryByText(/old@example.invalid/)).toBeNull()
+    expect(history.getByText(/old@example.invalid/)).toBeTruthy()
+    expect(history.queryByRole('button', { name: 'Disconnect' })).toBeNull()
+    fireEvent.click(current.getByRole('button', { name: 'Disconnect' }))
+    expect(confirm).toHaveBeenCalledWith(
+      'Disconnect mailbox@example.invalid from gmail? Its access will be revoked.',
+    )
+    expect(disconnect).not.toHaveBeenCalled()
+    confirm.mockReturnValue(true)
+    fireEvent.click(current.getByRole('button', { name: 'Disconnect' }))
+    await waitFor(() => expect(disconnect).toHaveBeenCalledWith('account-1'))
+    expect(await current.findByText('No connected accounts.')).toBeTruthy()
+    expect(history.getByText(/mailbox@example.invalid/)).toBeTruthy()
+    expect(current.getByRole('status').textContent).toContain('disconnected')
+  })
+
+  it('retains the grant when disconnect fails and permits retry', async () => {
+    vi.spyOn(api, 'listConnections').mockResolvedValue([account])
+    vi.spyOn(api, 'disconnectConnection').mockRejectedValue(new Error('Access service unavailable'))
+    vi.stubGlobal('confirm', () => true)
+    renderAccounts()
+    fireEvent.click(await screen.findByRole('button', { name: 'Disconnect' }))
+    expect(await screen.findByRole('alert')).toHaveProperty(
+      'textContent',
+      'Access service unavailable',
+    )
+    expect((screen.getByRole('button', { name: 'Disconnect' }) as HTMLButtonElement).disabled).toBe(
+      false,
+    )
+    expect(screen.getByText(/mailbox@example.invalid/)).toBeTruthy()
+  })
+})

--- a/frontend/src/components/SettingsPages.test.tsx
+++ b/frontend/src/components/SettingsPages.test.tsx
@@ -275,9 +275,10 @@ function stubFetch(
       private_key: 'Required once the review App ID is set.',
     },
   },
+  initialApps: AppsSettingsResponse = appSettings,
 ) {
   let savedSettings = { ...userSettings }
-  const savedApps = structuredClone(appSettings)
+  const savedApps = structuredClone(initialApps)
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
@@ -1101,6 +1102,135 @@ describe('canonical app settings', () => {
 })
 
 describe('settings resource read failures', () => {
+  it('uses a newly saved directory catalog in Agent defaults without remounting Settings', async () => {
+    stubFetch(false)
+    const originalFetch = fetch
+    let keySaved = false
+    const key = {
+      provider: 'cerebras',
+      keyTail: 'test',
+      updatedBy: { id: 'acc-1', username: 'test@example.invalid' },
+      updatedAt: '2026-09-05T08:00:00Z',
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const path = String(input)
+        if (path === '/api/providers/cerebras/key' && init?.method === 'POST') {
+          keySaved = true
+          return new Response(JSON.stringify(key), { status: 200 })
+        }
+        if (keySaved && path === '/api/providers/keys')
+          return new Response(JSON.stringify([key]), { status: 200 })
+        if (keySaved && path === '/api/providers/catalogs')
+          return new Response(
+            JSON.stringify([
+              ...providerCatalogs,
+              {
+                provider: 'cerebras',
+                label: 'Cerebras',
+                fetchedAt: '2026-09-05T09:00:00Z',
+                models: [{ id: 'cerebras/gpt-oss-120b', label: 'GPT OSS 120B' }],
+              },
+            ]),
+            { status: 200 },
+          )
+        return originalFetch(input, init)
+      }),
+    )
+    renderSettings('/settings/providers')
+    fireEvent.click(await screen.findByRole('button', { name: 'Add provider' }))
+    fireEvent.change(screen.getByLabelText('Add provider'), { target: { value: 'cerebras' } })
+    fireEvent.click(await screen.findByRole('button', { name: /^Cerebras/ }))
+    const resource = within(screen.getByRole('article', { name: 'Cerebras' }))
+    fireEvent.click(resource.getByRole('button', { name: 'Add API key' }))
+    fireEvent.change(resource.getByLabelText('API key'), { target: { value: 'local-test-key' } })
+    fireEvent.click(resource.getByRole('button', { name: 'Save' }))
+    await resource.findByText(/1 model · Catalog fetched/)
+    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    fireEvent.change(await screen.findByLabelText('Harness'), { target: { value: 'opencode' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Model' }))
+    expect((await screen.findByRole('option', { name: /GPT OSS 120B/ }) as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('lets an app integer be cleared, replaced, and saved as an integer', async () => {
+    const settings = structuredClone(appSettings)
+    const field = settings.apps.find((app) => app.name === 'field_notes')!.settings[0]!
+    Object.assign(field, {
+      name: 'board_size',
+      label: 'Board size',
+      type: 'int',
+      value: 50,
+      default: 50,
+    })
+    stubFetch(false, {}, settings)
+    renderSettings('/apps/field_notes/settings')
+    const input = (await screen.findByLabelText('Board size')) as HTMLInputElement
+    fireEvent.change(input, { target: { value: '' } })
+    expect(input.value).toBe('')
+    fireEvent.change(input, { target: { value: '53' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+    await waitFor(() => expect(screen.getByText('Saved')).toBeTruthy())
+    const request = vi
+      .mocked(fetch)
+      .mock.calls.find(
+        ([url, init]) => String(url) === '/api/settings/apps' && init?.method === 'PATCH',
+      )!
+    expect(JSON.parse(String(request[1]!.body))).toEqual({
+      appSettings: { field_notes: { board_size: 53 } },
+      workflowSettings: {},
+    })
+    expect(input.value).toBe('53')
+  })
+
+  it.each([
+    'providerCatalogs',
+    'providerSubscriptions',
+    'providerKeys',
+    'providers',
+    'harnesses',
+    'accounts',
+    'agents',
+  ] as const)(
+    'shows a failed %s read on Agent defaults and retries without false choices',
+    async (method) => {
+      stubFetch(false)
+      const original = api[method]
+      const request = vi
+        .spyOn(api, method)
+        .mockRejectedValueOnce(new Error('Offline'))
+        .mockImplementation(original)
+      renderSettings('/settings/agents')
+      const alert = await screen.findByRole('alert')
+      expect(alert.textContent).toContain('Could not load agent configuration.')
+      expect(screen.queryByText(/Choose a model with a connected credential/)).toBeNull()
+      expect(screen.queryByLabelText('Unattended runs use')).toBeNull()
+      fireEvent.click(within(alert).getByRole('button', { name: 'Try again' }))
+      await screen.findByText('Default execution')
+      expect(screen.queryByRole('alert')).toBeNull()
+      expect(request).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it('gates app Agents on failed model reads and retains its Options draft', async () => {
+    stubFetch(false)
+    vi.spyOn(api, 'providerCatalogs').mockRejectedValue(new Error('Offline'))
+    renderSettings('/apps/software_factory/settings')
+    fireEvent.change(await screen.findByLabelText('Linear trigger status'), {
+      target: { value: 'Draft Queue' },
+    })
+    fireEvent.click(screen.getByRole('link', { name: 'Agents' }))
+    expect(await screen.findByRole('alert')).toHaveProperty(
+      'textContent',
+      'Could not load agent configuration. Try again',
+    )
+    expect(screen.queryByText('coder')).toBeNull()
+    fireEvent.click(screen.getByRole('link', { name: 'Options' }))
+    expect((screen.getByLabelText('Linear trigger status') as HTMLInputElement).value).toBe(
+      'Draft Queue',
+    )
+  })
+
   it.each([
     ['connections', 'services', 'services'],
     ['connections', 'listConnections', 'connections'],
@@ -1121,9 +1251,10 @@ describe('settings resource read failures', () => {
       }
       const alert = await screen.findByRole('alert')
       expect(alert.textContent).toContain(`Could not load ${label}.`)
-      if (method === 'listConnections') expect(screen.queryByText('No connections yet.')).toBeNull()
+      if (method === 'listConnections')
+        expect(screen.queryByText('No connected accounts.')).toBeNull()
       if (method === 'skillCollections')
-        expect(screen.queryByText('No collections yet — import one above.')).toBeNull()
+        expect(screen.queryByText('No collections yet. Import one below.')).toBeNull()
       fireEvent.click(within(alert).getByRole('button', { name: 'Try again' }))
       await waitFor(() => expect(screen.queryByRole('alert')).toBeNull())
       expect(request).toHaveBeenCalledTimes(2)

--- a/frontend/src/components/SettingsPages.tsx
+++ b/frontend/src/components/SettingsPages.tsx
@@ -126,6 +126,18 @@ export function SettingsPages({
   })
   const keysQuery = useQuery({ queryKey: ['providerKeys'], queryFn: api.providerKeys })
   const catalogsQuery = useQuery({ queryKey: ['providerCatalogs'], queryFn: api.providerCatalogs })
+  const executionQueries = [
+    settingsQuery,
+    appsQuery,
+    harnessesQuery,
+    providersQuery,
+    subscriptionsQuery,
+    keysQuery,
+    catalogsQuery,
+    ...(!appName ? [agentsQuery, accountsQuery] : []),
+  ]
+  const executionReady = executionQueries.every((query) => query.isSuccess)
+  const executionFailed = executionQueries.some((query) => query.isError)
   const apps = (appsQuery.data?.apps ?? []).filter(
     (entry) =>
       entry.settings.length > 0 ||
@@ -200,6 +212,7 @@ export function SettingsPages({
     app && (app.settings.length || app.workflows.some((workflow) => workflow.fields.length)),
   )
   const paneSection = app?.agents.length && !hasOptions ? 'agents' : appTab
+  const executionPage = section === 'agents' || Boolean(appName && paneSection === 'agents')
   const Content = appName ? 'section' : 'main'
   const title =
     SECTIONS.find((entry) => entry.id === section)?.label ?? (app ? appLabel(app.name) : 'Settings')
@@ -569,7 +582,23 @@ export function SettingsPages({
           </p>
         )}
         {appName && appsQuery.isPending && <p role="status">Loading app settings…</p>}
+        {executionPage && !executionReady &&
+          (executionFailed ? (
+            <p role="alert" className="settings-error">
+              Could not load agent configuration.{' '}
+              <button
+                onClick={() => {
+                  for (const query of executionQueries) if (query.isError) void query.refetch()
+                }}
+              >
+                Try again
+              </button>
+            </p>
+          ) : (
+            <p role="status">Loading agent configuration…</p>
+          ))}
         {(settingsQuery.isError || appsQuery.isError) &&
+          !executionPage &&
           (appName || formPage || section === 'apps') && (
             <p role="alert" className="settings-error">
               Could not load settings.{' '}
@@ -591,27 +620,24 @@ export function SettingsPages({
                 setTimezone={setTimezone}
                 timezones={timezones}
                 clock={clock}
-                busy={saving || settingsQuery.isPending}
+                busy={saving || !settingsQuery.isSuccess}
               />
             )}
-            {page === 'agents' &&
-              (effectiveDefaults ? (
-                <AgentsPane
-                  defaults={effectiveDefaults}
-                  onDefaults={setDefaults}
-                  accounts={accountsQuery.data ?? []}
-                  resolved={agentsQuery.data ?? { apps: [] }}
-                  harnessByName={harnessByName}
-                  harnessColor={harnessColor}
-                  catalog={catalog}
-                  allowedEfforts={appsQuery.data?.allowedEfforts ?? []}
-                  onOpenApp={(name) => navigate(`/apps/${name}/settings`)}
-                  onAddProvider={() => navigate('/settings/providers')}
-                  busy={saving}
-                />
-              ) : (
-                <p role="status">Loading agent defaults…</p>
-              ))}
+            {page === 'agents' && executionReady && effectiveDefaults && (
+              <AgentsPane
+                defaults={effectiveDefaults}
+                onDefaults={setDefaults}
+                accounts={accountsQuery.data ?? []}
+                resolved={agentsQuery.data ?? { apps: [] }}
+                harnessByName={harnessByName}
+                harnessColor={harnessColor}
+                catalog={catalog}
+                allowedEfforts={appsQuery.data?.allowedEfforts ?? []}
+                onOpenApp={(name) => navigate(`/apps/${name}/settings`)}
+                onAddProvider={() => navigate('/settings/providers')}
+                busy={saving}
+              />
+            )}
             {page === 'providers' && (
               <ProvidersPane
                 providers={providers}
@@ -650,12 +676,21 @@ export function SettingsPages({
                   >
                     Accounts
                   </button>
+                  <button
+                    onClick={() => setConnectionsTab('revoked')}
+                    aria-current={connectionsTab === 'revoked' ? 'page' : undefined}
+                  >
+                    Revoked
+                  </button>
                 </nav>
                 <div hidden={connectionsTab !== 'services'}>
                   <ServicesPane />
                 </div>
                 <div hidden={connectionsTab !== 'accounts'}>
                   <ConnectionsPane />
+                </div>
+                <div hidden={connectionsTab !== 'revoked'}>
+                  <ConnectionsPane revokedOnly />
                 </div>
               </>
             )}
@@ -683,7 +718,9 @@ export function SettingsPages({
             )}
             {apps
               .filter(
-                (entry) => validAppPage && appName === entry.name && page === `apps/${entry.name}`,
+                (entry) =>
+                  validAppPage && appName === entry.name && page === `apps/${entry.name}` &&
+                  (paneSection !== 'agents' || executionReady),
               )
               .map((entry) => (
                 <div key={entry.name} className="app-settings-layout">

--- a/frontend/src/components/SettingsPanes.tsx
+++ b/frontend/src/components/SettingsPanes.tsx
@@ -844,7 +844,7 @@ export function ServicesPane() {
           <header className="mcp-pane-head">
             <h2 className="mcp-pane-title">Services</h2>
             <p className="mcp-pane-sub">
-              Connect the accounts druks uses to work with external services.
+              Configure the services your apps use. Manage account access in Accounts.
             </p>
           </header>
           <div className="svc-grid">
@@ -865,11 +865,8 @@ export function ServicesPane() {
                   </span>
                   <span className="svc-card-desc">{service.description}</span>
                   <span className="svc-card-foot">
-                    {identity ? (
-                      <span className="svc-card-id">{identity}</span>
-                    ) : (
-                      <span className="svc-card-cue">Configure</span>
-                    )}
+                    {identity && <span className="svc-card-id">{identity}</span>}
+                    <span className="svc-card-cue">Configure</span>
                     <span className="chev" aria-hidden="true" />
                   </span>
                 </button>
@@ -1075,11 +1072,17 @@ function ServiceAccess({ service }: { service: Service }) {
       `/api/oauth/${encodeURIComponent(service.slug)}/connect` +
         (connectionId ? `?connection=${encodeURIComponent(connectionId)}` : ''),
     )
-  const disconnect = (connectionId: string) => {
+  const disconnect = (connection: Connection) => {
+    if (
+      !window.confirm(
+        `Disconnect ${connectionIdentity(connection) ?? connection.provider} from ${service.title}?`,
+      )
+    )
+      return
     setBusy(true)
     setError(null)
     void api
-      .disconnectConnection(connectionId)
+      .disconnectConnection(connection.id)
       .then(() =>
         queryClient.invalidateQueries({
           predicate: (query) => ['services', 'connections'].includes(String(query.queryKey[0])),
@@ -1131,7 +1134,7 @@ function ServiceAccess({ service }: { service: Service }) {
             )}
             <button
               className="set-btn ghost"
-              onClick={() => disconnect(connection.id)}
+              onClick={() => disconnect(connection)}
               disabled={busy}
             >
               Disconnect
@@ -1166,7 +1169,7 @@ function ServiceAccess({ service }: { service: Service }) {
   )
 }
 
-export function ConnectionsPane() {
+export function ConnectionsPane({ revokedOnly = false }: { revokedOnly?: boolean }) {
   const queryClient = useQueryClient()
   const query = useQuery({
     queryKey: ['connections'],
@@ -1174,17 +1177,30 @@ export function ConnectionsPane() {
     staleTime: 60_000,
   })
   const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [notice, setNotice] = useState('')
 
-  const revoke = (connectionId: string) => {
-    setError(null)
-    void api
-      .disconnectConnection(connectionId)
-      .then(() =>
-        queryClient.invalidateQueries({
-          predicate: (query) => ['services', 'connections'].includes(String(query.queryKey[0])),
-        }),
+  const revoke = (connection: Connection) => {
+    const identity = connectionIdentity(connection) ?? connection.provider
+    if (
+      !window.confirm(
+        `Disconnect ${identity} from ${connection.provider}? Its access will be revoked.`,
       )
+    )
+      return
+    setBusy(true)
+    setError(null)
+    setNotice('')
+    void api
+      .disconnectConnection(connection.id)
+      .then(async () => {
+        await queryClient.invalidateQueries({
+          predicate: (query) => ['services', 'connections'].includes(String(query.queryKey[0])),
+        })
+        setNotice(`${identity} disconnected. Its record is in Revoked.`)
+      })
       .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setBusy(false))
   }
 
   const connections = query.data ?? []
@@ -1203,9 +1219,11 @@ export function ConnectionsPane() {
         </p>
       )}
       <header className="mcp-pane-head">
-        <h2 className="mcp-pane-title">Connections</h2>
+        <h2 className="mcp-pane-title">{revokedOnly ? 'Revoked accounts' : 'Accounts'}</h2>
         <p className="mcp-pane-sub">
-          The accounts you have signed in to. Revoke one here; revoked ones stay as history.
+          {revokedOnly
+            ? 'Account grants that no longer provide access.'
+            : 'Signed-in accounts and the access they grant. Configure new access through Services.'}
         </p>
       </header>
       {error && (
@@ -1213,33 +1231,45 @@ export function ConnectionsPane() {
           {error}
         </div>
       )}
-      {query.isSuccess && connections.length === 0 && (
-        <p className="mcp-pane-sub">No connections yet.</p>
+      {busy && <p role="status">Disconnecting account…</p>}
+      {notice && <p role="status">{notice}</p>}
+      {query.isSuccess && (revokedOnly ? revoked : live).length === 0 && (
+        <p className="mcp-pane-sub">
+          {revokedOnly ? 'No revoked accounts.' : 'No connected accounts.'}
+        </p>
       )}
       {connections.length > 0 && (
         <div className="set-card svc-facts">
-          {live.map((connection) => (
-            <div className="svc-fact" key={connection.id}>
-              <span className="svc-fact-key">{connection.provider}</span>
-              <span className="svc-fact-val">
-                {connectionIdentity(connection) ?? (connection.scopes.join(', ') || 'unlabeled')} ·{' '}
-                {new Date(connection.connectedAt).toLocaleDateString()}
-              </span>
-              <button className="set-btn ghost" onClick={() => revoke(connection.id)}>
-                Disconnect
-              </button>
-            </div>
-          ))}
-          {revoked.map((connection) => (
-            <div className="svc-fact svc-revoked" key={connection.id}>
-              <span className="svc-fact-key">{connection.provider}</span>
-              <span className="svc-fact-val">
-                {connectionIdentity(connection) ?? (connection.scopes.join(', ') || 'unlabeled')} ·
-                connected {new Date(connection.connectedAt).toLocaleDateString()} ·{' '}
-                {revokedCopy(connection)}
-              </span>
-            </div>
-          ))}
+          {!revokedOnly &&
+            live.map((connection) => (
+              <div className="svc-fact" key={connection.id}>
+                <span className="svc-fact-key">{connection.provider}</span>
+                <span className="svc-fact-val">
+                  {connectionIdentity(connection) ??
+                    (connection.scopes.join(', ') || 'unlabeled')}{' '}
+                  · {new Date(connection.connectedAt).toLocaleDateString()}
+                </span>
+                <button
+                  className="set-btn ghost"
+                  onClick={() => revoke(connection)}
+                  disabled={busy}
+                >
+                  Disconnect
+                </button>
+              </div>
+            ))}
+          {revokedOnly &&
+            revoked.map((connection) => (
+              <div className="svc-fact svc-revoked" key={connection.id}>
+                <span className="svc-fact-key">{connection.provider}</span>
+                <span className="svc-fact-val">
+                  {connectionIdentity(connection) ??
+                    (connection.scopes.join(', ') || 'unlabeled')}{' '}
+                  · connected {new Date(connection.connectedAt).toLocaleDateString()} ·{' '}
+                  {revokedCopy(connection)}
+                </span>
+              </div>
+            ))}
         </div>
       )}
     </div>
@@ -1264,6 +1294,7 @@ export function ProvidersPane({
   requestError: string | null
 }) {
   const [adding, setAdding] = useState(false)
+  const [managing, setManaging] = useState<string | null>(null)
   const [search, setSearch] = useState('')
   const [pendingProviders, setPendingProviders] = useState<Provider[]>([])
   const directoryQuery = useQuery({
@@ -1271,7 +1302,9 @@ export function ProvidersPane({
     queryFn: () => api.providerDirectory(),
     enabled:
       adding ||
-      providers.some((provider) => !registeredProviders.some((entry) => entry.id === provider.id)),
+      providers.some(
+        (provider) => !registeredProviders.some((entry) => entry.id === provider.id),
+      ),
     staleTime: 60_000,
     retry: 1,
   })
@@ -1288,7 +1321,9 @@ export function ProvidersPane({
   ])
   const configured = [
     ...providers,
-    ...pendingProviders.filter((pending) => !providers.some((known) => known.id === pending.id)),
+    ...pendingProviders.filter(
+      (pending) => !providers.some((known) => known.id === pending.id),
+    ),
   ].filter((provider) => configuredIds.has(provider.id))
   const providerColor = harnessColors(configured.map((provider) => provider.id))
   const query = search.trim().toLocaleLowerCase()
@@ -1326,7 +1361,6 @@ export function ProvidersPane({
       <header className="mcp-pane-head">
         <div className="provider-heading">
           <div>
-            <h2 className="mcp-pane-title">Providers</h2>
             <p className="mcp-pane-sub">Connect the accounts your agents use.</p>
           </div>
           <button
@@ -1391,6 +1425,7 @@ export function ProvidersPane({
                     className="provider-result-select"
                     onClick={() => {
                       setPendingProviders((current) => [...current, provider])
+                      setManaging(provider.id)
                       setAdding(false)
                       setSearch('')
                     }}
@@ -1447,7 +1482,12 @@ export function ProvidersPane({
         {configured.map((provider) => {
           const subscription = subscriptions.find((row) => row.provider === provider.id) ?? null
           const apiKey = keys.find((row) => row.provider === provider.id) ?? null
-          const isDirectoryProvider = !registeredProviders.some((entry) => entry.id === provider.id)
+          const usage = usageQuery.data?.providers.find((row) => row.id === provider.id)
+          const weekly = usage?.weeks.find((week) => week.model === null)
+          const catalog = catalogs.find((entry) => entry.provider === provider.id)
+          const isDirectoryProvider = !registeredProviders.some(
+            (entry) => entry.id === provider.id,
+          )
           const directoryEntry = directoryQuery.data?.find(
             (entry) => entry.provider === provider.id,
           )
@@ -1458,38 +1498,122 @@ export function ProvidersPane({
               className="provider-section"
               style={{ '--fam': providerColor[provider.id] } as CSSProperties}
             >
-              <header className="hr-ident">
-                <span className="hr-ident-dot" aria-hidden="true" />
-                <h3 className="hr-name">{provider.label}</h3>
-              </header>
-              {isDirectoryProvider && (
-                <div className="provider-source">
-                  {directoryEntry ? (
-                    <ProviderSource entry={directoryEntry} />
+              <div className="provider-summary">
+                <header className="hr-ident">
+                  <span className="hr-ident-dot" aria-hidden="true" />
+                  <div>
+                    <h3 className="hr-name">{provider.label}</h3>
+                    <p className="provider-account">
+                      {subscription?.providerEmail ||
+                        (apiKey ? `API key …${apiKey.keyTail}` : 'Setup incomplete')}
+                    </p>
+                  </div>
+                </header>
+                <div className="provider-access">
+                  {subscription && (
+                    <ServiceStatus
+                      connected={subscription.connected}
+                      label={
+                        subscription.connected
+                          ? 'Subscription connected'
+                          : 'Subscription expired'
+                      }
+                    />
+                  )}
+                  {apiKey && <span>API key set</span>}
+                  {!subscription && !apiKey && <span>No credentials</span>}
+                </div>
+                <div className="provider-summary-usage">
+                  {usage?.unlimited ? (
+                    <p>Quota: unmetered</p>
+                  ) : weekly ? (
+                    <QuotaRow label="Weekly" metric={weekly} />
                   ) : (
-                    <p className="provider-state" role="status">
-                      {directoryQuery.isLoading
-                        ? 'Loading provider details…'
-                        : 'Provider details are unavailable from Models.dev.'}
+                    <p>
+                      {usageQuery.isPending
+                        ? 'Loading quota…'
+                        : subscription
+                          ? 'Weekly quota unavailable'
+                          : 'API key billing · quota unavailable'}
                     </p>
                   )}
+                  {usage?.scrapedAt && (
+                    <p className={usage.stale ? 'provider-stale' : ''}>
+                      Usage {usage.stale ? 'stale · ' : ''}checked{' '}
+                      <time
+                        dateTime={usage.scrapedAt}
+                        title={new Date(usage.scrapedAt).toLocaleString()}
+                      >
+                        {relTimeFromIso(usage.scrapedAt)}
+                      </time>
+                    </p>
+                  )}
+                  {(usage?.error || usageQuery.isError) && (
+                    <p className="provider-stale">Usage refresh failed.</p>
+                  )}
                 </div>
-              )}
-              <ProviderConnect
-                provider={provider}
-                subscription={subscription}
-                apiKey={apiKey}
-                usage={usageQuery.data?.providers.find((row) => row.id === provider.id) ?? null}
-                keySpendToday={
-                  todayQuery.data?.providers.find((row) => row.id === provider.id)?.keySpendUsd ??
-                  null
-                }
-              />
+                <button
+                  className="set-btn ghost"
+                  aria-label={`${managing === provider.id ? 'Close' : 'Manage'} ${provider.label}`}
+                  aria-expanded={managing === provider.id}
+                  aria-controls={`provider-details-${provider.id}`}
+                  onClick={() => setManaging(managing === provider.id ? null : provider.id)}
+                >
+                  {managing === provider.id ? 'Close' : 'Manage'}
+                </button>
+              </div>
+              <div
+                id={`provider-details-${provider.id}`}
+                className="provider-details"
+                hidden={managing !== provider.id}
+              >
+                {isDirectoryProvider && (
+                  <div className="provider-source">
+                    {directoryEntry ? (
+                      <ProviderSource entry={directoryEntry} />
+                    ) : (
+                      <p className="provider-state" role="status">
+                        {directoryQuery.isLoading
+                          ? 'Loading provider details…'
+                          : 'Provider details are unavailable from Models.dev.'}
+                      </p>
+                    )}
+                  </div>
+                )}
+                <ProviderConnect
+                  provider={provider}
+                  subscription={subscription}
+                  apiKey={apiKey}
+                  usage={usage ?? null}
+                  keySpendToday={
+                    todayQuery.data?.providers.find((row) => row.id === provider.id)
+                      ?.keySpendUsd ?? null
+                  }
+                />
+                <p className="provider-catalog">
+                  {catalog ? (
+                    <>
+                      {catalog.models.length} {catalog.models.length === 1 ? 'model' : 'models'} ·
+                      Catalog fetched{' '}
+                      <time
+                        dateTime={catalog.fetchedAt}
+                        title={new Date(catalog.fetchedAt).toLocaleString()}
+                      >
+                        {relTimeFromIso(catalog.fetchedAt)}
+                      </time>
+                    </>
+                  ) : (
+                    'Model catalog unavailable'
+                  )}
+                </p>
+              </div>
             </article>
           )
         })}
       </div>
-      <p className="provider-save-note">Changes save automatically.</p>
+      <p className="provider-save-note">
+        Save keys in Manage. Connection and removal actions take effect immediately.
+      </p>
     </div>
   )
 }
@@ -1513,9 +1637,17 @@ export function ProviderConnect({
   const [key, setKey] = useState('')
   const [replacing, setReplacing] = useState(false)
   const [keyFormOpen, setKeyFormOpen] = useState(false)
+  const [notice, setNotice] = useState('')
 
-  const refresh = () => queryClient.invalidateQueries({ queryKey: ['providerSubscriptions'] })
-  const refreshKeys = () => queryClient.invalidateQueries({ queryKey: ['providerKeys'] })
+  const refresh = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['providerSubscriptions'] })
+    await queryClient.invalidateQueries({ queryKey: ['providerCatalogs'] })
+    await queryClient.invalidateQueries({ queryKey: ['usage'] })
+  }
+  const refreshKeys = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['providerKeys'] })
+    await queryClient.invalidateQueries({ queryKey: ['providerCatalogs'] })
+  }
   const flow = useProviderConnect(provider.id, async () => {
     await refresh()
   })
@@ -1525,20 +1657,28 @@ export function ProviderConnect({
   const run = (action: () => Promise<unknown>, after: () => Promise<unknown>) => {
     setBusy(true)
     setError(null)
+    setNotice('')
     void action()
       .then(after)
+      .then(() => setNotice('Saved.'))
       .catch((e) => setError(e instanceof Error ? e.message : String(e)))
       .finally(() => setBusy(false))
   }
 
   const disconnect = () => {
-    if (!window.confirm(`Disconnect ${provider.label}? Reconnect it before agents can run on it.`))
+    if (
+      !window.confirm(
+        `Disconnect the ${provider.label} subscription? Agents billed to it will need another subscription.`,
+      )
+    )
       return
     run(() => api.disconnectProvider(provider.id), refresh)
   }
 
   const removeKey = () => {
-    if (!window.confirm(`Remove the ${provider.label} API key? Agents billed to it stop running.`))
+    if (
+      !window.confirm(`Remove the ${provider.label} API key? Agents billed to it stop running.`)
+    )
       return
     run(() => api.removeProviderKey(provider.id), refreshKeys)
   }
@@ -1558,7 +1698,6 @@ export function ProviderConnect({
   // visible and ask for a Reconnect, not a first-time sign-in.
   const expired = Boolean(subscription) && !connected
   const showKeyForm = acceptsApiKey && (keyFormOpen || replacing)
-  const weekly = usage?.weeks.find((week) => week.model === null)
   return (
     <div className="hr-connect">
       {acceptsSubscription && (
@@ -1609,8 +1748,20 @@ export function ProviderConnect({
                 {subscription.providerEmail}
               </p>
               <div className="provider-quotas">
-                {usage?.fiveHour && <QuotaRow label="5-hour" metric={usage.fiveHour} />}
-                {weekly && <QuotaRow label="Weekly" metric={weekly} />}
+                {usage?.unlimited ? (
+                  <p>Quota: unmetered</p>
+                ) : (
+                  <>
+                    {usage?.fiveHour && <QuotaRow label="5-hour" metric={usage.fiveHour} />}
+                    {usage?.weeks.map((week) => (
+                      <QuotaRow
+                        key={week.model ?? 'all'}
+                        label={week.model ? `Weekly · ${week.model}` : 'Weekly'}
+                        metric={week}
+                      />
+                    ))}
+                  </>
+                )}
               </div>
             </>
           ) : (
@@ -1712,13 +1863,16 @@ export function ProviderConnect({
           {error ?? flow.error}
         </div>
       )}
+      {busy && <p role="status">Saving…</p>}
+      {notice && <p role="status">{notice}</p>}
     </div>
   )
 }
 
 function QuotaRow({ label, metric }: { label: string; metric: UsageMetric }) {
   useTicker(Boolean(metric.resetsAt))
-  if (metric.percentLeft === null) return null
+  if (metric.percentLeft === null)
+    return <p className="provider-state">{label} quota unavailable</p>
   const resets = metric.resetsAt
   const minutes = resets ? Math.max(0, Math.ceil(secondsUntil(resets) / 60)) : 0
   const remaining =
@@ -1881,6 +2035,29 @@ export function SkillsPane() {
       )}
 
       <section className="mcp-section">
+        <h3 className="mcp-h">
+          Collections <span className="gl-count">{collections.length}</span>
+        </h3>
+        {collectionsQuery.isSuccess && collections.length === 0 && (
+          <p className="mcp-help">No collections yet. Import one below.</p>
+        )}
+        {collections.length > 0 && (
+          <div className="skill-cols">
+            {collections.map((collection: SkillCollection) => (
+              <CollectionCard
+                key={collection.id}
+                collection={collection}
+                busy={busy}
+                onSync={sync}
+                onRemove={remove}
+                onToggle={toggle}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="mcp-section">
         <h3 className="mcp-h">Add a collection</h3>
         <p className="mcp-help">
           A GitHub repository druks scans for skills. Removing a collection removes its skills.
@@ -1914,29 +2091,6 @@ export function SkillsPane() {
             </button>
           </div>
         </div>
-      </section>
-
-      <section className="mcp-section">
-        <h3 className="mcp-h">
-          Collections <span className="gl-count">{collections.length}</span>
-        </h3>
-        {collectionsQuery.isSuccess && collections.length === 0 && (
-          <p className="mcp-help">No collections yet — import one above.</p>
-        )}
-        {collections.length > 0 && (
-          <div className="skill-cols">
-            {collections.map((collection: SkillCollection) => (
-              <CollectionCard
-                key={collection.id}
-                collection={collection}
-                busy={busy}
-                onSync={sync}
-                onRemove={remove}
-                onToggle={toggle}
-              />
-            ))}
-          </div>
-        )}
       </section>
     </div>
   )
@@ -2157,8 +2311,6 @@ export function McpServersPane() {
     setError(null)
     // Opened synchronously, while the click's activation is still live — a tab
     // opened after the await reads as an unsolicited popup and gets blocked.
-    // The grant lands via the provider's redirect to druks' callback; the list
-    // refetches on window focus when the operator returns from consent.
     const consentTab = window.open('', '_blank')
     try {
       const { authorizationUrl } = await api.connectMcpServer(name, identityMode)
@@ -2202,8 +2354,7 @@ export function McpServersPane() {
       )}
       <header className="mcp-pane-head">
         <p className="mcp-pane-sub">
-          Tools your agents can call. Enabled servers are carried into every sandbox VM; secrets
-          ride the run env and never land in emitted config.
+          Tools your agents can call. Enable installed servers or add one from the registry.
         </p>
       </header>
 
@@ -2213,11 +2364,33 @@ export function McpServersPane() {
         </div>
       )}
 
+      {servers.length > 0 && (
+        <section className="mcp-section">
+          <h3 className="mcp-h">
+            Servers<span className="gl-count">{servers.length}</span>
+          </h3>
+          <div className="mcp-servers">
+            {servers.map((server: McpServer) => (
+              <McpServerRow
+                key={server.name}
+                server={server}
+                busy={busy}
+                onToggle={toggle}
+                onRemove={remove}
+                onConnect={connect}
+                onDisconnect={disconnect}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+      {serversQuery.isSuccess && servers.length === 0 && (
+        <p className="mcp-help">No MCP servers installed.</p>
+      )}
+
       <section className="mcp-section">
         <h3 className="mcp-h">Add from registry</h3>
-        <p className="mcp-help">
-          Search the official MCP registry — most servers install with no token at all.
-        </p>
+        <p className="mcp-help">Search the official MCP registry for a hosted server.</p>
         <div className="mcp-reg-search">
           <label className="mcp-sr-only" htmlFor={`${fieldId}-search`}>
             Search the MCP registry
@@ -2381,7 +2554,9 @@ export function McpServersPane() {
                 data-lpignore="true"
                 disabled={busy}
               />
-              <p className="mcp-help">Stored write-only — never returned or emitted in config.</p>
+              <p className="mcp-help">
+                Stored write-only — never returned or emitted in config.
+              </p>
             </div>
           </div>
           <div>
@@ -2396,27 +2571,6 @@ export function McpServersPane() {
           </div>
         </div>
       </details>
-
-      {servers.length > 0 && (
-        <section className="mcp-section">
-          <h3 className="mcp-h">
-            Servers<span className="gl-count">{servers.length}</span>
-          </h3>
-          <div className="mcp-servers">
-            {servers.map((server: McpServer) => (
-              <McpServerRow
-                key={server.name}
-                server={server}
-                busy={busy}
-                onToggle={toggle}
-                onRemove={remove}
-                onConnect={connect}
-                onDisconnect={disconnect}
-              />
-            ))}
-          </div>
-        </section>
-      )}
     </div>
   )
 }
@@ -2610,10 +2764,24 @@ export function AgentAccessPane() {
       )}
       <div className="set-pane-head">
         <div className="set-pane-sub">
-          Give an agent, script, or CLI a token to call druks as you — same account and permissions,
-          no browser needed. Revoke it any time to cut access instantly.
+          Give an agent, script, or CLI a token to call druks as you — same account and
+          permissions, no browser needed. Revoke it any time to cut access instantly.
         </div>
       </div>
+      {pats.length > 0 && (
+        <div className="set-group">
+          <div className="set-group-label">
+            tokens<span className="gl-count">{pats.length}</span>
+          </div>
+          <div className="mcp-servers">
+            {pats.map((pat) => (
+              <PatRow key={pat.id} pat={pat} busy={busy} onRevoke={revoke} />
+            ))}
+          </div>
+        </div>
+      )}
+      {patsQuery.isSuccess && pats.length === 0 && <p className="mcp-help">No API tokens.</p>}
+
       <div className="set-group">
         <label className="set-group-label" htmlFor={tokenNameId}>
           Token name
@@ -2662,20 +2830,8 @@ export function AgentAccessPane() {
             </button>
           </div>
           <div className="set-field-help">
-            Send it as <b>Authorization: Bearer &lt;token&gt;</b>. This is the only time druks shows
-            it — a hash is stored, not the token.
-          </div>
-        </div>
-      )}
-      {pats.length > 0 && (
-        <div className="set-group">
-          <div className="set-group-label">
-            tokens<span className="gl-count">{pats.length}</span>
-          </div>
-          <div className="mcp-servers">
-            {pats.map((pat) => (
-              <PatRow key={pat.id} pat={pat} busy={busy} onRevoke={revoke} />
-            ))}
+            Send it as <b>Authorization: Bearer &lt;token&gt;</b>. This is the only time druks
+            shows it — a hash is stored, not the token.
           </div>
         </div>
       )}
@@ -2805,13 +2961,11 @@ export function AppPane({
     option.scope === 'workflow'
       ? onWorkflowField(option.kind, option.field.name, value)
       : onAppSetting(option.kind, option.field.name, value)
-  // The control speaks strings; the override store keeps the declared type.
   // Clearing a secret's box leaves its stored value unchanged.
   const setTypedOption = (option: (typeof optionFields)[number], next: string) => {
     if (option.field.type === 'secret') return setOption(option, next || undefined)
     if (option.field.type !== 'int') return setOption(option, next)
-    const parsed = Number.parseInt(next, 10)
-    if (Number.isFinite(parsed)) setOption(option, parsed)
+    setOption(option, next.trim() && Number.isInteger(Number(next)) ? Number(next) : next)
   }
   return (
     <div className="set-pane">

--- a/frontend/src/settings.css
+++ b/frontend/src/settings.css
@@ -30,6 +30,9 @@
 .settings-pane :is(.set-thead, .set-trow) { display: grid; min-width: 760px; grid-template-columns: minmax(150px, 1.4fr) 100px minmax(140px, 1.2fr) 104px 86px 86px; gap: 8px; padding: 8px 12px; }
 .settings-pane .agents-app { min-width: 760px; }
 .settings-context .set-btn { font-family: var(--font-sans); font-size: 15px; min-height: 40px; }
+.settings-context .hr-conn-btn { font-family: var(--font-sans); font-size: 15px; min-height: 40px; }
+.settings-pane :is(.hr-conn-error, .hr-conn-step, .browser-session-times dt, .browser-session-times dd) { font-size: 13px; }
+.settings-pane .mcp-custom-summary { font-family: var(--font-sans); font-size: 15px; }
 .settings-tabs { display: flex; gap: 24px; border-bottom: 1px solid var(--border); margin-bottom: 28px; }
 .settings-tabs button { min-height: 44px; color: var(--text-dim); border-bottom: 2px solid transparent; }
 .settings-tabs button[aria-current="page"] { color: var(--text); border-color: var(--bucket-run); }
@@ -79,10 +82,58 @@
 .settings-pane .model-chooser-trigger .cell-val { min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 
 @media (max-width: 649px) {
-  .settings-context .set-btn { min-height: 44px; }
+  .settings-context :is(.set-btn, .hr-conn-btn) { min-height: 44px; }
 }
 
 .settings-pane .mcp-pane-sub { font-size: 15px; }
+.settings-pane :is(.mcp-help, .provider-state, .provider-empty, .provider-save-note, .provider-directory-note, .provider-source, .provider-source p, .provider-account, .provider-key-details, .hr-quota, .hr-quota-reset, .svc-meta, .mcp-url, .mcp-tok, .browser-session-format, .browser-session-site, .browser-session-times, .browser-session-undeclared) { font-size: 13px; }
+.settings-pane :is(.mcp-h, .mcp-name, .mcp-conn, .provider-result-select strong, .provider-add-head label, .svc-card-name, .svc-card-desc, .svc-card-cue, .svc-back, .svc-alt, .browser-session-name) { font-family: var(--font-sans); font-size: 15px; letter-spacing: 0; text-transform: none; }
+.settings-pane .hr-conn-input { font-size: 15px; }
+.settings-pane .provider-section { padding: 20px 0; gap: 20px; }
+.provider-summary { display: grid; grid-template-columns: minmax(160px, 1fr) minmax(150px, .8fr) minmax(260px, 1.6fr) auto; align-items: center; gap: 24px; }
+.provider-summary > * { min-width: 0; }
+.provider-summary .hr-name { font-size: 18px; font-weight: 500; }
+.provider-summary .provider-account { margin-top: 5px; }
+.provider-access { display: flex; flex-direction: column; align-items: flex-start; gap: 6px; font-size: 13px; }
+.provider-summary-usage p { margin: 4px 0; color: var(--text-dim); font-size: 13px; }
+.settings-pane .hr-quota { grid-template-columns: minmax(0, 1fr) auto; gap: 6px 12px; }
+.settings-pane .hr-quota .us-bar { grid-column: 1 / -1; grid-row: 2; }
+.settings-pane .hr-quota-label { overflow-wrap: anywhere; }
+.settings-pane .hr-quota-reset { grid-column: 1 / -1; }
+.settings-pane .provider-stale { color: var(--bucket-human); }
+.provider-details { padding: 24px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); }
+.provider-details .provider-source { margin-bottom: 24px; }
+.provider-catalog { margin: 24px 0 0; color: var(--text-dim); font-size: 13px; }
+.settings-pane .svc-grid { grid-template-columns: minmax(0, 1fr); gap: 0; }
+.settings-pane .svc-card { display: grid; grid-template-columns: minmax(220px, 1fr) minmax(180px, 1.5fr) auto; align-items: center; gap: 24px; padding: 20px 0; border: 0; border-bottom: 1px solid var(--border); border-radius: 0; background: transparent; }
+.settings-pane .svc-card-top { justify-content: flex-start; gap: 20px; }
+.settings-pane .svc-card-desc { white-space: normal; }
+.settings-pane .svc-card-foot { margin: 0; justify-content: flex-end; }
+.settings-pane .svc-card-id { max-width: 180px; font-size: 13px; }
+.settings-pane .svc-fact { align-items: center; flex-wrap: wrap; padding: 8px 0; font-family: var(--font-sans); font-size: 15px; }
+.settings-pane .svc-fact-key { flex-shrink: 1; overflow-wrap: anywhere; }
+.settings-pane .svc-fact-val { flex: 1; min-width: 160px; white-space: normal; overflow-wrap: anywhere; font-size: 13px; }
+.settings-pane .svc-revoked { opacity: 1; color: var(--text-dim); }
+@media (max-width: 1200px) {
+  .provider-summary { grid-template-columns: minmax(0, 1fr) minmax(180px, 1fr) auto; gap: 16px; }
+  .provider-summary .hr-ident { grid-column: 1; }
+  .provider-access { grid-column: 1; grid-row: 2; }
+  .provider-summary-usage { grid-column: 2; grid-row: 1 / 3; }
+  .provider-summary > button { grid-column: 3; grid-row: 1 / 3; }
+  .settings-pane .svc-card { grid-template-columns: minmax(0, 1fr) auto; gap: 12px 20px; }
+  .settings-pane .svc-card-desc { grid-column: 1; }
+  .settings-pane .svc-card-foot { grid-column: 2; grid-row: 1 / 3; flex-wrap: wrap; }
+}
+@media (max-width: 649px) {
+  .provider-summary { grid-template-columns: minmax(0, 1fr) auto; gap: 12px; }
+  .provider-summary-usage { grid-column: 1 / -1; grid-row: 3; }
+  .provider-summary > button { grid-column: 2; grid-row: 1 / 3; }
+  .provider-details { padding: 16px; }
+  .settings-pane .hr-conn-input { font-size: 16px; }
+  .settings-pane .svc-card-top { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .settings-pane .svc-card-foot { flex-direction: column; align-items: flex-end; max-width: 100px; }
+  .settings-pane .svc-card-id { max-width: 100%; }
+}
 .settings-pane .settings-agents > * { max-width: 880px; }
 .settings-default-execution { padding: 24px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); }
 .settings-default-execution h2 { margin: 0 0 6px; font-size: 18px; font-weight: 500; }


### PR DESCRIPTION
Provider access, quota, and catalog details now fit compact rows with persistent Manage panels. Connections separates Services, Accounts, and Revoked grants. Installed resources remain visible above their add forms, and failed reads offer a retry without false empty states.

Validation: frontend lint, 331 tests, and build passed; both required CI checks passed. Actual layouts inspected at 1440, 1024, and 390 px. Local account disconnect, revoked history, integer clear/save, draft retention, and resource error states verified.
Stack: based on https://github.com/czpython/druks/pull/443.

External provider login and service OAuth were not exercised.
