### PR TITLE
DRU-448: Add a current-work Overview with owner review links

### DIFF
--- a/backend/druks/api/overview.py
+++ b/backend/druks/api/overview.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, Response
+from sqlalchemy import func, select
+
+from druks.api.schemas import OverviewRun, OverviewSchedule, OverviewSchedules, OverviewWork
+from druks.apps.loader import iter_apps
+from druks.database import db_session
+from druks.durable.enums import OPEN_STATES, RunState
+from druks.durable.models import Run
+from druks.user_settings.models import UserSettings
+
+PAGE_SIZE = 200
+router = APIRouter(prefix="/api/overview", tags=["overview"])
+
+
+@router.get("/work", response_model=OverviewWork)
+async def list_current_work(response: Response) -> OverviewWork:
+    response.headers["Cache-Control"] = "no-store"
+    owners = {workflow.kind: owner.name for owner in iter_apps() for workflow in owner.workflows()}
+    current = (
+        Run.get_open_subjects(
+            kinds=list(owners),
+            states=(*OPEN_STATES, RunState.ORPHANED),
+            include_subjectless=True,
+        )
+        .order_by(None)
+        .subquery()
+    )
+    statement = (
+        select(
+            current.c.run_id.label("run"),
+            current.c.kind,
+            current.c.state,
+            current.c.subject_type,
+            current.c.subject_id,
+            func.left(current.c.subject_label, 240).label("subject_label"),
+            current.c.updated_at,
+            current.c.input_requested_at.label("parked_at"),
+            current.c.request_label,
+            current.c.presentation,
+            current.c.request_url,
+            func.left(current.c.failure, 512).label("failure"),
+        )
+        .order_by(current.c.updated_at.desc(), current.c.run_id.desc())
+        .limit(PAGE_SIZE + 1)
+    )
+    rows = (await db_session().execute(statement)).all()
+    return OverviewWork(
+        rows=[
+            OverviewRun.model_validate({**row._mapping, "app": owners[row.kind]})
+            for row in rows[:PAGE_SIZE]
+        ],
+        has_more=len(rows) > PAGE_SIZE,
+    )
+
+
+@router.get("/schedules", response_model=OverviewSchedules)
+async def list_current_schedules(response: Response) -> OverviewSchedules:
+    """Configured cadence, not scheduler health."""
+    response.headers["Cache-Control"] = "no-store"
+    timezone = (await UserSettings.get()).timezone
+    return OverviewSchedules(
+        rows=[
+            OverviewSchedule(
+                app=owner.name,
+                kind=workflow.kind,
+                cron=await workflow.get_schedule(),
+                enabled=await workflow.has_enabled_schedule(),
+                timezone=timezone,
+            )
+            for owner in iter_apps()
+            for workflow in owner.workflows()
+            if workflow.every
+        ]
+    )

--- a/backend/druks/api/schemas.py
+++ b/backend/druks/api/schemas.py
@@ -49,6 +49,39 @@ class OpenSubjectsResponse(Schema):
     subjects: list[OpenSubjectResponse]
 
 
+class OverviewRun(Schema):
+    app: str
+    run: str
+    kind: str
+    state: RunState
+    subject_type: str | None
+    subject_id: str | None
+    subject_label: str | None
+    updated_at: datetime
+    parked_at: datetime | None
+    request_label: str | None
+    presentation: str | None
+    request_url: str | None
+    failure: str | None
+
+
+class OverviewWork(Schema):
+    rows: list[OverviewRun]
+    has_more: bool
+
+
+class OverviewSchedule(Schema):
+    app: str
+    kind: str
+    cron: str | None
+    enabled: bool
+    timezone: str
+
+
+class OverviewSchedules(Schema):
+    rows: list[OverviewSchedule]
+
+
 class ArtifactContent(Schema):
     # A call's renderable output, served to the in-app review so it can show the
     # plan (or other markdown) beside its controls.

--- a/backend/druks/api/server.py
+++ b/backend/druks/api/server.py
@@ -16,6 +16,7 @@ from druks.accounts.exceptions import AuthConfigurationError
 from druks.accounts.routes import router as auth_router
 from druks.api.artifacts import router as artifacts_router
 from druks.api.exceptions import AgentApiError
+from druks.api.overview import router as overview_router
 from druks.api.runs import router as runs_router
 from druks.api.subjects import router as subjects_router
 from druks.apps.loader import iter_apps, load
@@ -133,7 +134,7 @@ async def _release_db_session() -> AsyncIterator[None]:
         await session.commit()
     finally:
         await session.close()
-        if previous is not None:
+        if previous:
             db_session.registry.set(previous)
         else:
             db_session.registry.clear()
@@ -153,12 +154,6 @@ app = FastAPI(
 )
 
 
