### PR TITLE
DRU-449 Document command center navigation and verify full flows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,7 +60,7 @@ the error.
 Report that the installation succeeded. Tell the operator to open
 <http://127.0.0.1:8001>. Connect a provider under **Settings → Providers**.
 Agent runs require the selected provider credential. Then connect the GitHub
-App under **Settings → Services**. Run `docker compose exec web druks doctor --sandbox` to
+App under **Settings → Connections → Services**. Run `docker compose exec web druks doctor --sandbox` to
 prove the full sandbox path with a real container.
 
 ## Local customizations

--- a/backend/druks/contrib/software_factory/app.py
+++ b/backend/druks/contrib/software_factory/app.py
@@ -44,7 +44,7 @@ async def check_tracker_identity() -> CheckResult:
         ok=False,
         pending=True,
         detail=f"tracker is {settings.tracker} but it is not connected — "
-        "connect it in Settings → Services.",
+        "connect it in Settings → Connections → Services.",
     )
 
 

--- a/backend/druks/contrib/software_factory/exceptions.py
+++ b/backend/druks/contrib/software_factory/exceptions.py
@@ -18,5 +18,5 @@ class TrackerNotConfigured(AgentApiError):
     def __init__(self) -> None:
         super().__init__(
             "No ticket tracker is configured — select Linear or Jira in the Software Factory "
-            "settings and connect its identity in Settings → Services."
+            "settings and connect its identity in Settings → Connections → Services."
         )

--- a/backend/druks/contrib/software_factory/webhooks.py
+++ b/backend/druks/contrib/software_factory/webhooks.py
@@ -24,7 +24,7 @@ class LinearEvents(Webhook):
         except ServiceNotConnectedError as error:
             raise HTTPException(
                 status.HTTP_401_UNAUTHORIZED,
-                "Linear is not connected — connect it in Settings → Services.",
+                "Linear is not connected — connect it in Settings → Connections → Services.",
             ) from error
         verify_hmac_sha256(
             self.raw_body,
@@ -100,7 +100,7 @@ class JiraEvents(Webhook):
         except ServiceNotConnectedError as error:
             raise HTTPException(
                 status.HTTP_401_UNAUTHORIZED,
-                "Jira is not connected — connect it in Settings → Services.",
+                "Jira is not connected — connect it in Settings → Connections → Services.",
             ) from error
         provided = self.request.headers.get("x-druks-webhook-token") or ""
         if not hmac.compare_digest(provided, webhook_secret):
@@ -129,6 +129,7 @@ class JiraEvents(Webhook):
         fields = issue["fields"]
         issue_status = fields["status"]
         key = issue["key"]
+        base_url = (await services.Jira.get()).identity["base_url"]
         # Unassigned issues carry a null assignee; privacy settings can hide the email.
         assignee = fields["assignee"] or {}
         await publish(
@@ -138,7 +139,7 @@ class JiraEvents(Webhook):
                 "identifier": key,
                 "status": issue_status["name"],
                 "title": fields["summary"],
-                "url": await self._issue_url(key),
+                "url": f"{base_url.rstrip('/')}/browse/{key}",
                 "project_name": fields["project"]["name"],
                 "labels": fields["labels"],
                 "assignee_email": assignee.get("emailAddress"),
@@ -150,8 +151,3 @@ class JiraEvents(Webhook):
             },
         )
         return JSONResponse({"accepted": True})
-
-    async def _issue_url(self, key: str) -> str:
-        # Dispatch runs after request_is_authentic, so the row is connected here.
-        base_url = (await services.Jira.get()).identity["base_url"]
-        return f"{base_url.rstrip('/')}/browse/{key}"

