### PR TITLE
RepoWorkspace clones itself; Agent.get_profile() reads how an agent runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,9 @@ For app-surface changes, inspect the proof app at
   method to the class that holds the data. Do not add a namespace, facade,
   context object, or one-use helper module.
 - Do not import an app from an author-surface module. Import only
-  `druks.workflows`, `druks.agents`, `druks.events`, `druks.signals`, `druks.db`,
-  `druks.schemas`, `druks.prompts`, `druks.durable`, `druks.apps`, `druks.ui`,
-  and `druks.webhooks`. A reference to `druks.build` or another app in these modules
+  `druks.workflows`, `druks.workspaces`, `druks.agents`, `druks.events`,
+  `druks.signals`, `druks.db`, `druks.schemas`, `druks.prompts`, `druks.durable`,
+  `druks.apps`, `druks.ui`, and `druks.webhooks`. A reference to `druks.build` or another app in these modules
   inverts the platform.
 - Derive liveness from run state. Do not mirror it in a column. Store an external
   outcome after its owner announces it. Do not infer that outcome from run

--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -21,7 +21,7 @@ from druks.harnesses.exceptions import (
     HarnessInvalidOutputError,
     Retry,
 )
-from druks.harnesses.execution import resolve_execution
+from druks.harnesses.profiles import Profile, get_profile
 from druks.prompts import render_prompt
 from druks.sandbox import gate as sandbox_gate
 from druks.sandbox.client import sandbox_client
@@ -123,6 +123,13 @@ class Agent:
         object.__setattr__(self, "app", owner.name)
         agents.register(self)
 
+    async def get_profile(self) -> Profile:
+        """How this agent runs for the current run's actor, read from settings now."""
+        workflow = current_workflow.get(None)
+        if not workflow:
+            raise WorkflowError(f"agent {self.id!r} reads its profile only inside a workflow")
+        return await get_profile(self.id, workflow.account_id)
+
     async def __call__(
         self, *, contract: type[AgentOutput] | None = None, **context: object
     ) -> Any:
@@ -179,9 +186,9 @@ class Agent:
             async with step_session():
                 # The scrape belongs to the charged account — it differs from
                 # the run's on fallback.
-                execution = await resolve_execution(self.id, workflow.account_id)
-                provider_id = execution.model.partition("/")[0]
-                scrape = await UsageScrape.latest_for(provider_id, execution.charged_account_id)
+                profile = await get_profile(self.id, workflow.account_id)
+                provider_id = profile.model.partition("/")[0]
+                scrape = await UsageScrape.latest_for(provider_id, profile.charged_account_id)
                 if scrape:
                     now = datetime.now(UTC)
                     reset = scrape.soonest_reset_after(now)
@@ -253,10 +260,10 @@ class Agent:
         workflow = current_workflow.get()
         # Refusing an unservable call here beats provisioning a VM and
         # 401ing mid-run.
-        execution = await resolve_execution(self.id, workflow.account_id)
+        profile = await get_profile(self.id, workflow.account_id)
         # Plain snapshots: the commits below expire the ORM row mid-flight.
-        model, charged_account_id = execution.model, execution.charged_account_id
-        subscription_id = execution.subscription.id if execution.subscription else None
+        model, charged_account_id = profile.model, profile.charged_account_id
+        subscription_id = profile.subscription.id if profile.subscription else None
         # An agent call is a durability boundary — its effects don't roll back —
         # so commit here rather than hold the step's connection idle through the
         # minutes of provisioning and the run.
@@ -265,7 +272,7 @@ class Agent:
         artifact_dir = settings.artifacts_dir / f"run-{workflow_id}"
 
         engine = _step_engine()
-        call_id = execution.harness_class.mint_run_id(None)
+        call_id = profile.harness_class.mint_run_id(None)
 
         # Registered for provisioning through execution — the subscription's
         # rotation defers around it. A key never rotates.

--- a/backend/druks/api/server.py
+++ b/backend/druks/api/server.py
@@ -34,7 +34,7 @@ from druks.durable.engine import init_dbos, launch, shutdown
 from druks.durable.exceptions import AgentCallNotFound
 from druks.events.routes import router as events_router
 from druks.files.routes import router as files_router
-from druks.harnesses.exceptions import CatalogError, ExecutionSettingsError
+from druks.harnesses.exceptions import CatalogError, ProfileSettingsError
 from druks.harnesses.routes import router as providers_router
 from druks.mcp.catalog import load_mcp_catalog
 from druks.mcp.gateway import exceptions as gate_errors
@@ -219,10 +219,8 @@ async def _catalog_error_handler(request: Request, exc: CatalogError) -> JSONRes
     return JSONResponse(status_code=503, content={"error": "HTTP_503", "detail": detail})
 
 
-@app.exception_handler(ExecutionSettingsError)
-async def _execution_settings_handler(
-    request: Request, exc: ExecutionSettingsError
-) -> JSONResponse:
+@app.exception_handler(ProfileSettingsError)
+async def _profile_settings_handler(request: Request, exc: ProfileSettingsError) -> JSONResponse:
     return JSONResponse(status_code=422, content={"error": "HTTP_422", "detail": str(exc)})
 
 

--- a/backend/druks/contrib/review/workflows.py
+++ b/backend/druks/contrib/review/workflows.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from druks.accounts.models import Account
 from druks.contrib.review.app import Review
@@ -6,24 +6,27 @@ from druks.contrib.review.datastructures import PullRequest
 from druks.contrib.review.github import get_review_actor
 from druks.contrib.software_factory.models import ProjectRepo
 from druks.core.apis.github import GITHUB
-from druks.sandbox import repo as _repo
-from druks.sandbox.layout import get_github_token_remote_path, get_related_root, get_repo_root
+from druks.sandbox.layout import get_related_root
 from druks.services.models import ServiceIdentity
 from druks.workflows import Workflow
 from druks.workspaces import RepoWorkspace
 
-if TYPE_CHECKING:
-    from druks.sandbox.host import Host
-
 
 class ReviewWorkspace(RepoWorkspace):
-    # The target repo's checkout, plus room beside it for the siblings the reviewer
-    # decides to open. Claude scopes file access to cwd + add_dirs, so the related
-    # root is granted before anything is cloned into it.
+    # The default-branch checkout (the reviewer checks the PR out itself) plus room
+    # beside it for siblings; Claude's add_dirs grant needs the directory to exist.
 
     @property
     def related_root(self) -> str:
         return get_related_root(self.host.ssh_username)
+
+    async def get_github_token(self) -> str:
+        # The review is authored under the review actor's identity.
+        return await (await get_review_actor()).client.token_for_repo(self.get_repo())
+
+    async def run_agent(self, *, account_id: str | None, **kwargs: Any):
+        await self.host.exec(["mkdir", "-p", self.related_root], timeout=10.0)
+        return await super().run_agent(account_id=account_id, **kwargs)
 
     def get_agent_run_kwargs(self, **kwargs: Any) -> dict[str, Any]:
         kwargs = super().get_agent_run_kwargs(**kwargs)
@@ -55,29 +58,6 @@ class PullRequestReview(Workflow):
 
     async def run(self, requested_by: str) -> None:
         await Review.review_pull_request()
-
-    async def get_workspace_kwargs(self, host: "Host") -> dict[str, Any]:
-        # Cloned at the default branch — the reviewer checks the pull request out itself.
-        # The token is the review actor's: it authenticates the clone and ``gh``, so the
-        # review is authored under that identity. Siblings stay uncloned — the reviewer
-        # clones the ones it opens, into a directory that must exist for the grant to hold.
-        repo = (await self.subject).repo
-        github_token = await (await get_review_actor()).client.token_for_repo(repo)
-        await host.write_secret(
-            secret=github_token, remote=get_github_token_remote_path(host.ssh_username)
-        )
-        await _repo.ensure(
-            host,
-            repo_url=f"https://github.com/{repo}",
-            ref=None,
-            target_path=get_repo_root(host.ssh_username),
-        )
-        await host.exec(["mkdir", "-p", get_related_root(host.ssh_username)], timeout=10.0)
-        return {
-            **await super().get_workspace_kwargs(host),
-            "repo": repo,
-            "github_token": github_token,
-        }
 
     async def get_prompt_context(self, **context: Any) -> dict[str, Any]:
         target = await ProjectRepo.get_for_repo((await self.subject).repo, raise_on_missing=True)

--- a/backend/druks/contrib/software_factory/workflows.py
+++ b/backend/druks/contrib/software_factory/workflows.py
@@ -14,14 +14,8 @@ from druks.contrib.software_factory.enums import (
 )
 from druks.contrib.software_factory.models import ProjectRepo, WorkItem
 from druks.core.apis.github import GITHUB, get_github_client