-# Exception handlers — uniform JSON envelope.
-#
-# All errors share the shape::
-#
-#     {"error": "<CODE>", "detail": <string-or-list>}
-#
 @app.exception_handler(HTTPException)
 async def _http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
     return JSONResponse(
@@ -307,6 +302,7 @@ app.include_router(mcp_router, dependencies=_identity_gate)
 app.include_router(notifications_router, dependencies=_identity_gate)
 app.include_router(events_router, dependencies=_identity_gate)
 app.include_router(runs_router, dependencies=_identity_gate)
+app.include_router(overview_router, dependencies=_identity_gate)
 app.include_router(subjects_router, dependencies=_identity_gate)
 app.include_router(gateway_router, dependencies=_identity_gate)
 app.include_router(artifacts_router, dependencies=_identity_gate)
@@ -325,10 +321,7 @@ app.router.routes.append(
 )
 
 
-# Unknown /api/* paths return a JSON 404 across every method instead of
-# falling through to the SPA index.html, which would mislead API consumers
-# with a 200 OK + HTML. We need to catch GET/POST/PATCH/PUT/DELETE — a
-# bare ``@app.get`` only caught GETs.
+# Unknown API paths must return JSON, never the SPA's index.html.
 @app.api_route(
     "/api/{path:path}",
     methods=["GET", "POST", "PATCH", "PUT", "DELETE"],

--- a/backend/druks/durable/models.py
+++ b/backend/druks/durable/models.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -240,35 +241,50 @@ class Run(Base):
         )
 
     @classmethod
-    def get_open_subjects(cls) -> Select:
-        """Every open workflow — the newest run of each kind on each subject, still
-        going or failed — newest first across every installed app."""
+    def get_open_subjects(
+        cls,
+        *,
+        kinds: Sequence[str] | None = None,
+        states: Sequence[RunState] = OPEN_STATES,
+        include_subjectless: bool = False,
+    ) -> Select:
+        """Current runs per kind and subject, ranked before state filtering."""
         state = state_expression(cls.id, cls.input_gate, cls.created_at).label("state")
         attributes = workflow_status.c.attributes
         subject_type = attributes["subject_type"].as_string().label("subject_type")
         subject_id = attributes["subject_id"].as_string().label("subject_id")
         subject_label = attributes["subject_label"].as_string().label("subject_label")
-        driving = (
-            select(
-                subject_type,
-                subject_id,
-                subject_label,
-                cls.id.label("run_id"),
-                cls.kind,
-                cls.failure,
-                cls.created_at,
-                state,
-                func.row_number()
-                .over(
-                    partition_by=(cls.kind, subject_type, subject_id),
-                    order_by=(cls.created_at.desc(), cls.id.desc()),
-                )
-                .label("rank"),
+        driving = select(
+            subject_type,
+            subject_id,
+            subject_label,
+            cls.id.label("run_id"),
+            cls.kind,
+            cls.failure,
+            cls.created_at,
+            cls.updated_at.label("updated_at"),
+            cls.input_requested_at,
+            func.left(cls.input_request["label"].as_string(), 240).label("request_label"),
+            cls.input_request["presentation"].as_string().label("presentation"),
+            cls.input_request["url"].as_string().label("request_url"),
+            state,
+            func.row_number()
+            .over(
+                partition_by=(cls.kind, subject_type, func.coalesce(subject_id, cls.id)),
+                order_by=(cls.created_at.desc(), cls.id.desc()),
             )
-            .join_from(cls, workflow_status, workflow_status.c.workflow_uuid == cls.id)
-            .where(subject_id.is_not(None))
-            .subquery()
+            .label("rank"),
+        ).join_from(
+            cls,
+            workflow_status,
+            workflow_status.c.workflow_uuid == cls.id,
+            isouter=include_subjectless,
         )
+        if kinds is not None:
+            driving = driving.where(cls.kind.in_(kinds))
+        if not include_subjectless:
+            driving = driving.where(subject_id.is_not(None))
+        driving = driving.subquery()
         latest_call_id = (
             select(AgentCall.id)
             .where(AgentCall.run_id == driving.c.run_id)
@@ -281,7 +297,7 @@ class Run(Base):
             select(driving, latest_call_id)
             .where(
                 driving.c.rank == 1,
-                driving.c.state.in_([run_state.value for run_state in OPEN_STATES]),
+                driving.c.state.in_([run_state.value for run_state in states]),
             )
             .order_by(driving.c.created_at.desc(), driving.c.run_id.desc())
         )

--- a/backend/tests/test_overview.py
+++ b/backend/tests/test_overview.py
@@ -1,0 +1,141 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from druks.accounts.models import Account
+from druks.api import overview
+from druks.durable.dbos_state import workflow_status
+from druks.durable.models import Run
+from druks.testing import configure_app_for_test, make_settings, seed_run
+from druks.user_settings.models import SettingsOverride, UserSettings
+from druks_field_notes.models import Note
+from druks_field_notes.workflows import Summarize
+from fastapi.testclient import TestClient
+from uuid_utils import uuid7
+
+
+@pytest.fixture
+def client(tmp_path, druks_db):
+    app = configure_app_for_test(settings=make_settings(tmp_path))
+    with TestClient(app) as client:
+        yield client
+
+
+def current_work(client):
+    response = client.get("/api/overview/work")
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    return response.json()
+
+
+async def test_a_current_run_carries_request_facts_with_bounded_prose(client, druks_db):
+    note = await Note.create(body="decision")
+    run = await seed_run(
+        druks_db,
+        kind=Summarize.kind,
+        subject=note,
+        state="parked",
+        input_gate="review",
+        input_request={"presentation": "in_app", "label": "x" * 300, "questions": ["private"]},
+        failure="f" * 700,
+    )
+    run.input_requested_at = datetime(2026, 1, 1, tzinfo=UTC)
+    await druks_db.flush()
+
+    body = current_work(client)
+
+    assert body["hasMore"] is False
+    [row] = body["rows"]
+    assert (row["run"], row["app"], row["state"]) == (run.id, "field_notes", "parked")
+    assert row["parkedAt"] == "2026-01-01T00:00:00Z"
+    assert row["presentation"] == "in_app"
+    assert row["requestLabel"] == "x" * 240
+    assert row["failure"] == "f" * 512
+    assert "private" not in str(row)
+
+
+async def test_newer_success_hides_historical_failure(client, druks_db):
+    note = await Note.create(body="recovered")
+    failed = await seed_run(druks_db, kind=Summarize.kind, subject=note, state="failed")
+    failed.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    await seed_run(druks_db, kind=Summarize.kind, subject=note, state="finished")
+
+    assert current_work(client)["rows"] == []
+
+
+async def test_subjectless_and_orphaned_runs_each_stay_current(client, druks_db):
+    background = await seed_run(druks_db, kind=Summarize.kind, state="running")
+    orphan = Run(
+        id=str(uuid7()), kind=Summarize.kind, created_at=datetime.now(UTC) - timedelta(minutes=10)
+    )
+    druks_db.add(orphan)
+    await druks_db.flush()
+
+    rows = {row["run"]: row for row in current_work(client)["rows"]}
+
+    assert rows[background.id]["state"] == "running"
+    assert rows[orphan.id]["state"] == "orphaned"
+    assert rows[orphan.id]["subjectId"] is None
+
+
+async def test_only_installed_workflow_kinds_are_read(client, druks_db):
+    other = await Account.get_or_create("another@example.invalid")
+    note = await Note.create(body="shared run")
+    included = await seed_run(druks_db, kind=Summarize.kind, subject=note)
+    included.account_id = other.id
+    await seed_run(druks_db, kind="uninstalled.sweep")
+    await druks_db.flush()
+
+    assert [row["run"] for row in current_work(client)["rows"]] == [included.id]
+
+
+async def test_changed_time_orders_current_work(client, druks_db):
+    first = await seed_run(druks_db, kind=Summarize.kind, subject=await Note.create(body="first"))
+    second = await seed_run(druks_db, kind=Summarize.kind, subject=await Note.create(body="second"))
+    await druks_db.execute(
+        workflow_status.update()
+        .where(workflow_status.c.workflow_uuid == first.id)
+        .values(updated_at=int((datetime.now(UTC) + timedelta(minutes=1)).timestamp() * 1000))
+    )
+
+    assert [row["run"] for row in current_work(client)["rows"]] == [first.id, second.id]
+
+
+async def test_the_read_is_capped(client, druks_db, monkeypatch):
+    monkeypatch.setattr(overview, "PAGE_SIZE", 1)
+    for body in ("one", "two"):
+        await seed_run(druks_db, kind=Summarize.kind, subject=await Note.create(body=body))
+
+    body = current_work(client)
+
+    assert len(body["rows"]) == 1
+    assert body["hasMore"] is True
+
+
+async def test_schedules_resolve_paused_override_and_operator_timezone(
+    client, druks_db, monkeypatch
+):
+    monkeypatch.setattr(Summarize, "every", "0 9 * * *")
+    await SettingsOverride.set_workflow_setting(Summarize.kind, "schedule", "15 10 * * 1")
+    await SettingsOverride.set_workflow_setting(Summarize.kind, "schedule_enabled", False)
+    await (await UserSettings.get()).update_profile(timezone="Europe/Madrid")
+
+    response = client.get("/api/overview/schedules")
+
+    assert response.status_code == 200
+    assert {
+        "app": "field_notes",
+        "kind": Summarize.kind,
+        "cron": "15 10 * * 1",
+        "enabled": False,
+        "timezone": "Europe/Madrid",
+    } in response.json()["rows"]
+
+
+def test_overview_requires_the_existing_identity_gate(tmp_path, druks_db):
+    app = configure_app_for_test(
+        settings=make_settings(tmp_path, identity={"mode": "header", "header": "X-Edge-Email"}),
+        authenticated=False,
+    )
+    with TestClient(app) as anonymous:
+        assert anonymous.get("/api/overview/work").status_code == 401
+        assert anonymous.get("/api/overview/schedules").status_code == 401

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -116,6 +116,32 @@ Subjected workflow starts use DBOS queue deduplication per workflow kind and
 subject. A duplicate start returns the active run's id. Druks does not impose
 that policy on subjectless background runs.
 
+## Current work in Overview
+
+Overview reads current runs across the installed apps with the same identity
+gate as the shared run API. An authenticated operator sees installation-wide
+run facts. `Run.account_id` records attribution and does not restrict this
+read.
+
+For each workflow kind and subject, the newest run counts. A newer successful
+run therefore removes an older failure from Problems. A run without a subject,
+including one whose DBOS record is missing, counts on its own until it is
+cancelled. The read returns the 200 most recently changed current runs with
+bounded labels and failure text, never transcripts or complete review content.
+
+Needs you lists parked runs that carry a request the operator can act on,
+oldest request first. Other parked work is Waiting. Active work is running and
+queued runs. Problems is failed and orphaned runs. Scheduled work lists
+declared schedules with resolved cadence, pause state, and operator timezone.
+These are configuration facts, not proof that a future run will succeed.
+
+Review opens the owning app at the selected run and names the request round
+by its `parkedAt` timestamp. The owner reads the current gate. A different
+round shows a stale-link message, and an answer echoes the round it read, so
+the server rejects a stale one. An external request opens the app-declared
+HTTP or HTTPS address. Overview does not infer access health from
+configuration.
+
 ## Waiting for people and systems
 
 A `Gate` defines a typed reply and a durable receive topic. When a workflow

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,7 +25,7 @@ runs lint, tests, and build for PRs into `main` and `codex/` stack branches.
 
 - The work sidebar and searchable installed app roster
 - Settings
-- The Events and Usage pages
+- Overview, Events, and Usage
 - The optional system-health strip
 - Shared routing and fallback behavior.
 
@@ -35,8 +35,8 @@ declares the subnav tabs. The roster supplies these tabs to the frontend.
 Import the module one time from `src/apps/index.ts`. The shell finds the
 registration and does not hardcode the app name.
 
-The work sidebar keeps the same destinations across app pages. Events and
-Usage have shared routes. App-declared navigation appears below the page
+The work sidebar keeps the same destinations across app pages. Overview opens
+at `/`. Events and Usage have shared routes. App-declared navigation appears below the page
 header. Settings opens from the bottom of the sidebar. Below 650 px, a
 navigation button opens a modal drawer. Escape closes the drawer and returns
 focus to the button.
@@ -74,6 +74,30 @@ A separate app package can ship a built ES module in `<package>/dist/`. This
 module exposes `mount(el, ctx)`. Druks serves the module under `/app/<name>`.
 The shell imports and mounts it below the chrome. An import map (`src/runtime/`)
 supplies one shared React instance. See the app-author guide.
+
+## Overview and owner links
+
+Overview makes one current-work read and one schedule read, refreshed every
+30 seconds and on window focus, and sorts the rows into sections in the
+browser. A failed refresh keeps the last read visible and offers Retry. See
+[the current-work contract](../docs/concepts.md#current-work-in-overview) for
+selection, authorization, and limits.
+
+An app's `subjectPath(subject, target?)` returns its own destination. For
+Overview, `target` carries `run` and, for a decision, `parkedAt`. Build the
+query with `targetQuery` from the registry. The owner selects that run and
+passes `parkedAt` to `GateControls`, which shows a stale-link message when the
+current round differs. Return `undefined` when the app has no destination.
+
+The generic Python-app subject page supports this target. An app's standalone
+JavaScript frontend must supply its own navigation before Overview can link to
+a specific run.
+
+Keep raw paths and queries in the retained work context. Wouter's public
+`useLocation` and `useSearch` decode URI escapes. Subject pages read the raw
+router hooks, decode each subject component once, and let `subjectApi` encode
+the HTTP path. Canonical slug replacement preserves the raw query and hash
+and only runs while the owner page is visible.
 
 ## API and live data
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,8 +8,8 @@ import {
   type RefObject,
 } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Activity, ChartNoAxesCombined, Search, Settings } from 'lucide-react'
-import { Link, Route, Router, Switch, useLocation, useSearch, type RouterProps } from 'wouter'
+import { Activity, ChartNoAxesCombined, LayoutGrid, Search, Settings } from 'lucide-react'
+import { Link, Route, Router, Switch, useLocation, type RouterProps } from 'wouter'
 import { navigate as browserNavigate, useLocationProperty } from 'wouter/use-browser-location'
 
 import { api } from './api/client'
@@ -23,6 +23,7 @@ import { Page } from './components/Page'
 import { SettingsPages } from './components/SettingsPages'
 import { Sidebar } from './components/Sidebar'
 import { EventsPage } from './pages/EventsPage'
+import { OverviewPage } from './pages/OverviewPage'
 import { LoginWindowPage } from './pages/LoginWindowPage'
 import { SystemStrip } from './components/SystemStrip'
 import { UsagePage } from './pages/UsagePage'
@@ -146,7 +147,8 @@ function AppContexts({
   aroundNav: NonNullable<RouterProps['aroundNav']>
 }) {
   const [location] = useLocation()
-  const search = useSearch()
+  const search = useLocationProperty(() => window.location.search.slice(1))
+  const rawPath = useLocationProperty(() => window.location.pathname)
   const hash = useLocationProperty(() => window.location.hash)
   const isSettings = location === '/settings' || location.startsWith('/settings/')
   const wasSettings = useRef(isSettings)
@@ -159,11 +161,8 @@ function AppContexts({
   const [work, setWork] = useState<{ path: string; search: string; hash: string }>(
     () => window.history.state?.druksWork ?? { path: `${ROUTER_BASE}/`, search: '', hash: '' },
   )
-  if (
-    !isSettings &&
-    (work.path !== `${ROUTER_BASE}${location}` || work.search !== search || work.hash !== hash)
-  )
-    setWork({ path: `${ROUTER_BASE}${location}`, search, hash })
+  if (!isSettings && (work.path !== rawPath || work.search !== search || work.hash !== hash))
+    setWork({ path: rawPath, search, hash })
   if (
     isSettings &&
     storedWork &&
@@ -229,7 +228,7 @@ function AppShell({
   const app = urlApp ?? lastApp ?? defaultApp
   const ui = app ? getAppUI(app) : undefined
   const [search, setSearch] = useState('')
-  const wantsHealth = Boolean(ui?.systemStrip)
+  const wantsHealth = Boolean(urlApp && ui?.systemStrip)
   const healthQuery = useQuery({
     queryKey: ['system-health'],
     queryFn: api.systemHealth,
@@ -240,12 +239,6 @@ function AppShell({
   useEffect(() => {
     navCount.current += 1
   }, [location])
-
-  useEffect(() => {
-    if (!hidden && (location === '' || location === '/') && defaultApp) {
-      navigate(appHome(defaultApp), { replace: true })
-    }
-  }, [location, navigate, defaultApp, hidden])
 
   useEffect(() => {
     if (app) document.body.dataset.app = app
@@ -287,9 +280,9 @@ function AppShell({
   const appSettings = settingsQuery.data?.apps.find((entry) => entry.name === app)
   const hasSettings = Boolean(
     appSettings &&
-      (appSettings.settings.length ||
-        appSettings.agents.length ||
-        appSettings.workflows.some((workflow) => workflow.fields.length)),
+    (appSettings.settings.length ||
+      appSettings.agents.length ||
+      appSettings.workflows.some((workflow) => workflow.fields.length)),
   )
   const navigation: [string, string][] = urlApp
     ? [
@@ -309,13 +302,15 @@ function AppShell({
     appLabel(name).toLowerCase().includes(search.toLowerCase().trim()),
   )
   const title =
-    location === '/events'
-      ? 'Events'
-      : location === '/usage'
-        ? 'Usage'
-        : app
-          ? appLabel(app)
-          : 'Druks'
+    location === '/'
+      ? 'Overview'
+      : location === '/events'
+        ? 'Events'
+        : location === '/usage'
+          ? 'Usage'
+          : app
+            ? appLabel(app)
+            : 'Druks'
 
   return (
     <div className="command-center" hidden={hidden}>
@@ -323,8 +318,16 @@ function AppShell({
         Skip to content
       </a>
       <header className="command-header">
-        <Sidebar account={account} home={defaultApp ? appHome(defaultApp) : '/'}>
+        <Sidebar account={account} home="/">
           <nav className="sidebar-work" aria-label="Work">
+            <Link
+              href="/"
+              className="sidebar-link"
+              aria-current={location === '/' ? 'page' : undefined}
+            >
+              <LayoutGrid size={17} aria-hidden="true" />
+              Overview
+            </Link>
             <Link
               href="/events"
               className="sidebar-link"
@@ -435,6 +438,13 @@ function AppShell({
           </p>
         )}
         <Switch>
+          <Route path="/">
+            <OverviewPage
+              apps={
+                rosterQuery.data?.filter((entry) => !entry.builtin).map((entry) => entry.name) ?? []
+              }
+            />
+          </Route>
           <Route path="/apps/:name/settings/:tab?">
             {(params) => (
               <SettingsPages

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -7,6 +7,7 @@ import {
   getJSON,
   identityApi,
   postJSON,
+  subjectApi,
 } from './client'
 
 function failWith(status: number, statusText: string, body: string) {
@@ -19,6 +20,16 @@ function failWith(status: number, statusText: string, body: string) {
 afterEach(() => vi.unstubAllGlobals())
 
 describe('API error messages', () => {
+  it('shows a gateway conflict message without its JSON envelope', async () => {
+    failWith(409, 'Conflict', JSON.stringify({ code: 'stale_gate', message: 'This request has changed.', retryable: false }))
+    await expect(api.answerGate('run', { parkedAt: '2026-09-01T00:00:00Z', control: 'approve', answers: {}, note: '' })).rejects.toThrow('This request has changed.')
+  })
+
+  it('encodes a subject identity once for both its read and stream', () => {
+    const id = 'a%20b/c?#é'
+    expect(subjectApi.base('notes', 'file', id)).toBe('/api/notes/file/a%2520b%2Fc%3F%23%C3%A9')
+    expect(subjectApi.stream('notes', 'file', id)).toBe('/api/notes/file/a%2520b%2Fc%3F%23%C3%A9/stream')
+  })
   it('surfaces the backend detail as the error message', async () => {
     failWith(409, 'Conflict', JSON.stringify({ error: 'HTTP_409', detail: 'Set DRUKS_ENDPOINT.' }))
     await expect(postJSON('/api/x', {})).rejects.toThrow('Set DRUKS_ENDPOINT.')
@@ -43,7 +54,6 @@ describe('personal access tokens', () => {
     expect(createCall?.[1]?.method).toBe('POST')
     expect(JSON.parse(String(createCall?.[1]?.body))).toEqual({ name: 'ci bot' })
 
-    // Revoke answers the updated row, so the client parses the DELETE body.
     const revoked = await api.revokePat('p1')
     const revokeCall = fetchMock.mock.calls[1]
     expect(revokeCall?.[0]).toBe('/api/auth/personal-tokens/p1')
@@ -108,7 +118,6 @@ describe('request identity', () => {
       accountId = 'b2'
       await identityApi.me()
       expect(invalidated).toHaveBeenCalledTimes(1)
-      // Settled on b2: rechecking the same account broadcasts nothing.
       await identityApi.me()
       expect(invalidated).toHaveBeenCalledTimes(1)
     } finally {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -35,6 +35,8 @@ import type {
   Skill,
   SkillCollection,
   UserSettings,
+  OverviewSchedules,
+  OverviewWork,
 } from './types'
 
 // A 401 means the request's identity did not resolve: typed to branch on,
@@ -55,14 +57,13 @@ export class ApiError extends Error {
 
 export const IDENTITY_INVALIDATED_EVENT = 'druks:identity-invalidated'
 
-// FastAPI puts the human-readable message in ``detail``; throw that as the
-// Error message so consumers display it as-is. Non-JSON bodies (proxy pages,
-// validation arrays) fall back to the status line.
+// The API has FastAPI and gateway error envelopes. Both carry operator-facing prose.
 async function throwApiError(response: Response, path: string): Promise<never> {
   const body = await response.text().catch(() => '')
   let detail: unknown
   try {
-    detail = JSON.parse(body).detail
+    const error = JSON.parse(body)
+    detail = error.detail ?? error.message
   } catch {
     // not JSON — fall through to the status line
   }
@@ -195,7 +196,7 @@ export const identityApi = {
 // so an app keys these on its own subject type.
 export const subjectApi = {
   base: (app: string, subjectType: string, id: string | number) =>
-    `/api/${app}/${subjectType}/${id}`,
+    `/api/${encodeURIComponent(app)}/${encodeURIComponent(subjectType)}/${encodeURIComponent(id)}`,
   read: <S extends SubjectSummary>(app: string, subjectType: string, id: string | number) =>
     getJSON<SubjectResponse<S>>(subjectApi.base(app, subjectType, id)),
   boardStream: (app: string, subjectType: string) =>
@@ -223,6 +224,8 @@ async function sendOperation(method: string, path: string, body: unknown): Promi
 }
 
 export const api = {
+  overviewWork: () => getJSON<OverviewWork>('/api/overview/work'),
+  overviewSchedules: () => getJSON<OverviewSchedules>('/api/overview/schedules'),
   systemHealth: () => getJSON<DashboardHealth>('/api/system/health'),
   listApps: () => getJSON<App[]>('/api/apps'),
   // ``path`` is the location under the app's own root: "" for the landing

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,19 +1,5 @@
-/**
- * Hand-written aliases for the API response shapes.
- *
- * Replace these with `openapi-typescript` output once the backend is running:
- *
- *     npm run types:openapi
- *
- * That generates `src/api/openapi.ts` from `/openapi.json`; re-export the
- * components you need from there. For now we keep these typed by hand so the
- * frontend compiles without a running backend.
- *
- * Build-domain shapes (work items, runs, scope, plan) live in
- * ``build.ts``; this file holds the shared types.
- */
+/** Shared API response shapes. App-specific types stay with their app. */
 
-// --- Platform: subjects, runs, agent calls ---------------------------------
 
 // Served by the platform layer (durable/schemas.py) for every app. An
 // app keys its board/detail on its own subject summary; SubjectRow and
@@ -29,6 +15,39 @@ export type RunState =
   | 'cancelled'
   // The run's DBOS workflow row is gone; it will never start.
   | 'orphaned'
+
+export interface OverviewRun {
+  app: string
+  run: string
+  kind: string
+  state: RunState
+  subjectType: string | null
+  subjectId: string | null
+  subjectLabel: string | null
+  updatedAt: string
+  parkedAt: string | null
+  requestLabel: string | null
+  presentation: string | null
+  requestUrl: string | null
+  failure: string | null
+}
+
+export interface OverviewWork {
+  rows: OverviewRun[]
+  hasMore: boolean
+}
+
+export interface OverviewSchedule {
+  app: string
+  kind: string
+  cron: string | null
+  enabled: boolean
+  timezone: string
+}
+
+export interface OverviewSchedules {
+  rows: OverviewSchedule[]
+}
 
 // The base every app's subject summary satisfies; ``id`` keys its status,
 // timeline, and detail URL.
@@ -124,8 +143,7 @@ export interface RunSummary {
   state: RunState
   failure?: string | null
   gate: string | null
-  // The structured ask while this run is parked on the operator. Presence means
-  // "needs you".
+  // A retained ask is current only while the run is parked.
   inputRequest?: InputRequest | null
   createdAt: string
   updatedAt: string
@@ -202,7 +220,6 @@ export interface App {
   operations: Operation[]
 }
 
-// --- Druks UI --------------------------------------------------------------
 // The app's Python page declarations, as the shell sees them. They mirror
 // docs/druks-ui.md, and arrive in route-match order.
 export interface PageEntry {
@@ -470,7 +487,6 @@ export interface GateAnswer {
   note: string
 }
 
-// --- System health ---------------------------------------------------------
 
 export interface WebhookSource {
   source: string
@@ -497,9 +513,7 @@ export interface CatalogModel {
   label: string
 }
 
-/** One coding-agent harness's operator config — a DB record seeded from the
- * registry. Model ids are `provider/model`; the models a harness can run are
- * the catalogs of the providers it drives. */
+/** A registered harness's provider and billing capabilities. */
 export interface Harness {
   name: string
   /** Null for a key-only CLI. */
@@ -533,7 +547,6 @@ export interface ProviderDirectoryEntry {
   models: CatalogModel[]
 }
 
-/** One account's subscription at one provider. */
 /** The requester's subscription at a provider. */
 export interface ProviderSubscription {
   provider: string
@@ -610,7 +623,6 @@ export interface Service {
   connections: Connection[]
 }
 
-// --- Settings --------------------------------------------------------------
 
 export type Billing = 'subscription' | 'api_key'
 
@@ -684,7 +696,6 @@ export interface AgentsResponse {
   apps: AgentsApp[]
 }
 
-// --- Per-app settings (declaration-driven) --------------------------------
 
 export interface WorkflowSettingField {
   name: string
@@ -720,7 +731,7 @@ export interface AppSettings {
   description: string
   /** Lucide icon name for the rail glyph (see APP_ICONS); falls back if unknown. */
   icon: string
-  /** Built-in (platform-core) apps render under the Druks tab, not their own. */
+  /** Platform apps are excluded from the installed app roster. */
   builtin: boolean
   agents: AgentSetting[]
   workflows: WorkflowSettings[]
@@ -747,7 +758,6 @@ export interface UpdateAppsSettingsRequest {
   appSettings?: Record<string, Record<string, unknown>>
 }
 
-// --- Activity feed ---------------------------------------------------------
 
 export interface FeedItem {
   id: string
@@ -771,7 +781,6 @@ export interface FeedResponse {
   nextCursor: string | null
 }
 
-// --- Usage tab -------------------------------------------------------------
 
 export interface UsageMetric {
   percentLeft: number | null

--- a/frontend/src/apps/installed.test.tsx
+++ b/frontend/src/apps/installed.test.tsx
@@ -22,10 +22,26 @@ function roster(name: string, pages: App['pages']): App[] {
 }
 
 describe('page routes', () => {
+  it('keeps the run and request round on the generic subject page', () => {
+    registerInstalledApps(roster('target_app', []))
+    const target = { run: 'run-one', parkedAt: '2026-09-01T00:00:00.123456Z' }
+    const path = getAppUI('target_app')!.subjectPath!({ type: 'file', id: 'a%20b/c?#é' }, target)!
+    const url = new URL(path, 'https://example.invalid')
+    expect(url.pathname).toBe('/target_app/file/a%2520b%2Fc%3F%23%C3%A9')
+    expect(url.searchParams.get('run')).toBe('run-one')
+    expect(url.searchParams.get('parkedAt')).toBe(target.parkedAt)
+    expect(getAppUI('target_app')!.subjectPath!({ type: 'file', id: '1' })).toBe('/target_app/file/1')
+  })
   it('mounts one route per declared page, and the subject matcher last', () => {
     registerInstalledApps(
       roster('archive_app', [
-        { name: 'files', label: 'files', path: '/archive_app', parent: '', order: 0 },
+        {
+          name: 'files',
+          label: 'files',
+          path: '/archive_app',
+          parent: '',
+          order: 0,
+        },
         {
           name: 'one_file',
           label: 'one file',

--- a/frontend/src/apps/installed.tsx
+++ b/frontend/src/apps/installed.tsx
@@ -3,7 +3,7 @@ import { AppPage } from '../druksui/AppPage'
 import { AppHomePage } from '../pages/AppHomePage'
 import { SubjectPage } from '../pages/SubjectPage'
 import { InstalledAppHost } from './InstalledAppHost'
-import { getAppUI, registerAppUI, type AppRoute } from './registry'
+import { getAppUI, registerAppUI, targetQuery, type AppRoute, type AppUI } from './registry'
 
 // Bundled registration wins: a name already present is left alone, so this is
 // safe to call on every roster response.
@@ -26,7 +26,7 @@ function wouterPath(path: string): string {
   )
 }
 
-function installedUI(info: App) {
+function installedUI(info: App): AppUI {
   const name = info.name
   if (info.hasFrontend) {
     return {
@@ -59,18 +59,14 @@ function installedUI(info: App) {
   routes.push({
     // Wildcard, not :id — a subject id can contain slashes ("owner/repo#7").
     path: `/${name}/:subjectType/*`,
-    render: (params: Record<string, string>) => (
-      <SubjectPage
-        app={name}
-        subjectType={params.subjectType ?? ''}
-        subjectId={params['*'] ?? ''}
-      />
-    ),
+    render: () => <SubjectPage app={name} />,
   })
   return {
     name,
     routes,
-    subjectPath: ({ type, id }: { type: string; id: string }) =>
-      info.subjectTypes.includes(type) ? `/${name}/${type}/${id}` : undefined,
+    subjectPath: ({ type, id }, target) =>
+      info.subjectTypes.includes(type)
+        ? `/${name}/${encodeURIComponent(type)}/${encodeURIComponent(id)}${targetQuery(target)}`
+        : undefined,
   }
 }

--- a/frontend/src/apps/registry.tsx
+++ b/frontend/src/apps/registry.tsx
@@ -17,11 +17,24 @@ export interface AppUI {
   navigation?: [string, string][]
   // Where a feed row about one of this app's subjects navigates. The shell knows
   // an app has subjects, never where its pages put them.
-  subjectPath?: (subject: { type: string; id: string }) => string | undefined
+  subjectPath?: (subject: { type: string; id: string }, target?: SubjectTarget) => string | undefined
   // Whether the persistent system-health strip (webhook + spend) rides above this
   // app's list and detail surfaces. Opt-in — an app that doesn't track
   // code hosts leaves it off and the band never renders.
   systemStrip?: boolean
+}
+
+/** The run an owner link selects and, for a decision, its request round. */
+export interface SubjectTarget {
+  run: string
+  parkedAt?: string
+}
+
+export function targetQuery(target?: SubjectTarget): string {
+  const query = new URLSearchParams()
+  if (target) query.set('run', target.run)
+  if (target?.parkedAt) query.set('parkedAt', target.parkedAt)
+  return query.size ? `?${query}` : ''
 }
 
 export function appLabel(name: string): string {

--- a/frontend/src/apps/software_factory/WorkItemPage.tsx
+++ b/frontend/src/apps/software_factory/WorkItemPage.tsx
@@ -1,7 +1,7 @@
 import { Page } from '@druks/ui'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useMemo, useState } from 'react'
-import { Link, useLocation } from 'wouter'
+import { Link, useLocation, useRouter } from 'wouter'
 
 import { useSSE } from '../../api/sse'
 import { buildApi } from './api'
@@ -15,7 +15,8 @@ import type {
 } from '../../api/types'
 import { DetailLayout } from '../../components/DetailLayout'
 import { queryGate } from '../../components/QueryGate'
-import { CancelRun, InAppReview, RetryRun } from '../../components/RunControls'
+import { CancelRun, RetryRun } from '../../components/RunControls'
+import { GateControls } from '../../druksui/GateControls'
 import { RunTranscript } from '../../components/RunTranscript'
 import { computeElapsed, dur, formatTokenCount, relTime, secondsSince } from '../../lib/format'
 import { parkedLine, runSubLine, statusLine } from './statusLine'
@@ -28,6 +29,9 @@ interface Props {
 }
 
 export function WorkItemPage({ workItemId }: Props) {
+  const router = useRouter()
+  const useSearch = router.searchHook
+  const search = useSearch(router)
   const queryClient = useQueryClient()
   const query = useQuery({
     queryKey: ['work-item', workItemId],
@@ -38,28 +42,20 @@ export function WorkItemPage({ workItemId }: Props) {
     data ? workItemPath(data.summary.id, data.summary.ticketKey, data.summary.title) : null,
   )
 
-  // Push-driven cache: the detail stream re-emits the whole snapshot on any
-  // change, so we just replace the cached detail with it — no per-entity merge.
-  // Initial fetch is the only HTTP GET in the page lifetime unless the SSE
-  // connection drops (onError invalidates as a fallback).
   const queryKey = useMemo(() => ['work-item', workItemId] as const, [workItemId])
 
   const patchSnapshot = useCallback(
     (payload: unknown) => {
       queryClient.setQueryData<WorkItemDetail>(queryKey, payload as WorkItemDetail)
+      void queryClient.invalidateQueries({ queryKey: ['gate'] })
     },
     [queryClient, queryKey],
   )
 
-  // Stream for as long as the page is open — even a terminal-looking item can
-  // be re-triggered (operators restart cancelled tickets), and gating on
-  // outcome left no stream for the next trigger to arrive on. The server
-  // never hangs up (keepalives + polling until disconnect), so an always-on
-  // EventSource can't reconnect-loop.
+  // A completed item can receive another run, so its stream stays open.
   useSSE(buildApi.subjectStreamUrl(workItemId), {
     handlers: useMemo(() => ({ snapshot: patchSnapshot }), [patchSnapshot]),
     onError: () => {
-      // SSE dropped — re-sync via a full fetch so the cache catches up.
       queryClient.invalidateQueries({ queryKey: ['work-item', workItemId] }).catch(() => {})
     },
   })
@@ -68,14 +64,15 @@ export function WorkItemPage({ workItemId }: Props) {
     loadingMsg: 'loading work item',
     errorMsg: 'could not load work item',
   })
-  if (gate) return <Page scroll="internal" className="ins">{gate}</Page>
+  if (gate)
+    return (
+      <Page scroll="internal" className="ins">
+        {gate}
+      </Page>
+    )
 
-  return <WorkItemView data={query.data!} />
+  return <WorkItemView key={search} data={query.data!} />
 }
-
-// ===========================================================================
-//  Run metadata
-// ===========================================================================
 
 const STATE_GLYPH: Record<string, string> = {
   scheduled: '·',
@@ -104,9 +101,6 @@ interface Metrics {
 function runMetrics(run: RunSummary): Metrics {
   const cost = run.agentCalls.reduce((s, c) => s + (c.costUsd ?? 0), 0)
   const tokens = run.agentCalls.reduce((s, c) => s + (c.tokens?.totalTokens ?? 0), 0)
-  // Wall-clock time for the run: live count while running, start→last-update
-  // span otherwise (updatedAt is the terminal mirror, so it reads as "finish";
-  // a parked run shows the time worked so far).
   const elapsed = isRunning(run)
     ? secondsSince(run.createdAt)
     : (new Date(run.updatedAt).getTime() - new Date(run.createdAt).getTime()) / 1000
@@ -114,7 +108,7 @@ function runMetrics(run: RunSummary): Metrics {
 }
 
 interface Status {
-  cls: string
+  className: string
   label: string
   live: boolean
 }
@@ -130,19 +124,14 @@ const STATE_CLS: Record<RunState, string> = {
   orphaned: 'failed',
 }
 
-// The pill renders build's status line over the platform's facts; the
-// tone comes from the lifecycle state. Live (a dot animates) while a run is active.
 function statusView(status: SubjectStatus, resolution: PRResolution | null): Status {
   const live = status.state === 'running' || status.state === 'parked'
-  // Nothing has run yet — the pill rests, in the same tone as a cancelled row.
-  const cls = status.state ? STATE_CLS[status.state] : 'cancelled'
-  return { cls, label: statusLine(status, resolution), live }
+  const className = status.state ? STATE_CLS[status.state] : 'cancelled'
+  return { className, label: statusLine(status, resolution), live }
 }
 
-const fmtTok = (n: number) => (n > 0 ? formatTokenCount(n) : '0')
+const displayTokens = (n: number) => (n > 0 ? formatTokenCount(n) : '0')
 
-// The selected timeline entry: always a run; plus the call when one is
-// selected directly (the common case — runs with calls select through them).
 interface Selection {
   run: RunSummary
   call: AgentCallSummary | null
@@ -154,31 +143,34 @@ function resolveSelection(runs: RunSummary[], selected: string | null): Selectio
     const call = run.agentCalls.find((c) => c.id === selected)
     if (call) return { run, call }
   }
+  if (selected) return null
   // Default to the newest call of the newest run: while live that's the one
   // streaming, and once terminal it's the most useful glance.
   const last = runs.at(-1)
   return last ? { run: last, call: last.agentCalls.at(-1) ?? null } : null
 }
 
-// ===========================================================================
-//  Page
-// ===========================================================================
-
 function WorkItemView({ data }: { data: WorkItemDetail }) {
-  const wi = data.summary
+  const router = useRouter()
+  const useSearch = router.searchHook
+  const search = useSearch(router)
+  const target = new URLSearchParams(search)
+  const targetRun = target.get('run')
+  const targetRound = target.get('parkedAt') ?? undefined
+  const workItem = data.summary
   const runs = data.timeline
   const allCalls = runs.flatMap((run) => run.agentCalls)
   const totalCost = allCalls.reduce((s, c) => s + (c.costUsd ?? 0), 0)
   const totalTokens = allCalls.reduce((s, c) => s + (c.tokens?.totalTokens ?? 0), 0)
   const status = statusView(data.status, data.summary.resolution)
 
-  // Re-render once a second while anything is live so the elapsed counters
-  // (the work-item total, a running run's duration) tick on their own —
-  // they're computed from now(), and no SSE event fires between ticks.
   useTicker(status.live || runs.some(isRunning))
 
   const [selected, setSelected] = useState<string | null>(null)
-  const selection = resolveSelection(runs, selected)
+  const selectedId = selected ?? targetRun
+  const invalidRun = !selected && targetRun && !runs.some((run) => run.id === targetRun)
+  const selection = invalidRun ? null : resolveSelection(runs, selectedId)
+  const expected = targetRun === selection?.run.id ? targetRound : undefined
 
   const crumb = (
     <div className="ins-crumb">
@@ -194,7 +186,7 @@ function WorkItemView({ data }: { data: WorkItemDetail }) {
         rail={
           <>
             <InfoPanel
-              wi={wi}
+              workItem={workItem}
               status={status}
               totalCost={totalCost}
               totalTokens={totalTokens}
@@ -203,27 +195,31 @@ function WorkItemView({ data }: { data: WorkItemDetail }) {
               runs={runs}
               activity={data.activity}
               selection={selection}
-              onSelect={setSelected}
+              onSelect={(id) => setSelected(id)}
             />
           </>
         }
-        main={<RightPane data={data} selection={selection} />}
+        main={
+          selectedId && !selection ? (
+            <p role="alert">
+              This run does not belong to this work item or is no longer available.
+            </p>
+          ) : (
+            <RightPane data={data} selection={selection} expected={expected} />
+          )
+        }
       />
     </Page>
   )
 }
 
-// ===========================================================================
-//  Left rail — info + timeline
-// ===========================================================================
-
 function InfoPanel({
-  wi,
+  workItem,
   status,
   totalCost,
   totalTokens,
 }: {
-  wi: WorkItemSummary
+  workItem: WorkItemSummary
   status: Status
   totalCost: number
   totalTokens: number
@@ -234,57 +230,61 @@ function InfoPanel({
         <span className="ins-panel-title">info</span>
       </div>
       <div className="ins-info">
-        {/* Identity first (pr · repo · branch · source), then status last — so
-            the value column flows short→long instead of jagging, and status
-            reads as the conclusion of the block. */}
         <div className="ins-fields">
           <div className="ins-field">
             <span className="ins-field-k">pr</span>
             <span className="ins-field-v">
-              {wi.prNumber == null ? (
+              {workItem.prNumber == null ? (
                 <span style={{ color: 'var(--text-faint)' }}>not opened</span>
-              ) : wi.links.pr ? (
-                <a className="ins-link" href={wi.links.pr} target="_blank" rel="noreferrer">
-                  #{wi.prNumber}
+              ) : workItem.links.pr ? (
+                <a className="ins-link" href={workItem.links.pr} target="_blank" rel="noreferrer">
+                  #{workItem.prNumber}
                   <span className="ins-link-arrow">↗</span>
                 </a>
               ) : (
-                `#${wi.prNumber}`
+                `#${workItem.prNumber}`
               )}
             </span>
           </div>
           <div className="ins-field">
             <span className="ins-field-k">repo</span>
-            <span className="ins-field-v" title={wi.repo}>
-              <a className="ins-link" href={wi.links.repo} target="_blank" rel="noreferrer">
-                {wi.repo.includes('/') ? wi.repo.slice(wi.repo.indexOf('/') + 1) : wi.repo}
+            <span className="ins-field-v" title={workItem.repo}>
+              <a className="ins-link" href={workItem.links.repo} target="_blank" rel="noreferrer">
+                {workItem.repo.includes('/')
+                  ? workItem.repo.slice(workItem.repo.indexOf('/') + 1)
+                  : workItem.repo}
                 <span className="ins-link-arrow">↗</span>
               </a>
             </span>
           </div>
           <div className="ins-field">
             <span className="ins-field-k">branch</span>
-            <span className="ins-field-v" title={wi.branch ?? ''}>
-              {wi.branch ?? '—'}
+            <span className="ins-field-v" title={workItem.branch ?? ''}>
+              {workItem.branch ?? '—'}
             </span>
           </div>
           <div className="ins-field">
             <span className="ins-field-k">source</span>
-            <span className="ins-field-v" title={wi.ticketKey}>
-              {wi.links.ticket ? (
-                <a className="ins-link" href={wi.links.ticket} target="_blank" rel="noreferrer">
-                  {wi.source}
-                  {` · ${wi.ticketKey}`}
+            <span className="ins-field-v" title={workItem.ticketKey}>
+              {workItem.links.ticket ? (
+                <a
+                  className="ins-link"
+                  href={workItem.links.ticket}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {workItem.source}
+                  {` · ${workItem.ticketKey}`}
                   <span className="ins-link-arrow">↗</span>
                 </a>
               ) : (
-                `${wi.source}${wi.ticketKey ? ` · ${wi.ticketKey}` : ''}`
+                `${workItem.source}${workItem.ticketKey ? ` · ${workItem.ticketKey}` : ''}`
               )}
             </span>
           </div>
           <div className="ins-field">
             <span className="ins-field-k">status</span>
-            <span className={`ins-status ins-status-${status.cls}`}>
+            <span className={`ins-status ins-status-${status.className}`}>
               {status.live && <span className="ins-status-dot" />}
               {status.label}
             </span>
@@ -293,7 +293,7 @@ function InfoPanel({
         <div className="ins-stats">
           <div className="ins-stat">
             <span className="ins-stat-k">elapsed</span>
-            <span className="ins-stat-v">{dur(secondsSince(wi.createdAt))}</span>
+            <span className="ins-stat-v">{dur(secondsSince(workItem.createdAt))}</span>
           </div>
           <div className="ins-stat">
             <span className="ins-stat-k">cost</span>
@@ -301,7 +301,7 @@ function InfoPanel({
           </div>
           <div className="ins-stat">
             <span className="ins-stat-k">tokens</span>
-            <span className="ins-stat-v">{fmtTok(totalTokens)}</span>
+            <span className="ins-stat-v">{displayTokens(totalTokens)}</span>
           </div>
         </div>
       </div>
@@ -327,17 +327,18 @@ function TimelinePanel({
         <span className="ins-panel-right mono">{runs.length} runs</span>
       </div>
       <div className="ins-timeline">
-        {/* Latest-first: operators glance at "what's happening now" before
-            reading history. Backend emits chronological; reverse for display. */}
-        {runs.slice().reverse().map((run) => (
-          <RunRow
-            key={run.id}
-            run={run}
-            activity={activity}
-            selection={selection}
-            onSelect={onSelect}
-          />
-        ))}
+        {runs
+          .slice()
+          .reverse()
+          .map((run) => (
+            <RunRow
+              key={run.id}
+              run={run}
+              activity={activity}
+              selection={selection}
+              onSelect={onSelect}
+            />
+          ))}
       </div>
     </div>
   )
@@ -354,17 +355,26 @@ function RunRow({
   selection: Selection | null
   onSelect: (id: string) => void
 }) {
-  const m = runMetrics(run)
+  const metrics = runMetrics(run)
   const selectedHere = selection?.run.id === run.id
   // A single call duplicates the run's own row (same label, same ledger) —
   // fold it into the parent instead of showing both.
   const collapseCalls = run.agentCalls.length <= 1
-  const sub = runSubLine(run, activity, collapseCalls)
+  const subtitle = runSubLine(run, activity, collapseCalls)
   return (
     <div className="wic-run">
       <div
+        role="button"
+        tabIndex={0}
+        aria-label={`Select ${run.label} run ${run.id}`}
         className={`wic-op ${selectedHere && (collapseCalls || selection?.call == null) ? 'wic-op-selected' : ''} ${isRunning(run) ? 'wic-op-running' : ''}`}
         onClick={() => onSelect(run.id)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            onSelect(run.id)
+          }
+        }}
       >
         <div className="wic-op-spine">
           <span className={`wic-op-node wic-node-${run.state}`}>
@@ -380,13 +390,15 @@ function RunRow({
           </div>
           <span className={`wic-op-sub wic-sub-${run.state}`}>
             <span className="wic-op-sub-dot" />
-            {sub}
+            {subtitle}
             {!isRunning(run) && <span> · {relTime(secondsSince(run.updatedAt))}</span>}
           </span>
         </div>
         <div className="wic-op-ledger">
-          <span className="wic-op-dur">{m.elapsed > 0 ? dur(m.elapsed) : '–'}</span>
-          <span className="wic-op-cost">{m.cost > 0 ? '$' + m.cost.toFixed(2) : '–'}</span>
+          <span className="wic-op-dur">{metrics.elapsed > 0 ? dur(metrics.elapsed) : '–'}</span>
+          <span className="wic-op-cost">
+            {metrics.cost > 0 ? '$' + metrics.cost.toFixed(2) : '–'}
+          </span>
         </div>
       </div>
       {!collapseCalls &&
@@ -413,7 +425,19 @@ function CallRow({
 }) {
   const elapsed = computeElapsed(call.startedAt, call.finishedAt) ?? 0
   return (
-    <div className={`wic-call ${selected ? 'wic-call-selected' : ''}`} onClick={onSelect}>
+    <div
+      className={`wic-call ${selected ? 'wic-call-selected' : ''}`}
+      role="button"
+      tabIndex={0}
+      aria-label={`Select ${call.label} call ${call.id}`}
+      onClick={onSelect}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onSelect()
+        }
+      }}
+    >
       <span className={`wic-call-glyph wic-g-${call.status}`}>
         {CALL_GLYPH[call.status] ?? '·'}
       </span>
@@ -428,19 +452,23 @@ function CallRow({
   )
 }
 
-// ===========================================================================
-//  Right pane — title hero + run inspector
-// ===========================================================================
-
-function RightPane({ data, selection }: { data: WorkItemDetail; selection: Selection | null }) {
-  const wi = data.summary
+function RightPane({
+  data,
+  selection,
+  expected,
+}: {
+  data: WorkItemDetail
+  selection: Selection | null
+  expected?: string
+}) {
+  const workItem = data.summary
   return (
     <>
       <div className="ins-hero">
-        <div className="ins-hero-line" title={`${wi.ticketKey} — ${wi.title}`}>
-          <span className="ins-hero-key">{wi.ticketKey}</span>
+        <div className="ins-hero-line" title={`${workItem.ticketKey} — ${workItem.title}`}>
+          <span className="ins-hero-key">{workItem.ticketKey}</span>
           <span className="ins-hero-dash">—</span>
-          {wi.title}
+          {workItem.title}
         </div>
       </div>
       {selection && (
@@ -449,6 +477,7 @@ function RightPane({ data, selection }: { data: WorkItemDetail; selection: Selec
           data={data}
           run={selection.run}
           call={selection.call}
+          expected={expected}
         />
       )}
     </>
@@ -459,26 +488,29 @@ function RunInspector({
   data,
   run,
   call,
+  expected,
 }: {
   data: WorkItemDetail
   run: RunSummary
   call: AgentCallSummary | null
+  expected?: string
 }) {
   // An in-app review is the whole ask — it replaces the transcript instead of
   // stacking above it; the tabs flip between them. External asks keep their
   // one-line banner over the transcript. The ask is run-level, so it only
   // fronts the newest call; picking an earlier call is a request for that
   // call's transcript.
-  const review = run.inputRequest?.presentation === 'in_app' ? run.inputRequest : null
+  const review =
+    run.state === 'parked' && run.inputRequest?.presentation === 'in_app' ? run.inputRequest : null
   const isNewestCall = call == null || call.id === run.agentCalls.at(-1)?.id
   const [tab, setTab] = useState<'review' | 'transcript'>(
-    review && isNewestCall ? 'review' : 'transcript'
+    expected || (review && isNewestCall) ? 'review' : 'transcript',
   )
-  const showReview = review && tab === 'review'
+  const showReview = (expected || review) && tab === 'review'
   return (
     <>
       <RunHeader data={data} run={run} call={call} />
-      {review && (
+      {(expected || review) && (
         <div className="ins-tabs">
           <button
             type="button"
@@ -499,7 +531,7 @@ function RunInspector({
       <div className="ins-step-body">
         <RunFailure run={run} />
         {showReview ? (
-          <InAppReview runId={run.id} ask={review} />
+          <GateControls run={run.id} expected={expected} />
         ) : (
           <>
             {!review && <RunNeedsInput run={run} prUrl={data.summary.links.pr} />}
@@ -521,10 +553,10 @@ function RunHeader({
   call: AgentCallSummary | null
 }) {
   const [, navigate] = useLocation()
-  const wi = data.summary
-  const m = runMetrics(run)
+  const workItem = data.summary
+  const metrics = runMetrics(run)
   const live = isRunning(run)
-  const timing = m.elapsed > 0 ? dur(m.elapsed) : live ? 'live' : '—'
+  const timing = metrics.elapsed > 0 ? dur(metrics.elapsed) : live ? 'live' : '—'
   return (
     <div className="ins-step-head">
       <span className="ins-sh-meta">
@@ -532,10 +564,10 @@ function RunHeader({
           <span className="ins-sh-k">{live ? 'elapsed' : 'duration'}</span> {timing}
         </span>
         <span className="ins-sh-cell">
-          <span className="ins-sh-k">cost</span> ${m.cost.toFixed(2)}
+          <span className="ins-sh-k">cost</span> ${metrics.cost.toFixed(2)}
         </span>
         <span className="ins-sh-cell">
-          <span className="ins-sh-k">tokens</span> {fmtTok(m.tokens)}
+          <span className="ins-sh-k">tokens</span> {displayTokens(metrics.tokens)}
         </span>
       </span>
       <span className="ins-sh-actions">
@@ -547,7 +579,9 @@ function RunHeader({
           <button
             type="button"
             className="ins-run-link"
-            onClick={() => navigate(agentCallPath(wi.id, wi.ticketKey, wi.title, call.id))}
+            onClick={() =>
+              navigate(agentCallPath(workItem.id, workItem.ticketKey, workItem.title, call.id))
+            }
           >
             open full run ↗
           </button>
@@ -557,7 +591,6 @@ function RunHeader({
   )
 }
 
-// Shown for any failed run — the full failure text.
 function RunFailure({ run }: { run: RunSummary }) {
   if (run.state !== 'failed' || !run.failure) return null
   return (
@@ -570,12 +603,9 @@ function RunFailure({ run }: { run: RunSummary }) {
   )
 }
 
-// A run parked on an external ask (PR review, ticket comment): a one-line
-// "needs you" banner pointing where the action happens. In-app asks render
-// through the review tab instead.
 function RunNeedsInput({ run, prUrl }: { run: RunSummary; prUrl?: string | null }) {
-  const ask = run.inputRequest
-  if (!ask) return null
+  const ask = run.state === 'parked' ? run.inputRequest : null
+  if (ask?.presentation !== 'external') return null
   return (
     <div className="ins-needs">
       <div className="ins-needs-k">

--- a/frontend/src/apps/software_factory/ui.tsx
+++ b/frontend/src/apps/software_factory/ui.tsx
@@ -1,4 +1,4 @@
-import { registerAppUI } from '../registry'
+import { registerAppUI, targetQuery } from '../registry'
 import { SOFTWARE_FACTORY } from './api'
 import { parseLeadingId } from './slug'
 import { AgentCallPage } from './AgentCallPage'
@@ -8,9 +8,6 @@ import { ProjectsPage } from './projects/ProjectsPage'
 import { WorkItemPage } from './WorkItemPage'
 import { WorkItemsPage } from './WorkItemsPage'
 
-// Software Factory contributes its UI through the same registry any app uses — its pages
-// are not the app's spine, they're one app's routes. Its pages are React, so it
-// declares its own tabs; feed, settings, and usage it gets for free.
 registerAppUI({
   name: SOFTWARE_FACTORY,
   home: `/${SOFTWARE_FACTORY}`,
@@ -22,7 +19,10 @@ registerAppUI({
   ],
   // Software Factory's other subject, a project repo, has no page of its own — a row about one
   // stays unclickable rather than landing on the work item that shares its id.
-  subjectPath: ({ type, id }) => (type === 'work_item' ? `/${SOFTWARE_FACTORY}/work-items/${id}` : undefined),
+  subjectPath: ({ type, id }, target) =>
+    type === 'work_item'
+      ? `/${SOFTWARE_FACTORY}/work-items/${encodeURIComponent(id)}${targetQuery(target)}`
+      : undefined,
   routes: [
     { path: `/${SOFTWARE_FACTORY}`, render: () => <WorkItemsPage /> },
     { path: `/${SOFTWARE_FACTORY}/history`, render: () => <HistoryPage /> },

--- a/frontend/src/command-center.css
+++ b/frontend/src/command-center.css
@@ -93,6 +93,11 @@
 ::selection { background: var(--border-loud); color: var(--text); }
 input, textarea { caret-color: var(--bucket-run); }
 button.mono, label.mono { font-family: var(--font-sans); font-size: 15px; }
+.command-center :is(.review-question legend, .review-option, .review-note, .review-btn, .ins-needs-body) { font-family: var(--font-sans); font-size: 15px; }
+.command-center :is(.review-artifact-title, .review-helper, .review-error, .review-recommended) { font-family: var(--font-sans); font-size: 13px; }
+.command-center .review-option { min-height: 44px; }
+.command-center .subject-run { font-family: var(--font-sans); }
+.command-center :is(.wic-op, .wic-call)[role="button"]:focus-visible { outline: 2px solid var(--bucket-run); outline-offset: -2px; }
 
 @media (max-width: 1024px) {
   .command-header { padding-inline: 24px; }
@@ -118,5 +123,5 @@ button.mono, label.mono { font-family: var(--font-sans); font-size: 15px; }
   .back-to-app { min-height: 44px; }
   .command-center :is(input, select, textarea) { font-size: 16px; }
   .sidebar-search, .sidebar-search input { min-height: 44px; }
-  .command-center button { min-height: 44px; }
+  .command-center :is(button, .wic-op[role="button"], .wic-call[role="button"]) { min-height: 44px; }
 }

--- a/frontend/src/components/RunControls.test.tsx
+++ b/frontend/src/components/RunControls.test.tsx
@@ -126,19 +126,38 @@ describe('the lent run controls', () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/artifacts/art-1')
   })
 
-  it('renders the panel without the artifact when the read fails', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => new Response('nope', { status: 404, statusText: 'Not Found' })),
+  it('blocks approval after an artifact read fails and allows a retry', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response('nope', { status: 404, statusText: 'Not Found' }),
     )
+    vi.stubGlobal('fetch', fetchMock)
     render(
       <InAppReview
         runId="run-123"
         ask={{ presentation: 'in_app', controls: ['approve'], artifact_id: 'gone' }}
       />,
     )
-    // The ask's own controls are what the operator answers; a missing artifact
-    // must not take the gate down with it.
-    expect(await screen.findByText('Approve')).toBeTruthy()
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'Could not load the review artifact.',
+    )
+    expect((screen.getByRole('button', { name: 'Approve' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            kind: 'plan',
+            title: 'Recovered plan',
+            content: 'Read before approval',
+          }),
+          { status: 200 },
+        ),
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByText('Recovered plan')).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Approve' }) as HTMLButtonElement).disabled).toBe(
+      false,
+    )
   })
 })

--- a/frontend/src/components/RunControls.tsx
+++ b/frontend/src/components/RunControls.tsx
@@ -1,13 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useId, useState } from 'react'
 
 import { api } from '../api/client'
 import type { ArtifactContent, InputRequest } from '../api/types'
 import { Markdown } from './Markdown'
 
-// Cancel is a run-level action: end any active run, parked or running. A destructive
-// stop, so it confirms first and takes an optional reason (the recorded cancel note).
-// The detail stream re-emits the snapshot on the state flip, so this control unmounts
-// itself — no local success handling.
 export function CancelRun({ runId }: { runId: string }) {
   const [confirming, setConfirming] = useState(false)
   const [reason, setReason] = useState('')
@@ -35,6 +31,7 @@ export function CancelRun({ runId }: { runId: string }) {
   return (
     <span className="ins-cancel-confirm">
       <input
+        aria-label="Reason for cancellation"
         type="text"
         className="ins-cancel-reason mono"
         placeholder="reason (optional)"
@@ -83,24 +80,21 @@ export function RetryRun({ runId }: { runId: string }) {
   )
 }
 
-// Button label per control verb; the ask's controls are a fixed workflow vocabulary.
 const CONTROL_LABEL: Record<string, string> = {
   approve: 'Approve',
   request_changes: 'Request changes',
   revise_contract: 'Revise contract',
 }
 
-// The in-app review: the reviewed artifact, structured question options, one
-// note, and the workflow's controls. A click resumes the run with
-// {control, answers, note}; free text is content for the next agent prompt,
-// never a control.
 export function InAppReview({
   runId,
   ask,
   send,
+  disabled = false,
 }: {
   runId: string
   ask: InputRequest
+  disabled?: boolean
   // How the answer reaches the platform. A page's GateControls answers through
   // the gate route with the run's parkedAt; without one, this resumes the run.
   send?: (answer: {
@@ -109,41 +103,39 @@ export function InAppReview({
     note: string
   }) => Promise<unknown>
 }) {
+  const formId = useId()
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [note, setNote] = useState('')
   const [pending, setPending] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const critique = ask.context?.trim() ?? ''
 
-  // Fetched here rather than through react-query: an installed app borrows this
-  // component through the import map and mounts it outside the shell's tree,
-  // where there is no QueryClientProvider. One artifact, read once per ask.
-  // Held with the id it belongs to, so a new ask stops showing the old plan on
-  // the render that changes it rather than after its fetch lands.
+  // Installed apps can mount this component without a QueryClientProvider.
   const [fetched, setFetched] = useState<{ id: string; content: ArtifactContent } | null>(null)
   const artifact = fetched && fetched.id === ask.artifact_id ? fetched.content : null
+  const [attempt, setAttempt] = useState(0)
+  const [failedRead, setFailedRead] = useState<{ id: string; attempt: number } | null>(null)
+  const artifactFailed = failedRead?.id === ask.artifact_id && failedRead?.attempt === attempt
   useEffect(() => {
     const artifactId = ask.artifact_id
     if (!artifactId) return
     let live = true
-    // A missing artifact leaves the panel without it: the ask's own questions
-    // and controls are what the operator answers.
     api
       .artifact(artifactId)
       .then((content) => live && setFetched({ id: artifactId, content }))
-      .catch(() => {})
+      .catch(() => {
+        if (live) setFailedRead({ id: artifactId, attempt })
+      })
     return () => {
       live = false
     }
-  }, [ask.artifact_id])
+  }, [ask.artifact_id, attempt])
 
   async function choose(control: string) {
     setPending(control)
     setError(null)
     const answer = { control, answers, note: note.trim() }
     try {
-      // The run un-parks; the subject's SSE stream re-emits the snapshot and this
-      // banner clears itself.
       if (send) {
         await send(answer)
       } else {
@@ -157,6 +149,18 @@ export function InAppReview({
 
   return (
     <div className="ins-needs">
+      {ask.artifact_id &&
+        !artifact &&
+        (artifactFailed ? (
+          <div className="review-error" role="alert">
+            Could not load the review artifact.{' '}
+            <button className="set-btn ghost" onClick={() => setAttempt((current) => current + 1)}>
+              Retry
+            </button>
+          </div>
+        ) : (
+          <p role="status">Loading review artifact…</p>
+        ))}
       {critique && (
         <div className="review-artifact">
           <div className="review-artifact-title">Critique</div>
@@ -178,34 +182,28 @@ export function InAppReview({
               <label key={option.id} className="review-option">
                 <input
                   type="radio"
-                  name={question.id}
+                  name={`${formId}-${question.id}`}
                   checked={picked === option.id}
-                  onChange={() =>
-                    setAnswers((prev) => ({ ...prev, [question.id]: option.id }))
-                  }
+                  onChange={() => setAnswers((prev) => ({ ...prev, [question.id]: option.id }))}
                 />
                 {option.label}
-                {option.recommended && (
-                  <span className="review-recommended">recommended</span>
-                )}
+                {option.recommended && <span className="review-recommended">recommended</span>}
               </label>
             ))}
           </fieldset>
         )
       })}
-      <label className="review-note-label" htmlFor={`${runId}-note`}>
+      <label className="review-note-label" htmlFor={`${formId}-note`}>
         Your note
       </label>
       <textarea
-        id={`${runId}-note`}
+        id={`${formId}-note`}
         className="review-note"
         placeholder="optional note — what should change?"
         value={note}
         onChange={(e) => setNote(e.target.value)}
       />
-      <div className="review-helper">
-        A note is sent to the agent as feedback.
-      </div>
+      <div className="review-helper">A note is sent to the agent as feedback.</div>
       <div className="review-controls">
         {ask.controls?.map((control) => {
           const needsGuidance =
@@ -217,7 +215,12 @@ export function InAppReview({
             <button
               key={control}
               className={`review-btn review-btn-${control}`}
-              disabled={pending !== null || needsGuidance}
+              disabled={
+                disabled ||
+                pending !== null ||
+                needsGuidance ||
+                (control === 'approve' && Boolean(ask.artifact_id) && !artifact)
+              }
               title={needsGuidance ? 'add an answer or a note first' : undefined}
               onClick={() => choose(control)}
             >

--- a/frontend/src/druksui/GateControls.test.tsx
+++ b/frontend/src/druksui/GateControls.test.tsx
@@ -1,12 +1,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { api } from '../api/client'
+import { api, ApiError } from '../api/client'
 import type { Gate } from '../api/types'
 import { GateControls } from './GateControls'
 
-vi.mock('../api/client', () => ({
+vi.mock('../api/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/client')>()),
   api: { getGate: vi.fn(), answerGate: vi.fn(), artifact: vi.fn() },
 }))
 
@@ -40,11 +41,11 @@ const GATE: Gate = {
   artifact: null,
 }
 
-function renderControls() {
+function renderControls(expected?: string) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return render(
     <QueryClientProvider client={queryClient}>
-      <GateControls run="run-6f0a" />
+      <GateControls run="run-6f0a" expected={expected} />
     </QueryClientProvider>,
   )
 }
@@ -82,7 +83,9 @@ describe('GateControls', () => {
 
   it('shows a stale answer as a failure the operator can read', async () => {
     getGate.mockResolvedValue(GATE)
-    answerGate.mockRejectedValue(new Error('Run run-6f0a has re-parked since the parked_at you read'))
+    answerGate.mockRejectedValue(
+      new Error('Run run-6f0a has re-parked since the parked_at you read'),
+    )
     renderControls()
 
     await waitFor(() => expect(screen.getByText('Approve')).toBeTruthy())
@@ -95,6 +98,98 @@ describe('GateControls', () => {
     getGate.mockRejectedValue(new Error('Run run-6f0a is not parked'))
     renderControls()
 
-    await waitFor(() => expect(screen.getByText('this run is not waiting on you')).toBeTruthy())
+    expect(await screen.findByText('The input request is unavailable.')).toBeTruthy()
+    expect(screen.queryByText('Approve')).toBeNull()
+    getGate.mockResolvedValue(GATE)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByText('Approve')).toBeTruthy()
+  })
+
+  it('rejects an owner link for a different request round', async () => {
+    getGate.mockResolvedValue(GATE)
+    renderControls('2026-08-29T09:14:02.000001Z')
+    expect(await screen.findByText(/This input request has changed/)).toBeTruthy()
+    expect(screen.queryByText('Approve')).toBeNull()
+    expect(answerGate).not.toHaveBeenCalled()
+  })
+
+  it('waits for a current read before it exposes a cached request', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    queryClient.setQueryData(['gate', GATE.run], GATE)
+    getGate.mockResolvedValue({ ...GATE, parkedAt: '2026-08-30T09:14:02Z' })
+    render(
+      <QueryClientProvider client={queryClient}>
+        <GateControls run={GATE.run} expected={GATE.parkedAt} />
+      </QueryClientProvider>,
+    )
+    expect(screen.queryByText('Approve')).toBeNull()
+    expect(await screen.findByText(/This input request has changed/)).toBeTruthy()
+    expect(screen.queryByText('Approve')).toBeNull()
+  })
+
+  it('keeps the same-round draft while a refresh fails and disables its actions', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    getGate.mockResolvedValue(GATE)
+    render(
+      <QueryClientProvider client={client}>
+        <GateControls run={GATE.run} />
+      </QueryClientProvider>,
+    )
+    await screen.findByText('Approve')
+    fireEvent.change(screen.getByRole('textbox', { name: 'Your note' }), {
+      target: { value: 'Keep the rollback step.' },
+    })
+    fireEvent.click(screen.getAllByRole('radio')[0]!)
+    getGate.mockRejectedValue(new Error('Offline'))
+    await act(() => client.invalidateQueries({ queryKey: ['gate', GATE.run] }))
+    expect(await screen.findByText(/Your draft is retained/)).toBeTruthy()
+    expect((screen.getByText('Approve') as HTMLButtonElement).disabled).toBe(true)
+    getGate.mockResolvedValue(GATE)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await waitFor(() =>
+      expect((screen.getByText('Approve') as HTMLButtonElement).disabled).toBe(false),
+    )
+    expect((screen.getByRole('textbox', { name: 'Your note' }) as HTMLTextAreaElement).value).toBe(
+      'Keep the rollback step.',
+    )
+    expect((screen.getAllByRole('radio')[0] as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('removes answer controls after a successful answer even before the next snapshot', async () => {
+    getGate.mockResolvedValue(GATE)
+    answerGate.mockResolvedValue({ run: GATE.run, parkedAt: GATE.parkedAt, result: 'answered' })
+    renderControls()
+    fireEvent.click(await screen.findByText('Approve'))
+    expect(await screen.findByText('Answer sent.')).toBeTruthy()
+    expect(screen.queryByText('Approve')).toBeNull()
+    await waitFor(() => expect(getGate).toHaveBeenCalledTimes(2))
+  })
+
+  it('keeps a sent answer when the next read reports the gate closed', async () => {
+    getGate.mockResolvedValue(GATE)
+    answerGate.mockResolvedValue({ run: GATE.run, parkedAt: GATE.parkedAt, result: 'answered' })
+    renderControls()
+    fireEvent.click(await screen.findByText('Approve'))
+    getGate.mockRejectedValue(new ApiError('The gate is no longer open.', 409, null))
+    expect(await screen.findByText('Answer sent.')).toBeTruthy()
+    await waitFor(() => expect(getGate).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText('The input request is unavailable.')).toBeNull()
+    expect(screen.getByText('Answer sent.')).toBeTruthy()
+  })
+
+  it.each([404, 409])('removes a cached request when the server returns %s', async (status) => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    getGate.mockResolvedValue(GATE)
+    render(
+      <QueryClientProvider client={client}>
+        <GateControls run={GATE.run} />
+      </QueryClientProvider>,
+    )
+    await screen.findByText('Approve')
+    getGate.mockRejectedValue(new ApiError('The gate is no longer open.', status, null))
+    await act(() => client.invalidateQueries({ queryKey: ['gate', GATE.run] }))
+    expect(await screen.findByText('The input request is unavailable.')).toBeTruthy()
+    expect(screen.queryByText('Approve')).toBeNull()
+    expect(screen.queryByText(/Your draft is retained/)).toBeNull()
   })
 })

--- a/frontend/src/druksui/GateControls.tsx
+++ b/frontend/src/druksui/GateControls.tsx
@@ -1,35 +1,67 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
 
-import { api } from '../api/client'
+import { api, ApiError } from '../api/client'
 import { EmptyState } from '../components/EmptyState'
 import { InAppReview } from '../components/RunControls'
 
-/** The operator's answer to a parked run. The block names only the run; the
- * ask, its options, and its artifact come from the gate. The answer echoes the
- * run's ``parkedAt``, so a run that re-parked rejects it. When the run resumes,
- * the region that follows its subject refreshes and these controls go away. */
-export function GateControls({ run }: { run: string }) {
-  const gate = useQuery({ queryKey: ['gate', run], queryFn: () => api.getGate(run), retry: false })
+/** The operator's answer to a parked run. The answer echoes the gate's ``parkedAt``,
+ * so the server rejects one for a round that has since changed. ``expected`` is the
+ * round an owner link named; a different current round is shown, not answered. */
+export function GateControls({ run, expected }: { run: string; expected?: string }) {
+  const queryClient = useQueryClient()
+  const [answeredAt, setAnsweredAt] = useState<string | null>(null)
+  const gate = useQuery({
+    queryKey: ['gate', run],
+    queryFn: () => api.getGate(run),
+    retry: false,
+    refetchOnMount: 'always',
+  })
 
-  if (gate.isLoading) return <EmptyState glyph="…" msg="reading the gate" />
-  if (gate.isError || !gate.data) {
+  // The read after an answer finds the run resumed and reports a closed gate.
+  if (answeredAt && (!gate.data || gate.data.parkedAt === answeredAt))
+    return <p role="status">Answer sent.</p>
+  if (!gate.isFetchedAfterMount || gate.isPending)
+    return <EmptyState glyph="…" msg="Reading the input request…" />
+  if (!gate.data || (gate.error instanceof ApiError && [404, 409].includes(gate.error.status))) {
     return (
-      <EmptyState
-        glyph="·"
-        msg="this run is not waiting on you"
-        sub={gate.error instanceof Error ? gate.error.message : undefined}
-      />
+      <div role="alert">
+        <EmptyState glyph="·" msg="The input request is unavailable." sub={gate.error?.message} />
+        <button className="set-btn ghost" onClick={() => void gate.refetch()}>
+          Retry
+        </button>
+      </div>
+    )
+  }
+  if (expected && gate.data.parkedAt !== expected) {
+    return (
+      <p role="alert">
+        This input request has changed. Return to Overview to open the current request.
+      </p>
     )
   }
   const parkedAt = gate.data.parkedAt
   return (
-    <InAppReview
-      // A run that parks again asks a new question, so the controls start over
-      // rather than keeping the last round's answers and pending state.
-      key={parkedAt}
-      runId={run}
-      ask={gate.data.ask}
-      send={(answer) => api.answerGate(run, { parkedAt, ...answer })}
-    />
+    <>
+      {gate.isError && (
+        <p role="alert">
+          Could not refresh this request. Your draft is retained.{' '}
+          <button onClick={() => void gate.refetch()}>Retry</button>
+        </p>
+      )}
+      <InAppReview
+        // A run that parks again asks a new question, so the controls start over
+        // rather than keeping the last round's answers and pending state.
+        key={parkedAt}
+        runId={run}
+        ask={gate.data.ask}
+        disabled={gate.isError}
+        send={async (answer) => {
+          await api.answerGate(run, { parkedAt, ...answer })
+          setAnsweredAt(parkedAt)
+          await queryClient.invalidateQueries({ queryKey: ['gate', run] })
+        }}
+      />
+    </>
   )
 }

--- a/frontend/src/druksui/SubjectStream.tsx
+++ b/frontend/src/druksui/SubjectStream.tsx
@@ -18,7 +18,7 @@ export function SubjectStream({
 }) {
   let path = subjectApi.boardStream(app, subject.subjectType)
   if (subject.subjectId) {
-    path = subjectApi.stream(app, subject.subjectType, encodeURIComponent(subject.subjectId))
+    path = subjectApi.stream(app, subject.subjectType, subject.subjectId)
   }
   useSSE(path, { handlers: { snapshot: () => onSnapshot(subject) } })
   return null

--- a/frontend/src/druksui/accessibility.test.tsx
+++ b/frontend/src/druksui/accessibility.test.tsx
@@ -12,7 +12,8 @@ import catalog from './catalog.json'
 import { PagesContext } from './pages'
 
 vi.mock('../components/RunTranscript', () => ({ RunTranscript: () => <pre /> }))
-vi.mock('../api/client', () => ({
+vi.mock('../api/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api/client')>()),
   api: { getGate: vi.fn(), answerGate: vi.fn(), artifact: vi.fn(), callOperation: vi.fn(), readPage: vi.fn() },
 }))
 
@@ -32,8 +33,8 @@ const CATALOG: Block[] = [
   { block: 'gate_controls', run: 'run-6f0a' },
 ]
 
-vi.mocked(api.getGate).mockResolvedValue({
-  run: 'run-6f0a',
+vi.mocked(api.getGate).mockImplementation(async (run) => ({
+  run,
   gate: 'review',
   parkedAt: '2026-08-29T09:14:02Z',
   ask: {
@@ -44,7 +45,7 @@ vi.mocked(api.getGate).mockResolvedValue({
     ],
   },
   artifact: null,
-})
+}))
 
 function renderBlocks(blocks: Block[]) {
   const { hook } = memoryLocation({ path: '/field_notes' })
@@ -70,7 +71,7 @@ describe('every V1 renderer', () => {
   it('renders the wire snapshot without a single unknown block', async () => {
     renderCatalog()
 
-    await waitFor(() => expect(screen.getByText('Approve')).toBeTruthy())
+    await waitFor(() => expect(screen.getAllByText('Approve')).toHaveLength(2))
     expect(screen.queryAllByRole('alert')).toHaveLength(0)
   })
 
@@ -84,7 +85,7 @@ describe('every V1 renderer', () => {
 
   it('gives every input its own label', async () => {
     const { container } = renderCatalog()
-    await waitFor(() => expect(screen.getByText('Approve')).toBeTruthy())
+    await waitFor(() => expect(screen.getAllByText('Approve')).toHaveLength(2))
 
     for (const input of Array.from(container.querySelectorAll('input, textarea, select'))) {
       const labelled =
@@ -136,7 +137,7 @@ describe('every V1 renderer', () => {
 
   it('gives every control a name and takes focus in reading order', async () => {
     const { container } = renderCatalog()
-    await waitFor(() => expect(screen.getByText('Approve')).toBeTruthy())
+    await waitFor(() => expect(screen.getAllByText('Approve')).toHaveLength(2))
 
     const controls = Array.from(
       container.querySelectorAll<HTMLElement>('button, a[href], input, textarea, select'),
@@ -333,7 +334,6 @@ describe('every V1 renderer', () => {
 
     screen.getByRole('button', { name: 'Rescout peer' }).click()
 
-    // Success is announced; before this a reader heard nothing at all.
     await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Rescout peer'))
   })
 })

--- a/frontend/src/lib/useCanonicalPath.test.tsx
+++ b/frontend/src/lib/useCanonicalPath.test.tsx
@@ -1,0 +1,47 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+import { Router } from 'wouter'
+import { memoryLocation } from 'wouter/memory-location'
+
+import { useCanonicalPath } from './useCanonicalPath'
+
+function Detail({ canonical }: { canonical: string | null }) {
+  useCanonicalPath(canonical)
+  return null
+}
+afterEach(cleanup)
+
+it('preserves the raw query and hash when a detail gets its canonical slug', async () => {
+  window.history.replaceState(
+    null,
+    '',
+    '/work/7?run=older&gate=review%252Fplan&parkedAt=precise#artifact',
+  )
+  render(
+    <Router>
+      <Detail canonical="/work/7-title" />
+    </Router>,
+  )
+  await waitFor(() => expect(window.location.pathname).toBe('/work/7-title'))
+  expect(window.location.search).toBe('?run=older&gate=review%252Fplan&parkedAt=precise')
+  expect(window.location.hash).toBe('#artifact')
+})
+
+it('does not navigate out of Settings when a hidden detail read completes', async () => {
+  window.history.replaceState(null, '', '/settings/profile')
+  const location = memoryLocation({ path: '/work/7?run=older', record: true })
+  const view = render(
+    <Router hook={location.hook}>
+      <Detail canonical={null} />
+    </Router>,
+  )
+  view.rerender(
+    <Router hook={location.hook}>
+      <Detail canonical="/work/7-title" />
+    </Router>,
+  )
+  expect(window.location.pathname).toBe('/settings/profile')
+  expect(location.history).toEqual(['/work/7?run=older'])
+  await act(() => window.history.replaceState(null, '', '/work/7?run=older'))
+  await waitFor(() => expect(location.history).toEqual(['/work/7-title?run=older']))
+})

--- a/frontend/src/lib/useCanonicalPath.ts
+++ b/frontend/src/lib/useCanonicalPath.ts
@@ -1,22 +1,19 @@
 import { useEffect } from 'react'
-import { useLocation } from 'wouter'
+import { useLocation, useRouter } from 'wouter'
+import { useLocationProperty } from 'wouter/use-browser-location'
 
-/**
- * Replace the current URL with ``canonical`` if they differ. Used by
- * detail pages once they've loaded enough data to compute their
- * canonical ``/<type>/<id>-<slug>`` form. Pass ``null`` while the data
- * is still loading — the hook is a no-op until you have something to
- * navigate to.
- *
- * ``replace: true`` so the user's back button doesn't get a duplicate
- * non-canonical history entry.
- */
+/** Keep one history entry for the loaded detail page, including its run target. */
 export function useCanonicalPath(canonical: string | null | undefined): void {
   const [location, navigate] = useLocation()
+  const router = useRouter()
+  const useSearch = router.searchHook
+  const usePath = router.hook
+  const search = useSearch(router).replace(/^\?/, '')
+  const [rawPath] = usePath(router)
+  const visiblePath = useLocationProperty(() => window.location.pathname)
   useEffect(() => {
-    if (!canonical) return
-    if (location !== canonical) {
-      navigate(canonical, { replace: true })
+    if (canonical && location !== canonical && visiblePath === rawPath) {
+      navigate(`${canonical}${search ? `?${search}` : ''}${window.location.hash}`, { replace: true })
     }
-  }, [location, canonical, navigate])
+  }, [location, canonical, navigate, visiblePath, rawPath, search])
 }

--- a/frontend/src/overview.css
+++ b/frontend/src/overview.css
@@ -1,0 +1,51 @@
+.overview .page-shell-body { padding: 36px 40px 48px; }
+.overview-head { display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; }
+.overview h1 { margin: 0 0 10px; font-size: 26px; font-weight: 500; letter-spacing: -.02em; }
+.overview-head p { margin: 0; color: var(--text-mid); }
+.overview-filter select { min-height: 44px; max-width: 240px; padding: 0 12px; border: 1px solid var(--border-loud); border-radius: 5px; background: var(--surface); color: var(--text); font: inherit; text-transform: capitalize; }
+.overview-counts { display: flex; flex-wrap: wrap; gap: 12px 24px; padding: 36px 0 18px; border-bottom: 1px solid var(--border); color: var(--text-mid); }
+.overview-counts strong { color: var(--text); font-weight: 500; }
+.overview-section { margin-top: 30px; }
+.overview-section > header { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; }
+.overview h2 { margin: 0; font-size: 18px; font-weight: 500; }
+.overview-section > header > span { font-size: 13px; color: var(--text-dim); }
+.overview-alert { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 16px; margin: 18px 0 0; color: var(--bucket-dead); font-size: 13px; }
+.overview-alert button { display: inline-flex; align-items: center; gap: 6px; min-height: 40px; color: var(--text); text-decoration: underline; }
+.overview-row { display: grid; grid-template-columns: 18px minmax(0, 1fr) auto 110px; gap: 16px; align-items: center; padding: 20px 0; border-top: 1px solid var(--border); }
+.overview-row > svg { color: var(--text-dim); }
+.overview-parked > svg { color: var(--bucket-human); }
+.overview-running > svg, .overview-scheduled > svg { color: var(--bucket-run); }
+.overview-failed > svg, .overview-orphaned > svg { color: var(--bucket-dead); }
+.overview-identity { min-width: 0; display: flex; flex-direction: column; gap: 6px; overflow-wrap: anywhere; }
+.overview-identity strong { font-weight: 500; }
+.overview-identity strong.mono { font-size: 13px; }
+.overview-identity > span, .overview-identity p, .overview-age, .overview-schedule, .overview-unavailable { font-size: 13px; color: var(--text-mid); }
+.overview-identity p { margin: 0; white-space: pre-wrap; }
+.overview-age { text-align: right; }
+.overview-action { display: inline-flex; align-items: center; justify-content: center; min-height: 40px; padding: 0 14px; color: var(--text); text-decoration: none; border: 1px solid transparent; border-radius: 4px; }
+.overview-action:hover { background: var(--surface-2); }
+.overview-action.primary { background: color-mix(in oklch, var(--bucket-run) 20%, var(--surface)); border-color: color-mix(in oklch, var(--bucket-run) 40%, var(--border)); }
+.overview-schedule { display: flex; flex-direction: column; gap: 5px; text-align: right; }
+.overview-unavailable { display: flex; flex-direction: column; gap: 6px; }
+.overview-unavailable a { color: var(--text); min-height: 32px; display: inline-flex; align-items: center; }
+.overview-empty, .overview-more, .overview-access { color: var(--text-dim); }
+.overview-empty { margin: 0; padding: 18px 0; border-top: 1px solid var(--border); }
+.overview-more, .overview-access { font-size: 13px; }
+.overview-access { padding-top: 24px; border-top: 1px solid var(--border); margin-top: 32px; }
+@media (max-width: 1024px) {
+  .overview .page-shell-body { padding-inline: 24px; }
+  .overview-row { grid-template-columns: 18px minmax(0, 1fr) 110px; }
+  .overview-age, .overview-schedule { grid-column: 2; text-align: left; }
+  .overview-action, .overview-unavailable { grid-column: 3; grid-row: 1 / 3; }
+}
+@media (max-width: 649px) {
+  .overview .page-shell-body { padding: 24px 20px 32px; }
+  .overview-head { flex-wrap: wrap; gap: 20px; }
+  .overview-filter, .overview-filter select { width: 100%; max-width: none; }
+  .overview-filter select { font-size: 16px; }
+  .overview-counts { padding-top: 24px; gap: 10px 20px; }
+  .overview-row { grid-template-columns: 18px minmax(0, 1fr); gap: 10px 14px; }
+  .overview-action, .overview-unavailable { grid-column: 2; grid-row: auto; justify-self: start; }
+  .overview-action, .overview-unavailable a, .overview-alert button { min-height: 44px; }
+  .overview-section > header { flex-wrap: wrap; gap: 6px; }
+}

--- a/frontend/src/pages/OverviewPage.test.tsx
+++ b/frontend/src/pages/OverviewPage.test.tsx
@@ -1,0 +1,148 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Router } from 'wouter'
+
+import { api } from '../api/client'
+import type { OverviewRun } from '../api/types'
+import { registerAppUI, targetQuery } from '../apps/registry'
+import { OverviewPage } from './OverviewPage'
+
+vi.mock('../api/client', () => ({ api: { overviewWork: vi.fn(), overviewSchedules: vi.fn() } }))
+
+const pending: OverviewRun = {
+  app: 'notes',
+  run: 'run-one',
+  kind: 'summarize',
+  state: 'parked',
+  subjectType: 'note',
+  subjectId: '7',
+  subjectLabel: 'One long subject',
+  updatedAt: '2026-09-01T00:00:00Z',
+  parkedAt: '2026-09-01T12:34:56.123456Z',
+  requestLabel: 'Review this note',
+  presentation: 'in_app',
+  requestUrl: null,
+  failure: null,
+}
+const work = vi.mocked(api.overviewWork)
+const schedules = vi.mocked(api.overviewSchedules)
+const href = (link: HTMLElement) => new URL(link.getAttribute('href')!, window.location.origin)
+
+function mount(apps: string[] = ['notes']) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <Router>
+        <OverviewPage apps={apps} />
+      </Router>
+    </QueryClientProvider>,
+  )
+  return client
+}
+
+beforeEach(() => {
+  window.history.replaceState(null, '', '/')
+  work.mockResolvedValue({ rows: [], hasMore: false })
+  schedules.mockResolvedValue({ rows: [] })
+  registerAppUI({
+    name: 'notes',
+    routes: [],
+    subjectPath: ({ type, id }, target) => `/${type}/${id}${targetQuery(target)}`,
+  })
+})
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('Overview', () => {
+  it('sorts one read into sections and links a decision to its run and round', async () => {
+    work.mockResolvedValue({
+      rows: [
+        { ...pending, run: 'later', parkedAt: '2026-09-02T00:00:00Z' },
+        pending,
+        { ...pending, run: 'waiting', presentation: null, requestLabel: null },
+        { ...pending, run: 'running', state: 'running' },
+        { ...pending, run: 'failed', state: 'failed', failure: 'Stopped' },
+      ],
+      hasMore: true,
+    })
+    mount()
+    await screen.findAllByRole('link', { name: 'Review' })
+    const needsYou = screen.getByRole('region', { name: 'Needs you' })
+    const links = within(needsYou).getAllByRole('link', { name: 'Review' })
+    expect(links.map((link) => href(link).searchParams.get('run'))).toEqual(['run-one', 'later'])
+    expect(href(links[0]!).pathname).toBe('/note/7')
+    expect(href(links[0]!).searchParams.get('parkedAt')).toBe(pending.parkedAt)
+    const waiting = screen.getByRole('region', { name: 'Waiting' })
+    expect(href(within(waiting).getByRole('link', { name: 'Open' })).search).toBe('?run=waiting')
+    expect(within(screen.getByRole('region', { name: 'Active work' })).getByText(/Running/)).toBeTruthy()
+    expect(within(screen.getByRole('region', { name: 'Problems' })).getByText('Stopped')).toBeTruthy()
+    expect(screen.getByLabelText('Current work counts').textContent).toContain('2 need you')
+    expect(screen.getByText(/Showing the 200/)).toBeTruthy()
+  })
+
+  it('keeps the last read visible after a failed refresh and retries both reads', async () => {
+    work.mockResolvedValue({ rows: [pending], hasMore: false })
+    const client = mount()
+    await screen.findByRole('link', { name: 'Review' })
+    work.mockRejectedValue(new Error('Offline'))
+    await act(() => client.invalidateQueries({ queryKey: ['overview'] }))
+    expect((await screen.findByRole('alert')).textContent).toContain(
+      'last successful read remains visible',
+    )
+    expect(screen.getByRole('link', { name: 'Review' })).toBeTruthy()
+    work.mockResolvedValue({ rows: [], hasMore: false })
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByText('No current input requests.')).toBeTruthy()
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(schedules).toHaveBeenCalledTimes(3)
+  })
+
+  it('filters every section by app and shows paused schedule facts', async () => {
+    work.mockResolvedValue({ rows: [pending, { ...pending, run: 'other', app: 'other' }], hasMore: false })
+    schedules.mockResolvedValue({
+      rows: [
+        { app: 'notes', kind: 'notes.daily', cron: '0 9 * * *', enabled: false, timezone: 'Europe/Madrid' },
+        { app: 'other', kind: 'other.daily', cron: '0 9 * * *', enabled: true, timezone: 'Europe/Madrid' },
+      ],
+    })
+    mount(['notes', 'other'])
+    expect(await screen.findByText('Paused')).toBeTruthy()
+    expect(screen.getByText('Enabled')).toBeTruthy()
+    expect(screen.getByText('Review destination unavailable')).toBeTruthy()
+    fireEvent.change(screen.getByRole('combobox', { name: 'Filter by app' }), {
+      target: { value: 'notes' },
+    })
+    await waitFor(() => expect(screen.queryByText('Enabled')).toBeNull())
+    expect(screen.queryByText('Review destination unavailable')).toBeNull()
+    expect(screen.getByLabelText('Current work counts').textContent).toContain('1 needs you')
+    expect(screen.getByRole('link', { name: 'Settings' }).getAttribute('href')).toBe(
+      '/apps/notes/settings',
+    )
+    expect(screen.getByText('Europe/Madrid')).toBeTruthy()
+  })
+
+  it('does not invent a review destination or accept an unsafe external URL', async () => {
+    work.mockResolvedValue({
+      rows: [
+        { ...pending, app: 'unsupported' },
+        { ...pending, run: 'external', presentation: 'external', requestUrl: 'javascript:alert(1)' },
+        {
+          ...pending,
+          run: 'external-safe',
+          presentation: 'external',
+          requestUrl: 'https://example.invalid/review',
+        },
+      ],
+      hasMore: false,
+    })
+    mount()
+    expect(await screen.findAllByText('Review destination unavailable')).toHaveLength(2)
+    expect(screen.queryByRole('link', { name: 'Review' })).toBeNull()
+    expect(screen.getByRole('link', { name: 'Open request' }).getAttribute('href')).toBe(
+      'https://example.invalid/review',
+    )
+  })
+})

--- a/frontend/src/pages/OverviewPage.tsx
+++ b/frontend/src/pages/OverviewPage.tsx
@@ -1,0 +1,230 @@
+import { useQuery } from '@tanstack/react-query'
+import { CircleAlert, Clock3, RefreshCw } from 'lucide-react'
+import { Link, useLocation, useSearch } from 'wouter'
+
+import { api } from '../api/client'
+import type { OverviewRun } from '../api/types'
+import { appHome, appLabel, getAppUI } from '../apps/registry'
+import { Page } from '../components/Page'
+import { relTimeFromIso } from '../lib/format'
+import '../overview.css'
+
+const isPending = (row: OverviewRun) =>
+  row.state === 'parked' && Boolean(row.parkedAt && row.presentation)
+
+const SECTIONS: {
+  id: string
+  title: string
+  empty: string
+  select: (rows: OverviewRun[]) => OverviewRun[]
+}[] = [
+  {
+    id: 'pending',
+    title: 'Needs you',
+    empty: 'No current input requests.',
+    select: (rows) =>
+      rows.filter(isPending).sort((a, b) => Date.parse(a.parkedAt!) - Date.parse(b.parkedAt!)),
+  },
+  {
+    id: 'active',
+    title: 'Active work',
+    empty: 'No running or queued work.',
+    select: (rows) => rows.filter((row) => row.state === 'running' || row.state === 'scheduled'),
+  },
+  {
+    id: 'waiting',
+    title: 'Waiting',
+    empty: 'No other parked work.',
+    select: (rows) => rows.filter((row) => row.state === 'parked' && !isPending(row)),
+  },
+  {
+    id: 'problems',
+    title: 'Problems',
+    empty: 'No current failed or orphaned runs.',
+    select: (rows) => rows.filter((row) => row.state === 'failed' || row.state === 'orphaned'),
+  },
+]
+
+const STATE_LABEL: Record<string, string> = {
+  scheduled: 'Queued',
+  running: 'Running',
+  parked: 'Waiting',
+  failed: 'Failed',
+  orphaned: 'Orphaned',
+}
+
+const POLL = { refetchInterval: 30_000, refetchOnWindowFocus: true, retry: false } as const
+
+export function OverviewPage({ apps }: { apps: string[] }) {
+  const [, navigate] = useLocation()
+  const app = new URLSearchParams(useSearch()).get('app') ?? ''
+  const work = useQuery({ queryKey: ['overview', 'work'], queryFn: api.overviewWork, ...POLL })
+  const schedules = useQuery({
+    queryKey: ['overview', 'schedules'],
+    queryFn: api.overviewSchedules,
+    ...POLL,
+  })
+  const rows = (work.data?.rows ?? []).filter((row) => !app || row.app === app)
+  const scheduleRows = (schedules.data?.rows ?? []).filter((row) => !app || row.app === app)
+  const sections = SECTIONS.map((section) => ({ ...section, rows: section.select(rows) }))
+  const [needsYou, active] = sections
+  const pendingCount = needsYou!.rows.length
+  const failed = work.isError || schedules.isError
+
+  return (
+    <Page className="overview">
+      <header className="overview-head">
+        <div>
+          <h1>Overview</h1>
+          <p>Your apps, active work, and decisions in one place.</p>
+        </div>
+        <label className="overview-filter">
+          <select
+            aria-label="Filter by app"
+            value={app}
+            onChange={(event) =>
+              navigate(event.target.value ? `/?app=${encodeURIComponent(event.target.value)}` : '/')
+            }
+          >
+            <option value="">All apps</option>
+            {apps.map((name) => (
+              <option key={name} value={name}>
+                {appLabel(name)}
+              </option>
+            ))}
+            {app && !apps.includes(app) && <option value={app}>{appLabel(app)}</option>}
+          </select>
+        </label>
+      </header>
+      <div className="overview-counts" aria-label="Current work counts">
+        <span>
+          <strong>{work.data ? pendingCount : '—'}</strong> {pendingCount === 1 ? 'needs' : 'need'}{' '}
+          you
+        </span>
+        <span>
+          <strong>{work.data ? active!.rows.length : '—'}</strong> active
+        </span>
+        <span>
+          <strong>{schedules.data ? scheduleRows.length : '—'}</strong>{' '}
+          {scheduleRows.length === 1 ? 'schedule' : 'schedules'}
+        </span>
+        <span>
+          <strong>{apps.length}</strong> installed apps
+        </span>
+      </div>
+      {failed && (
+        <p className="overview-alert" role="alert">
+          Could not refresh Overview.{' '}
+          {work.data ? 'The last successful read remains visible.' : 'No data is available.'}{' '}
+          <button
+            disabled={work.isFetching || schedules.isFetching}
+            onClick={() => {
+              void work.refetch()
+              void schedules.refetch()
+            }}
+          >
+            <RefreshCw size={14} aria-hidden="true" />
+            Retry
+          </button>
+        </p>
+      )}
+      {work.isPending && <p role="status">Loading…</p>}
+      {sections.map((section) => (
+        <section
+          key={section.id}
+          className="overview-section"
+          aria-labelledby={`overview-${section.id}`}
+        >
+          <header>
+            <h2 id={`overview-${section.id}`}>{section.title}</h2>
+            {section.id === 'pending' && <span>Oldest first</span>}
+          </header>
+          {work.data && section.rows.length === 0 && (
+            <p className="overview-empty">{section.empty}</p>
+          )}
+          {section.rows.map((row) => (
+            <WorkRow key={row.run} row={row} pending={section.id === 'pending'} />
+          ))}
+        </section>
+      ))}
+      {work.data?.hasMore && (
+        <p className="overview-more">
+          Showing the 200 most recently changed runs. Older current work is not listed.
+        </p>
+      )}
+      <section className="overview-section" aria-labelledby="overview-schedules">
+        <header>
+          <h2 id="overview-schedules">Scheduled work</h2>
+          <span>Configured cadence</span>
+        </header>
+        {schedules.data && scheduleRows.length === 0 && (
+          <p className="overview-empty">No app declares a workflow schedule.</p>
+        )}
+        {scheduleRows.map((schedule) => (
+          <div className="overview-row" key={schedule.kind}>
+            <Clock3 size={17} aria-hidden="true" />
+            <div className="overview-identity">
+              <strong className="mono">{schedule.kind}</strong>
+              <span className="app-name">{appLabel(schedule.app)}</span>
+            </div>
+            <div className="overview-schedule">
+              <span>{schedule.enabled ? 'Enabled' : 'Paused'}</span>
+              <code>{schedule.cron ?? 'No cadence'}</code>
+              <span>{schedule.timezone}</span>
+            </div>
+            <Link className="overview-action" href={`/apps/${schedule.app}/settings`}>
+              Settings
+            </Link>
+          </div>
+        ))}
+      </section>
+      <p className="overview-access">Access health has not been checked.</p>
+    </Page>
+  )
+}
+
+function WorkRow({ row, pending }: { row: OverviewRun; pending: boolean }) {
+  const subject =
+    row.subjectType && row.subjectId ? { type: row.subjectType, id: row.subjectId } : null
+  const target = { run: row.run, parkedAt: pending ? (row.parkedAt ?? undefined) : undefined }
+  const owner = subject ? getAppUI(row.app)?.subjectPath?.(subject, target) : undefined
+  const external = pending && row.presentation === 'external'
+  const externalUrl =
+    external && row.requestUrl && /^https?:\/\//i.test(row.requestUrl) ? row.requestUrl : undefined
+  const destination = external ? externalUrl : owner
+  const label = pending ? row.requestLabel || 'Input requested' : row.subjectLabel || row.kind
+  return (
+    <div className={`overview-row overview-${row.state}`}>
+      <CircleAlert size={17} aria-hidden="true" />
+      <div className="overview-identity">
+        <strong>{label}</strong>
+        <span>
+          <span className="app-name">{appLabel(row.app)}</span>
+          {pending && row.subjectLabel ? ` · ${row.subjectLabel}` : ` · ${row.kind}`}
+        </span>
+        {row.failure && <p>{row.failure}</p>}
+        {row.state === 'orphaned' && <p>The workflow record is missing.</p>}
+      </div>
+      <span className="overview-age" title={pending ? (row.parkedAt ?? undefined) : row.updatedAt}>
+        {STATE_LABEL[row.state]} ·{' '}
+        {relTimeFromIso(pending ? row.parkedAt : row.updatedAt)}
+      </span>
+      {destination ? (
+        external ? (
+          <a className="overview-action" href={destination} target="_blank" rel="noreferrer">
+            Open request
+          </a>
+        ) : (
+          <Link className={`overview-action${pending ? ' primary' : ''}`} href={destination}>
+            {pending ? 'Review' : 'Open'}
+          </Link>
+        )
+      ) : (
+        <div className="overview-unavailable">
+          <span>{pending ? 'Review destination unavailable' : 'Run destination unavailable'}</span>
+          <Link href={appHome(row.app)}>Open app</Link>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/OwnerNavigation.test.tsx
+++ b/frontend/src/pages/OwnerNavigation.test.tsx
@@ -1,0 +1,180 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Router } from 'wouter'
+import { memoryLocation } from 'wouter/memory-location'
+
+import { subjectApi } from '../api/client'
+import type { RunSummary, SubjectResponse } from '../api/types'
+import { buildApi, type WorkItemDetail } from '../apps/software_factory/api'
+import { WorkItemPage } from '../apps/software_factory/WorkItemPage'
+import { SubjectPage } from './SubjectPage'
+
+vi.mock('../api/sse', () => ({ useSSE: vi.fn() }))
+vi.mock('../api/client', () => ({ subjectApi: { read: vi.fn(), stream: vi.fn(() => '/stream') } }))
+vi.mock('../apps/software_factory/api', () => ({
+  buildApi: { workItem: vi.fn(), subjectStreamUrl: vi.fn(() => '/stream') },
+}))
+vi.mock('../druksui/GateControls', () => ({
+  GateControls: ({ run, expected }: { run: string; expected?: string }) => (
+    <div data-testid="gate">{JSON.stringify({ run, expected })}</div>
+  ),
+}))
+vi.mock('../components/RunControls', () => ({
+  CancelRun: () => null,
+  RetryRun: () => <button>Retry run</button>,
+}))
+vi.mock('../components/RunTranscript', () => ({ RunTranscript: () => <div>Transcript</div> }))
+
+const run = (id: string): RunSummary => ({
+  id,
+  kind: 'notes.summarize',
+  label: id,
+  state: 'parked',
+  gate: 'review',
+  inputRequest: { presentation: 'in_app', controls: ['approve'] },
+  createdAt: '2026-09-01T00:00:00Z',
+  updatedAt: '2026-09-01T00:00:00Z',
+  accountUsername: 'operator',
+  agentCalls: [],
+})
+const status: SubjectResponse['status'] = {
+  state: 'parked',
+  run: 'newer',
+  kind: 'notes.summarize',
+  agent: null,
+  gate: 'review',
+  failure: null,
+  reason: null,
+  triggeredAt: null,
+  accountUsername: 'operator',
+}
+const subject: SubjectResponse = {
+  summary: { id: '7', label: 'A note' },
+  status,
+  timeline: [run('older'), run('newer')],
+}
+const item: WorkItemDetail = {
+  ...subject,
+  summary: {
+    id: '7',
+    label: 'A task',
+    title: 'A task',
+    source: 'linear',
+    repo: 'org/repo',
+    projectName: 'Project',
+    ticketKey: 'DRU-7',
+    resolution: null,
+    createdAt: '2026-09-01T00:00:00Z',
+    updatedAt: '2026-09-01T00:00:00Z',
+    links: { repo: 'https://example.invalid/repo' },
+  },
+}
+
+function mount(page: 'subject' | 'work', path: string) {
+  const location = memoryLocation({ path })
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={client}>
+      <Router hook={location.hook}>
+        {page === 'subject' ? <SubjectPage app="notes" /> : <WorkItemPage workItemId={7} />}
+      </Router>
+    </QueryClientProvider>,
+  )
+  return location
+}
+beforeEach(() => {
+  vi.mocked(subjectApi.read).mockResolvedValue(subject)
+  vi.mocked(buildApi.workItem).mockResolvedValue(item)
+  Element.prototype.scrollIntoView = vi.fn()
+})
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('owner navigation', () => {
+  it.each(['failed', 'cancelled'] as const)(
+    'offers retry only for a failed run: %s',
+    async (state) => {
+      vi.mocked(subjectApi.read).mockResolvedValue({
+        ...subject,
+        timeline: [{ ...run('stopped'), state, inputRequest: null }],
+      })
+      mount('subject', '/notes/note/7?run=stopped')
+      await screen.findByText(state, { exact: true })
+      expect(Boolean(screen.queryByRole('button', { name: 'Retry run' }))).toBe(state === 'failed')
+    },
+  )
+  it.each(['subject', 'work'] as const)(
+    'selects the requested older run in the %s owner and preserves the exact round',
+    async (page) => {
+      const path = page === 'subject' ? '/notes/note/7' : '/software_factory/work-items/7'
+      const location = mount(
+        page,
+        `${path}?${new URLSearchParams({ run: 'older', parkedAt: '2026-09-01T12:34:56.123456Z' })}`,
+      )
+      const gates = () => screen.getAllByTestId('gate').map((gate) => JSON.parse(gate.textContent!))
+      await waitFor(() =>
+        expect(gates()).toContainEqual({ run: 'older', expected: '2026-09-01T12:34:56.123456Z' }),
+      )
+      await act(() => location.navigate(`${path}?run=newer&parkedAt=later`))
+      await waitFor(() => expect(gates()).toContainEqual({ run: 'newer', expected: 'later' }))
+      expect(gates().find((gate) => gate.run === 'older')?.expected).toBeUndefined()
+    },
+  )
+
+  it.each(['subject', 'work'] as const)(
+    'does not send an unknown %s run\'s round to another review',
+    async (page) => {
+      mount(
+        page,
+        `${page === 'subject' ? '/notes/note/7' : '/software_factory/work-items/7'}?run=missing&parkedAt=old`,
+      )
+      expect(await screen.findByText(/This run does not belong/)).toBeTruthy()
+      for (const gate of screen.queryAllByTestId('gate'))
+        expect(JSON.parse(gate.textContent!).expected).toBeUndefined()
+    },
+  )
+
+  it('restores the URL run after manual selection and query-only Back navigation', async () => {
+    const path = '/software_factory/work-items/7'
+    const first = `${path}?run=older`
+    const location = mount('work', first)
+    await screen.findByTestId('gate')
+    fireEvent.click(screen.getByRole('button', { name: 'Select newer run newer' }))
+    expect(JSON.parse(screen.getByTestId('gate').textContent!).run).toBe('newer')
+    await act(() => location.navigate(`${path}?run=newer`))
+    await act(() => location.navigate(first))
+    expect(JSON.parse(screen.getByTestId('gate').textContent!).run).toBe('older')
+  })
+
+  it('decodes a subject identity exactly once', async () => {
+    mount('subject', '/notes/note/a%2520b%2Fc%3F%23%C3%A9')
+    await waitFor(() => expect(subjectApi.read).toHaveBeenCalledWith('notes', 'note', 'a%20b/c?#é'))
+  })
+
+  it('shows malformed subject addresses without calling the API', async () => {
+    mount('subject', '/notes/note/%')
+    expect(await screen.findByRole('alert')).toBeTruthy()
+    expect(subjectApi.read).not.toHaveBeenCalled()
+  })
+
+  it('does not label a failed retained request as current', async () => {
+    vi.mocked(buildApi.workItem).mockResolvedValue({
+      ...item,
+      timeline: [
+        {
+          ...run('failed'),
+          state: 'failed',
+          failure: 'Stopped',
+          inputRequest: { presentation: 'external' },
+        },
+      ],
+    })
+    mount('work', '/software_factory/work-items/7?run=failed')
+    expect((await screen.findAllByText('Stopped')).length).toBeGreaterThan(0)
+    expect(screen.queryByText('needs you')).toBeNull()
+    expect(screen.queryByTestId('gate')).toBeNull()
+  })
+})

--- a/frontend/src/pages/SubjectPage.tsx
+++ b/frontend/src/pages/SubjectPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useMemo, useState } from 'react'
-import { Link } from 'wouter'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useRouter } from 'wouter'
 
 import { subjectApi } from '../api/client'
 import { useSSE } from '../api/sse'
@@ -9,26 +9,60 @@ import { EmptyState } from '../components/EmptyState'
 import { Fact, Facts } from '../components/Facts'
 import { Page } from '../components/Page'
 import { queryGate } from '../components/QueryGate'
-import { CancelRun, InAppReview, RetryRun } from '../components/RunControls'
+import { CancelRun, RetryRun } from '../components/RunControls'
+import { GateControls } from '../druksui/GateControls'
 import { RunTranscript } from '../components/RunTranscript'
 import { StatusGlyph } from '../components/StatusGlyph'
 import { relTimeFromIso } from '../lib/format'
 import { summaryEntries } from '../lib/summary'
 
-// The generic subject page any installed app gets without shipping UI: the
-// summary as facts, the run timeline, the newest run's transcript, and the gate
-// controls when a run parks on the operator.
-
-interface Props {
-  app: string
-  subjectType: string
-  subjectId: string
-}
-
 const isActiveRun = (run: RunSummary) =>
   run.state === 'running' || run.state === 'parked' || run.state === 'scheduled'
 
-export function SubjectPage({ app, subjectType, subjectId }: Props) {
+// wouter's decodeURI leaves an escaped slash in a subject id alone, so the page
+// decodes each part of the raw path once itself.
+export function SubjectPage({ app }: { app: string }) {
+  const router = useRouter()
+  const usePath = router.hook
+  const useSearch = router.searchHook
+  const [path] = usePath(router)
+  const search = useSearch(router)
+  const identity = path.slice(`${router.base}/${app}/`.length)
+  const slash = identity.indexOf('/')
+  let subjectType = ''
+  let subjectId = ''
+  let invalidAddress = slash < 1
+  try {
+    subjectType = decodeURIComponent(identity.slice(0, slash))
+    subjectId = decodeURIComponent(identity.slice(slash + 1))
+  } catch {
+    invalidAddress = true
+  }
+  if (!invalidAddress && subjectId)
+    return (
+      <SubjectDetail app={app} subjectType={subjectType} subjectId={subjectId} search={search} />
+    )
+  return (
+    <Page>
+      <p role="alert">This subject address is invalid. Return to Overview to open the work.</p>
+    </Page>
+  )
+}
+
+function SubjectDetail({
+  app,
+  subjectType,
+  subjectId,
+  search,
+}: {
+  app: string
+  subjectType: string
+  subjectId: string
+  search: string
+}) {
+  const target = new URLSearchParams(search)
+  const selectedRun = target.get('run')
+  const parkedAt = target.get('parkedAt') ?? undefined
   const queryClient = useQueryClient()
   const queryKey = useMemo(
     () => ['subject', app, subjectType, subjectId] as const,
@@ -39,11 +73,10 @@ export function SubjectPage({ app, subjectType, subjectId }: Props) {
     queryFn: () => subjectApi.read(app, subjectType, subjectId),
   })
 
-  // Push-driven cache, same as every detail page: the stream re-emits the whole
-  // snapshot on change; a dropped stream falls back to one refetch.
   const patchSnapshot = useCallback(
     (payload: unknown) => {
       queryClient.setQueryData<SubjectResponse>(queryKey, payload as SubjectResponse)
+      void queryClient.invalidateQueries({ queryKey: ['gate'] })
     },
     [queryClient, queryKey],
   )
@@ -59,7 +92,12 @@ export function SubjectPage({ app, subjectType, subjectId }: Props) {
     loadingMsg: `loading ${label}`,
     errorMsg: `could not load ${label} ${subjectId}`,
   })
-  if (gate) return <Page scroll="internal" className="ins">{gate}</Page>
+  if (gate)
+    return (
+      <Page scroll="internal" className="ins">
+        {gate}
+      </Page>
+    )
 
   const data = query.data!
   const runs = [...data.timeline].reverse()
@@ -82,11 +120,21 @@ export function SubjectPage({ app, subjectType, subjectId }: Props) {
         ))}
         {data.activity && <Fact k="now">{data.activity.label}</Fact>}
       </Facts>
+      {selectedRun && !runs.some((run) => run.id === selectedRun) && (
+        <p role="alert">This run does not belong to this subject or is no longer available.</p>
+      )}
       {runs.length === 0 ? (
         <EmptyState glyph="∅" msg="no runs yet" />
       ) : (
         runs.map((run, index) => (
-          <RunBlock key={run.id} app={app} run={run} defaultOpen={index === 0} />
+          <RunBlock
+            key={run.id}
+            app={app}
+            run={run}
+            defaultOpen={index === 0}
+            selected={run.id === selectedRun}
+            expected={run.id === selectedRun ? parkedAt : undefined}
+          />
         ))
       )}
     </Page>
@@ -97,32 +145,52 @@ function RunBlock({
   app,
   run,
   defaultOpen,
+  selected,
+  expected,
 }: {
   app: string
   run: RunSummary
   defaultOpen: boolean
+  selected: boolean
+  expected?: string
 }) {
   const ask = run.state === 'parked' ? run.inputRequest : null
   const call = run.agentCalls.at(-1)
-  const [open, setOpen] = useState(defaultOpen)
+  const [open, setOpen] = useState(defaultOpen || selected)
+  const block = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (selected) {
+      block.current?.focus({ preventScroll: true })
+      block.current?.scrollIntoView({ block: 'start' })
+    }
+  }, [selected])
   return (
-    <div className="subject-run mono">
+    <div
+      className="subject-run mono"
+      ref={block}
+      tabIndex={-1}
+      aria-label={`${run.label} run ${run.id}`}
+    >
       <div className="subject-run-head">
         <StatusGlyph state={run.state} />
         <span>{run.label}</span>
         <span className="dim">{run.state}</span>
         <span className="dim">{relTimeFromIso(run.updatedAt)}</span>
         {isActiveRun(run) && <CancelRun runId={run.id} />}
-        {(run.state === 'failed' || run.state === 'cancelled') && <RetryRun runId={run.id} />}
+        {run.state === 'failed' && <RetryRun runId={run.id} />}
       </div>
-      {ask?.presentation === 'in_app' && <InAppReview runId={run.id} ask={ask} />}
+      {(expected || ask?.presentation === 'in_app') && (
+        <GateControls run={run.id} expected={expected} />
+      )}
       {ask?.presentation === 'external' && (
         <div className="ins-needs">
           <div className="ins-needs-k">
             <span>◆</span> needs you
           </div>
           <div className="ins-needs-body">
-            {run.gate ? `Waiting on ${run.gate.replaceAll('_', ' ')}.` : 'This run is waiting on you.'}
+            {run.gate
+              ? `Waiting on ${run.gate.replaceAll('_', ' ')}.`
+              : 'This run is waiting on you.'}
           </div>
         </div>
       )}
@@ -139,7 +207,7 @@ function RunBlock({
           type="button"
           className="ins-run-link subject-run-more"
           aria-expanded={open}
-          onClick={() => setOpen((v) => !v)}
+          onClick={() => setOpen(!open)}
         >
           {open ? '▾' : '▸'} transcript
         </button>


### PR DESCRIPTION
Overview shows current input requests, active work, waiting runs, problems, and declared schedules across installed apps. One work read and one schedule read refresh every 30 seconds; the browser sorts the rows into sections. A failed refresh keeps the last read visible and offers Retry. Owner links select the exact run and, for a decision, its request round. A changed round shows a stale-link message instead of the new question, and a sent answer stays sent when the follow-up read finds the gate closed.

Validation: frontend lint, 357 tests, and build; backend Ruff, proof-app install, and the overview and agent-route tests. The full backend suite was not run after the trim. Real UI checks at 1440/1024/390 px covered the first draft only. No external provider or OAuth login was tested.
Stack: based on main. DRU-448.