### PR TITLE
App-qualified agent ids

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -105,10 +105,11 @@ class Agent:
     # ``include_plugins=False`` skips the operator's plugin state for prompts
     # that hit no MCP server.
     include_plugins: bool = True
-    # ``id`` is the agent's durable key (settings, timeline, registry): the attribute
-    # name it's declared as, or an explicit ``id=`` for a standalone agent (a test, a
-    # one-off). ``app`` is the owning App's name, read from the class in
-    # __set_name__ to group the settings UI — blank for a standalone agent (no owner).
+    # ``id`` is the agent's durable key (settings, timeline, registry, step name):
+    # ``<app>.<attribute>`` for an agent declared on an App, or the explicit ``id=``
+    # of a standalone agent (a test, a one-off). ``app`` is the owning App's name,
+    # read from the class in __set_name__ to group the settings UI — blank for a
+    # standalone agent (no owner).
     id: str = field(default="", compare=False)
     app: str = field(init=False, compare=False, default="")
 
@@ -119,7 +120,7 @@ class Agent:
     def __set_name__(self, owner: type, attr: str) -> None:
         if self.id:  # explicit id: already registered in __post_init__
             return
-        object.__setattr__(self, "id", attr)
+        object.__setattr__(self, "id", f"{owner.name}.{attr}")
         object.__setattr__(self, "app", owner.name)
         agents.register(self)
 

--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -90,7 +90,7 @@ class AgentOutput(BaseModel):
 @dataclass(frozen=True)
 class Agent:
     contract: type[AgentOutput]
-    # Display label for the settings UI; ``id`` is shown when it's None.
+    # Display label for the settings UI; the attribute name shows when it's None.
     name: str | None = None
     # Short human-friendly blurb of what the agent does, shown in the settings UI.
     description: str = ""