-from druks.sandbox import repo as _repo
 from druks.sandbox.datastructures import RequiredMcpServer
-from druks.sandbox.layout import (
-    get_github_token_remote_path,
-    get_related_root,
-    get_repo_root,
-    get_work_root,
-)
+from druks.sandbox.layout import get_related_root, get_work_root
 from druks.services.exceptions import ServiceNotConnectedError
 from druks.services.models import ServiceIdentity
 from druks.settings import load_settings
@@ -43,10 +37,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True, kw_only=True)
 class BuildWorkspace(RepoWorkspace):
-    # The base RepoWorkspace brings the cloned repo + token; a build run adds its
-    # curated skills, PR branch, and github MCP token.
     skills: tuple[str, ...]
-    branch: str | None = None
     # Installation token for build's github MCP server, minted per repo from
     # the identity reviews act as. Required — there is no build without github.
     mcp_token: str
@@ -58,11 +49,14 @@ class BuildWorkspace(RepoWorkspace):
     def get_required_mcp_servers(self) -> tuple[RequiredMcpServer, ...]:
         return (RequiredMcpServer(name=GITHUB_MCP_NAME, url=GITHUB_MCP_URL, token=self.mcp_token),)
 
+    async def run_agent(self, *, account_id: str | None, **kwargs: Any):
+        # Agents clone related repos on demand; Claude's --add-dir target must exist first.
+        related_root = get_related_root(self.host.ssh_username)
+        await self.host.exec(["mkdir", "-p", related_root], timeout=10.0)
+        return await super().run_agent(account_id=account_id, **kwargs)
+
     def get_agent_run_kwargs(self, **kwargs: Any) -> dict[str, Any]:
-        # Agents clone related repos on demand under get_related_root; grant file-tool
-        # access to the whole dir (Claude scopes file access to cwd + add_dirs;
-        # Codex has full FS access and ignores it). get_related_root is never the repo
-        # cwd — Claude wedges (no stdout, forever) on ``--add-dir <cwd>``.
+        # Never the repo cwd — Claude wedges (no stdout, forever) on ``--add-dir <cwd>``.
         kwargs = super().get_agent_run_kwargs(**kwargs)
         kwargs["add_dirs"] = (get_related_root(self.host.ssh_username),)
         kwargs["skills"] = self.skills
@@ -167,30 +161,8 @@ class Build(Workflow):
             await self._implement_phase()
 
     async def get_workspace_kwargs(self, host: "Host") -> dict[str, Any]:
-        # The BuildWorkspace fields: mint a fresh GitHub token, push it, and clone the
-        # primary repo (at branch) into the VM. Re-runs per agent call — the clone is
-        # idempotent (one test -d on a warm VM) so it's cheap, and the ~60min token
-        # mints fresh each time. Warm-host rotation depends on this per-call rebuild:
-        # never hoist the clone to a once-per-run step, or a rotated-in bare VM would
-        # have no working tree. Related repos are NOT pre-cloned: agents clone the
-        # ones they actually need under get_related_root (the prompt names them, the
-        # credential helper handles auth). The mkdir keeps Claude's --add-dir target
-        # valid before the first on-demand clone.
-        repo = (await self.subject).repo
-        # Planning agents run before the first implement provisions the branch — their
-        # VMs clone the default branch; every agent after delivery gets the PR branch.
-        branch = self.branch
-        github_token = await (await get_github_client()).token_for_repo(repo)
-        await host.write_secret(
-            secret=github_token, remote=get_github_token_remote_path(host.ssh_username)
-        )
-        await _repo.ensure(
-            host,
-            repo_url=f"https://github.com/{repo}",
-            ref=branch,
-            target_path=get_repo_root(host.ssh_username),
-        )
-        await host.exec(["mkdir", "-p", get_related_root(host.ssh_username)], timeout=10.0)
+        kwargs = await super().get_workspace_kwargs(host)
+        repo = kwargs["subject"].repo
         try:
             mcp_token = await (await get_review_actor()).client.token_for_repo(repo)
         except Exception as error:
@@ -202,10 +174,9 @@ class Build(Workflow):
                 "for its github MCP server."
             ) from error
         return {
-            **await super().get_workspace_kwargs(host),
-            "repo": repo,
-            "branch": branch,
-            "github_token": github_token,
+            **kwargs,
+            # None until the first implement provisions the PR branch.
+            "branch": self.branch,
             "mcp_token": mcp_token,
             "skills": tuple(self._profile.get("recommended_skills", [])),
         }
@@ -418,6 +389,11 @@ class Build(Workflow):
                 logger.warning("Could not set draft=%s on %s#%s.", draft, repo, self.pr_number)
 
 
+class ProfileWorkspace(RepoWorkspace):
+    def get_repo(self) -> str:
+        return self.subject.full_name
+
+
 class Profile(Workflow):
     """Profiles a repo once, when it joins a project: the repo_profiler agent
     reads the checkout and reports stack, verification commands, and recommended
@@ -426,7 +402,7 @@ class Profile(Workflow):
     the reaction to a .druks/software_factory/config.yml push."""
 
     subject = ProjectRepo
-    workspace_class = RepoWorkspace
+    workspace_class = ProfileWorkspace
 
     @classmethod
     async def dispatch(cls, repo: ProjectRepo, *, refresh_only: bool = False) -> str:
@@ -463,24 +439,6 @@ class Profile(Workflow):
                 detected=baseline.get("verification") or {}
             )
         await project_repo.set_profile(baseline=baseline, effective=effective)