--- a/backend/druks/core/webhooks/github.py
+++ b/backend/druks/core/webhooks/github.py
@@ -37,7 +37,7 @@ class GitHubEvents(Webhook):
         except ServiceNotConnectedError as error:
             raise HTTPException(
                 status.HTTP_401_UNAUTHORIZED,
-                "GitHub is not connected — connect it in Settings → Services.",
+                "GitHub is not connected — connect it in Settings → Connections → Services.",
             ) from error
         verify_hmac_sha256(
             self.raw_body,

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -68,7 +68,7 @@ async def check_service_identities(settings: Settings) -> list[CheckResult]:
     for app in iter_apps():
         app.discover()
 
-    async def _read() -> list[CheckResult]:
+    try:
         async with _check_engine(settings) as engine, session_scope(engine):
             results: list[CheckResult] = []
             for service in services.all():
@@ -82,16 +82,13 @@ async def check_service_identities(settings: Settings) -> list[CheckResult]:
                             ok=not service.required,
                             pending=service.required,
                             detail=f"not connected — connect {service.title} in "
-                            "Settings → Services.",
+                            "Settings → Connections → Services.",
                         )
                     )
                     continue
                 facts = " ".join(f"{key}={value}" for key, value in row.identity.items())
                 results.append(CheckResult(name=name, ok=True, detail=f"connected; {facts}"))
             return results
