### PR TITLE
Move app settings to a gear in the header

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,8 +48,8 @@ a failed request keeps the operator on that page with its draft. Resource
 actions, such as connecting a provider or minting an API token, apply at once.
 Back to Druks restores the previous work URL and keeps the work page mounted.
 
-App settings use `/apps/<name>/settings` in the work context. The app's page
-navigation and the central App settings index link to this same route.
+App settings use `/apps/<name>/settings` in the work context. A gear beside the
+app name in the header and the central App settings index link to this same route.
 Options and Agents appear only when the app declares those controls. Both
 sections share one app draft. Leaving the app form offers Save, Discard, and
 Stay. An app without controls has no Settings destination. Backend app schemas

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -261,15 +261,13 @@ function AppShell({
 
   const declaredNavigation =
     ui?.navigation ?? rosterQuery.data?.find((entry) => entry.name === app)?.navigation
-  const hasSettings = Boolean(settingsQuery.data?.apps.some((entry) => entry.name === app))
-  const navigation: [string, string][] = urlApp
-    ? [
-        ...(declaredNavigation ?? []),
-        ...(hasSettings ? [[`/apps/${urlApp}/settings`, 'Settings'] as [string, string]] : []),
-      ]
-    : []
+  const appSettingsPath =
+    urlApp && settingsQuery.data?.apps.some((entry) => entry.name === urlApp)
+      ? `/apps/${urlApp}/settings`
+      : undefined
+  const navigation = urlApp ? (declaredNavigation ?? []) : []
   const activeTab = navigation
-    ?.map(([url]) => url)
+    .map(([url]) => url)
     .filter((url) => location === url || location.startsWith(`${url}/`))
     .sort((left, right) => right.length - left.length)[0]
   const visibleApps = registered.filter((name) =>
@@ -374,13 +372,28 @@ function AppShell({
         <div className="command-breadcrumb">
           <span>Command center /</span>
           <strong className="app-name">{title}</strong>
+          {appSettingsPath && (
+            <Link
+              href={appSettingsPath}
+              className="command-app-settings"
+              aria-label={`${title} settings`}
+              title={`${title} settings`}
+              aria-current={
+                location === appSettingsPath || location.startsWith(`${appSettingsPath}/`)
+                  ? 'page'
+                  : undefined
+              }
+            >
+              <Settings size={17} aria-hidden="true" />
+            </Link>
+          )}
         </div>
         <div className="command-utilities">
           <WakeLockIndicator />
           <span className="mono command-timezone">{timezone}</span>
         </div>
       </header>
-      {urlApp && navigation && navigation.length > 0 && (
+      {urlApp && navigation.length > 0 && (
         <nav className="command-app-navigation" aria-label={`${appLabel(urlApp)} pages`}>
           {navigation.map(([url, name]) => (
             <Link

--- a/frontend/src/command-center.css
+++ b/frontend/src/command-center.css
@@ -25,7 +25,7 @@
 
 .command-breadcrumb {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 4px;
   font-size: 13px;
   min-width: 0;
@@ -34,6 +34,9 @@
 
 .command-breadcrumb > span { color: var(--text-dim); }
 .command-breadcrumb strong { font-weight: 500; }
+.command-app-settings { display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; width: 32px; height: 32px; margin-left: 4px; border-radius: 5px; color: var(--text-mid); text-decoration: none; }
+.command-app-settings:visited { color: var(--text-mid); }
+.command-app-settings:hover, .command-app-settings[aria-current="page"] { color: var(--text); background: var(--surface-3); }
 .command-utilities { display: flex; align-items: center; gap: 20px; margin-left: auto; flex-shrink: 0; }
 .command-timezone { color: var(--text-mid); }
 .app-main { display: flex; flex: 1; flex-direction: column; min-width: 0; min-height: 0; overflow: hidden; }
@@ -105,6 +108,7 @@
   .command-header { padding: 6px 12px; gap: 6px; }
   .command-breadcrumb > span, .command-timezone { display: none; }
   .command-breadcrumb { font-size: 15px; }
+  .command-app-settings { width: 44px; height: 44px; }
   .command-utilities { padding-inline: 8px; }
   .navigation-toggle, .navigation-close { display: inline-flex; }
   .navigation-close { position: absolute; top: 16px; right: 12px; }

--- a/frontend/src/components/SettingsPages.test.tsx
+++ b/frontend/src/components/SettingsPages.test.tsx
@@ -991,6 +991,7 @@ describe('canonical app settings', () => {
     fireEvent.click(appLink)
     await waitFor(() => expect(window.location.pathname).toBe('/software_factory'))
     expect(screen.queryByRole('navigation', { name: 'Software Factory pages' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Software Factory settings' })).toBeNull()
   })
 
   it('saves a workflow cadence through the app settings route', async () => {
@@ -1145,10 +1146,8 @@ describe('canonical app settings', () => {
   it('restores app settings from shared settings and guards new edits after return', async () => {
     stubFetch(false)
     renderSettings('/apps/software_factory/settings/agents')
-    const pages = await screen.findByRole('navigation', { name: 'Software Factory pages' })
-    expect(within(pages).getByRole('link', { name: 'Settings' }).getAttribute('aria-current')).toBe(
-      'page',
-    )
+    const settings = await screen.findByRole('link', { name: 'Software Factory settings' })
+    expect(settings.getAttribute('aria-current')).toBe('page')
     fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
     await screen.findByRole('heading', { name: 'Agent defaults' })
     fireEvent.click(screen.getByRole('link', { name: 'Back to Druks' }))


### PR DESCRIPTION
## What changed

App settings open from one gear beside the app name in the existing header. The shell no longer adds a Settings tab to app navigation. The gear has an app-specific label, a native tooltip, an active state, and a 44 px phone touch target. Global Settings stays in the sidebar footer.

Closes [DRU-465](https://linear.app/fellaworks/issue/DRU-465/move-app-settings-to-a-gear-in-the-header).

## Risk

Frontend navigation and CSS only. The gear uses the existing settings route and draft protection. No API or database changes.

## Verification

- `npm --prefix frontend run lint` — passed.
- `npm --prefix frontend test` — all 390 tests passed. Updated existing assertions.
- `npm --prefix frontend run build` — passed.
- Chrome with local API fixtures at 1600 px and 390 px: header alignment, keyboard activation, active state, settings routes, draft protection, and gear visibility passed. No page errors or horizontal overflow.
- Backend tests and live-server checks were not run; this change is frontend-only.