-
-    async def get_workspace_kwargs(self, host: "Host") -> dict[str, Any]:
-        repo = (await ProjectRepo.get(self.input.repo_id)).full_name
-        github_token = await (await get_github_client()).token_for_repo(repo)
-        await host.write_secret(
-            secret=github_token, remote=get_github_token_remote_path(host.ssh_username)
-        )
-        await _repo.ensure(
-            host,
-            repo_url=f"https://github.com/{repo}",
-            ref=None,
-            target_path=get_repo_root(host.ssh_username),
-        )
-        return {
-            **await super().get_workspace_kwargs(host),
-            "repo": repo,
-            "github_token": github_token,
-        }
 
     async def get_prompt_context(self, **context: Any) -> dict[str, Any]:
         return {

--- a/backend/druks/harnesses/exceptions.py
+++ b/backend/druks/harnesses/exceptions.py
@@ -142,5 +142,5 @@ class CatalogError(Exception):
         self.tag = tag
 
 
-class ExecutionSettingsError(HarnessError):
+class ProfileSettingsError(HarnessError):
     """A (harness, model, billing) triple no installed harness runs; a 422."""

--- a/backend/druks/harnesses/profiles.py
+++ b/backend/druks/harnesses/profiles.py
@@ -5,55 +5,70 @@ from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
 from druks.user_settings.models import SettingsOverride, UserSettings
 
 from .base import Harness
-from .exceptions import ExecutionSettingsError, HarnessNotConnectedError
+from .exceptions import HarnessNotConnectedError, ProfileSettingsError
 from .models import ProviderCatalog, ProviderKey, ProviderSubscription
 from .providers import get_provider, is_registered, provider_label
 from .registry import get_harness
 
 
 @dataclass(frozen=True)
-class Execution:
+class Profile:
+    """How an agent runs for one account: harness, model, effort, billing, read from
+    Settings → Agents at call time. ``key`` rides here because an app driving its
+    own CLI in the VM builds that CLI's environment; the harness fills only the
+    calling agent's."""
+
     harness_class: type[Harness]
     model: str
     subscription: ProviderSubscription | None
     key: str | None
+    billing: str
     effort: str
     timeout: int
     fast_mode: bool
+
+    @property
+    def harness(self) -> str:
+        return self.harness_class.name
+
+    @property
+    def model_id(self) -> str:
+        """The model as the CLI names it, without the provider namespace."""
+        return self.model.partition("/")[2]
 
     @property
     def charged_account_id(self) -> str:
         return self.subscription.account_id if self.subscription else SYSTEM_ACCOUNT_ID
 
 
-async def check_execution(harness_name: str, model: str, billing: str) -> type[Harness]:
+async def check_profile(harness_name: str, model: str, billing: str) -> type[Harness]:
     """The harness that runs the triple; a triple no harness runs raises."""
     harness = get_harness(harness_name)
     if not harness:
-        raise ExecutionSettingsError(f"no installed harness is named {harness_name!r}.")
+        raise ProfileSettingsError(f"no installed harness is named {harness_name!r}.")
     provider_id = model.partition("/")[0]
     if is_registered(provider_id):
         provider = get_provider(provider_id)
         if not harness.has_provider(provider):
-            raise ExecutionSettingsError(f"{harness_name} does not run {provider.label} models.")
+            raise ProfileSettingsError(f"{harness_name} does not run {provider.label} models.")
     else:
         catalog = await ProviderCatalog.get(provider_id)
         if not catalog:
-            raise ExecutionSettingsError(
+            raise ProfileSettingsError(
                 f"model {model!r} names no provider; add one in Settings → Providers."
             )
         if harness.provider:
-            raise ExecutionSettingsError(f"{harness_name} does not run {catalog.label} models.")
+            raise ProfileSettingsError(f"{harness_name} does not run {catalog.label} models.")
         if model not in {entry["id"] for entry in catalog.models}:
-            raise ExecutionSettingsError(f"{catalog.label} lists no model {model!r}.")
+            raise ProfileSettingsError(f"{catalog.label} lists no model {model!r}.")
     if billing not in harness.billing_options:
-        raise ExecutionSettingsError(
+        raise ProfileSettingsError(
             f"{harness_name} runs on an API key only; set billing to api_key."
         )
     return harness
 
 
-async def resolve_execution(agent_name: str, account_id: str | None) -> Execution:
+async def get_profile(agent_name: str, account_id: str | None) -> Profile:
     """How ``agent_name`` runs as ``account_id``, or as the fallback account
     when the run has no actor. A missing credential raises."""
     from druks.apps.registry import agents  # cycle: apps → agents → this module
@@ -65,7 +80,7 @@ async def resolve_execution(agent_name: str, account_id: str | None) -> Executio
     harness_name = (await SettingsOverride.agent_harness(agent_name)).value
     model = (await SettingsOverride.agent_model(agent_name)).value
     billing = (await SettingsOverride.agent_billing(agent_name)).value
-    harness_class = await check_execution(harness_name, model, billing)
+    harness_class = await check_profile(harness_name, model, billing)
     provider_id = model.partition("/")[0]
     subscription = None
     key = None
@@ -80,11 +95,12 @@ async def resolve_execution(agent_name: str, account_id: str | None) -> Executio
             provider_id, account_id or settings.fallback_account_id
         )
     timeout = (await SettingsOverride.agent_timeout(agent_name, agent.timeout)).value
-    return Execution(
+    return Profile(
         harness_class=harness_class,
         model=model,
         subscription=subscription,
         key=key,
+        billing=billing,
         effort=(await SettingsOverride.agent_effort(agent_name)).value,
         # Capped so a single call always fits inside a fresh sandbox lease.
         timeout=min(timeout, MAX_AGENT_TIMEOUT_SECONDS),

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -228,15 +228,15 @@ class Host:
         # druks.sandbox is mid-init.
         from druks.durable.enums import AgentCallStatus
         from druks.harnesses.datastructures import SandboxSettings
-        from druks.harnesses.execution import resolve_execution
+        from druks.harnesses.profiles import get_profile
 
         settings = load_settings()
-        execution = await resolve_execution(agent, account_id)
-        model, timeout = execution.model, execution.timeout
-        harness = execution.harness_class(
+        profile = await get_profile(agent, account_id)
+        model, timeout = profile.model, profile.timeout
+        harness = profile.harness_class(
             model=model,
-            fast_mode=execution.fast_mode,
-            effort=execution.effort,
+            fast_mode=profile.fast_mode,
+            effort=profile.effort,
             sandbox=SandboxSettings.maybe_from_settings(settings),
         )
 
@@ -261,8 +261,8 @@ class Host:
                 extra_env=extra_env,
                 mcp_servers=mcp_servers,
                 call_id=run_id,
-                subscription=execution.subscription,
-                key=execution.key,
+                subscription=profile.subscription,
+                key=profile.key,
             )
         except HarnessError as exc:
             error = exc

--- a/backend/druks/user_settings/routes.py
+++ b/backend/druks/user_settings/routes.py
@@ -8,7 +8,7 @@ from druks.apps.loader import get_app, iter_apps
 from druks.apps.registry import agents, workflows
 from druks.durable.engine import apply_schedules
 from druks.harnesses.base import Harness
-from druks.harnesses.execution import check_execution
+from druks.harnesses.profiles import check_profile
 from druks.harnesses.registry import get_harnesses
 from druks.notifications.models import Destination
 
@@ -28,7 +28,7 @@ from .schemas import (
 router = APIRouter(prefix="/api/settings", tags=["settings"])
 agents_router = APIRouter(prefix="/api/agents", tags=["settings"])
 
-_EXECUTION_DEFAULTS = (
+_PROFILE_DEFAULTS = (
     "default_harness",
     "default_model",
     "default_billing",
@@ -86,10 +86,10 @@ async def update_user_settings(
     defaults = {
         field: value
         for field, value in body.model_dump(exclude_unset=True, exclude_none=True).items()
-        if field in _EXECUTION_DEFAULTS
+        if field in _PROFILE_DEFAULTS
     }
     if defaults:
-        await check_execution(
+        await check_profile(
             defaults.get("default_harness", row.default_harness),
             defaults.get("default_model", row.default_model),
             defaults.get("default_billing", row.default_billing),
@@ -97,7 +97,7 @@ async def update_user_settings(
         await row.update_profile(**defaults)
         for agent in agents.all():
             name = agent.id
-            await check_execution(
+            await check_profile(
                 (await SettingsOverride.agent_harness(name)).value,
                 (await SettingsOverride.agent_model(name)).value,
                 (await SettingsOverride.agent_billing(name)).value,
@@ -143,7 +143,7 @@ async def update_app_settings(body: AppsSettingsUpdate) -> AppsSettingsResponse:
     for name in {*body.agent_harnesses, *body.agent_models, *body.agent_billings}:
         if name not in agents:
             raise HTTPException(status_code=422, detail=f"Unknown agent {name!r}")
-        await check_execution(
+        await check_profile(
             (await SettingsOverride.agent_harness(name)).value,
             (await SettingsOverride.agent_model(name)).value,
             (await SettingsOverride.agent_billing(name)).value,

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -824,13 +824,11 @@ class Workflow:
         return dict(context)
 
     async def get_workspace_kwargs(self, host: "Host") -> dict[str, Any]:
-        # Extend via super() to add the fields workspace_class needs (an app clones + mints
-        # here). Base: just the VM.
-        return {"host": host}
+        # Extend via super() to add the fields workspace_class needs beyond these.
+        return {"host": host, "subject": await self.subject}
 
     async def get_workspace(self, host: "Host") -> Workspace:
-        # What an agent runs in on this run's VM, built per agent call from workspace_class
-        # + the app's kwargs — so short-lived tokens (git) mint fresh each call.
+        # Built per agent call, so nothing is held across steps.
         return self.workspace_class(**await self.get_workspace_kwargs(host))
 
     async def _lease_host(self) -> str | None:

--- a/backend/druks/workspaces.py
+++ b/backend/druks/workspaces.py
@@ -22,9 +22,10 @@ from druks.mcp.constants import TOKEN_ENV_PREFIX
 from druks.mcp.enums import TokenSource
 from druks.mcp.exceptions import MissingTokenError, SourceEnvVarUnsetError
 from druks.mcp.helpers import get_bearer_token_env_var, get_grant_account
+from druks.sandbox import repo as checkout
 from druks.sandbox.datastructures import AgentResult, McpServer, RequiredMcpServer
 from druks.sandbox.exceptions import ExecFailed
-from druks.sandbox.layout import get_repo_root, get_work_root
+from druks.sandbox.layout import get_github_token_remote_path, get_repo_root, get_work_root
 from druks.user_settings.models import UserSettings
 
 if TYPE_CHECKING:
@@ -33,18 +34,17 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class Workspace:
-    # What an agent runs in: the VM it abstracts. An app subclasses this and
-    # overrides get_agent_run_kwargs for its project scaffolding (repo token, dirs)
-    # and get_required_mcp_servers for MCP servers it credentials itself.
+    # What an agent runs in: the VM it abstracts.
     host: "Host"
+    # What the run is about; None for a workflow about nothing.
+    subject: Any = None
 
     @property
     def host_id(self) -> str:
         return self.host.id
 
     def get_agent_run_kwargs(self, **kwargs: Any) -> dict[str, Any]:
-        # Override to add what the agent's run needs on this workspace (github_token,
-        # add_dirs). Base: pass the run's kwargs through untouched.
+        # Override to add what the run needs on this workspace (add_dirs, skills).
         return kwargs
 
     def get_required_mcp_servers(self) -> tuple[RequiredMcpServer, ...]:
@@ -220,23 +220,37 @@ class Workspace:
 
 @dataclass(frozen=True)
 class RepoWorkspace(Workspace):
-    # A VM with the target repo cloned in and a short-lived token its agent
-    # pushes/reads through. Build's workspace extends this with the PR branch
-    # and the github MCP token; the profiler uses it as-is.
-    repo: str
-    github_token: str
+    """A VM with the subject's ``repo`` cloned at ``branch`` (default branch when
+    None), re-cloned and re-tokened before every agent call."""
+
+    branch: str | None = None
 
     @property
     def repo_path(self) -> str:
         return get_repo_root(self.host.ssh_username)
 
-    def get_agent_run_kwargs(self, **kwargs: Any) -> dict[str, Any]:
-        kwargs["github_token"] = self.github_token
-        return kwargs
+    def get_repo(self) -> str:
+        # Override when the subject names its ``owner/name`` differently.
+        return self.subject.repo
 
-    async def run_agent(self, *, account_id: str | None, **kwargs: Any):
+    async def get_github_token(self) -> str:
+        # Override to clone and act as another identity than the operator App.
+        return await (await get_github_client()).token_for_repo(self.get_repo())
+
+    async def run_agent(self, *, account_id: str | None, **kwargs: Any) -> AgentResult:
+        github_token = await self.get_github_token()
+        # The clone authenticates through the VM's credential helper, which reads this file.
+        await self.host.write_secret(
+            secret=github_token, remote=get_github_token_remote_path(self.host.ssh_username)
+        )
+        await checkout.ensure(
+            self.host,
+            repo_url=f"https://github.com/{self.get_repo()}",
+            ref=self.branch,
+            target_path=self.repo_path,
+        )
         await self.set_git_identity(account_id)
-        return await super().run_agent(account_id=account_id, **kwargs)
+        return await super().run_agent(account_id=account_id, github_token=github_token, **kwargs)
 
     async def set_git_identity(self, account_id: str | None) -> None:
         """Commits in the repo are authored as the operator's bot user, with a

--- a/backend/tests/druks-field_notes/druks_field_notes/app.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/app.py
@@ -88,10 +88,14 @@ class FieldNotes(App):
                 return {"sync_token": "Required when visibility is public."}
             return {}
 
-    # The one agent this app runs: it reads a note and writes its gist.
     summarize = Agent(
         description="reads a note and writes its one-line gist",
         prompt="field_notes/summarize.md",
+        contract=GistOutput,
+    )
+    survey = Agent(
+        description="reads a cloned repository and writes its one-line gist",
+        prompt="field_notes/survey.md",
         contract=GistOutput,
     )
 

--- a/backend/tests/druks-field_notes/druks_field_notes/migrations/versions/field_notes_0002_repositories.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/migrations/versions/field_notes_0002_repositories.py
@@ -1,0 +1,30 @@
+"""field_notes: repositories table
+
+Revision ID: field_notes_0002
+Revises: field_notes_0001
+Create Date: 2026-09-06 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "field_notes_0002"
+down_revision = "field_notes_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "field_notes_repositories",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("repo", sa.String(), nullable=False),
+        sa.Column("gist", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("repo"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("field_notes_repositories")

--- a/backend/tests/druks-field_notes/druks_field_notes/models.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/models.py
@@ -4,7 +4,7 @@ from druks.db import StoredSubject, db_session
 from sqlalchemy import select
 from sqlalchemy.orm import Mapped, mapped_column
 
-from druks_field_notes.schemas import NoteSummary
+from druks_field_notes.schemas import NoteSummary, RepositorySummary
 
 
 class Note(StoredSubject):
@@ -48,3 +48,38 @@ class Note(StoredSubject):
 
         notes = await cls.list_recent(limit=(await FieldNotes.settings()).board_size)
         return [note.get_summary() for note in notes]
+
+
+class Repository(StoredSubject):
+    __tablename__ = "field_notes_repositories"
+
+    # ``owner/name``; a Survey run's RepoWorkspace clones it.
+    repo: Mapped[str] = mapped_column(unique=True)
+    gist: Mapped[str | None]
+
+    @classmethod
+    async def create(cls, *, repo: str) -> "Repository":
+        session = db_session()
+        repository = cls(repo=repo)
+        session.add(repository)
+        await session.flush()
+        return repository
+
+    @classmethod
+    async def get(cls, repository_id: int) -> "Repository | None":
+        return await db_session().get(cls, repository_id)
+
+    async def save_gist(self, gist: str) -> None:
+        self.gist = gist
+        await db_session().flush()
+
+    def get_label(self) -> str:
+        return self.repo
+
+    def get_summary(self) -> RepositorySummary:
+        return RepositorySummary.model_validate(self)
+
+    @classmethod
+    async def list_summaries(cls, account_id: str | None) -> list[RepositorySummary]:
+        rows = await db_session().scalars(select(cls).order_by(cls.repo))
+        return [row.get_summary() for row in rows]

--- a/backend/tests/druks-field_notes/druks_field_notes/schemas.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/schemas.py
@@ -9,3 +9,8 @@ class NoteSummary(SubjectSummary):
     body: str
     gist: str | None = None
     created_at: datetime
+
+
+class RepositorySummary(SubjectSummary):
+    repo: str
+    gist: str | None = None

--- a/backend/tests/druks-field_notes/druks_field_notes/templates/prompts/field_notes/survey.md
+++ b/backend/tests/druks-field_notes/druks_field_notes/templates/prompts/field_notes/survey.md
@@ -1,0 +1,5 @@
+You are reading the repository checked out at {{ workspace.repo_path }} and
+writing what it is in a single sentence.
+
+Read its README and top-level layout. Return one clear sentence as the `gist`
+field of your structured output — nothing else.

--- a/backend/tests/druks-field_notes/druks_field_notes/workflows.py
+++ b/backend/tests/druks-field_notes/druks_field_notes/workflows.py
@@ -1,8 +1,9 @@
 from druks.sandbox import Sandbox
 from druks.workflows import Workflow
+from druks.workspaces import RepoWorkspace
 
 from druks_field_notes.app import FieldNotes
-from druks_field_notes.models import Note
+from druks_field_notes.models import Note, Repository
 
 
 class Summarize(Workflow):
@@ -24,3 +25,19 @@ class Summarize(Workflow):
         # Launch policy for a note: one run per note, keyed by its subject; the
         # signed-in requester attributes it ambiently.
         return await cls.start(subject=note)
+
+
+class Survey(Workflow):
+    """Reads one repository, cloned into the VM by the workspace, and writes its gist."""
+
+    subject = Repository
+    workspace_class = RepoWorkspace
+
+    async def run(self) -> None:
+        repository = await self.subject
+        result = await FieldNotes.survey()
+        await repository.save_gist(result.gist)
+
+    @classmethod
+    async def dispatch(cls, *, repository: Repository) -> str:
+        return await cls.start(subject=repository)

--- a/backend/tests/druks-field_notes/tests/test_routes.py
+++ b/backend/tests/druks-field_notes/tests/test_routes.py
@@ -1,4 +1,4 @@
-from druks_field_notes.models import Note
+from druks_field_notes.models import Note, Repository
 from druks_field_notes.workflows import Summarize
 
 
@@ -28,3 +28,20 @@ async def test_notes_routes_create_and_list_notes(druks_client, monkeypatch):
     assert listed.status_code == 200
     assert listed.json()[0]["body"] == "the pump ran hot"
     assert listed.json()[0]["gist"] is None
+
+
+async def test_repository_board_and_detail_read_the_subject(druks_client):
+    repository = await Repository.create(repo="acme/widgets")
+
+    board = await druks_client.get("/api/field_notes/repository")
+    detail = await druks_client.get(f"/api/field_notes/repository/{repository.id}")
+
+    assert board.status_code == 200
+    assert [row["summary"]["repo"] for row in board.json()["rows"]] == ["acme/widgets"]
+    assert detail.status_code == 200
+    assert detail.json()["summary"] == {
+        "id": str(repository.id),
+        "label": "acme/widgets",
+        "repo": "acme/widgets",
+        "gist": None,
+    }

--- a/backend/tests/druks-field_notes/tests/test_workflows.py
+++ b/backend/tests/druks-field_notes/tests/test_workflows.py
@@ -1,10 +1,12 @@
+from types import SimpleNamespace
 from unittest import mock
 
+from druks.sandbox.layout import get_repo_root
 from druks.testing import run_workflow
 from druks_field_notes.app import FieldNotes
 from druks_field_notes.contracts import GistOutput
-from druks_field_notes.models import Note
-from druks_field_notes.workflows import Summarize
+from druks_field_notes.models import Note, Repository
+from druks_field_notes.workflows import Summarize, Survey
 
 
 async def test_summarize_writes_the_gist(druks_db, monkeypatch):
@@ -27,3 +29,25 @@ async def test_dispatch_starts_the_workflow_for_the_note(monkeypatch):
 
     assert run_id == "run-1"
     start.assert_awaited_once_with(subject=note)
+
+
+async def test_survey_writes_the_repository_gist(druks_db, monkeypatch):
+    repository = await Repository.create(repo="acme/widgets")
+    survey = mock.AsyncMock(return_value=GistOutput(gist="Widgets for every shelf."))
+    monkeypatch.setattr(FieldNotes, "survey", staticmethod(survey))
+
+    await run_workflow(Survey, subject=repository)
+
+    survey.assert_awaited_once_with()
+    assert (await Repository.get(repository.id)).gist == "Widgets for every shelf."
+
+
+async def test_survey_workspace_clones_the_subject_repo(druks_db):
+    workflow = Survey()
+    workflow.subject = await Repository.create(repo="acme/widgets")
+    host = SimpleNamespace(id="h1", ssh_username="exedev")
+
+    workspace = await workflow.get_workspace(host)
+
+    assert (workspace.get_repo(), workspace.branch) == ("acme/widgets", None)
+    assert workspace.repo_path == get_repo_root("exedev")

--- a/backend/tests/software_factory/test_build_workspace.py
+++ b/backend/tests/software_factory/test_build_workspace.py
@@ -25,9 +25,8 @@ def test_build_workspace_grants_related_root_add_dir():
     # scaffolding kwargs never carry it.
     workspace = BuildWorkspace(
         host=_FakeSandbox(),  # type: ignore[arg-type]
-        repo="o/main",
+        subject=SimpleNamespace(repo="o/main"),
         branch="b",
-        github_token="t",
         mcp_token="ghs_review",
         skills=("python-house-rules",),
     )
@@ -35,10 +34,35 @@ def test_build_workspace_grants_related_root_add_dir():
 
     assert kwargs["model"] == "m"  # the run's own kwargs pass through
     assert kwargs["add_dirs"] == (get_related_root("exedev"),)
-    assert kwargs["github_token"] == "t"
     assert kwargs["skills"] == ("python-house-rules",)
     assert "mcp_servers" not in kwargs
     assert "extra_env" not in kwargs
+
+
+async def test_build_workspace_makes_the_related_root_before_the_clone(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    execs: list[list[str]] = []
+
+    async def fake_exec(self: Any, argv: list[str], **_kw: Any) -> None:
+        execs.append(argv)
+
+    async def base_run_agent(self: Any, **kwargs: Any) -> str:
+        execs.append(["run_agent"])
+        return "ran"
+
+    workspace = BuildWorkspace(
+        host=host_mod.Host(record=SimpleNamespace(id="h1", ssh_username="exedev")),  # type: ignore[arg-type]
+        subject=SimpleNamespace(repo="o/main"),
+        branch="b",
+        mcp_token="ghs_review",
+        skills=(),
+    )
+    monkeypatch.setattr(host_mod.Host, "exec", fake_exec)
+    monkeypatch.setattr(RepoWorkspace, "run_agent", base_run_agent)
+
+    assert await workspace.run_agent(account_id=None) == "ran"
+    assert execs == [["mkdir", "-p", get_related_root("exedev")], ["run_agent"]]
 
 
 async def test_build_workspace_declares_its_github_mcp(druks_db):
@@ -48,9 +72,8 @@ async def test_build_workspace_declares_its_github_mcp(druks_db):
     # in the run env.
     workspace = BuildWorkspace(
         host=_FakeSandbox(),  # type: ignore[arg-type]
-        repo="o/main",
+        subject=SimpleNamespace(repo="o/main"),
         branch="b",
-        github_token="t",
         mcp_token="ghs_review",
         skills=("python-house-rules",),
     )
@@ -62,49 +85,19 @@ async def test_build_workspace_declares_its_github_mcp(druks_db):
     assert "ghs_review" not in repr(github)
 
 
-def _workspace_kwargs_stubs(monkeypatch: pytest.MonkeyPatch, *, review_actor):
-    ensured: list[str] = []
-    execs: list[list[str]] = []
-
-    async def _token(_repo: str) -> str:
-        return "tok"
-
-    async def _noop(self: Any, **_kw: Any) -> None:
-        pass
-
-    async def fake_ensure(_sb: Any, *, repo_url: str, ref: Any, target_path: str) -> None:
-        ensured.append(repo_url)
-
-    async def fake_exec(self: Any, argv: list[str], **_kw: Any) -> Any:
-        execs.append(argv)
-        return SimpleNamespace(ok=True, exit_code=0, stdout="", stderr="")
-
-    monkeypatch.setattr(host_mod.Host, "write_secret", _noop)
-    monkeypatch.setattr(host_mod.Host, "exec", fake_exec)
-
-    async def _github_client():
-        return SimpleNamespace(token_for_repo=_token)
-
+def _review_actor_stub(monkeypatch: pytest.MonkeyPatch, *, review_actor) -> None:
     async def _review_actor():
         return review_actor()
 
-    monkeypatch.setattr(
-        "druks.contrib.software_factory.workflows.get_github_client", _github_client
-    )
     monkeypatch.setattr("druks.contrib.software_factory.workflows.get_review_actor", _review_actor)
-    monkeypatch.setattr("druks.sandbox.repo.ensure", fake_ensure)
-    return ensured, execs
 
 
 @pytest.mark.asyncio
-async def test_get_workspace_kwargs_clones_primary_only(monkeypatch: pytest.MonkeyPatch):
-    # Only the primary repo is provisioned; related repos are the agents' job.
-    # get_related_root is mkdir'd so Claude's --add-dir target exists before the
-    # first on-demand clone.
+async def test_get_workspace_kwargs_carries_the_build_fields(monkeypatch: pytest.MonkeyPatch):
     async def _review_token(_repo: str) -> str:
         return "ghs_review"
 
-    ensured, execs = _workspace_kwargs_stubs(
+    _review_actor_stub(
         monkeypatch,
         review_actor=lambda: SimpleNamespace(
             client=SimpleNamespace(token_for_repo=_review_token), mode="approve"
@@ -118,11 +111,13 @@ async def test_get_workspace_kwargs_clones_primary_only(monkeypatch: pytest.Monk
     workflow._profile = {"recommended_skills": ["python-house-rules"]}
     kwargs = await workflow.get_workspace_kwargs(sandbox)
 
-    assert ensured == ["https://github.com/o/app"]
-    assert ["mkdir", "-p", get_related_root("exedev")] in execs
-    assert kwargs["mcp_token"] == "ghs_review"
-    assert kwargs["skills"] == ("python-house-rules",)
-    assert "related" not in kwargs
+    assert kwargs == {
+        "host": sandbox,
+        "subject": workflow.__dict__["subject"],
+        "branch": None,
+        "mcp_token": "ghs_review",
+        "skills": ("python-house-rules",),
+    }
 
 
 @pytest.mark.asyncio
@@ -134,7 +129,7 @@ async def test_get_workspace_kwargs_fails_loudly_when_the_token_wont_mint(
     async def _no_token(_repo: str) -> str:
         raise RuntimeError("app not installed on this repo")
 
-    _workspace_kwargs_stubs(
+    _review_actor_stub(
         monkeypatch,
         review_actor=lambda: SimpleNamespace(
             client=SimpleNamespace(token_for_repo=_no_token), mode="comment"
@@ -187,7 +182,7 @@ async def test_set_git_identity_stamps_the_workspace_repo(
 ) -> None:
     repo_path = tmp_path / "repo"
     subprocess.run(["git", "init", "-q", str(repo_path)], check=True)
-    workspace = RepoWorkspace(host=_IdentitySandbox(repo_path), repo="o/main", github_token="t")  # type: ignore[arg-type]
+    workspace = RepoWorkspace(host=_IdentitySandbox(repo_path))  # type: ignore[arg-type]
     hook = repo_path / ".git" / "hooks" / "prepare-commit-msg"
     message = repo_path / "COMMIT_EDITMSG"
 

--- a/backend/tests/test_app_roster.py
+++ b/backend/tests/test_app_roster.py
@@ -16,6 +16,6 @@ def test_roster_lists_installed_apps_with_subject_types(tmp_path: Path):
     assert software_factory["navigation"] == []
     assert software_factory["icon"]
     field_notes = roster["field_notes"]
-    assert field_notes["subjectTypes"] == ["note"]
+    assert field_notes["subjectTypes"] == ["note", "repository"]
     # Derived from the landing page the app declares, labelled by that page.
     assert field_notes["navigation"] == [["/field_notes", "notes"]]

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -1,26 +1,29 @@
+from types import SimpleNamespace
+
 import pytest
 from conftest import connect_provider
 from druks import agents
 from druks.accounts.constants import SYSTEM_ACCOUNT_ID
 from druks.accounts.models import Account
 from druks.harnesses.claude import ClaudeHarness
-from druks.harnesses.exceptions import ExecutionSettingsError, HarnessNotConnectedError
-from druks.harnesses.execution import check_execution, resolve_execution
+from druks.harnesses.exceptions import HarnessNotConnectedError, ProfileSettingsError
 from druks.harnesses.models import ProviderCatalog, ProviderKey, ProviderSubscription
 from druks.harnesses.opencode import OpenCodeHarness
+from druks.harnesses.profiles import check_profile, get_profile
 from druks.harnesses.providers import AnthropicProvider
 from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
 from druks.user_settings.models import SettingsOverride, UserSettings
+from druks.workflows import WorkflowError, current_workflow
 
 
 class _Output(agents.AgentOutput):
     ok: bool
 
 
-PROBE = agents.Agent(id="execution_probe", prompt="probe.md", contract=_Output)
-DECLARED = agents.Agent(id="execution_declared", prompt="probe.md", contract=_Output, timeout=900)
+PROBE = agents.Agent(id="profile_probe", prompt="probe.md", contract=_Output)
+DECLARED = agents.Agent(id="profile_declared", prompt="probe.md", contract=_Output, timeout=900)
 OVERSIZED = agents.Agent(
-    id="execution_oversized",
+    id="profile_oversized",
     prompt="probe.md",
     contract=_Output,
     timeout=MAX_AGENT_TIMEOUT_SECONDS * 2,
@@ -29,21 +32,20 @@ OVERSIZED = agents.Agent(
 
 async def test_check_judges_the_triple_together(druks_db):
     assert (
-        await check_execution("claude", "anthropic/claude-opus-4-7", "subscription")
-        is ClaudeHarness
+        await check_profile("claude", "anthropic/claude-opus-4-7", "subscription") is ClaudeHarness
     )
-    assert await check_execution("claude", "anthropic/claude-opus-4-7", "api_key") is ClaudeHarness
+    assert await check_profile("claude", "anthropic/claude-opus-4-7", "api_key") is ClaudeHarness
     assert (
-        await check_execution("opencode", "anthropic/claude-opus-4-7", "api_key") is OpenCodeHarness
+        await check_profile("opencode", "anthropic/claude-opus-4-7", "api_key") is OpenCodeHarness
     )
-    with pytest.raises(ExecutionSettingsError, match="claude does not run OpenAI models"):
-        await check_execution("claude", "openai/gpt-5.5", "subscription")
-    with pytest.raises(ExecutionSettingsError, match="opencode runs on an API key only"):
-        await check_execution("opencode", "anthropic/claude-opus-4-7", "subscription")
-    with pytest.raises(ExecutionSettingsError, match="no installed harness is named 'grok'"):
-        await check_execution("grok", "anthropic/claude-opus-4-7", "subscription")
-    with pytest.raises(ExecutionSettingsError, match="names no provider"):
-        await check_execution("claude", "claude-opus-4-7", "subscription")
+    with pytest.raises(ProfileSettingsError, match="claude does not run OpenAI models"):
+        await check_profile("claude", "openai/gpt-5.5", "subscription")
+    with pytest.raises(ProfileSettingsError, match="opencode runs on an API key only"):
+        await check_profile("opencode", "anthropic/claude-opus-4-7", "subscription")
+    with pytest.raises(ProfileSettingsError, match="no installed harness is named 'grok'"):
+        await check_profile("grok", "anthropic/claude-opus-4-7", "subscription")
+    with pytest.raises(ProfileSettingsError, match="names no provider"):
+        await check_profile("claude", "claude-opus-4-7", "subscription")
 
 
 async def _subscription(email: str) -> ProviderSubscription:
@@ -64,8 +66,8 @@ async def test_a_subscription_agent_runs_as_its_actor_or_the_fallback_account(dr
     fallback = await _subscription("a@example.com")  # the first login is the fallback
     actor = await _subscription("b@example.com")
 
-    as_actor = await resolve_execution(PROBE.id, actor.account_id)
-    unattended = await resolve_execution(PROBE.id, None)
+    as_actor = await get_profile(PROBE.id, actor.account_id)
+    unattended = await get_profile(PROBE.id, None)
 
     assert as_actor.subscription.id == actor.id
     assert as_actor.charged_account_id == actor.account_id
@@ -83,7 +85,7 @@ async def test_a_subscription_agent_refuses_without_the_actors_own_subscription(
 
     # Neither the fallback account's subscription nor the key stands in.
     with pytest.raises(HarnessNotConnectedError, match="connect your Anthropic subscription"):
-        await resolve_execution(PROBE.id, stranger.id)
+        await get_profile(PROBE.id, stranger.id)
 
 
 async def test_a_key_agent_runs_on_the_installations_key_for_anyone(druks_db):
@@ -91,8 +93,8 @@ async def test_a_key_agent_runs_on_the_installations_key_for_anyone(druks_db):
     await _key()
     await SettingsOverride.set_agent_billing(PROBE.id, "api_key")
 
-    as_actor = await resolve_execution(PROBE.id, actor.account_id)
-    unattended = await resolve_execution(PROBE.id, None)
+    as_actor = await get_profile(PROBE.id, actor.account_id)
+    unattended = await get_profile(PROBE.id, None)
 
     assert (as_actor.key, as_actor.subscription) == ("sk-shared", None)
     assert unattended.key == "sk-shared"
@@ -105,7 +107,7 @@ async def test_a_key_agent_refuses_without_the_key(druks_db):
     await SettingsOverride.set_agent_billing(PROBE.id, "api_key")
 
     with pytest.raises(HarnessNotConnectedError, match="add the Anthropic API key"):
-        await resolve_execution(PROBE.id, actor.account_id)
+        await get_profile(PROBE.id, actor.account_id)
 
 
 async def test_opencode_runs_an_added_provider_with_its_key_and_model(druks_db):
@@ -123,11 +125,11 @@ async def test_opencode_runs_an_added_provider_with_its_key_and_model(druks_db):
     await SettingsOverride.set_agent_model(PROBE.id, "openrouter/anthropic/claude-sonnet-4")
     await SettingsOverride.set_agent_billing(PROBE.id, "api_key")
 
-    execution = await resolve_execution(PROBE.id, None)
+    profile = await get_profile(PROBE.id, None)
 
-    assert execution.harness_class is OpenCodeHarness
-    assert execution.model == "openrouter/anthropic/claude-sonnet-4"
-    assert execution.key == "sk-openrouter"
+    assert profile.harness_class is OpenCodeHarness
+    assert profile.model == "openrouter/anthropic/claude-sonnet-4"
+    assert profile.key == "sk-openrouter"
 
 
 async def test_an_added_provider_without_a_key_names_it(druks_db):
@@ -137,19 +139,19 @@ async def test_an_added_provider_without_a_key_names_it(druks_db):
     await SettingsOverride.set_agent_billing(PROBE.id, "api_key")
 
     with pytest.raises(HarnessNotConnectedError, match="add the Groq API key in Settings"):
-        await resolve_execution(PROBE.id, None)
+        await get_profile(PROBE.id, None)
 
 
 async def test_an_added_provider_runs_only_on_an_unbound_cli_and_its_own_models(druks_db):
     await ProviderCatalog.create("groq", [{"id": "groq/llama-4", "label": "Llama 4"}], label="Groq")
 
-    with pytest.raises(ExecutionSettingsError, match="claude does not run Groq models"):
-        await check_execution("claude", "groq/llama-4", "api_key")
-    with pytest.raises(ExecutionSettingsError, match="Groq lists no model 'groq/llama-9'"):
-        await check_execution("opencode", "groq/llama-9", "api_key")
-    with pytest.raises(ExecutionSettingsError, match="names no provider; add one"):
-        await check_execution("opencode", "nobody/model", "api_key")
-    assert await check_execution("opencode", "groq/llama-4", "api_key") is OpenCodeHarness
+    with pytest.raises(ProfileSettingsError, match="claude does not run Groq models"):
+        await check_profile("claude", "groq/llama-4", "api_key")
+    with pytest.raises(ProfileSettingsError, match="Groq lists no model 'groq/llama-9'"):
+        await check_profile("opencode", "groq/llama-9", "api_key")
+    with pytest.raises(ProfileSettingsError, match="names no provider; add one"):
+        await check_profile("opencode", "nobody/model", "api_key")
+    assert await check_profile("opencode", "groq/llama-4", "api_key") is OpenCodeHarness
 
 
 async def test_a_key_only_harness_bills_the_key(druks_db):
@@ -158,18 +160,18 @@ async def test_a_key_only_harness_bills_the_key(druks_db):
     await SettingsOverride.set_agent_harness(PROBE.id, "opencode")
     await SettingsOverride.set_agent_billing(PROBE.id, "api_key")
 
-    execution = await resolve_execution(PROBE.id, None)
+    profile = await get_profile(PROBE.id, None)
 
-    assert execution.harness_class is OpenCodeHarness
-    assert execution.key == "sk-shared"
+    assert profile.harness_class is OpenCodeHarness
+    assert profile.key == "sk-shared"
 
 
 async def test_a_stored_triple_no_harness_runs_refuses(druks_db):
     await _subscription("a@example.com")
     await SettingsOverride.set_agent_harness(PROBE.id, "opencode")
 
-    with pytest.raises(ExecutionSettingsError, match="opencode runs on an API key only"):
-        await resolve_execution(PROBE.id, None)
+    with pytest.raises(ProfileSettingsError, match="opencode runs on an API key only"):
+        await get_profile(PROBE.id, None)
 
 
 async def test_effort_timeout_and_fast_mode_follow_the_defaults_and_overrides(druks_db):
@@ -178,9 +180,9 @@ async def test_effort_timeout_and_fast_mode_follow_the_defaults_and_overrides(dr
     await settings.update_profile(default_effort="low", default_timeout=600, fast_mode=True)
     await SettingsOverride.set_agent_effort(DECLARED.id, "medium")
 
-    probe = await resolve_execution(PROBE.id, None)
-    declared = await resolve_execution(DECLARED.id, None)
-    oversized = await resolve_execution(OVERSIZED.id, None)
+    probe = await get_profile(PROBE.id, None)
+    declared = await get_profile(DECLARED.id, None)
+    oversized = await get_profile(OVERSIZED.id, None)
 
     assert (probe.effort, probe.timeout, probe.fast_mode) == ("low", 600, True)
     assert (declared.effort, declared.timeout) == ("medium", 900)
@@ -188,6 +190,23 @@ async def test_effort_timeout_and_fast_mode_follow_the_defaults_and_overrides(dr
     assert oversized.timeout == MAX_AGENT_TIMEOUT_SECONDS
 
 
+async def test_an_agent_reads_its_own_profile(druks_db):
+    await _subscription("a@example.com")
+    await _key()
+
+    token = current_workflow.set(SimpleNamespace(account_id=None))
+    subscribed = await PROBE.get_profile()
+    await SettingsOverride.set_agent_billing(PROBE.id, "api_key")
+    keyed = await PROBE.get_profile()
+    current_workflow.reset(token)
+    with pytest.raises(WorkflowError, match="only inside a workflow"):
+        await PROBE.get_profile()
+
+    assert (subscribed.harness, subscribed.model_id) == ("claude", "claude-opus-4-7")
+    assert (subscribed.billing, subscribed.key) == ("subscription", None)
+    assert (keyed.billing, keyed.key) == ("api_key", "sk-shared")
+
+
 async def test_an_unregistered_agent_is_named(druks_db):
     with pytest.raises(KeyError, match="no agent is registered as 'ghost'"):
-        await resolve_execution("ghost", None)
+        await get_profile("ghost", None)

--- a/backend/tests/test_proof_app.py
+++ b/backend/tests/test_proof_app.py
@@ -9,14 +9,14 @@ def test_boot_loads_the_external_app():
 
     assert app.name == "field_notes"
     assert app.package == _PACKAGE
-    assert [subject.__name__ for subject in app.subjects()] == ["Note"]
+    assert [subject.__name__ for subject in app.subjects()] == ["Note", "Repository"]
 
 
 def test_discovery_registers_the_tables_and_capabilities():
     app = load_app("field_notes")
 
     assert "field_notes_notes" in Base.metadata.tables
-    assert [workflow.__name__ for workflow in app.workflows()] == ["Summarize"]
+    assert [workflow.__name__ for workflow in app.workflows()] == ["Summarize", "Survey"]
 
     capability_modules = {module.__name__ for module in app.capability_modules()}
     assert f"{_PACKAGE}.subscribers" in capability_modules
@@ -29,5 +29,6 @@ def test_migration_is_the_history_root():
 
     package_dir = app.package_dir()
     assert app.migrations_dir() == package_dir / "migrations"
-    (baseline,) = (package_dir / "migrations" / "versions").glob("*.py")
-    assert baseline.name.startswith("field_notes_")
+    baseline, *later = sorted((package_dir / "migrations" / "versions").glob("*.py"))
+    assert baseline.name.startswith("field_notes_0001")
+    assert all(path.name.startswith("field_notes_") for path in later)

--- a/backend/tests/test_proof_app_install.py
+++ b/backend/tests/test_proof_app_install.py
@@ -12,7 +12,7 @@ _CHECK = textwrap.dedent(
     assert "field_notes" in names, names
 
     app = load_app("field_notes")
-    assert [subject.__name__ for subject in app.subjects()] == ["Note"]
+    assert [subject.__name__ for subject in app.subjects()] == ["Note", "Repository"]
     assert app.settings_model is not None
     assert list(app.settings_model.model_fields) == [
         "board_size",
@@ -20,7 +20,7 @@ _CHECK = textwrap.dedent(
         "sync_signing_key",
         "sync_token",
     ]
-    assert [workflow.__name__ for workflow in app.workflows()] == ["Summarize"]
+    assert [workflow.__name__ for workflow in app.workflows()] == ["Summarize", "Survey"]
     assert {router.prefix for router in app.routers()} >= {"/notes", "/note"}
     assert app.migrations_dir() is not None
     print("ok")

--- a/backend/tests/test_proof_app_migration.py
+++ b/backend/tests/test_proof_app_migration.py
@@ -25,7 +25,10 @@ def _config() -> Config:
 
 
 def _drop(conn) -> None:
-    conn.exec_driver_sql("DROP TABLE IF EXISTS field_notes_notes, alembic_version_field_notes")
+    conn.exec_driver_sql(
+        "DROP TABLE IF EXISTS field_notes_notes, field_notes_repositories, "
+        "alembic_version_field_notes"
+    )
 
 
 def test_proof_migration_applies_under_its_own_version_table(request):
@@ -37,12 +40,12 @@ def test_proof_migration_applies_under_its_own_version_table(request):
     try:
         command.upgrade(_config(), "head")
         with engine.connect() as conn:
-            table = conn.exec_driver_sql("SELECT to_regclass('field_notes_notes')").scalar()
-            assert table is not None
+            for table in ("field_notes_notes", "field_notes_repositories"):
+                assert conn.exec_driver_sql(f"SELECT to_regclass('{table}')").scalar()
             head = conn.exec_driver_sql(
                 "SELECT version_num FROM alembic_version_field_notes"
             ).scalar()
-            assert head == "field_notes_0001"
+            assert head == "field_notes_0002"
     finally:
         with engine.connect() as conn:
             _drop(conn)

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -522,20 +522,21 @@ def test_agent_result_names_the_agent_in_its_failure():
 def _patch_harness_resolution(monkeypatch: pytest.MonkeyPatch) -> None:
     # run_agent resolves the call through the one resolver; these tests are
     # about the failure boundary, not resolution.
-    from druks.harnesses.execution import Execution
+    from druks.harnesses.profiles import Profile
 
-    async def resolve_execution(agent, account_id):
-        return Execution(
+    async def get_profile(agent, account_id):
+        return Profile(
             harness_class=ClaudeHarness,
             model="anthropic/claude-opus-4-7",
             subscription=SimpleNamespace(id="subscription-1", account_id="acc"),
             key=None,
+            billing="subscription",
             effort="high",
             timeout=60,
             fast_mode=False,
         )
 
-    monkeypatch.setattr("druks.harnesses.execution.resolve_execution", resolve_execution)
+    monkeypatch.setattr("druks.harnesses.profiles.get_profile", get_profile)
 
 
 async def test_run_agent_carries_foreign_failures_as_harness_errors(

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from druks import workspaces as workspace_mod
+from druks.sandbox.layout import get_github_token_remote_path, get_repo_root
+from druks.workspaces import RepoWorkspace, Workspace
+
+
+class _RecordingHost:
+    id = "h1"
+    ssh_username = "exedev"
+
+    def __init__(self) -> None:
+        self.events: list[tuple[Any, ...]] = []
+
+    async def write_secret(self, *, secret: str, remote: str) -> None:
+        self.events.append(("write_secret", remote, secret))
+
+
+async def test_repo_workspace_mints_writes_and_clones_before_every_agent_call(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    host = _RecordingHost()
+    subject = SimpleNamespace(repo="acme/widgets")
+    workspace = RepoWorkspace(host=host, subject=subject, branch="feature")  # type: ignore[arg-type]
+
+    async def _token(self: RepoWorkspace) -> str:
+        return "ghs_fresh"
+
+    async def _ensure(_host: Any, *, repo_url: str, ref: str | None, target_path: str) -> None:
+        host.events.append(("clone", repo_url, ref, target_path))
+
+    async def _git_identity(self: RepoWorkspace, account_id: str | None) -> None:
+        host.events.append(("git_identity", account_id))
+
+    async def _run(self: Workspace, *, account_id: str | None, **kwargs: Any) -> str:
+        host.events.append(("run_agent", account_id, kwargs))
+        return "result"
+
+    monkeypatch.setattr(RepoWorkspace, "get_github_token", _token)
+    monkeypatch.setattr(workspace_mod.checkout, "ensure", _ensure)
+    monkeypatch.setattr(RepoWorkspace, "set_git_identity", _git_identity)
+    monkeypatch.setattr(Workspace, "run_agent", _run)
+
+    assert await workspace.run_agent(account_id="acct", prompt="p") == "result"
+    assert host.events == [
+        ("write_secret", get_github_token_remote_path("exedev"), "ghs_fresh"),
+        ("clone", "https://github.com/acme/widgets", "feature", get_repo_root("exedev")),
+        ("git_identity", "acct"),
+        ("run_agent", "acct", {"github_token": "ghs_fresh", "prompt": "p"}),
+    ]

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -382,15 +382,67 @@ If an agent produces a file, use [`File` and `FileField`](files.md).
 The contract declares the file, Druks transports and serves it, and the app can
 persist its stable reference on an app row.
 
+An app that runs a CLI of its own inside the sandbox reads how a declared agent
+would run, and hands that to the CLI. Declare the agent and never call it; the
+operator configures it in **Settings → Agents** like any other:
+
+```python
+profile = await NightWatch.auditor.get_profile()
+profile.harness   # "claude" | "codex" | "opencode" | "pi"
+profile.model_id  # the model as that CLI names it, provider prefix stripped
+profile.model     # "provider/model"
+profile.effort
+profile.billing   # "subscription" | "api_key"
+profile.key       # the provider API key under api_key billing, else None
+```
+
+`get_profile()` runs inside a workflow and reads the settings at call time for
+the run's own actor, the same read Druks makes for the calling agent. A
+missing login or key raises before any sandbox work. Under subscription
+billing there is no key. The VM home holds the login of the calling agent's
+subscription only, so a nested CLI on another provider needs `api_key` billing.
+
 Do not ask the framework to infer domain side effects from agent prose.
 The prompt or a subsequent explicit step owns those actions.
 
 ## Customize the workspace
 
-Every agent uses a `Workspace` around a Drukbox sandbox. Override
-`Workflow.workspace_class` and `get_workspace_kwargs()` for app-specific
-workspace behavior. This behavior can clone a repository, mint a short-lived
-token, or require an MCP server.
+Every agent uses a `Workspace` around a Drukbox sandbox. `Workflow.workspace_class`
+names the kind. A workflow about a GitHub repository declares `RepoWorkspace`
+and nothing else:
+
+```python
+from druks.workspaces import RepoWorkspace
+
+
+class Sweep(Workflow):
+    subject = Repository  # a StoredSubject with a ``repo`` column, "owner/name"
+    workspace_class = RepoWorkspace
+```
+
+Before every agent call Druks mints the GitHub App token for the subject's
+`repo`, writes it into the VM, and clones the default branch into
+`workspace.repo_path`. Prompts read `{{ workspace.repo_path }}`. In the VM,
+git and `gh` read the token through the sandbox helper. The clone is
+idempotent, so a warm host keeps its working tree and a host rotated in bare
+gets one back.
+
+Every workspace holds the run's `subject`. `RepoWorkspace.get_repo()` reads
+its `repo` column. Override it when the subject names the repository
+differently:
+
+```python
+class SweepWorkspace(RepoWorkspace):
+    def get_repo(self) -> str:
+        return self.subject.full_name
+```
+
+Override `Workflow.get_workspace_kwargs()` to pass `branch` or the fields a
+subclass adds. Extend `RepoWorkspace` by adding fields, not by cloning again.
+Override `get_github_token()` to clone and act as another identity,
+`run_agent()` to prepare the VM before the call, `get_agent_run_kwargs()` to
+grant directories or skills, and `get_required_mcp_servers()` to require an
+MCP server the workspace credentials itself.
 
 Keep durable state outside the VM. A workflow can set
 `steps_reuse_sandbox = True` to retain one host across a segment. Druks releases
@@ -1428,6 +1480,7 @@ Import from concern namespaces, not from `druks.durable` or internal modules:
 | `druks.agents` | `Agent`, `AgentOutput` |
 | `druks.workflows` | `Workflow`, `Gate`, `step`, run/agent response types, lifecycle enums and workflow errors |
 | `druks.sandbox` | `Sandbox` |
+| `druks.workspaces` | `Workspace`, `RepoWorkspace` |
 | `druks.db` | `Base`, `StoredSubject`, `db_session` |
 | `druks.schemas` | `Schema` |
 | `druks.ui` | `Action`, `Block`, `Callout`, `Card`, `Cards`, `Chart`, `ChartSeries`, `CheckboxField`, `Columns`, `Divider`, `EmptyState`, `Fact`, `Facts`, `Field`, `FileSummary`, `Files`, `Follows`, `Form`, `GateControls`, `Image`, `ImageGallery`, `Link`, `List`, `Markdown`, `Metric`, `Metrics`, `MultiSelectField`, `NumberField`, `NumberValue`, `Option`, `Page`, `Progress`, `ProgressStep`, `RadioField`, `Section`, `SecretField`, `SelectField`, `Stack`, `StatusValue`, `Table`, `TableColumn`, `TableRow`, `Text`, `TextAreaField`, `TextField`, `TextValue`, `TimeValue`, `Timeline`, `TimelineItem`, `UploadField`, `Value`, `page` |


### PR DESCRIPTION
Two author-surface gaps, closed on the platform so an app that clones a repository and drives a nested CLI is written against public imports only.

## RepoWorkspace does the clone

```python
class Hunt(Workflow):
    subject = Repository          # a StoredSubject with a `repo` column, "owner/name"
    workspace_class = RepoWorkspace
```

- `RepoWorkspace.run_agent()` mints the GitHub App token, writes it to the VM, runs the idempotent clone at `branch` (default branch when None), sets the git identity, and passes the token to the harness. Per call, like review did.
- Every `Workspace` holds the run's `subject`; the workflow hands it over with the host. `RepoWorkspace.get_repo()` reads `subject.repo` and is the override when a subject names the repository differently (`ProfileWorkspace` reads `full_name`).
- `github_token` is no longer a constructor field. `get_github_token()` is the override for cloning as another identity; `ReviewWorkspace` uses it for the review actor.
- review and software_factory drop their three copies of mint + `write_secret` + `ensure` and the `druks.sandbox.repo` / `druks.sandbox.layout` / `druks.core.apis.github` imports they carried for it.
- `druks.workspaces` (`Workspace`, `RepoWorkspace`) joins the stable-imports table and AGENTS.md's namespace list.

## Agent.get_profile()

```python
profile = await BugHunter.clawpatch.get_profile()
profile.harness    # "claude" | "codex" | "opencode" | "pi"
profile.model_id   # as the CLI names it, provider prefix stripped
profile.model      # "provider/model"
profile.effort
profile.billing    # "subscription" | "api_key"
profile.key        # the API key under api_key billing, else None
```

`Profile` replaces `Execution` (module `harnesses/profiles.py`, `get_profile`, `check_profile`, `ProfileSettingsError`) and gains `billing` plus the `harness` / `model_id` projections. `Agent.get_profile()` reads it for the current run's actor, the same read an agent call makes, and raises outside a workflow. The key stays on the value: an app that drives a CLI of its own inside the VM builds that CLI's environment itself; the harness fills only the calling agent's. The guide says the VM home holds only the calling agent's subscription login.

## Proof app

`field_notes` gains a `Repository` subject (`repo`, `gist`, board and detail read-side), a `Survey` workflow on `RepoWorkspace`, the `survey` agent, and migration `field_notes_0002`. Tests cover the subject-driven workspace and the per-call mint → write → clone → identity → run order.

## Not done

`apps/registry.py` keys agents by the flat attribute name across apps, so two apps declaring `file_tickets` collide at boot. An app-qualified key needs the `agent_*:{name}` override rows migrated to the qualified name, with the owning app known at migration time. Left for a follow-up.

## Verification

- `ruff check backend` and `ruff format --check backend`: clean.
- `pytest backend/` with the proof app installed: 1604 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
