### PR TITLE
Unify command center app names and page layout

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -109,7 +109,7 @@ describe('command center navigation', () => {
   it('keeps app destinations stable on list and detail pages', async () => {
     renderApp()
     const apps = await screen.findByRole('navigation', { name: 'Apps' })
-    await within(apps).findByRole('link', { name: 'external' })
+    await within(apps).findByRole('link', { name: 'External' })
     const links = within(apps)
       .getAllByRole('link')
       .map((link) => link.getAttribute('href'))
@@ -120,7 +120,7 @@ describe('command center navigation', () => {
         .getAllByRole('link')
         .map((link) => link.getAttribute('href')),
     ).toEqual(links)
-    expect(within(apps).getByRole('link', { name: 'notes' }).getAttribute('aria-current')).toBe(
+    expect(within(apps).getByRole('link', { name: 'Notes' }).getAttribute('aria-current')).toBe(
       'page',
     )
     expect(
@@ -132,7 +132,7 @@ describe('command center navigation', () => {
 
   it('selects deep links and follows browser history', async () => {
     renderApp('/notes/history')
-    const pages = await screen.findByRole('navigation', { name: 'notes pages' })
+    const pages = await screen.findByRole('navigation', { name: 'Notes pages' })
     expect(within(pages).getByRole('link', { name: 'History' }).getAttribute('aria-current')).toBe(
       'page',
     )
@@ -144,7 +144,7 @@ describe('command center navigation', () => {
     })
     await screen.findByRole('heading', { name: 'Note history' })
     expect(
-      within(screen.getByRole('navigation', { name: 'notes pages' }))
+      within(screen.getByRole('navigation', { name: 'Notes pages' }))
         .getByRole('link', { name: 'History' })
         .getAttribute('aria-current'),
     ).toBe('page')
@@ -152,15 +152,15 @@ describe('command center navigation', () => {
 
   it('opens installed generic and standalone apps', async () => {
     renderApp()
-    fireEvent.click(await screen.findByRole('link', { name: 'headless' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Headless' }))
     await screen.findByRole('heading', { name: 'headless home' })
-    fireEvent.click(screen.getByRole('link', { name: 'external' }))
+    fireEvent.click(screen.getByRole('link', { name: 'External' }))
     await screen.findByRole('heading', { name: 'external mounted' })
   })
 
   it('filters the roster without removing shared destinations', async () => {
     renderApp()
-    await screen.findByRole('link', { name: 'external' })
+    await screen.findByRole('link', { name: 'External' })
     fireEvent.change(screen.getByRole('textbox', { name: 'Find an app' }), {
       target: { value: 'EXTERNAL' },
     })
@@ -258,7 +258,7 @@ describe('command center navigation', () => {
     }))
     vi.mocked(api.listApps).mockResolvedValueOnce([...roster, ...apps])
     renderApp()
-    await screen.findByRole('link', { name: 'department 39 with a long app name' })
+    await screen.findByRole('link', { name: 'Department 39 With A Long App Name' })
     fireEvent.change(screen.getByRole('textbox', { name: 'Find an app' }), {
       target: { value: 'department 39' },
     })

--- a/frontend/src/apps/InstalledAppHost.tsx
+++ b/frontend/src/apps/InstalledAppHost.tsx
@@ -5,7 +5,7 @@ import { EmptyState } from '../components/EmptyState'
 import { Markdown } from '../components/Markdown'
 import { Page } from '../components/Page'
 import { appAccent } from '../lib/appColors'
-import { registeredApps } from './registry'
+import { appLabel, registeredApps } from './registry'
 
 // The shell↔app mount contract. A dist app's entry module exports
 // ``shellApi`` (the contract version it was built against) and
@@ -110,7 +110,7 @@ export function InstalledAppHost({ name }: { name: string }) {
   if (error) {
     return (
       <Page>
-        <EmptyState glyph="✕" msg={`${name} failed to mount: ${error}`} />
+        <EmptyState glyph="✕" msg={`${appLabel(name)} failed to mount: ${error}`} />
       </Page>
     )
   }

--- a/frontend/src/apps/registry.tsx
+++ b/frontend/src/apps/registry.tsx
@@ -35,7 +35,10 @@ export function targetQuery(target?: SubjectTarget): string {
 }
 
 export function appLabel(name: string): string {
-  return name.replace(/_/g, ' ')
+  return name
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
 }
 
 const REGISTRY = new Map<string, AppUI>()

--- a/frontend/src/command-center.css
+++ b/frontend/src/command-center.css
@@ -1,5 +1,7 @@
 :root {
   --sidebar-width: 220px;
+  --page-gutter: 32px;
+  --page-padding: 32px var(--page-gutter) 48px;
 }
 
 .command-center {
@@ -15,7 +17,7 @@
   flex: 0 0 auto;
   align-items: center;
   min-height: 58px;
-  padding: 8px 40px;
+  padding: 8px var(--page-gutter);
   gap: 12px;
   border-bottom: 1px solid var(--border);
   background: var(--bg);
@@ -32,7 +34,6 @@
 
 .command-breadcrumb > span { color: var(--text-dim); }
 .command-breadcrumb strong { font-weight: 500; }
-.app-name { text-transform: capitalize; }
 .command-utilities { display: flex; align-items: center; gap: 20px; margin-left: auto; flex-shrink: 0; }
 .command-timezone { color: var(--text-mid); }
 .app-main { display: flex; flex: 1; flex-direction: column; min-width: 0; min-height: 0; overflow: hidden; }
@@ -71,17 +72,13 @@
 .sidebar-message { margin: 12px 10px; color: var(--text-dim); font-size: 13px; overflow-wrap: anywhere; }
 .sidebar-retry { text-decoration: underline; min-height: 44px; color: var(--text); }
 .sidebar-footer { padding-top: 12px; margin-top: 12px; border-top: 1px solid var(--border); }
-.sidebar-account { display: flex; flex: 0 0 auto; align-items: center; gap: 10px; padding: 16px 10px 0; }
-.sidebar-account > div { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
-.sidebar-avatar { display: grid; place-items: center; width: 32px; height: 32px; flex-shrink: 0; border-radius: 50%; background: var(--surface-3); font-size: 12px; }
-.sidebar-username { display: block; font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.sidebar-account-label { color: var(--text-dim); font-size: 13px; }
+.sidebar-account { flex: 0 0 auto; padding: 16px 10px 0; font-size: 13px; color: var(--text-mid); overflow-wrap: anywhere; }
 .navigation-toggle, .navigation-close { display: none; align-items: center; justify-content: center; width: 44px; height: 44px; flex-shrink: 0; color: var(--text-mid); border-radius: 5px; }
 .sidebar-drawer { inset: 0 auto 0 0; width: min(300px, calc(100vw - 44px)); height: 100dvh; max-width: none; max-height: none; margin: 0; padding: 0; border: 0; background: var(--surface); }
 .sidebar-drawer .sidebar { width: 100%; }
 .sidebar-drawer::backdrop { background: rgb(0 0 0 / 60%); }
 
-.command-app-navigation { display: flex; flex: 0 0 auto; gap: 20px; padding: 0 40px; border-bottom: 1px solid var(--border); overflow-x: auto; scrollbar-width: thin; }
+.command-app-navigation { display: flex; flex: 0 0 auto; gap: 20px; padding: 0 var(--page-gutter); border-bottom: 1px solid var(--border); overflow-x: auto; scrollbar-width: thin; }
 .command-tab { display: inline-flex; align-items: center; min-height: 46px; padding: 8px 0; color: var(--text-dim); border-bottom: 2px solid transparent; text-decoration: none; text-transform: capitalize; white-space: nowrap; }
 .command-tab:hover, .command-tab[aria-current="page"] { color: var(--text); }
 .command-tab[aria-current="page"] { border-bottom-color: var(--text); }
@@ -96,13 +93,13 @@
 .command-center :is(.wic-op, .wic-call)[role="button"]:focus-visible { outline: 2px solid var(--text); outline-offset: -2px; }
 
 @media (max-width: 1024px) {
-  .command-header { padding-inline: 24px; }
-  .command-app-navigation { padding-inline: 24px; }
-  .event-row { grid-template-columns: auto minmax(0, 1fr) auto; gap: 8px 12px; padding-inline: 20px; }
+  :root { --page-gutter: 24px; }
+  .event-row { grid-template-columns: auto minmax(0, 1fr) auto; gap: 8px 12px; padding-inline: var(--page-gutter); }
   .event-summary { grid-column: 1 / -1; white-space: normal; overflow-wrap: anywhere; }
 }
 
 @media (max-width: 649px) {
+  :root { --page-gutter: 20px; --page-padding: 24px var(--page-gutter) 32px; }
   .command-center { padding-left: 0; }
   .sidebar-desktop { display: none; }
   .command-header { padding: 6px 12px; gap: 6px; }
@@ -112,16 +109,9 @@
   .navigation-toggle, .navigation-close { display: inline-flex; }
   .navigation-close { position: absolute; top: 16px; right: 12px; }
   .sidebar-brand { margin-right: 48px; }
-  .command-app-navigation { padding-inline: 20px; }
-  .active-page-head { flex-direction: column; align-items: stretch; gap: 16px; padding-inline: 20px; }
-  .page-usage { width: 100%; padding-inline: 20px; }
+  .active-page-head { flex-direction: column; align-items: stretch; gap: 16px; }
   .us-head { flex-wrap: wrap; }
   .command-center :is(input, select, textarea) { font-size: 16px; }
   .sidebar-search, .sidebar-search input { min-height: 44px; }
   :is(.sidebar button, .command-header button, .wic-op[role="button"], .wic-call[role="button"]) { min-height: 44px; }
 }
-
-.sidebar-account-details summary { cursor: pointer; list-style: none; min-height: 44px; padding: 12px 0; line-height: 20px; }
-.sidebar-account-details summary::-webkit-details-marker { display: none; }
-.sidebar-account-details > span { display: block; margin-top: 8px; overflow-wrap: anywhere; font-size: 13px; color: var(--text-mid); }
-.sidebar-account-details summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; }

--- a/frontend/src/components/Page.tsx
+++ b/frontend/src/components/Page.tsx
@@ -15,17 +15,18 @@ import type { ReactNode } from 'react'
  */
 interface PageProps {
   children: ReactNode
-  /** Page-specific styling (max-width, background, padding). Don't
-   * override flex / overflow / min-height — .page-shell owns those. */
+  /** Page-specific styling. Page owns width, gutters, and scrolling. */
   className?: string
   header?: ReactNode
   scroll?: 'page' | 'internal'
+  /** Apply shared content spacing. Omit for full-width lists and split panes. */
+  inset?: boolean
 }
 
-export function Page({ children, className, header, scroll = 'page' }: PageProps) {
+export function Page({ children, className, header, scroll = 'page', inset = false }: PageProps) {
   const cls = ['page-shell', className].filter(Boolean).join(' ')
   return (
-    <div className={cls} data-scroll={scroll}>
+    <div className={cls} data-scroll={scroll} data-inset={inset}>
       {header !== undefined && <div className="page-shell-header">{header}</div>}
       <div className="page-shell-body">{children}</div>
     </div>

--- a/frontend/src/components/SettingsPages.test.tsx
+++ b/frontend/src/components/SettingsPages.test.tsx
@@ -452,9 +452,9 @@ describe('SettingsPages app fields', () => {
     renderSettings()
 
     fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'field notes' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Field Notes' }))
 
-    expect(screen.getByText('field notes options')).toBeTruthy()
+    expect(screen.getByText('Field Notes options')).toBeTruthy()
   })
 
   it('renders every 422 message under the field named by the backend', async () => {
@@ -462,7 +462,7 @@ describe('SettingsPages app fields', () => {
     renderSettings()
 
     fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'review' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Review' }))
     const appIdField = screen.getByText('Review App ID').closest('.set-field')
     const appIdInput = appIdField?.querySelector('input')
     expect(appIdInput).toBeTruthy()
@@ -482,8 +482,8 @@ describe('SettingsPages app fields', () => {
     renderSettings()
 
     fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'software factory' }))
-    const options = screen.getByText('software factory options').closest('.set-group')
+    fireEvent.click(await screen.findByRole('link', { name: 'Software Factory' }))
+    const options = screen.getByText('Software Factory options').closest('.set-group')
     expect(options?.textContent?.indexOf('Tracker')).toBeLessThan(
       options?.textContent?.indexOf('Linear') ?? -1,
     )
@@ -519,7 +519,7 @@ describe('SettingsPages app fields', () => {
     renderSettings()
 
     fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'review' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Review' }))
     const pemField = screen.getByText('Review App private key').closest('.set-field')
     const textarea = pemField?.querySelector('textarea')
     expect(textarea).toBeTruthy()
@@ -552,7 +552,7 @@ describe('SettingsPages app fields', () => {
     renderSettings()
 
     fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'software factory' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Software Factory' }))
     const trackerField = screen.getByText('Tracker').closest('.set-field')
     fireEvent.change(trackerField?.querySelector('select') as HTMLSelectElement, {
       target: { value: 'jira' },
@@ -587,7 +587,7 @@ describe('SettingsPages agents', () => {
     ).toBeTruthy()
     expect(await screen.findByText('coder')).toBeTruthy()
     expect(screen.getByText('critic')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Open software factory' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Open Software Factory' })).toBeTruthy()
     expect(screen.getByText('API key ⚬')).toBeTruthy()
     expect(screen.getByText('openai/gpt-5.5')).toBeTruthy()
   })
@@ -618,7 +618,7 @@ describe('SettingsPages agents', () => {
     stubFetch()
     renderSettings()
     fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'software factory' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Software Factory' }))
     fireEvent.click(await screen.findByRole('link', { name: 'Agents' }))
     await screen.findByText('coder')
     const harnessCell = screen.getByText('codex').closest('button')!
@@ -984,13 +984,13 @@ describe('canonical app settings', () => {
       apps: appSettings.apps.filter((entry) => entry.name !== 'software_factory'),
     })
     renderSettings('/settings/apps')
-    expect(await screen.findByRole('link', { name: 'review' })).toBeTruthy()
-    expect(screen.queryByRole('link', { name: 'software factory' })).toBeNull()
+    expect(await screen.findByRole('link', { name: 'Review' })).toBeTruthy()
+    expect(screen.queryByRole('link', { name: 'Software Factory' })).toBeNull()
     fireEvent.click(screen.getByRole('link', { name: 'Back to Druks' }))
-    const appLink = await screen.findByRole('link', { name: 'software factory' })
+    const appLink = await screen.findByRole('link', { name: 'Software Factory' })
     fireEvent.click(appLink)
     await waitFor(() => expect(window.location.pathname).toBe('/software_factory'))
-    expect(screen.queryByRole('navigation', { name: 'software factory pages' })).toBeNull()
+    expect(screen.queryByRole('navigation', { name: 'Software Factory pages' })).toBeNull()
   })
 
   it('saves a workflow cadence through the app settings route', async () => {
@@ -1045,7 +1045,7 @@ describe('canonical app settings', () => {
     expect(within(results).getByRole('link', { name: /Notebook/ }).getAttribute('href')).toBe(
       '/apps/field_notes/settings?field=app.field_notes.notebook',
     )
-    expect(within(results).getByText('field notes · Field')).toBeTruthy()
+    expect(within(results).getByText('Field Notes · Field')).toBeTruthy()
     fireEvent.change(screen.getByLabelText('Search settings'), { target: { value: 'mcp' } })
     expect(within(results).getByRole('link', { name: /MCP servers/ }).getAttribute('href')).toBe(
       '/settings/mcp',
@@ -1127,7 +1127,7 @@ describe('canonical app settings', () => {
       target: { value: 'Europe/Madrid' },
     })
     fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    const destination = await screen.findByRole('link', { name: 'field notes' })
+    const destination = await screen.findByRole('link', { name: 'Field Notes' })
     expect(destination.getAttribute('href')).toBe('/apps/field_notes/settings')
     fireEvent.click(destination)
     expect(window.location.pathname).toBe('/settings/apps')
@@ -1145,7 +1145,7 @@ describe('canonical app settings', () => {
   it('restores app settings from shared settings and guards new edits after return', async () => {
     stubFetch(false)
     renderSettings('/apps/software_factory/settings/agents')
-    const pages = await screen.findByRole('navigation', { name: 'software factory pages' })
+    const pages = await screen.findByRole('navigation', { name: 'Software Factory pages' })
     expect(within(pages).getByRole('link', { name: 'Settings' }).getAttribute('aria-current')).toBe(
       'page',
     )

--- a/frontend/src/components/SettingsPages.tsx
+++ b/frontend/src/components/SettingsPages.tsx
@@ -14,6 +14,7 @@ import { appLabel } from '../apps/registry'
 import { useTicker } from '../lib/useTicker'
 import { absTime } from '../lib/format'
 import { harnessColors } from '../lib/harnessColors'
+import { Page } from './Page'
 import { Sidebar } from './Sidebar'
 import { BrowserSessionsPane } from './BrowserSessionsPane'
 import {
@@ -494,299 +495,301 @@ export function SettingsPages({
       )}
       <Content
         ref={content}
-        className="settings-main"
+        className="app-main"
         id={appName ? 'app-settings-content' : 'settings-content'}
         tabIndex={-1}
       >
-        <div className="settings-page-head">
-          <div>
-            <h1 tabIndex={-1} ref={heading}>
-              {title}
-            </h1>
-          </div>
-          {!appName && (
-            <label className="settings-search">
-              <Search size={17} aria-hidden="true" />
-              <input
-                type="search"
-                aria-label="Search settings"
-                placeholder="Search settings"
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-              />
-            </label>
-          )}
-        </div>
-        {appName && app && (
-          <>
-            <p className="app-settings-description">{app.description}</p>
-            {hasOptions && app.agents.length > 0 && (
-              <nav className="settings-tabs" aria-label="App settings sections">
-                <Link
-                  href={`/apps/${app.name}/settings`}
-                  aria-current={paneSection === 'options' ? 'page' : undefined}
-                >
-                  Options
-                </Link>
-                <Link
-                  href={`/apps/${app.name}/settings/agents`}
-                  aria-current={paneSection === 'agents' ? 'page' : undefined}
-                >
-                  Agents
-                </Link>
-              </nav>
-            )}
-          </>
-        )}
-        {search.trim() && (
-          <div className="settings-search-results" aria-label="Settings search results">
-            {searchResults.length === 0 ? (
-              <p>No matching settings.</p>
-            ) : (
-              searchResults.map((entry, index) => (
-                <Link
-                  key={`${entry.path}:${entry.label}:${index}`}
-                  href={entry.path}
-                  onClick={() => setSearch('')}
-                >
-                  <span>{entry.label}</span>{' '}
-                  <small>{entry.owner} · {entry.kind}</small>
-                </Link>
-              ))
+        <Page inset>
+          <div className="settings-page-head">
+            <div>
+              <h1 tabIndex={-1} ref={heading}>
+                {title}
+              </h1>
+            </div>
+            {!appName && (
+              <label className="settings-search">
+                <Search size={17} aria-hidden="true" />
+                <input
+                  type="search"
+                  aria-label="Search settings"
+                  placeholder="Search settings"
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                />
+              </label>
             )}
           </div>
-        )}
-        {errors[section] && (
-          <p ref={errorNotice} tabIndex={-1} role="alert" className="settings-error">
-            {errors[section]}
-          </p>
-        )}
-        {appName && appsQuery.isPending && <p role="status">Loading app settings…</p>}
-        {executionPage && !executionReady &&
-          (executionFailed ? (
-            <p role="alert" className="settings-error">
-              Could not load agent configuration.{' '}
-              <button
-                onClick={() => {
-                  for (const query of executionQueries) if (query.isError) void query.refetch()
-                }}
-              >
-                Try again
-              </button>
-            </p>
-          ) : (
-            <p role="status">Loading agent configuration…</p>
-          ))}
-        {(settingsQuery.isError || appsQuery.isError) &&
-          !executionPage &&
-          (appName || formPage || section === 'apps') && (
-            <p role="alert" className="settings-error">
-              Could not load settings.{' '}
-              <button
-                onClick={() => {
-                  void settingsQuery.refetch()
-                  void appsQuery.refetch()
-                }}
-              >
-                Try again
-              </button>
-            </p>
-          )}
-        {visited.map((page) => (
-          <div key={page} hidden={page !== section} className="settings-pane">
-            {page === 'general' && (
-              <GeneralPane
-                timezone={effectiveTimezone}
-                setTimezone={setTimezone}
-                timezones={timezones}
-                clock={clock}
-                busy={saving || !settingsQuery.isSuccess}
-              />
-            )}
-            {page === 'agents' && executionReady && effectiveDefaults && (
-              <AgentsPane
-                defaults={effectiveDefaults}
-                onDefaults={setDefaults}
-                accounts={accountsQuery.data ?? []}
-                resolved={agentsQuery.data ?? { apps: [] }}
-                harnessByName={harnessByName}
-                harnessColor={harnessColor}
-                catalog={catalog}
-                allowedEfforts={appsQuery.data?.allowedEfforts ?? []}
-                onOpenApp={(name) => navigate(`/apps/${name}/settings`)}
-                onAddProvider={() => navigate('/settings/providers')}
-                busy={saving}
-              />
-            )}
-            {page === 'providers' && (
-              <ProvidersPane
-                providers={providers}
-                registeredProviders={providersQuery.data ?? []}
-                subscriptions={subscriptionsQuery.data ?? []}
-                keys={keysQuery.data ?? []}
-                catalogs={catalogs}
-                loading={
-                  providersQuery.isPending ||
-                  subscriptionsQuery.isPending ||
-                  keysQuery.isPending ||
-                  catalogsQuery.isPending
-                }
-                requestError={
-                  [
-                    providersQuery.error,
-                    subscriptionsQuery.error,
-                    keysQuery.error,
-                    catalogsQuery.error,
-                  ].find((error) => error)?.message ?? null
-                }
-                onRetry={() => {
-                  for (const query of executionQueries) if (query.isError) void query.refetch()
-                }}
-              />
-            )}
-            {page === 'connections' && (
-              <>
-                <nav className="settings-tabs" aria-label="Connections">
-                  <button
-                    onClick={() => setConnectionsTab('services')}
-                    aria-current={connectionsTab === 'services' ? 'page' : undefined}
-                  >
-                    Services
-                  </button>
-                  <button
-                    onClick={() => setConnectionsTab('accounts')}
-                    aria-current={connectionsTab === 'accounts' ? 'page' : undefined}
-                  >
-                    Accounts
-                  </button>
-                  <button
-                    onClick={() => setConnectionsTab('revoked')}
-                    aria-current={connectionsTab === 'revoked' ? 'page' : undefined}
-                  >
-                    Revoked
-                  </button>
-                </nav>
-                <div hidden={connectionsTab !== 'services'}>
-                  <ServicesPane />
-                </div>
-                <div hidden={connectionsTab !== 'accounts'}>
-                  <ConnectionsPane />
-                </div>
-                <div hidden={connectionsTab !== 'revoked'}>
-                  <ConnectionsPane revokedOnly />
-                </div>
-              </>
-            )}
-            {page === 'mcp' && <McpServersPane />}
-            {page === 'skills' && <SkillsPane />}
-            {page === 'browser-sessions' && <BrowserSessionsPane />}
-            {page === 'api-tokens' && <AgentAccessPane />}
-            {page === 'apps' && !search.trim() && (
-              <div className="settings-app-index">
-                {apps.map((entry) => (
+          {appName && app && (
+            <>
+              <p className="app-settings-description">{app.description}</p>
+              {hasOptions && app.agents.length > 0 && (
+                <nav className="settings-tabs" aria-label="App settings sections">
                   <Link
-                    key={entry.name}
-                    aria-label={appLabel(entry.name)}
-                    href={`/apps/${entry.name}/settings`}
+                    href={`/apps/${app.name}/settings`}
+                    aria-current={paneSection === 'options' ? 'page' : undefined}
                   >
-                    <strong>{appLabel(entry.name)}</strong>
-                    <span>{entry.description}</span>
+                    Options
                   </Link>
-                ))}
-                {appsQuery.isPending && <p role="status">Loading app settings…</p>}
-                {!appsQuery.isPending && !appsQuery.isError && apps.length === 0 && (
-                  <p>No installed app declares settings.</p>
-                )}
-              </div>
-            )}
-            {apps
-              .filter(
-                (entry) =>
-                  validAppPage && appName === entry.name && page === `apps/${entry.name}` &&
-                  (paneSection !== 'agents' || executionReady),
-              )
-              .map((entry) => (
-                <div key={entry.name} className="app-settings-layout">
-                  <AppPane
-                    app={entry}
-                    section={paneSection}
-                    edits={appEdits[entry.name] ?? {}}
-                    fieldErrors={appProblems[entry.name] ?? {}}
-                    harnessColor={harnessColor}
-                    catalog={catalog}
-                    harnessByName={harnessByName}
-                    defaults={savedDefaults}
-                    allowedEfforts={appsQuery.data?.allowedEfforts ?? []}
-                    busy={saving}
-                    onAgentHarness={(name, value) =>
-                      editApp(entry.name, (current) => ({
-                        ...current,
-                        agentHarnesses: { ...current.agentHarnesses, [name]: value },
-                      }))
-                    }
-                    onAgentModel={(name, value) =>
-                      editApp(entry.name, (current) => ({
-                        ...current,
-                        agentModels: { ...current.agentModels, [name]: value },
-                      }))
-                    }
-                    onAgentBilling={(name, value) =>
-                      editApp(entry.name, (current) => ({
-                        ...current,
-                        agentBillings: { ...current.agentBillings, [name]: value },
-                      }))
-                    }
-                    onAgentEffort={(name, value) =>
-                      editApp(entry.name, (current) => ({
-                        ...current,
-                        agentEfforts: { ...current.agentEfforts, [name]: value },
-                      }))
-                    }
-                    onAgentTimeout={(name, value) =>
-                      editApp(entry.name, (current) => ({
-                        ...current,
-                        agentTimeouts: { ...current.agentTimeouts, [name]: value },
-                      }))
-                    }
-                    onWorkflowField={(kind, field, value) =>
-                      editApp(entry.name, (current) => ({
-                        ...current,
-                        workflowSettings: {
-                          ...current.workflowSettings,
-                          [kind]: withField(current.workflowSettings?.[kind], field, value),
-                        },
-                      }))
-                    }
-                    onAppSetting={(name, field, value) => {
-                      editApp(entry.name, (current) => ({
-                        ...current,
-                        appSettings: {
-                          ...current.appSettings,
-                          [name]: withField(current.appSettings?.[name], field, value),
-                        },
-                      }))
-                      setAppProblems((current) => {
-                        const next = { ...current[name] }
-                        delete next[field]
-                        return { ...current, [name]: next }
-                      })
-                    }}
-                    onAddProvider={() => navigate('/settings/providers')}
-                  />
-                  <aside className="app-settings-owner">
-                    <p>Changes apply to {appLabel(entry.name)}. Unset agent fields inherit the shared defaults.</p>
-                    <Link href="/settings/agents">
-                      Agent defaults <ArrowUpRight size={15} aria-hidden="true" />
-                    </Link>
-                  </aside>
-                </div>
-              ))}
-          </div>
-        ))}
-        {appsQuery.isSuccess &&
-          (!validAppPage || (!SECTIONS.some((entry) => entry.id === section) && !app)) && (
-            <p>No settings page matches this address.</p>
+                  <Link
+                    href={`/apps/${app.name}/settings/agents`}
+                    aria-current={paneSection === 'agents' ? 'page' : undefined}
+                  >
+                    Agents
+                  </Link>
+                </nav>
+              )}
+            </>
           )}
+          {search.trim() && (
+            <div className="settings-search-results" aria-label="Settings search results">
+              {searchResults.length === 0 ? (
+                <p>No matching settings.</p>
+              ) : (
+                searchResults.map((entry, index) => (
+                  <Link
+                    key={`${entry.path}:${entry.label}:${index}`}
+                    href={entry.path}
+                    onClick={() => setSearch('')}
+                  >
+                    <span>{entry.label}</span>{' '}
+                    <small>{entry.owner} · {entry.kind}</small>
+                  </Link>
+                ))
+              )}
+            </div>
+          )}
+          {errors[section] && (
+            <p ref={errorNotice} tabIndex={-1} role="alert" className="settings-error">
+              {errors[section]}
+            </p>
+          )}
+          {appName && appsQuery.isPending && <p role="status">Loading app settings…</p>}
+          {executionPage && !executionReady &&
+            (executionFailed ? (
+              <p role="alert" className="settings-error">
+                Could not load agent configuration.{' '}
+                <button
+                  onClick={() => {
+                    for (const query of executionQueries) if (query.isError) void query.refetch()
+                  }}
+                >
+                  Try again
+                </button>
+              </p>
+            ) : (
+              <p role="status">Loading agent configuration…</p>
+            ))}
+          {(settingsQuery.isError || appsQuery.isError) &&
+            !executionPage &&
+            (appName || formPage || section === 'apps') && (
+              <p role="alert" className="settings-error">
+                Could not load settings.{' '}
+                <button
+                  onClick={() => {
+                    void settingsQuery.refetch()
+                    void appsQuery.refetch()
+                  }}
+                >
+                  Try again
+                </button>
+              </p>
+            )}
+          {visited.map((page) => (
+            <div key={page} hidden={page !== section} className="settings-pane">
+              {page === 'general' && (
+                <GeneralPane
+                  timezone={effectiveTimezone}
+                  setTimezone={setTimezone}
+                  timezones={timezones}
+                  clock={clock}
+                  busy={saving || !settingsQuery.isSuccess}
+                />
+              )}
+              {page === 'agents' && executionReady && effectiveDefaults && (
+                <AgentsPane
+                  defaults={effectiveDefaults}
+                  onDefaults={setDefaults}
+                  accounts={accountsQuery.data ?? []}
+                  resolved={agentsQuery.data ?? { apps: [] }}
+                  harnessByName={harnessByName}
+                  harnessColor={harnessColor}
+                  catalog={catalog}
+                  allowedEfforts={appsQuery.data?.allowedEfforts ?? []}
+                  onOpenApp={(name) => navigate(`/apps/${name}/settings`)}
+                  onAddProvider={() => navigate('/settings/providers')}
+                  busy={saving}
+                />
+              )}
+              {page === 'providers' && (
+                <ProvidersPane
+                  providers={providers}
+                  registeredProviders={providersQuery.data ?? []}
+                  subscriptions={subscriptionsQuery.data ?? []}
+                  keys={keysQuery.data ?? []}
+                  catalogs={catalogs}
+                  loading={
+                    providersQuery.isPending ||
+                    subscriptionsQuery.isPending ||
+                    keysQuery.isPending ||
+                    catalogsQuery.isPending
+                  }
+                  requestError={
+                    [
+                      providersQuery.error,
+                      subscriptionsQuery.error,
+                      keysQuery.error,
+                      catalogsQuery.error,
+                    ].find((error) => error)?.message ?? null
+                  }
+                  onRetry={() => {
+                    for (const query of executionQueries) if (query.isError) void query.refetch()
+                  }}
+                />
+              )}
+              {page === 'connections' && (
+                <>
+                  <nav className="settings-tabs" aria-label="Connections">
+                    <button
+                      onClick={() => setConnectionsTab('services')}
+                      aria-current={connectionsTab === 'services' ? 'page' : undefined}
+                    >
+                      Services
+                    </button>
+                    <button
+                      onClick={() => setConnectionsTab('accounts')}
+                      aria-current={connectionsTab === 'accounts' ? 'page' : undefined}
+                    >
+                      Accounts
+                    </button>
+                    <button
+                      onClick={() => setConnectionsTab('revoked')}
+                      aria-current={connectionsTab === 'revoked' ? 'page' : undefined}
+                    >
+                      Revoked
+                    </button>
+                  </nav>
+                  <div hidden={connectionsTab !== 'services'}>
+                    <ServicesPane />
+                  </div>
+                  <div hidden={connectionsTab !== 'accounts'}>
+                    <ConnectionsPane />
+                  </div>
+                  <div hidden={connectionsTab !== 'revoked'}>
+                    <ConnectionsPane revokedOnly />
+                  </div>
+                </>
+              )}
+              {page === 'mcp' && <McpServersPane />}
+              {page === 'skills' && <SkillsPane />}
+              {page === 'browser-sessions' && <BrowserSessionsPane />}
+              {page === 'api-tokens' && <AgentAccessPane />}
+              {page === 'apps' && !search.trim() && (
+                <div className="settings-app-index">
+                  {apps.map((entry) => (
+                    <Link
+                      key={entry.name}
+                      aria-label={appLabel(entry.name)}
+                      href={`/apps/${entry.name}/settings`}
+                    >
+                      <strong>{appLabel(entry.name)}</strong>
+                      <span>{entry.description}</span>
+                    </Link>
+                  ))}
+                  {appsQuery.isPending && <p role="status">Loading app settings…</p>}
+                  {!appsQuery.isPending && !appsQuery.isError && apps.length === 0 && (
+                    <p>No installed app declares settings.</p>
+                  )}
+                </div>
+              )}
+              {apps
+                .filter(
+                  (entry) =>
+                    validAppPage && appName === entry.name && page === `apps/${entry.name}` &&
+                    (paneSection !== 'agents' || executionReady),
+                )
+                .map((entry) => (
+                  <div key={entry.name} className="app-settings-layout">
+                    <AppPane
+                      app={entry}
+                      section={paneSection}
+                      edits={appEdits[entry.name] ?? {}}
+                      fieldErrors={appProblems[entry.name] ?? {}}
+                      harnessColor={harnessColor}
+                      catalog={catalog}
+                      harnessByName={harnessByName}
+                      defaults={savedDefaults}
+                      allowedEfforts={appsQuery.data?.allowedEfforts ?? []}
+                      busy={saving}
+                      onAgentHarness={(name, value) =>
+                        editApp(entry.name, (current) => ({
+                          ...current,
+                          agentHarnesses: { ...current.agentHarnesses, [name]: value },
+                        }))
+                      }
+                      onAgentModel={(name, value) =>
+                        editApp(entry.name, (current) => ({
+                          ...current,
+                          agentModels: { ...current.agentModels, [name]: value },
+                        }))
+                      }
+                      onAgentBilling={(name, value) =>
+                        editApp(entry.name, (current) => ({
+                          ...current,
+                          agentBillings: { ...current.agentBillings, [name]: value },
+                        }))
+                      }
+                      onAgentEffort={(name, value) =>
+                        editApp(entry.name, (current) => ({
+                          ...current,
+                          agentEfforts: { ...current.agentEfforts, [name]: value },
+                        }))
+                      }
+                      onAgentTimeout={(name, value) =>
+                        editApp(entry.name, (current) => ({
+                          ...current,
+                          agentTimeouts: { ...current.agentTimeouts, [name]: value },
+                        }))
+                      }
+                      onWorkflowField={(kind, field, value) =>
+                        editApp(entry.name, (current) => ({
+                          ...current,
+                          workflowSettings: {
+                            ...current.workflowSettings,
+                            [kind]: withField(current.workflowSettings?.[kind], field, value),
+                          },
+                        }))
+                      }
+                      onAppSetting={(name, field, value) => {
+                        editApp(entry.name, (current) => ({
+                          ...current,
+                          appSettings: {
+                            ...current.appSettings,
+                            [name]: withField(current.appSettings?.[name], field, value),
+                          },
+                        }))
+                        setAppProblems((current) => {
+                          const next = { ...current[name] }
+                          delete next[field]
+                          return { ...current, [name]: next }
+                        })
+                      }}
+                      onAddProvider={() => navigate('/settings/providers')}
+                    />
+                    <aside className="app-settings-owner">
+                      <p>Changes apply to {appLabel(entry.name)}. Unset agent fields inherit the shared defaults.</p>
+                      <Link href="/settings/agents">
+                        Agent defaults <ArrowUpRight size={15} aria-hidden="true" />
+                      </Link>
+                    </aside>
+                  </div>
+                ))}
+            </div>
+          ))}
+          {appsQuery.isSuccess &&
+            (!validAppPage || (!SECTIONS.some((entry) => entry.id === section) && !app)) && (
+              <p>No settings page matches this address.</p>
+            )}
+        </Page>
       </Content>
       {formPage && (
         <footer className="settings-save-bar">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -38,16 +38,7 @@ export function Sidebar({
       </Link>
       {children}
       <div className="sidebar-account">
-        <span className="sidebar-avatar" aria-hidden="true">
-          {account.username.slice(0, 2).toUpperCase()}
-        </span>
-        <div>
-          <details className="sidebar-account-details">
-            <summary className="sidebar-username">{account.username.split('@')[0]}</summary>
-            <span>{account.username}</span>
-          </details>
-          <span className="sidebar-account-label">Your account</span>
-        </div>
+        {account.username}
       </div>
     </>
   )

--- a/frontend/src/dashboard.css
+++ b/frontend/src/dashboard.css
@@ -1,8 +1,7 @@
-.dashboard .page-shell-body { padding: 36px 40px 48px; }
 .dashboard-head { display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; }
 .dashboard h1 { margin: 0 0 10px; font-size: 26px; font-weight: 500; letter-spacing: -.02em; }
 .dashboard-head p { margin: 0; color: var(--text-mid); }
-.dashboard-filter select { min-height: 44px; max-width: 240px; padding: 0 12px; border: 1px solid var(--border-loud); border-radius: 5px; background: var(--surface); color: var(--text); font: inherit; text-transform: capitalize; }
+.dashboard-filter select { min-height: 44px; max-width: 240px; padding: 0 12px; border: 1px solid var(--border-loud); border-radius: 5px; background: var(--surface); color: var(--text); font: inherit; }
 .dashboard-counts { display: flex; flex-wrap: wrap; gap: 12px 24px; padding: 36px 0 18px; border-bottom: 1px solid var(--border); color: var(--text-mid); }
 .dashboard-counts strong { color: var(--text); font-weight: 500; }
 .dashboard-section { margin-top: 30px; }
@@ -28,18 +27,15 @@
 .dashboard-schedule { display: flex; flex-direction: column; gap: 5px; text-align: right; }
 .dashboard-unavailable { display: flex; flex-direction: column; gap: 6px; }
 .dashboard-unavailable a { color: var(--text); min-height: 32px; display: inline-flex; align-items: center; }
-.dashboard-empty, .dashboard-more, .dashboard-access { color: var(--text-dim); }
+.dashboard-empty, .dashboard-more { color: var(--text-dim); }
 .dashboard-empty { margin: 0; padding: 18px 0; border-top: 1px solid var(--border); }
-.dashboard-more, .dashboard-access { font-size: 13px; }
-.dashboard-access { padding-top: 24px; border-top: 1px solid var(--border); margin-top: 32px; }
+.dashboard-more { font-size: 13px; }
 @media (max-width: 1024px) {
-  .dashboard .page-shell-body { padding-inline: 24px; }
   .dashboard-row { grid-template-columns: 18px minmax(0, 1fr) 110px; }
   .dashboard-age, .dashboard-schedule { grid-column: 2; text-align: left; }
   .dashboard-action, .dashboard-unavailable { grid-column: 3; grid-row: 1 / 3; }
 }
 @media (max-width: 649px) {
-  .dashboard .page-shell-body { padding: 24px 20px 32px; }
   .dashboard-head { flex-wrap: wrap; gap: 20px; }
   .dashboard-filter, .dashboard-filter select { width: 100%; max-width: none; }
   .dashboard-filter select { font-size: 16px; }

--- a/frontend/src/druksui/AppPage.test.tsx
+++ b/frontend/src/druksui/AppPage.test.tsx
@@ -177,7 +177,7 @@ describe('a declared page', () => {
     )
 
     await waitFor(() =>
-      expect(screen.getByText('field_notes could not render this page')).toBeTruthy(),
+      expect(screen.getByText('Field Notes could not render this page')).toBeTruthy(),
     )
     expect(screen.getByText('try again')).toBeTruthy()
   })
@@ -280,7 +280,7 @@ describe('a page snapshot the renderer cannot walk', () => {
     renderAt('/field_notes', 'notes', broken as unknown as PageSnapshot)
 
     await waitFor(() =>
-      expect(screen.getByText('field_notes could not render this page')).toBeTruthy(),
+      expect(screen.getByText('Field Notes could not render this page')).toBeTruthy(),
     )
     expect(screen.getByText('the page snapshot was not renderable')).toBeTruthy()
   })

--- a/frontend/src/druksui/AppPage.tsx
+++ b/frontend/src/druksui/AppPage.tsx
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useMemo, useRef, type ReactNode } from 'react'
 import { Link as RouteLink } from 'wouter'
 
+import { appLabel } from '../apps/registry'
 import { api } from '../api/client'
 import type { Action, Follows, Link, PageEntry, PageSnapshot } from '../api/types'
 import { EmptyState } from '../components/EmptyState'
@@ -81,19 +82,19 @@ export function AppPage({ app, page }: { app: string; page: string }) {
   const chrome = { app, page, location, parent, root, tabs }
 
   if (snapshot.isLoading) {
-    const waiting = `loading ${app.replaceAll('_', ' ')}`
+    const waiting = `loading ${appLabel(app)}`
     // The breadcrumb and the tabs come from the roster, which is already warm,
     // so the page keeps its frame while the body arrives. A cold deeplink has
     // no roster yet and waits bare.
     if (!pages.length) {
       return (
-        <Page className="dui-page">
+        <Page inset className="dui-page">
           <EmptyState glyph="…" msg={waiting} />
         </Page>
       )
     }
     return (
-      <Page className="dui-page">
+      <Page inset className="dui-page">
         {/* The title is the app's to compute, so it is held rather than
             guessed: a page label would show the wrong words first. */}
         <PageChrome {...chrome} title="…" />
@@ -124,7 +125,7 @@ export function AppPage({ app, page }: { app: string; page: string }) {
         />
       ))}
       <PagesContext.Provider value={{ app, pages, operations, target }}>
-        <Page className="dui-page">
+        <Page inset className="dui-page">
           <PageChrome
             {...chrome}
             title={snapshot.data.title}
@@ -185,7 +186,7 @@ function PageChrome({
         ) : null}
       </div>
       {tabs.length > 0 && root && (
-        <nav className="dui-tabs" aria-label={`${app} page tabs`}>
+        <nav className="dui-tabs" aria-label={`${appLabel(app)} page tabs`}>
           {tabs.map((tab) => (
             <RouteLink
               key={tab.name}
@@ -204,10 +205,10 @@ function PageChrome({
 
 function appError(app: string, detail: string, retry: () => void): ReactNode {
   return (
-    <Page className="dui-page">
+    <Page inset className="dui-page">
       <EmptyState
         glyph="!"
-        msg={`${app} could not render this page`}
+        msg={`${appLabel(app)} could not render this page`}
         sub={detail || undefined}
         action={
           <button type="button" className="dui-retry" onClick={retry}>

--- a/frontend/src/lib/feed.test.ts
+++ b/frontend/src/lib/feed.test.ts
@@ -33,7 +33,7 @@ describe('eventLine', () => {
     const line = eventLine(event({ kind: 'merged', app: 'software_factory' }))
 
     expect(line.label).toBe('merged')
-    expect(line.source).toBe('software_factory')
+    expect(line.source).toBe('Software Factory')
     expect(line.bucket).toBe('event-kind-audit')
   })
 

--- a/frontend/src/lib/feed.ts
+++ b/frontend/src/lib/feed.ts
@@ -1,5 +1,5 @@
 import type { FeedItem } from '../api/types'
-import { getAppUI } from '../apps/registry'
+import { appLabel, getAppUI } from '../apps/registry'
 
 // What a workflow doing something is called. The platform owns these words because it
 // owns the lifecycle; an app's own milestones are already named by their type.
@@ -29,7 +29,7 @@ export function eventLine(event: FeedItem): EventLine {
   return {
     label: label(event),
     subject: event.subjectLabel ?? '',
-    source: localName(event.workflow) || event.app || 'druks',
+    source: localName(event.workflow) || appLabel(event.app || 'druks'),
     path: subjectPath(event),
     bucket: isLifecycle(event) ? `event-kind-${event.kind.slice('workflow.'.length)}` : 'event-kind-audit',
   }

--- a/frontend/src/operations.css
+++ b/frontend/src/operations.css
@@ -1,4 +1,4 @@
-.page-work-items .row-work-item { display: grid; grid-template-columns: minmax(0, 1fr) minmax(130px, .3fr) 140px; gap: 20px; height: auto; min-height: 84px; padding: 18px 24px; }
+.page-work-items .row-work-item { display: grid; grid-template-columns: minmax(0, 1fr) minmax(130px, .3fr) 140px; gap: 20px; height: auto; min-height: 84px; padding: 18px var(--page-gutter); }
 .work-item-identity { min-width: 0; }
 .work-item-title { display: block; color: var(--text); font-size: 15px; font-weight: 500; text-decoration: none; overflow-wrap: anywhere; }
 .work-item-title:hover { text-decoration: underline; }
@@ -35,7 +35,7 @@
 .us-read-error { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-bottom: 24px; color: var(--outcome-failed); }
 .us-read-error p { flex: 1 1 240px; margin: 0; }
 @media (max-width: 649px) {
-  .page-work-items .row-work-item { grid-template-columns: minmax(0, 1fr); gap: 12px; padding: 20px; }
+  .page-work-items .row-work-item { grid-template-columns: minmax(0, 1fr); gap: 12px; padding-block: 20px; }
   .work-item-references { align-items: flex-start; flex-direction: column; gap: 4px; }
   .work-item-references a { display: inline-flex; align-items: center; min-height: 44px; }
   .work-item-title { min-height: 44px; }

--- a/frontend/src/pages/AppHomePage.tsx
+++ b/frontend/src/pages/AppHomePage.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useLocation } from 'wouter'
 
+import { appLabel } from '../apps/registry'
 import { subjectApi } from '../api/client'
 import { useSSE } from '../api/sse'
 import type { SubjectRow } from '../api/types'
@@ -25,7 +26,7 @@ export function AppHomePage({ app, description, subjectTypes }: Props) {
     <Page
       scroll="internal"
       className="page-subjects"
-      header={<PageHeader eyebrow={app.replaceAll('_', ' ')} />}
+      header={<PageHeader eyebrow={appLabel(app)} />}
     >
       {subjectTypes.length === 0 ? (
         <EmptyState glyph="◳" msg="nothing to show yet" sub={description} />

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -76,7 +76,7 @@ describe('Dashboard', () => {
     expect(details[0]!.textContent).toContain(failure)
     expect(details[0]!.querySelectorAll('code')[0]!.textContent).toBe('latest')
     expect(details[0]!.textContent).toContain('Earlier error')
-    expect(within(problems).getByRole('link', { name: 'Open events' }).getAttribute('href')).toBe('/events?app=notes')
+    expect(within(problems).getAllByRole('link', { name: 'Open' })[0]!.getAttribute('href')).toBe('/events?app=notes')
     expect(details[0]!.open).toBe(false)
   })
 
@@ -164,9 +164,11 @@ describe('Dashboard', () => {
     mount()
     expect(await screen.findAllByText('Review destination unavailable')).toHaveLength(2)
     expect(screen.queryByRole('link', { name: 'Review' })).toBeNull()
-    expect(screen.getByRole('link', { name: 'Open request' }).getAttribute('href')).toBe(
+    expect(screen.getAllByRole('link', { name: 'Open' }).map((link) => link.getAttribute('href'))).toEqual([
+      '/unsupported',
+      '/notes',
       'https://example.invalid/review',
-    )
+    ])
   })
 })
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -83,7 +83,7 @@ export function DashboardPage({ apps }: { apps: string[] }) {
   const failed = work.isError || schedules.isError
 
   return (
-    <Page className="dashboard">
+    <Page inset className="dashboard">
       <header className="dashboard-head">
         <div>
           <h1>Dashboard</h1>
@@ -191,7 +191,6 @@ export function DashboardPage({ apps }: { apps: string[] }) {
           </div>
         ))}
       </section>
-      <p className="dashboard-access">Access health has not been checked.</p>
     </Page>
   )
 }
@@ -241,7 +240,7 @@ function WorkRow({ row, pending, failures }: { row: DashboardRun; pending: boole
       {destination ? (
         external ? (
           <a className="dashboard-action" href={destination} target="_blank" rel="noreferrer">
-            Open request
+            Open
           </a>
         ) : (
           <Link className={`dashboard-action${pending ? ' primary' : ''}`} href={destination}>
@@ -250,12 +249,12 @@ function WorkRow({ row, pending, failures }: { row: DashboardRun; pending: boole
         )
       ) : failures ? (
         <Link className="dashboard-action" href={`/events?app=${encodeURIComponent(row.app)}`}>
-          Open events
+          Open
         </Link>
       ) : (
         <div className="dashboard-unavailable">
           <span>{pending ? 'Review destination unavailable' : 'Run destination unavailable'}</span>
-          <Link href={appHome(row.app)}>Open app</Link>
+          <Link href={appHome(row.app)}>Open</Link>
         </div>
       )}
     </div>

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -8,7 +8,7 @@ import { useSSE } from '../api/sse'
 import type { FeedItem } from '../api/types'
 import { EmptyState } from '../components/EmptyState'
 import { Page } from '../components/Page'
-import { registeredApps } from '../apps/registry'
+import { appLabel, registeredApps } from '../apps/registry'
 import { eventLine } from '../lib/feed'
 import { relTimeFromIso } from '../lib/format'
 import { useFormatters } from '../lib/preferences'
@@ -186,7 +186,7 @@ function AppFilter({
           aria-pressed={name === filter}
           onClick={() => onPick(name)}
         >
-          {name ?? 'all'}
+          {name ? appLabel(name) : 'All'}
         </button>
       ))}
     </div>

--- a/frontend/src/pages/UsagePage.tsx
+++ b/frontend/src/pages/UsagePage.tsx
@@ -4,7 +4,7 @@ import { UsagePanel } from '../components/UsagePanel'
 
 export function UsagePage() {
   return (
-    <Page scroll="page" className="page-usage">
+    <Page inset scroll="page" className="page-usage">
       <UsagePanel />
     </Page>
   )

--- a/frontend/src/settings.css
+++ b/frontend/src/settings.css
@@ -4,7 +4,6 @@
 .settings-navigation > div + div { margin-top: 20px; }
 .settings-navigation .sidebar-group-title { padding-bottom: 4px; }
 .settings-back { font-size: 13px; }
-.settings-main { flex: 1; min-height: 0; overflow: auto; padding: 34px 40px 48px; }
 .settings-page-head { display: flex; flex-wrap: wrap; align-items: flex-start; justify-content: space-between; gap: 24px; margin-bottom: 32px; }
 .settings-page-head h1 { margin: 0; font-size: 26px; font-weight: 500; letter-spacing: -0.02em; text-transform: capitalize; }
 .settings-search { display: flex; align-items: center; gap: 10px; width: 280px; max-width: 100%; min-height: 44px; padding: 0 12px; color: var(--text-dim); background: var(--surface); border: 1px solid var(--border-loud); border-radius: 5px; }
@@ -44,7 +43,7 @@
 .settings-app-index span { color: var(--text-dim); }
 .settings-error { color: var(--outcome-failed); padding: 12px 0; }
 .settings-error button { text-decoration: underline; }
-.settings-save-bar { display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; gap: 16px; min-height: 72px; padding: 12px 40px; border-top: 1px solid var(--border); background: var(--surface); }
+.settings-save-bar { display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; gap: 16px; min-height: 72px; padding: 12px var(--page-gutter); border-top: 1px solid var(--border); background: var(--surface); }
 .settings-save-bar > span { font-size: 13px; color: var(--text-dim); }
 .settings-save-bar > div { display: flex; gap: 10px; }
 .settings-leave-dialog { width: min(460px, calc(100vw - 32px)); padding: 24px; border: 1px solid var(--border-loud); border-radius: 8px; background: var(--surface); color: var(--text); }
@@ -53,17 +52,11 @@
 .settings-leave-dialog p { color: var(--text-mid); line-height: 1.5; }
 .settings-leave-dialog > div { display: flex; justify-content: flex-end; gap: 8px; margin-top: 24px; }
 
-@media (max-width: 1024px) {
-  .settings-main { padding-inline: 24px; }
-  .settings-save-bar { padding-inline: 24px; }
-}
-
 @media (max-width: 649px) {
-  .settings-main { padding: 24px 20px 32px; }
   .settings-search { width: 100%; }
   .settings-page-head { gap: 20px; margin-bottom: 24px; }
   .settings-page-head h1 { font-size: 26px; }
-  .settings-save-bar { padding: 12px 20px; flex-wrap: wrap; }
+  .settings-save-bar { flex-wrap: wrap; }
   .settings-save-bar > div { margin-left: auto; }
   .settings-pane .set-select { font-size: 16px; min-height: 44px; }
   .settings-search-results a { flex-wrap: wrap; gap: 6px; }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -125,11 +125,14 @@ button { background: none; border: none; color: inherit; cursor: pointer; font: 
 }
 
 .page-shell {
+  width: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   flex: 1;
   min-height: 0;
 }
+.page-shell[data-inset="true"] { padding: var(--page-padding); }
 .page-shell[data-scroll="page"] { overflow: auto; }
 .page-shell[data-scroll="internal"] { overflow: hidden; }
 .page-shell-header { flex-shrink: 0; }
@@ -532,7 +535,7 @@ a.row-repo:hover { color: var(--bucket-run); text-decoration: underline; }
 .wi-updated { text-align: right; white-space: nowrap; font-size: 11px; }
 
 .wi-group-head {
-  padding: 10px 20px 4px;
+  padding: 10px var(--page-gutter) 4px;
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em;
 }
 .wi-group + .wi-group .wi-group-head { border-top: 1px solid var(--border-soft); }
@@ -540,7 +543,7 @@ a.row-repo:hover { color: var(--bucket-run); text-decoration: underline; }
 
 .active-page-head {
   display: flex; align-items: flex-end; justify-content: space-between;
-  padding: 24px 28px 16px;
+  padding: 24px var(--page-gutter) 16px;
   gap: 24px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
@@ -609,7 +612,7 @@ a.row-repo:hover { color: var(--bucket-run); text-decoration: underline; }
   display: grid; align-items: center;
   grid-template-columns: 16px 110px minmax(0, 1fr) 130px 60px 84px minmax(0, 88px);
   gap: 14px;
-  padding: 0 28px;
+  padding: 0 var(--page-gutter);
   min-height: var(--row-h);
   border-bottom: 1px solid var(--border-soft);
   cursor: pointer;
@@ -621,7 +624,7 @@ a.row-repo:hover { color: var(--bucket-run); text-decoration: underline; }
   display: grid; align-items: center;
   grid-template-columns: 16px 110px minmax(0, 1fr) 130px 60px 84px minmax(0, 88px);
   gap: 14px;
-  padding: 6px 28px;
+  padding: 6px var(--page-gutter);
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em;
@@ -1146,12 +1149,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
   margin: 1em 0;
 }
 
-.page-usage {
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: 24px 32px 64px;
-}
-
 .us-col { display: flex; flex-direction: column; }
 
 .us-head {
@@ -1549,10 +1546,10 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .event-row {
   display: grid;
 
-  grid-template-columns: 110px 240px 90px minmax(0, 1fr);
+  grid-template-columns: 110px 240px minmax(120px, 180px) minmax(0, 1fr);
   gap: 18px;
   align-items: center;
-  padding: 8px 28px;
+  padding: 8px var(--page-gutter);
   border-bottom: 1px solid var(--border-soft);
   font-size: 15px;
 }
@@ -1978,7 +1975,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
   --dui-primary-active: #5942b7;
   --dui-control-height: 40px;
   color-scheme: dark;
-  padding: 28px 32px 48px;
 }
 body[data-palette="desat"] .dui-page {
   --dui-primary: #655b9f;
@@ -2078,7 +2074,6 @@ body[data-palette="mono"] .dui-page {
 .dui-unknown { font-size: 12px; color: var(--outcome-failed); border: 1px solid color-mix(in oklch, var(--outcome-failed) 30%, transparent); border-radius: 6px; padding: 9px 12px; margin: 10px 0; }
 
 @media (max-width: 720px) {
-  .dui-page { padding: 20px 16px 40px; }
   .dui-page-head, .dui-section-head { align-items: flex-start; flex-direction: column; }
   .dui-title { font-size: 24px; line-height: 32px; }
   .dui-tabs { overflow-x: auto; }


### PR DESCRIPTION
The command center showed raw app IDs in some views, and Usage had a separate centered width limit. App names now use the shared `appLabel` function. Dashboard, Usage, Python app pages, and Settings use shared Page spacing. Page gutters are 32 px on desktop, 24 px on tablet, and 20 px on phones.

- Give Events source names more room and keep app IDs unchanged in routes and filters.
- Remove the unchecked access-health note from Dashboard and use “Open” for its navigation links.
- Show only the account email as plain text in the sidebar.

Verification: frontend lint, production build, and all 390 existing tests passed. The 64 Settings tests also passed after the final fixture edit. Browser checks with local API fixtures covered Dashboard, Usage, Events, and General settings at 390, 1000, 1600, and 2560 px. All used the same content gutter with no horizontal overflow. Settings search focus, scrolling above the save bar, and Discard also passed. No test cases were added. Backend checks were not run; no backend code changed.

A separate existing issue was observed on both this branch and main: a cold `/settings/general?field=timezone` load can leave focus on the heading while the initial control is disabled. Search-result navigation works. This PR does not change that behavior.

Closes DRU-464.