--- a/backend/druks/contrib/software_factory/app.py
+++ b/backend/druks/contrib/software_factory/app.py
@@ -150,7 +150,7 @@ class SoftwareFactory(App):
         ``source`` to get it only when that source is the selected one — a
         work item syncs only to the tracker that owns it."""
         settings = await cls.settings()
-        if source is not None and source != settings.tracker:
+        if source and source != settings.tracker:
             return
         try:
             if settings.tracker == "linear":
@@ -172,8 +172,9 @@ class SoftwareFactory(App):
         except ServiceNotConnectedError:
             return
 
-    # The app's agents — any of its workflows run them. The attribute name is each
-    # agent's id (its durable settings/timeline key).
+    # The app's agents — any of its workflows run them. The app name and the
+    # attribute name form each agent's id (``software_factory.implement``), its
+    # durable settings and timeline key.
     generate_plan = Agent(
         description="ticket → implementation plan",
         prompt="software_factory/build/generate_plan.md",

--- a/backend/druks/user_settings/reads.py
+++ b/backend/druks/user_settings/reads.py
@@ -28,7 +28,8 @@ async def get_agent_setting(agent: "Agent") -> AgentSettingResponse:
     effort = await SettingsOverride.agent_effort(agent.id)
     timeout = await SettingsOverride.agent_timeout(agent.id, agent.timeout)
     return AgentSettingResponse(
-        name=agent.name or agent.id,
+        name=agent.id,
+        label=agent.name or agent.id.rsplit(".", 1)[-1],
         description=agent.description,
         harness=harness.value,
         harness_source=harness.source,

--- a/backend/druks/user_settings/schemas.py
+++ b/backend/druks/user_settings/schemas.py
@@ -62,6 +62,7 @@ Source = Literal["agent", "default"]
 
 class AgentSettingResponse(Schema):
     name: str
+    label: str
     description: str
     harness: str
     harness_source: Source

--- a/backend/migrations/versions/d2f7a9c4e816_app_qualified_agent_ids.py
+++ b/backend/migrations/versions/d2f7a9c4e816_app_qualified_agent_ids.py
@@ -1,0 +1,67 @@
+"""An agent override and a recorded agent step key on the app-qualified agent id.
+
+Revision ID: d2f7a9c4e816
+Revises: b4d7e2a9c1f6
+Create Date: 2026-09-06
+"""
+
+import re
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d2f7a9c4e816"
+down_revision: str | Sequence[str] | None = "b4d7e2a9c1f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_KEYS = ("agent_harness", "agent_model", "agent_billing", "agent_effort", "agent_timeout")
+# The bundled app's agents at this revision. The database does not record which
+# app declares an agent, so an override or a recorded step of any other app's
+# agent keeps its flat name; the operator sets the override again in Settings → Apps.
+_AGENTS = (
+    "generate_plan",
+    "review_plan",
+    "revise_contract",
+    "implement",
+    "evaluate_implementation",
+    "triage_human_feedback",
+    "repo_profiler",
+    "review_pull_request",
+)
+
+
+def _rename(old: str, new: str) -> None:
+    """Move the bundled agents' names from the ``old`` prefix to the ``new`` one."""
+    op.execute(
+        sa.text(
+            "UPDATE settings_overrides SET key = split_part(key, ':', 1) || ':' || :new "
+            "|| substr(split_part(key, ':', 2), CAST(:cut AS integer)) "
+            "WHERE split_part(key, ':', 1) IN :keys AND split_part(key, ':', 2) IN :names"
+        ).bindparams(
+            sa.bindparam("new", value=new),
+            sa.bindparam("cut", value=len(old) + 1),
+            sa.bindparam("keys", expanding=True, value=list(_KEYS)),
+            sa.bindparam("names", expanding=True, value=[old + agent for agent in _AGENTS]),
+        )
+    )
+    # DBOS replays a retried run's steps under their recorded names, so they
+    # follow the id. A fresh install migrates before DBOS creates its schema.
+    if op.get_bind().execute(sa.text("SELECT to_regclass('dbos.operation_outputs')")).scalar():
+        pattern = r"\.agent\." + re.escape(old) + "(" + "|".join(_AGENTS) + r")(\.retry_wait)?$"
+        op.execute(
+            sa.text(
+                "UPDATE dbos.operation_outputs "
+                "SET function_name = regexp_replace(function_name, :pattern, :replacement) "
+                "WHERE function_name ~ :pattern"
+            ).bindparams(pattern=pattern, replacement=rf".agent.{new}\1\2")
+        )
+
+
+def upgrade() -> None:
+    _rename("", "software_factory.")
+
+
+def downgrade() -> None:
+    _rename("software_factory.", "")

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -193,6 +193,7 @@ def test_agents_lists_every_apps_agents_as_they_resolve(tmp_path: Path):
     assert agents["software_factory.generate_plan"]["harnessSource"] == "default"
     assert set(agents["software_factory.generate_plan"]) == {
         "name",
+        "label",
         "description",
         "harness",
         "harnessSource",
@@ -268,6 +269,7 @@ def test_apps_surface_build_agents_and_workflow_defaults(tmp_path: Path):
     agents = {a["name"]: a for a in build["agents"]}
     assert agents["software_factory.generate_plan"] == {
         "name": "software_factory.generate_plan",
+        "label": "generate_plan",
         "description": "ticket → implementation plan",
         "harness": "claude",
         "harnessSource": "default",

--- a/backend/tests/test_api_settings.py
+++ b/backend/tests/test_api_settings.py
@@ -139,17 +139,17 @@ def test_patch_settings_updates_the_defaults_every_agent_inherits(tmp_path: Path
         assert patch.status_code == 200
         assert patch.json()["defaultModel"] == "openai/gpt-5.5"
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-    assert agents["implement"]["harness"] == "codex"
-    assert agents["implement"]["harnessSource"] == "default"
-    assert agents["implement"]["model"] == "openai/gpt-5.5"
-    assert agents["implement"]["source"] == "default"
+    assert agents["software_factory.implement"]["harness"] == "codex"
+    assert agents["software_factory.implement"]["harnessSource"] == "default"
+    assert agents["software_factory.implement"]["model"] == "openai/gpt-5.5"
+    assert agents["software_factory.implement"]["source"] == "default"
 
 
 def test_patch_settings_rejects_defaults_that_break_an_agent_override(tmp_path: Path):
     with _build_client(tmp_path) as client:
         override = client.patch(
             "/api/settings/apps",
-            json={"agentModels": {"generate_plan": "anthropic/claude-opus-4-7"}},
+            json={"agentModels": {"software_factory.generate_plan": "anthropic/claude-opus-4-7"}},
         )
         assert override.status_code == 200
 
@@ -175,8 +175,8 @@ def test_agents_lists_every_apps_agents_as_they_resolve(tmp_path: Path):
         client.patch(
             "/api/settings/apps",
             json={
-                "agentHarnesses": {"implement": "codex"},
-                "agentModels": {"implement": "openai/gpt-5.5"},
+                "agentHarnesses": {"software_factory.implement": "codex"},
+                "agentModels": {"software_factory.implement": "openai/gpt-5.5"},
             },
         )
         body = client.get("/api/agents").json()
@@ -184,14 +184,14 @@ def test_agents_lists_every_apps_agents_as_they_resolve(tmp_path: Path):
     assert "software_factory" in apps
     assert "field_notes" in apps
     agents = {a["name"]: a for a in apps["software_factory"]["agents"]}
-    assert agents["implement"]["harness"] == "codex"
-    assert agents["implement"]["harnessSource"] == "agent"
-    assert agents["implement"]["model"] == "openai/gpt-5.5"
-    assert agents["implement"]["source"] == "agent"
-    assert agents["implement"]["billing"] == "subscription"
-    assert agents["implement"]["billingSource"] == "default"
-    assert agents["generate_plan"]["harnessSource"] == "default"
-    assert set(agents["generate_plan"]) == {
+    assert agents["software_factory.implement"]["harness"] == "codex"
+    assert agents["software_factory.implement"]["harnessSource"] == "agent"
+    assert agents["software_factory.implement"]["model"] == "openai/gpt-5.5"
+    assert agents["software_factory.implement"]["source"] == "agent"
+    assert agents["software_factory.implement"]["billing"] == "subscription"
+    assert agents["software_factory.implement"]["billingSource"] == "default"
+    assert agents["software_factory.generate_plan"]["harnessSource"] == "default"
+    assert set(agents["software_factory.generate_plan"]) == {
         "name",
         "description",
         "harness",
@@ -209,25 +209,34 @@ def test_agents_lists_every_apps_agents_as_they_resolve(tmp_path: Path):
 
 def test_apps_judge_an_agents_triple_as_it_resolves(tmp_path: Path):
     with _build_client(tmp_path) as client:
-        response = client.patch("/api/settings/apps", json={"agentHarnesses": {"implement": "pi"}})
+        response = client.patch(
+            "/api/settings/apps", json={"agentHarnesses": {"software_factory.implement": "pi"}}
+        )
         assert response.status_code == 422
         assert "API key only" in response.json()["detail"]
         response = client.patch(
-            "/api/settings/apps", json={"agentModels": {"implement": "openai/gpt-5.5"}}
+            "/api/settings/apps",
+            json={"agentModels": {"software_factory.implement": "openai/gpt-5.5"}},
         )
         assert response.status_code == 422
         assert "does not run OpenAI" in response.json()["detail"]
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        assert agents["implement"]["harnessSource"] == "default"
-        assert agents["implement"]["source"] == "default"
+        assert agents["software_factory.implement"]["harnessSource"] == "default"
+        assert agents["software_factory.implement"]["source"] == "default"
         response = client.patch(
             "/api/settings/apps",
-            json={"agentHarnesses": {"implement": "pi"}, "agentBillings": {"implement": "api_key"}},
+            json={
+                "agentHarnesses": {"software_factory.implement": "pi"},
+                "agentBillings": {"software_factory.implement": "api_key"},
+            },
         )
         assert response.status_code == 200
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        assert (agents["implement"]["harness"], agents["implement"]["billing"]) == ("pi", "api_key")
-        assert agents["implement"]["billingSource"] == "agent"
+        assert (
+            agents["software_factory.implement"]["harness"],
+            agents["software_factory.implement"]["billing"],
+        ) == ("pi", "api_key")
+        assert agents["software_factory.implement"]["billingSource"] == "agent"
         response = client.patch("/api/settings/apps", json={"agentBillings": {"ghost": "api_key"}})
         assert response.status_code == 422
 
@@ -248,7 +257,7 @@ def test_apps_surface_build_agents(tmp_path: Path):
     apps = {m["name"]: m for m in body["apps"]}
 
     build_agents = {a["name"]: a for a in apps["software_factory"]["agents"]}
-    assert "generate_plan" in build_agents
+    assert "software_factory.generate_plan" in build_agents
     assert "planning" not in build_agents
 
 
@@ -257,8 +266,8 @@ def test_apps_surface_build_agents_and_workflow_defaults(tmp_path: Path):
         build = _software_factory_app(client)
 
     agents = {a["name"]: a for a in build["agents"]}
-    assert agents["generate_plan"] == {
-        "name": "generate_plan",
+    assert agents["software_factory.generate_plan"] == {
+        "name": "software_factory.generate_plan",
         "description": "ticket → implementation plan",
         "harness": "claude",
         "harnessSource": "default",
@@ -271,8 +280,8 @@ def test_apps_surface_build_agents_and_workflow_defaults(tmp_path: Path):
         "timeout": 1800,
         "timeoutSource": "default",
     }
-    assert agents["implement"]["model"] == "anthropic/claude-opus-4-7"
-    assert agents["evaluate_implementation"]["effortSource"] == "default"
+    assert agents["software_factory.implement"]["model"] == "anthropic/claude-opus-4-7"
+    assert agents["software_factory.evaluate_implementation"]["effortSource"] == "default"
     fields = {f["name"]: f for f in build["workflows"][0]["fields"]}
     assert fields["max_implementation_revisions"]["value"] == 5
     assert fields["plan_gate"] == {
@@ -449,7 +458,7 @@ def test_incoherent_app_save_is_rejected_and_rolled_back_before_schedules(
         response = client.patch(
             "/api/settings/apps",
             json={
-                "agentModels": {"generate_plan": "anthropic/claude-opus-4-7"},
+                "agentModels": {"software_factory.generate_plan": "anthropic/claude-opus-4-7"},
                 "appSettings": {"software_factory": {"review_app_id": "42"}},
             },
         )
@@ -461,7 +470,7 @@ def test_incoherent_app_save_is_rejected_and_rolled_back_before_schedules(
         assert not reconciled
         assert _software_factory_settings_fields(client)["review_app_id"]["secretSet"] is False
         agents = {agent["name"]: agent for agent in _software_factory_app(client)["agents"]}
-        assert agents["generate_plan"]["model"] == "anthropic/claude-opus-4-7"
+        assert agents["software_factory.generate_plan"]["model"] == "anthropic/claude-opus-4-7"
 
 
 async def test_clearing_the_identity_deletes_its_overrides_and_stays_coherent(tmp_path: Path):
@@ -508,37 +517,39 @@ def test_apps_override_agent_model_persists(tmp_path: Path):
         patch = client.patch(
             "/api/settings/apps",
             json={
-                "agentHarnesses": {"implement": "codex"},
-                "agentModels": {"implement": "openai/gpt-5.5"},
+                "agentHarnesses": {"software_factory.implement": "codex"},
+                "agentModels": {"software_factory.implement": "openai/gpt-5.5"},
             },
         )
         assert patch.status_code == 200
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
 
-    assert agents["implement"]["model"] == "openai/gpt-5.5"
-    assert agents["implement"]["source"] == "agent"
+    assert agents["software_factory.implement"]["model"] == "openai/gpt-5.5"
+    assert agents["software_factory.implement"]["source"] == "agent"
 
 
 def test_apps_default_effort_and_per_agent_effort_override(tmp_path: Path):
     with _build_client(tmp_path) as client:
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        assert agents["generate_plan"]["effort"] == "high"
-        assert agents["generate_plan"]["effortSource"] == "default"
+        assert agents["software_factory.generate_plan"]["effort"] == "high"
+        assert agents["software_factory.generate_plan"]["effortSource"] == "default"
 
         client.patch("/api/settings", json={"defaultEffort": "low"})
-        client.patch("/api/settings/apps", json={"agentEfforts": {"generate_plan": "high"}})
+        client.patch(
+            "/api/settings/apps", json={"agentEfforts": {"software_factory.generate_plan": "high"}}
+        )
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        assert agents["generate_plan"]["effort"] == "high"
-        assert agents["generate_plan"]["effortSource"] == "agent"
-        assert agents["revise_contract"]["effort"] == "low"
-        assert agents["revise_contract"]["effortSource"] == "default"
+        assert agents["software_factory.generate_plan"]["effort"] == "high"
+        assert agents["software_factory.generate_plan"]["effortSource"] == "agent"
+        assert agents["software_factory.revise_contract"]["effort"] == "low"
+        assert agents["software_factory.revise_contract"]["effortSource"] == "default"
 
 
 def test_apps_reject_unknown_effort(tmp_path: Path):
     with _build_client(tmp_path) as client:
         response = client.patch(
             "/api/settings/apps",
-            json={"agentEfforts": {"implement": "turbo"}},
+            json={"agentEfforts": {"software_factory.implement": "turbo"}},
         )
     assert response.status_code == 422
     assert "agentEfforts" in str(response.json()["detail"])
@@ -547,23 +558,25 @@ def test_apps_reject_unknown_effort(tmp_path: Path):
 def test_apps_default_timeout_and_per_agent_timeout_override(tmp_path: Path):
     with _build_client(tmp_path) as client:
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        assert agents["implement"]["timeout"] == 1800
-        assert agents["implement"]["timeoutSource"] == "default"
+        assert agents["software_factory.implement"]["timeout"] == 1800
+        assert agents["software_factory.implement"]["timeoutSource"] == "default"
 
         client.patch("/api/settings", json={"defaultTimeout": 1200})
-        client.patch("/api/settings/apps", json={"agentTimeouts": {"implement": 3600}})
+        client.patch(
+            "/api/settings/apps", json={"agentTimeouts": {"software_factory.implement": 3600}}
+        )
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        assert agents["implement"]["timeout"] == 3600
-        assert agents["implement"]["timeoutSource"] == "agent"
-        assert agents["review_plan"]["timeout"] == 1200
-        assert agents["review_plan"]["timeoutSource"] == "default"
+        assert agents["software_factory.implement"]["timeout"] == 3600
+        assert agents["software_factory.implement"]["timeoutSource"] == "agent"
+        assert agents["software_factory.review_plan"]["timeout"] == 1200
+        assert agents["software_factory.review_plan"]["timeoutSource"] == "default"
 
 
 def test_apps_reject_non_positive_timeout(tmp_path: Path):
     with _build_client(tmp_path) as client:
         response = client.patch(
             "/api/settings/apps",
-            json={"agentTimeouts": {"implement": 0}},
+            json={"agentTimeouts": {"software_factory.implement": 0}},
         )
     assert response.status_code == 422
 
@@ -590,16 +603,18 @@ def test_apps_clearing_an_override_reverts_to_the_operator_default(tmp_path: Pat
     with _build_client(tmp_path) as client:
         client.patch(
             "/api/settings/apps",
-            json={"agentModels": {"generate_plan": "anthropic/claude-opus-4-7"}},
+            json={"agentModels": {"software_factory.generate_plan": "anthropic/claude-opus-4-7"}},
         )
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        assert agents["generate_plan"]["model"] == "anthropic/claude-opus-4-7"
-        assert agents["generate_plan"]["source"] == "agent"
+        assert agents["software_factory.generate_plan"]["model"] == "anthropic/claude-opus-4-7"
+        assert agents["software_factory.generate_plan"]["source"] == "agent"
 
-        client.patch("/api/settings/apps", json={"agentModels": {"generate_plan": None}})
+        client.patch(
+            "/api/settings/apps", json={"agentModels": {"software_factory.generate_plan": None}}
+        )
         agents = {a["name"]: a for a in _software_factory_app(client)["agents"]}
-        assert agents["generate_plan"]["model"] == "anthropic/claude-opus-4-7"
-        assert agents["generate_plan"]["source"] == "default"
+        assert agents["software_factory.generate_plan"]["model"] == "anthropic/claude-opus-4-7"
+        assert agents["software_factory.generate_plan"]["source"] == "default"
 
 
 def test_apps_reject_unknown_agent_model(tmp_path: Path):
@@ -607,7 +622,7 @@ def test_apps_reject_unknown_agent_model(tmp_path: Path):
         # No installed harness owns this namespace, so nothing could run it.
         response = client.patch(
             "/api/settings/apps",
-            json={"agentModels": {"implement": "llama-3-70b"}},
+            json={"agentModels": {"software_factory.implement": "llama-3-70b"}},
         )
     assert response.status_code == 422
     assert "llama-3-70b" in response.json()["detail"]

--- a/backend/tests/test_migration_app_qualified_agent_ids.py
+++ b/backend/tests/test_migration_app_qualified_agent_ids.py
@@ -1,0 +1,86 @@
+import importlib.util
+from pathlib import Path
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from druks.testing import seed_run
+from druks.user_settings.models import SettingsOverride
+from sqlalchemy import text
+
+# Data-only, so it runs inside the suite's rolled-back transaction against the
+# current schema.
+_MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "migrations"
+    / "versions"
+    / "d2f7a9c4e816_app_qualified_agent_ids.py"
+)
+_STEPS = "SELECT function_name FROM dbos.operation_outputs ORDER BY workflow_uuid, function_id"
+_OVERRIDES = "SELECT key FROM settings_overrides ORDER BY key"
+
+
+async def _apply(druks_db, step) -> None:
+    def run(connection) -> None:
+        with Operations.context(MigrationContext.configure(connection)):
+            step()
+
+    await druks_db.flush()
+    await (await druks_db.connection()).run_sync(run)
+
+
+async def _column(druks_db, statement: str) -> list[str]:
+    return list((await druks_db.execute(text(statement))).scalars())
+
+
+async def test_bundled_agent_overrides_and_steps_take_the_apps_name(druks_db):
+    await SettingsOverride.set_agent_model("implement", "openai/gpt-5.5")
+    await SettingsOverride.set_agent_effort("review_pull_request", "low")
+    # An agent of an app the migration does not know keeps its flat name.
+    await SettingsOverride.set_agent_timeout("engage", 90)
+    await SettingsOverride.set_workflow_setting("software_factory.build", "review_code", False)
+    await seed_run(druks_db, kind="software_factory.build", run_id="build-run", state="failed")
+    await seed_run(druks_db, kind="x_me.engage", run_id="engage-run", state="failed")
+    for run_id, function_id, step in (
+        ("build-run", 1, "software_factory.build.agent.implement"),
+        ("build-run", 2, "software_factory.build.agent.implement.retry_wait"),
+        ("engage-run", 1, "x_me.engage.agent.engage"),
+    ):
+        await druks_db.execute(
+            text(
+                "INSERT INTO dbos.operation_outputs "
+                "(workflow_uuid, function_id, function_name, error) "
+                "VALUES (:run, :function_id, :step, 'boom')"
+            ),
+            {"run": run_id, "function_id": function_id, "step": step},
+        )
+    spec = importlib.util.spec_from_file_location("app_qualified_agent_ids", _MIGRATION)
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    await _apply(druks_db, migration.upgrade)
+
+    assert await _column(druks_db, _OVERRIDES) == [
+        "agent_effort:software_factory.review_pull_request",
+        "agent_model:software_factory.implement",
+        "agent_timeout:engage",
+        "workflow:software_factory.build:review_code",
+    ]
+    assert await _column(druks_db, _STEPS) == [
+        "software_factory.build.agent.software_factory.implement",
+        "software_factory.build.agent.software_factory.implement.retry_wait",
+        "x_me.engage.agent.engage",
+    ]
+
+    await _apply(druks_db, migration.downgrade)
+
+    assert await _column(druks_db, _OVERRIDES) == [
+        "agent_effort:review_pull_request",
+        "agent_model:implement",
+        "agent_timeout:engage",
+        "workflow:software_factory.build:review_code",
+    ]
+    assert await _column(druks_db, _STEPS) == [
+        "software_factory.build.agent.implement",
+        "software_factory.build.agent.implement.retry_wait",
+        "x_me.engage.agent.engage",
+    ]

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -14,6 +14,7 @@ from druks.harnesses.opencode import OpenCodeHarness
 from druks.harnesses.profiles import check_profile, get_profile
 from druks.harnesses.providers import AnthropicProvider
 from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
+from druks.user_settings import reads
 from druks.user_settings.models import SettingsOverride, UserSettings
 from druks.workflows import WorkflowError, current_workflow
 
@@ -221,7 +222,9 @@ async def test_two_apps_declare_the_same_agent_name(druks_db):
 
     class BugHunter(App):
         name = "bug_hunter"
-        file_tickets = agents.Agent(prompt="probe.md", contract=_Output, timeout=300)
+        file_tickets = agents.Agent(
+            name="File tickets", prompt="probe.md", contract=_Output, timeout=300
+        )
 
     try:
         await _subscription("a@example.com")
@@ -229,6 +232,10 @@ async def test_two_apps_declare_the_same_agent_name(druks_db):
         declared = (Ticketing.agents(), BugHunter.agents())
         ticketing = await get_profile(Ticketing.file_tickets.id, None)
         bug_hunter = await get_profile(BugHunter.file_tickets.id, None)
+        settings = [
+            await reads.get_agent_setting(agent)
+            for agent in (Ticketing.file_tickets, BugHunter.file_tickets)
+        ]
     finally:
         for app in (Ticketing, BugHunter):
             agent_registry._items.pop(app.file_tickets.id)
@@ -240,3 +247,8 @@ async def test_two_apps_declare_the_same_agent_name(druks_db):
     assert declared == ([Ticketing.file_tickets], [BugHunter.file_tickets])
     assert (ticketing.effort, ticketing.timeout) == ("high", 1800)
     assert (bug_hunter.effort, bug_hunter.timeout) == ("low", 300)
+    # The settings wire keys on the id; the declared name is only its label.
+    assert [(setting.name, setting.label, setting.effort) for setting in settings] == [
+        ("ticketing.file_tickets", "file_tickets", "high"),
+        ("bug_hunter.file_tickets", "File tickets", "low"),
+    ]

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -5,6 +5,8 @@ from conftest import connect_provider
 from druks import agents
 from druks.accounts.constants import SYSTEM_ACCOUNT_ID
 from druks.accounts.models import Account
+from druks.apps import App
+from druks.apps.registry import agents as agent_registry
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.exceptions import HarnessNotConnectedError, ProfileSettingsError
 from druks.harnesses.models import ProviderCatalog, ProviderKey, ProviderSubscription
@@ -210,3 +212,31 @@ async def test_an_agent_reads_its_own_profile(druks_db):
 async def test_an_unregistered_agent_is_named(druks_db):
     with pytest.raises(KeyError, match="no agent is registered as 'ghost'"):
         await get_profile("ghost", None)
+
+
+async def test_two_apps_declare_the_same_agent_name(druks_db):
+    class Ticketing(App):
+        name = "ticketing"
+        file_tickets = agents.Agent(prompt="probe.md", contract=_Output)
+
+    class BugHunter(App):
+        name = "bug_hunter"
+        file_tickets = agents.Agent(prompt="probe.md", contract=_Output, timeout=300)
+
+    try:
+        await _subscription("a@example.com")
+        await SettingsOverride.set_agent_effort(BugHunter.file_tickets.id, "low")
+        declared = (Ticketing.agents(), BugHunter.agents())
+        ticketing = await get_profile(Ticketing.file_tickets.id, None)
+        bug_hunter = await get_profile(BugHunter.file_tickets.id, None)
+    finally:
+        for app in (Ticketing, BugHunter):
+            agent_registry._items.pop(app.file_tickets.id)
+
+    assert (Ticketing.file_tickets.id, BugHunter.file_tickets.id) == (
+        "ticketing.file_tickets",
+        "bug_hunter.file_tickets",
+    )
+    assert declared == ([Ticketing.file_tickets], [BugHunter.file_tickets])
+    assert (ticketing.effort, ticketing.timeout) == ("high", 1800)
+    assert (bug_hunter.effort, bug_hunter.timeout) == ("low", 300)

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -358,6 +358,9 @@ class NightWatch(App):
     )
 ```
 
+The app name and the attribute name form the agent's id: `night_watch.report`.
+Settings overrides, the timeline, and the step name use that id.
+
 Call it only inside a workflow:
 
 ```python

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -656,6 +656,7 @@ export type Source = 'agent' | 'default'
 export type TimeoutSource = 'agent' | 'declared' | 'default'
 
 export interface AgentSetting {
+  /** The agent's durable id, `<app>.<attribute>` — the key in an update's agent maps. */
   name: string
   /** Short human-friendly blurb of what the agent does. */
   description: string

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -658,6 +658,8 @@ export type TimeoutSource = 'agent' | 'declared' | 'default'
 export interface AgentSetting {
   /** The agent's durable id, `<app>.<attribute>` — the key in an update's agent maps. */
   name: string
+  /** The declared display name, else the attribute name. */
+  label: string
   /** Short human-friendly blurb of what the agent does. */
   description: string
   harness: string

--- a/frontend/src/components/SettingsPages.test.tsx
+++ b/frontend/src/components/SettingsPages.test.tsx
@@ -46,6 +46,7 @@ const userSettings = {
 
 const coder: AgentSetting = {
   name: 'software_factory.coder',
+  label: 'coder',
   description: 'writes the change',
   harness: 'codex',
   harnessSource: 'agent',
@@ -61,6 +62,7 @@ const coder: AgentSetting = {
 
 const critic: AgentSetting = {
   name: 'review.critic',
+  label: 'critic',
   description: 'reviews the change',
   harness: 'opencode',
   harnessSource: 'agent',

--- a/frontend/src/components/SettingsPages.test.tsx
+++ b/frontend/src/components/SettingsPages.test.tsx
@@ -45,7 +45,7 @@ const userSettings = {
 }
 
 const coder: AgentSetting = {
-  name: 'coder',
+  name: 'software_factory.coder',
   description: 'writes the change',
   harness: 'codex',
   harnessSource: 'agent',
@@ -60,7 +60,7 @@ const coder: AgentSetting = {
 }
 
 const critic: AgentSetting = {
-  name: 'critic',
+  name: 'review.critic',
   description: 'reviews the change',
   harness: 'opencode',
   harnessSource: 'agent',
@@ -1084,7 +1084,7 @@ describe('canonical app settings', () => {
         ([path, init]) => String(path) === '/api/settings/apps' && init?.method === 'PATCH',
       )
     expect(JSON.parse(String(patch?.[1]?.body))).toEqual({
-      agentEfforts: { coder: 'low' },
+      agentEfforts: { 'software_factory.coder': 'low' },
       appSettings: { software_factory: { linear_trigger_status: 'Agent Queue' } },
       workflowSettings: {},
     })
@@ -1413,8 +1413,8 @@ it('focuses the same search result on each click', async () => {
 it('keeps focus on another agent field after saving an app reached through search', async () => {
   stubFetch(false)
   const scroll = mockScroll()
-  renderSettings('/apps/software_factory/settings/agents?field=agent.coder.model')
-  await waitFor(() => expect(document.activeElement?.closest('[data-setting]')?.getAttribute('data-setting')).toBe('agent.coder.model'))
+  renderSettings('/apps/software_factory/settings/agents?field=agent.software_factory.coder.model')
+  await waitFor(() => expect(document.activeElement?.closest('[data-setting]')?.getAttribute('data-setting')).toBe('agent.software_factory.coder.model'))
   fireEvent.click(screen.getByRole('button', { name: /^effort:/ }))
   fireEvent.click(screen.getByRole('button', { name: 'low' }))
   const harness = screen.getByRole('button', { name: /^harness:/ })

--- a/frontend/src/components/SettingsPages.tsx
+++ b/frontend/src/components/SettingsPages.tsx
@@ -14,7 +14,6 @@ import { appLabel } from '../apps/registry'
 import { useTicker } from '../lib/useTicker'
 import { absTime } from '../lib/format'
 import { harnessColors } from '../lib/harnessColors'
-import { localName } from '../lib/feed'
 import { Sidebar } from './Sidebar'
 import { BrowserSessionsPane } from './BrowserSessionsPane'
 import {
@@ -383,7 +382,7 @@ export function SettingsPages({
       }
     }),
     ...entry.agents.flatMap((agent) => [SETTINGS_FIELDS.harness, SETTINGS_FIELDS.model, SETTINGS_FIELDS.billing, SETTINGS_FIELDS.effort, SETTINGS_FIELDS.timeout].map((field) => ({
-      label: `${field.label} · ${localName(agent.name)}`, owner: appLabel(entry.name), kind: 'Field',
+      label: `${field.label} · ${agent.label}`, owner: appLabel(entry.name), kind: 'Field',
       terms: `agent override inheritance ${agent.description}`,
       path: `/apps/${entry.name}/settings/agents?field=${encodeURIComponent(`agent.${agent.name}.${field.field}`)}`,
     }))),

--- a/frontend/src/components/SettingsPages.tsx
+++ b/frontend/src/components/SettingsPages.tsx
@@ -14,6 +14,7 @@ import { appLabel } from '../apps/registry'
 import { useTicker } from '../lib/useTicker'
 import { absTime } from '../lib/format'
 import { harnessColors } from '../lib/harnessColors'
+import { localName } from '../lib/feed'
 import { Sidebar } from './Sidebar'
 import { BrowserSessionsPane } from './BrowserSessionsPane'
 import {
@@ -382,7 +383,7 @@ export function SettingsPages({
       }
     }),
     ...entry.agents.flatMap((agent) => [SETTINGS_FIELDS.harness, SETTINGS_FIELDS.model, SETTINGS_FIELDS.billing, SETTINGS_FIELDS.effort, SETTINGS_FIELDS.timeout].map((field) => ({
-      label: `${field.label} · ${agent.name}`, owner: appLabel(entry.name), kind: 'Field',
+      label: `${field.label} · ${localName(agent.name)}`, owner: appLabel(entry.name), kind: 'Field',
       terms: `agent override inheritance ${agent.description}`,
       path: `/apps/${entry.name}/settings/agents?field=${encodeURIComponent(`agent.${agent.name}.${field.field}`)}`,
     }))),

--- a/frontend/src/components/SettingsPanes.tsx
+++ b/frontend/src/components/SettingsPanes.tsx
@@ -13,6 +13,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Plus } from 'lucide-react'
 
 import { api } from '../api/client'
+import { localName } from '../lib/feed'
 import { TextInput } from './Control'
 import { SettingField } from './SettingField'
 import { ConnectSteps, useProviderConnect } from './ProviderConnectFlow'
@@ -780,7 +781,7 @@ function ResolvedAgentRow({
   return (
     <div className="set-trow">
       <div className="agent-cell agents-agent">
-        <span className="agent-name">{agent.name}</span>
+        <span className="agent-name">{localName(agent.name)}</span>
         <span className="agent-desc">{agent.description}</span>
       </div>
       <div>
@@ -3198,9 +3199,9 @@ function AgentRecords({
           disabled: busy,
         }
         return (
-          <section key={agent.name} className="agent-record" aria-label={agent.name}>
+          <section key={agent.name} className="agent-record" aria-label={localName(agent.name)}>
             <header className="agent-identity">
-              <h3>{agent.name}</h3>
+              <h3>{localName(agent.name)}</h3>
               <p>{agent.description}</p>
             </header>
             <div className="agent-field agent-field-harness" role="group" aria-label="Harness" data-setting={`agent.${agent.name}.${SETTINGS_FIELDS.harness.field}`}>

--- a/frontend/src/components/SettingsPanes.tsx
+++ b/frontend/src/components/SettingsPanes.tsx
@@ -13,7 +13,6 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Plus } from 'lucide-react'
 
 import { api } from '../api/client'
-import { localName } from '../lib/feed'
 import { TextInput } from './Control'
 import { SettingField } from './SettingField'
 import { ConnectSteps, useProviderConnect } from './ProviderConnectFlow'
@@ -781,7 +780,7 @@ function ResolvedAgentRow({
   return (
     <div className="set-trow">
       <div className="agent-cell agents-agent">
-        <span className="agent-name">{localName(agent.name)}</span>
+        <span className="agent-name">{agent.label}</span>
         <span className="agent-desc">{agent.description}</span>
       </div>
       <div>
@@ -3199,9 +3198,9 @@ function AgentRecords({
           disabled: busy,
         }
         return (
-          <section key={agent.name} className="agent-record" aria-label={localName(agent.name)}>
+          <section key={agent.name} className="agent-record" aria-label={agent.label}>
             <header className="agent-identity">
-              <h3>{localName(agent.name)}</h3>
+              <h3>{agent.label}</h3>
               <p>{agent.description}</p>
             </header>
             <div className="agent-field agent-field-harness" role="group" aria-label="Harness" data-setting={`agent.${agent.name}.${SETTINGS_FIELDS.harness.field}`}>

--- a/frontend/src/lib/feed.ts
+++ b/frontend/src/lib/feed.ts
@@ -59,7 +59,7 @@ function isLifecycle(event: FeedItem): boolean {
 }
 
 // "software_factory.build" → "build": the durable kind identifies the workflow, its tail names it.
-function localName(kind: string | null | undefined): string {
+export function localName(kind: string | null | undefined): string {
   return kind ? (kind.split('.').pop() ?? '') : ''
 }
 

--- a/frontend/src/lib/feed.ts
+++ b/frontend/src/lib/feed.ts
@@ -59,7 +59,7 @@ function isLifecycle(event: FeedItem): boolean {
 }
 
 // "software_factory.build" → "build": the durable kind identifies the workflow, its tail names it.
-export function localName(kind: string | null | undefined): string {
+function localName(kind: string | null | undefined): string {
   return kind ? (kind.split('.').pop() ?? '') : ''
 }
 


### PR DESCRIPTION
An agent declared on an App takes `<app>.<attribute>` as its id: `software_factory.file_tickets`. This is the rule `Workflow.kind` already follows. The id is the one durable name, so the registry key, the `agent_*:` override keys, `get_profile`, `AgentCall.agent`, the DBOS step name, and the settings wire carry it with no further change. Two apps can now declare the same attribute name. A standalone agent with an explicit `id=` keeps it. App code does not change: an author still writes `file_tickets = Agent(...)` and calls `await BugHunter.file_tickets(...)`.

The id itself is qualified, not the registry key alone, because the profile lookup, the override keys, the timeline, and the settings PATCH body would each need a second name otherwise.

The settings wire carries the id as `name` and the declared display name, else the attribute name, as `label`. The pages show the label and key their edits by the id.

Migration `d2f7a9c4e816` rewrites the bundled app's override rows to the qualified key and its recorded agent steps in `dbos.operation_outputs` to the qualified step name, so a retried run replays under the names the code now uses. The database does not record which app declares an agent, and a migration cannot read the app registry, so an override or a recorded step of any other app's agent keeps its flat name. Set the override again in Settings → Apps.

Historic `agent_calls.agent` values stay as recorded. They are display-only, and the timeline label derives the same word from the flat and the qualified name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