-
-    try:
-        return await _read()
     except Exception as error:  # noqa: BLE001 — a DB-read failure is a fail, not a crash
         return [
             CheckResult(
@@ -106,20 +103,17 @@ async def check_installations(settings: Settings) -> CheckResult:
     factory reads the service-identity row, so a one-off Session is bound
     into the ambient ``db_session`` registry for the duration."""
 
-    async def _list_accounts() -> tuple[str, ...]:
+    try:
         async with _check_engine(settings) as engine:
             async with session_scope(engine):
                 client = await get_github_client()
-            return await client.list_installation_accounts()
-
-    try:
-        accounts = await _list_accounts()
+            accounts = await client.list_installation_accounts()
     except ServiceNotConnectedError:
         return CheckResult(
             name="installations",
             ok=False,
             pending=True,
-            detail="github is not connected — connect it in Settings → Services.",
+            detail="github is not connected — connect it in Settings → Connections → Services.",
         )
     except Exception as exc:  # noqa: BLE001 — doctor reports, never raises
         return CheckResult(
@@ -506,40 +500,37 @@ async def check_apps(settings: Settings) -> list[CheckResult]:
     """Each installed app's resolved settings and own checks, namespaced under it.
     Read off the class headlessly through the loader, so doctor never imports an
     app's private modules. A check or settings clean that raises is contained
-    under the app's name, and core checks remain separate ``CHECKS`` entries."""
+    under the app's name. Core checks remain separate from app checks."""
 
-    async def _read() -> list[CheckResult]:
-        async with _check_engine(settings) as engine, session_scope(engine):
-            results: list[CheckResult] = []
-            for app in iter_apps():
-                if settings_model := app.settings_model:
-                    try:
-                        problems = (await app.settings()).clean()
-                        detail = "; ".join(
-                            f"{settings_model.model_fields[field].title or field}: {message}"
-                            for field, message in problems.items()
+    async with _check_engine(settings) as engine, session_scope(engine):
+        results: list[CheckResult] = []
+        for app in iter_apps():
+            if settings_model := app.settings_model:
+                try:
+                    problems = (await app.settings()).clean()
+                    detail = "; ".join(
+                        f"{settings_model.model_fields[field].title or field}: {message}"
+                        for field, message in problems.items()
+                    )
+                except Exception as error:  # noqa: BLE001 — settings fail, doctor continues
+                    results.append(
+                        CheckResult(
+                            name=f"{app.name}:settings",
+                            ok=False,
+                            detail=f"check raised: {error}",
                         )
-                    except Exception as error:  # noqa: BLE001 — settings fail, doctor continues
-                        results.append(
-                            CheckResult(
-                                name=f"{app.name}:settings",
-                                ok=False,
-                                detail=f"check raised: {error}",
-                            )
+                    )
+                else:
+                    results.append(
+                        CheckResult(
+                            name=f"{app.name}:settings",
+                            ok=not problems,
+                            detail=detail or "coherent",
                         )
-                    else:
-                        results.append(
-                            CheckResult(
-                                name=f"{app.name}:settings",
-                                ok=not problems,
-                                detail=detail or "coherent",
-                            )
-                        )
-                for check in app.checks or ():
-                    results.append(await _run_app_check(app.name, check))
-            return results
-
-    return await _read()
+                    )
+            for check in app.checks or ():
+                results.append(await _run_app_check(app.name, check))
+        return results
 
 
 async def _run_app_check(app_name: str, check) -> CheckResult:

--- a/backend/druks/services/exceptions.py
+++ b/backend/druks/services/exceptions.py
@@ -4,7 +4,9 @@ class ServiceNotConnectedError(Exception):
 
     def __init__(self, service: str) -> None:
         self.service = service
-        super().__init__(f"{service} is not connected — connect it in Settings → Services.")
+        super().__init__(
+            f"{service} is not connected — connect it in Settings → Connections → Services."
+        )
 
 
 class ServiceConnectError(Exception):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ without replacing the process.
 | Plane | Examples | Stored in |
 | --- | --- | --- |
 | Deployment | identity, ingress, Drukbox, encryption key | `~/druks/druks.toml` |
-| Dashboard | timezone, the GitHub connection, harness and tracker credentials, workflow and agent overrides, notifications, MCP servers, skills | Postgres |
+| Dashboard | timezone, the GitHub connection, harness and tracker credentials, workflow and agent overrides, MCP servers, skills | Postgres |
 
 The installer creates the deployment `.env` from `druks.toml`. Compose, Druks,
 and Drukbox consume this build artifact. Do not edit `.env`. Edit `druks.toml`,
@@ -168,7 +168,7 @@ setup state.
 ## Personal access tokens
 
 Agents and other non-browser clients use personal access tokens for the
-internal API. Mint these tokens in Settings → Tokens. Send a token as
+internal API. Mint these tokens in Settings → API tokens. Send a token as
 `Authorization: Bearer <token>`. A token has the form
 `druks_pat_<prefix>_<secret>`. Druks stores only the SHA-256 hash of the full
 token. It shows the plaintext one time and expires the token after 365 days.
@@ -179,7 +179,7 @@ signed-in identity. It refuses requests that contain an `Authorization` header.
 Thus, a leaked token cannot mint or revoke tokens.
 
 If someone compromises a token, mint a replacement. Then revoke the old token in
-Settings → Tokens. Revocation is immediate. The list shows the prefix and last
+Settings → API tokens. Revocation is immediate. The list shows the prefix and last
 use of each token.
 
 Druks updates last use each hour. Agents consume the API
@@ -196,8 +196,8 @@ in Postgres. They do not come from TOML, the environment, or a PEM file.
 Until an operator connects GitHub, agent runs stop with a direct message.
 `druks doctor` reports that no GitHub connection exists.
 
-Connect it from **Settings → Services**. **Create GitHub App** starts the GitHub
-manifest flow. Enter a GitHub organization, or leave the field empty for a
+Connect it from **Settings → Connections → Services**. **Create GitHub App**
+starts the GitHub manifest flow. Enter a GitHub organization, or leave the field empty for a
 personal account. Accept the request on GitHub. Druks stores the credentials and
 opens the installation page. Install the GitHub App on the applicable
 repositories.
@@ -233,16 +233,16 @@ installation set defines where `software_factory` can act. Personal access
 tokens are not a supported substitute.
 
 **To upgrade an existing installation**, paste the credentials one time on each
-active host. Open Settings → Services. Connect GitHub with the existing operator
-GitHub App ID, private key, and webhook secret. Do not create a replacement
-GitHub App. The current webhook and installations continue to use the pasted
-credentials.
+active host. Open **Settings → Connections → Services**. Connect GitHub with the
+existing operator GitHub App ID, private key, and webhook secret. Do not create
+a replacement GitHub App. The current webhook and installations continue to use
+the pasted credentials.
 
 ### Review identity (optional)
 
 The bundled `review` app can post its verdict reviews as a second
 GitHub App, so GitHub accepts approvals on Druks-authored pull requests.
-Configure it in **Settings → Review**. Enter the review GitHub App ID and its PEM
+Configure it in **Review → Settings**. Enter the review GitHub App ID and its PEM
 private key, both stored encrypted and empty-as-unset. Leave the pair empty and
 reviews publish as operator comments. Set both values to publish separate
 approval reviews. The review GitHub App needs read access to metadata and
@@ -254,10 +254,10 @@ client at another compatible GitHub API endpoint.
 ## Ticketing integrations
 
 Tracker credentials are service identities. Connect Linear or Jira Cloud from
-**Settings → Services**. The Linear identity uses an API key and webhook secret.
-The Jira identity uses a base URL, email, API token, and webhook secret. Druks
+**Settings → Connections → Services**. The Linear identity uses an API key
+and webhook secret. The Jira identity uses a base URL, email, API token, and webhook secret. Druks
 validates the credentials before it stores them. Select the tracker and its
-workflow statuses in **Settings → Software Factory**.
+workflow statuses in **Software Factory → Settings**.
 
 Webhook URLs remain `/_external/linear/events/` and
 `/_external/jira/events/`. The Jira webhook uses a Jira Automation
@@ -290,10 +290,10 @@ When an agent runs, OpenCode selects the endpoint.
 
 Before you save a key, check the provider documentation and domain.
 
-Cards show five-hour and general weekly limits with the time until reset.
-Tooltips show exact reset times. **Catalog status** shows each provider's last
-update. Anthropic and OpenAI fetch separate model lists. Added providers use
-the cached Models.dev directory.
+Provider rows show access state and weekly quota when available. Open
+**Manage** for credential controls, detailed usage, exact reset times, and the
+model catalog timestamp. Anthropic and OpenAI fetch separate model lists.
+Added providers use the cached Models.dev directory.
 
 The `claude` and `codex` CLIs run on their own vendor's subscription or key.
 `opencode` and `pi` run on an API key only. OpenCode can run a supported
@@ -320,10 +320,9 @@ read-only at `/harnesses`. Claude and Codex each read their named directory:
 Missing files are optional. Codex uses `.credentials.json` for MCP credentials.
 Provider credentials do not belong in this root. OpenCode and Pi do not read it.
 The default harness, model, billing, effort, and timeout live in
-**Settings → Agents**. Each agent can override any of them on its app's page.
-**Unattended runs
-(webhooks, schedules) run as** names the account whose subscription an
-unattended run bills. A call refuses before provisioning a VM if its selected
+**Settings → Agent defaults**. Each agent can override any of them on its app's page.
+**Unattended runs use** names the account whose subscription an unattended
+run bills. A call refuses before provisioning a VM if its selected
 credential is missing.
 
 ## Sandboxes
@@ -393,13 +392,13 @@ topology.
 
 ## Notifications
 
-Manage destinations from the dashboard. The current destination type is a Slack
-incoming webhook. Actionable messages use Slack Block Kit. Other messages use
-the same URL through Apprise.
+The dashboard has no notifications page yet. Manage destinations through the
+API. The current destination type is a Slack incoming webhook. Actionable
+messages use Slack Block Kit. Other messages use the same URL through Apprise.
 `SLACK_SIGNING_SECRET` authenticates Slack interactivity callbacks.
 
-Choose one enabled destination as the gate-notification destination in
-Settings. A parked subjected run then produces a durable notification. Failure
+Select one enabled destination as the gate-notification destination through
+the API. A parked subjected run then produces a durable notification. Failure
 to deliver the notification does not unpark or fail the run.
 
 ## MCP servers

--- a/docs/connect-your-agent.md
+++ b/docs/connect-your-agent.md
@@ -18,7 +18,7 @@ from the agent-tagged API routes. The platform contributes seven tools:
 Each installed app can add its own tools. `tools/list` is the live catalog.
 Each request uses a personal access token in
 `Authorization: Bearer <token>`. Mint and revoke tokens in
-**Settings → Tokens**. See
+**Settings → API tokens**. See
 [personal access tokens](configuration.md#personal-access-tokens) for token
 lifecycle and incident steps.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -78,7 +78,7 @@ remote shape, fill `[sandbox.<provider>]` from the Drukbox
 The installer also creates `paths.harness_config_root`. Put optional CLI
 configuration in the harness directory under that root.
 
-After boot, connect the GitHub App that Druks uses from **Settings → Services**.
+After boot, connect the GitHub App that Druks uses from **Settings → Connections → Services**.
 Use the permission table in [Configuration](configuration.md#github).
 
 The sandbox backend defaults to the local `docker` shape. On the first run, set

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -55,7 +55,7 @@ data store. If sandbox SSH is unreachable on macOS, enable host networking in
 the Docker Desktop settings.
 
 For the bundled `software_factory` app, connect its GitHub App after startup.
-Use **Settings → Services** in the dashboard. Create the app there, or paste the
+Use **Settings → Connections → Services** in the dashboard. Create the app there, or paste the
 credentials of an existing GitHub App. See
 [the GitHub connection](configuration.md#github).
 
@@ -177,7 +177,7 @@ value.
 
 GitHub, Linear, and Jira cannot connect to a loopback listener. Dashboard-initiated
 actions work locally, but provider-driven flows need an HTTPS tunnel forwarding
-to `127.0.0.1:8001`. Connect tracker credentials under **Settings → Services** and
+to `127.0.0.1:8001`. Connect tracker credentials under **Settings → Connections → Services** and
 keep the exact public paths:
 
 ```text

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,7 +72,7 @@ app.
 
 To use it:
 
-1. Open **Settings → Services**.
+1. Open **Settings → Connections → Services**.
 2. Create or connect the operator GitHub App.
 3. Install that GitHub App on the repository that Druks will use.
 4. Open **Software Factory → Projects**.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -107,7 +107,8 @@ Examine the webhook path:
 2. If `webhook_ingress` fails, fix DNS, TLS, or edge routing before you examine the provider.
 3. Make sure that the provider URL is
    `https://<host>/_external/<provider>/events/`.
-4. Make sure that its webhook secret matches the related `druks.toml` value.
+4. Make sure that its webhook secret matches the service configuration in
+   **Settings → Connections → Services**.
 5. Examine the provider delivery log and `docker compose logs web`.
 
 When you set `urls.webhook_host`, the doctor sends an unsigned GitHub probe and
@@ -122,7 +123,7 @@ be idempotent.
 
 Examine the MCP path:
 
-1. If the endpoint returns 401, mint a new token in **Settings → Tokens**.
+1. If the endpoint returns 401, mint a new token in **Settings → API tokens**.
 2. Send the token as `Authorization: Bearer <token>`.
 3. If the edge redirects or returns 404, run the installer again.
 4. As an alternative, copy `deploy/caddy/Caddyfile`.
@@ -141,7 +142,7 @@ provisioning a sandbox.
 
 ### Model has no harness
 
-A model id is `provider/model`, such as `anthropic/claude-opus-4-7`; a bare id
+A model id is `provider/model`, such as `anthropic/claude-opus-4-7`. A bare id
 names no harness. Clear a stale per-agent override in Settings or pick a model
 from the picker.
 Druks does not silently route an unknown model to another CLI.
@@ -176,7 +177,7 @@ approve, request changes, or cancel. The owner system answers an external gate.
 If no notification arrived:
 
 - Make sure that an enabled destination is the gate destination.
-- Examine the Notifications page and its recorded delivery error.
+- Read the notification through the API and examine its recorded delivery error.
 - If it is an in-app gate, answer from the subject page.
 
 Notification failure deliberately leaves the run parked and resumable.

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -191,7 +191,7 @@ For example, a webhook can resolve the ticket assignee.
 
 Each agent call uses the subscription of the run account. A run with no
 account uses the installation fallback account's subscription. A missing
-subscription refuses the call; Druks never falls through to another account
+subscription refuses the call. Druks never falls through to another account
 or to an API key. An API key is the installation's, owned by no account, so a
 call billed to it records the system account as the charged account. The call
 records the charged account. Thus, you can see fallback use.
@@ -325,7 +325,7 @@ class Sweep(Workflow):
 
     @step
     async def load_settings(self) -> "Sweep.Settings":
-        return self.settings()
+        return await self.settings()
 ```
 
 Reading settings inside a step snapshots them for replay. Reading them directly
@@ -335,7 +335,7 @@ from replayed orchestration allows later edits to change an in-flight run.
 
 An agent belongs to the app class. Which CLI runs it, which model, which
 login it bills, and at what effort are the operator's choices: defaults in
-**Settings → Agents**, overridden per agent on the app's own page. `timeout`
+**Settings → Agent defaults**, overridden per agent on the app's own page. `timeout`
 is the one declarable knob, because how long a step may take is a fact about
 the task.
 
@@ -349,6 +349,8 @@ class ReportOutput(AgentOutput):
 
 
 class NightWatch(App):
+    name = "night_watch"
+
     report = Agent(
         prompt="night_watch/report.md",
         contract=ReportOutput,
@@ -544,17 +546,21 @@ subclass `StoredSubject` instead of `Base`. The class name is the subject type:
 
 ```python
 from druks.db import StoredSubject
+from druks.workflows import SubjectSummary
 
 
 class Repository(StoredSubject):
-    __tablename__ = "repositories"
+    __tablename__ = "night_watch_repositories"
 
     def get_label(self) -> str:
         return self.full_name
 
+    def get_summary(self) -> SubjectSummary:
+        return SubjectSummary.model_validate(self)
+
     @classmethod
-    def list_summaries(cls, account_id: str | None) -> list[SubjectSummary]:
-        return [repository.get_summary() for repository in cls.list_open()]
+    async def list_summaries(cls, account_id: str | None) -> list[SubjectSummary]:
+        return [repository.get_summary() for repository in await cls.list_open()]
 ```
 
 Select the rows for the board. Druks supplies the other behavior. Each subject
@@ -578,13 +584,16 @@ If you keep no row for a subject, subclass `Subject`. The platform requires only
 an identity. The ID is the full record and its label:
 
 ```python
-from druks.workflows import Subject
+from druks.workflows import Subject, SubjectSummary
 
 
 class PullRequest(Subject):
+    def get_summary(self) -> SubjectSummary:
+        return SubjectSummary.model_validate(self)
+
     @classmethod
-    def list_summaries(cls, account_id: str | None) -> list[SubjectSummary]:
-        return [pull_request.get_summary() for pull_request in cls.list_open()]
+    async def list_summaries(cls, account_id: str | None) -> list[SubjectSummary]:
+        return [pull_request.get_summary() for pull_request in await cls.list_open()]
 ```
 
 Each ID names one of these subjects, so a detail read always answers. Override
@@ -612,7 +621,7 @@ Pass the subject instance to each component that requires one. This includes a
 workflow start, gate answer, or event:
 
 ```python
-await NightWatch.dispatch(subject=repository)
+await Sweep.start(subject=repository, repo=repository.full_name)
 ```
 
 Inside the workflow, `self.subject` resolves through the declared class. It is
@@ -624,7 +633,7 @@ Your app names domain outcomes. For example, a work item ships or an operator ca
 Druks owns the active run state. Read this state from the status:
 
 ```python
-status = repository.get_status()
+status = await repository.get_status()
 if status.is_parked:
     ...  # a run stopped to ask a human something
 ```
@@ -634,7 +643,7 @@ question it stopped on. While a run is active, `await repository.get_phase()`
 returns the step it is on.
 
 A subject that Druks did not run has no state: `status.state` is None, and so
-is `status.run`. `get_status(workflow=NightWatch)` narrows the read to one
+is `status.run`. `await repository.get_status(workflow=Sweep)` narrows the read to one
 workflow's runs. It answers the same way when the subject has no run of that
 kind.
 
@@ -654,7 +663,7 @@ fifty rows costs one query rather than fifty.
 Record an event through the app. Druks stamps its ownership:
 
 ```python
-NightWatch.record_event(
+await NightWatch.record_event(
     type="report.published",
     subject=repository,
     payload={"url": report_url},
@@ -712,7 +721,7 @@ class NightWatchWebhook(Webhook):
     provider = "night_watch"
     category = "events"
 
-    def request_is_authentic(self) -> bool:
+    async def request_is_authentic(self) -> bool:
         verify_hmac_sha256(
             self.raw_body,
             self.request.headers.get("x-signature"),
@@ -849,8 +858,8 @@ Set `slug = "gmail"` on the class to keep the old key.
 Read it back through the same class:
 
 ```python
-Gmail.get().secrets["client_secret"]   # raises ServiceNotConnectedError when unset
-Gmail.is_connected()
+(await Gmail.get()).secrets["client_secret"]   # raises ServiceNotConnectedError when unset
+await Gmail.is_connected()
 ```
 
 An optional `verify` classmethod proves the paste against the live provider
@@ -968,13 +977,13 @@ connection. Workflow code reads them through the declaration. It gets one token
 for each connection:
 
 ```python
-for connection in NightWatch.acme.list_for_account(account_id):
+for connection in await NightWatch.acme.list_for_account(account_id):
     token = await connection.get_access_token()
 ```
 
 `account_id` is the caller: `self.account_id` in a run body,
 `current_account_id.get()` in a route, the handler's argument in a
-subscriber, the platform's argument in `list_summaries`. `NightWatch.acme.get(connection_id)` returns one connection
+subscriber, the platform's argument in `list_summaries`. `await NightWatch.acme.get(connection_id)` returns one connection
 when your own row stored its id. Each connection carries `id`, `scopes`, `identity` — the
 provider's facts for the sign-in — `account_id` — the druks account that
 signed it in — and `connected_at`. The handle serves
@@ -994,7 +1003,7 @@ Reconsent names the row, so it also makes a revoked connection live again
 under its old id. A fresh sign-in that matches the `identity_key` does the
 same.
 
-Add `?next=/app/night_watch/accounts` to land the user back on your
+Add `?next=/night_watch/accounts` to land the user back on your
 page after consent instead of the generic "connected" page. `next`
 must be a bare path that starts with `/`. Druks rejects a URL with a scheme or
 host. Thus, the connection flow cannot redirect away from the host. Register
@@ -1094,7 +1103,7 @@ equality condition. Its controller must be non-secret and unconditional, and a
 `Literal` controller requires one of its declared members.
 
 Hidden fields keep their stored values. Read the resolved model with
-`NightWatch.settings()`. The settings form runs `clean()` against the
+`await NightWatch.settings()`. The settings form runs `clean()` against the
 resolved settings after the proposed edits and rejects an incoherent save. `druks doctor`
 runs the same method over stored settings so rows from older releases or manual database
 edits remain visible. Workflow settings stay plain Pydantic `BaseModel` declarations.
@@ -1111,7 +1120,7 @@ fixtures directly without a `conftest.py` or `pytest_plugins` declaration:
 
 | Fixture | Contract |
 | --- | --- |
-| `druks_db` | A SQLAlchemy `Session` bound to a per-test transaction. Commits become savepoints, and teardown rolls the outer transaction back. |
+| `druks_db` | A SQLAlchemy `AsyncSession` bound to a per-test transaction. Commits become savepoints, and teardown rolls the outer transaction back. |
 | `druks_client` | An authenticated `TestClient` with installed apps mounted, sharing `druks_db`'s connection. |
 | `druks_redis` | The test Redis database, flushed before the test. |
 | `druks_without_dispatch` | Workflow starts and run-phase writes become no-ops, for tests that stand up no durable engine. |
@@ -1126,7 +1135,7 @@ no lifecycle events, no retries:
 ```python
 from druks.testing import run_workflow
 
-summary = await run_workflow(Sweep, subject=repository, since="2026-07-01")
+summary = await run_workflow(RecordHeartbeat, subject=None, source="night_watch")
 ```
 
 `@step` calls inside a `run_multistep` body still need the real engine.
@@ -1136,24 +1145,23 @@ Seed platform-owned run and agent-call rows with plain functions:
 ```python
 from druks.testing import seed_call, seed_run
 
-run = seed_run(
+run = await seed_run(
     druks_db,
     kind=Sweep.kind,
     subject=repository,
     state="running",
 )
-call = seed_call(
+call = await seed_call(
     druks_db,
     run,
-    NightWatch.report,
+    NightWatch.report.id,
     status="running",
 )
 ```
 
 `seed_run` writes both the run row and its DBOS workflow status. That status
 determines `Run.state`. `seed_run` requires `kind`. If you seed
-`state="pending_input"`, pass `input_gate`. `seed_call` accepts an `Agent` or
-its string ID.
+`state="parked"`, pass `input_gate`. `seed_call` accepts an agent's string ID.
 
 `make_settings(tmp_path, **overrides)` builds isolated Druks settings.
 `configure_app_for_test(settings=..., authenticated=False)` returns the mounted
@@ -1276,7 +1284,7 @@ async def note(note_id: int):
 
 The shell replaces the named region and leaves the rest of the page alone, so
 scroll position, focus, and half-filled inputs outside it survive. A region
-that follows a subject must have a name; that is how the shell finds it.
+that follows a subject must have a name. That is how the shell finds it.
 
 `GateControls` names only the run. The shell reads the ask, its options, its
 context, and its artifact from the parked run, and submits the operator's
@@ -1356,7 +1364,7 @@ inline reveal form, and no general client-state API. Static child pages already
 give tabs, and the URL holds the current one.
 
 `MoneyValue`, `PercentValue`, `DurationValue`, and date and time input fields
-are agreed and named. Druks adds each one when an app needs it; ask rather than
+are agreed and named. Druks adds each one when an app needs it. Ask instead of
 working around it.
 
 The [Druks UI contract](druks-ui.md) holds the block, value, and field catalog,
@@ -1366,17 +1374,17 @@ actions, and liveness.
 
 An installed app is visible in the dashboard without a custom UI. The shell
 reads the installed roster from `/api/apps`. It gives each app an entry in the
-app switcher and generic pages. Each subject type gets a board. Each subject
+Apps sidebar and generic pages. Each subject type gets a board. Each subject
 gets a page with its timeline, transcripts, and gate controls. The subject
 summary fields form the board row.
 
 No additional declaration is necessary.
-The shell derives the switcher label from `name` (underscores become spaces).
+The shell derives the sidebar label from `name` (underscores become spaces).
 
 An app that needs full control of its interface ships a frontend instead — the
 escape hatch, not the ordinary path. Its pages are its own JavaScript, so it
 declares its own tabs there and leaves `App.navigation` empty. The scaffold
-writes no JavaScript and no `dist/`; add one only when the block catalog cannot
+writes no JavaScript and no `dist/`. Add one only when the block catalog cannot
 say what your app needs to say.
 
 The frontend is an ES module that the shell mounts


### PR DESCRIPTION
The guides and recovery messages now use the command center's shared and app settings routes. The author guide also corrects examples found during the required full-file review.

Validation: frontend lint, 364 tests and build; backend Ruff checks, proof-app install and 1,617 tests. Both required CI checks passed. The full backend suite also passed with current main in a separate integration checkout. Actual 1440/1024/390 px views, keyboard navigation, exact review return with retained draft, settings forms and local resource actions were checked.
Stack: based on https://github.com/czpython/druks/pull/445.

External provider login, service OAuth, sandbox provisioning and production integration writes were not exercised. The existing doctor single/list result contract is retained and recorded in DRU-449.
