### PR TITLE
Refine Providers, Agents and Connections settings

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,14 +292,16 @@ When an agent runs, OpenCode selects the endpoint.
 Before you save a key, check the provider documentation and domain.
 
 Provider rows show access state and weekly quota when available. Open
-**Manage** for credential controls, detailed usage, exact reset times, and the
-model catalog timestamp. Anthropic and OpenAI fetch separate model lists.
+**Manage** for credential controls, the 5-hour quota when available, and the
+model catalog timestamp. The weekly quota stays in the provider row.
+Anthropic and OpenAI fetch separate model lists.
 Added providers use the cached Models.dev directory.
 
 The `claude` and `codex` CLIs run on their own vendor's subscription or key.
 `opencode` and `pi` run on an API key only. OpenCode can run a supported
 Models.dev provider after its key is stored. A model ID is `provider/model`
 for each harness, for example `openai/gpt-5.5`.
+The harness menus disable `opencode` and `pi` until a provider API key is configured.
 
 `paths.harness_config_root` points at optional CLI configuration that Druks
 carries into sandboxes. The installer creates the root. Compose mounts it
@@ -321,7 +323,7 @@ read-only at `/harnesses`. Claude and Codex each read their named directory:
 Missing files are optional. Codex uses `.credentials.json` for MCP credentials.
 Provider credentials do not belong in this root. OpenCode and Pi do not read it.
 The default harness, model, billing, effort, and timeout live in
-**Settings → Agent defaults**. Each agent can override any of them on its app's page.
+**Settings → Agents**. Each agent can override any of them on its app's page.
 **Unattended runs use** names the account whose subscription an unattended
 run bills. A call refuses before provisioning a VM if its selected
 credential is missing.

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -335,7 +335,7 @@ from replayed orchestration allows later edits to change an in-flight run.
 
 An agent belongs to the app class. Which CLI runs it, which model, which
 login it bills, and at what effort are the operator's choices: defaults in
-**Settings → Agent defaults**, overridden per agent on the app's own page. `timeout`
+**Settings → Agents**, overridden per agent on the app's own page. `timeout`
 is the one declarable knob, because how long a step may take is a fact about
 the task.
 
@@ -388,7 +388,7 @@ persist its stable reference on an app row.
 An app that runs a CLI of its own inside the sandbox reads how a declared agent
 would run, and hands that to the CLI. Declare the agent and never call it; the
 operator configures it in the app's **Settings → Agents**. Shared defaults
-are in **Settings → Agent defaults**:
+are in **Settings → Agents**:
 
 ```python
 profile = await NightWatch.auditor.get_profile()

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -41,7 +41,7 @@ navigation button opens a modal drawer. Escape closes the drawer and returns
 focus to the button.
 
 Shared settings use `/settings/<section>` routes. Search matches section names
-and app field labels. General and Agent defaults retain separate
+and app field labels. General and Agents retain separate
 drafts across settings pages. Save changes applies only the current page.
 Leaving Settings offers Save, Discard, and Stay. Save applies each dirty page;
 a failed request keeps the operator on that page with its draft. Resource

--- a/frontend/src/components/ProviderConnect.test.tsx
+++ b/frontend/src/components/ProviderConnect.test.tsx
@@ -139,9 +139,9 @@ describe('ProviderConnect', () => {
     expect(screen.getByText('Connected')).toBeTruthy()
     expect(screen.getByText('Claude Max · claude-seat@corp.com')).toBeTruthy()
     expect(screen.getByLabelText('82% remaining')).toBeTruthy()
-    expect(screen.getByLabelText('41% remaining')).toBeTruthy()
+    expect(screen.queryByLabelText('41% remaining')).toBeNull()
     expect(screen.getByText('5-hour')).toBeTruthy()
-    expect(screen.getByText('Weekly')).toBeTruthy()
+    expect(screen.queryByText('Weekly')).toBeNull()
     expect(screen.queryByText(/Token expires/)).toBeNull()
     expect(screen.queryByText('Expired')).toBeNull()
     expect(screen.queryByRole('button', { name: 'Reconnect' })).toBeNull()
@@ -151,7 +151,7 @@ describe('ProviderConnect', () => {
     expect(screen.queryByText('Remove API key')).toBeNull()
   })
 
-  it('shows the 5-hour and general weekly quotas and keeps reset times relative', () => {
+  it('shows the extra 5-hour quota and keeps its reset time relative', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-09-05T10:00:00Z'))
     renderCard(provider(), {
@@ -182,11 +182,11 @@ describe('ProviderConnect', () => {
       },
     })
 
-    expect(screen.getAllByText('Weekly')).toHaveLength(1)
-    expect(screen.getByLabelText('83% remaining').textContent).toBe('83% left')
+    expect(screen.queryByText('Weekly')).toBeNull()
+    expect(screen.queryByLabelText('83% remaining')).toBeNull()
     expect(screen.queryByLabelText('69% remaining')).toBeNull()
     expect(screen.queryByText('Weekly · Fable')).toBeNull()
-    expect(screen.getByText('Resets in 6d')).toBeTruthy()
+    expect(screen.queryByText('Resets in 6d')).toBeNull()
     expect(screen.getByText('Resets in 2h').getAttribute('dateTime')).toBe('2026-09-05T12:00:00Z')
     expect(screen.getByText('Resets in 2h').getAttribute('title')).toBeTruthy()
     act(() => {

--- a/frontend/src/components/ResourcePages.test.tsx
+++ b/frontend/src/components/ResourcePages.test.tsx
@@ -93,6 +93,8 @@ describe('Provider resource rows', () => {
     expect(summary.textContent).not.toContain('Not configured')
 
     fireEvent.click(screen.getByRole('button', { name: 'Manage Anthropic' }))
+    expect(screen.getAllByLabelText('41% remaining')).toHaveLength(1)
+    expect(screen.getByLabelText('82% remaining')).toBeTruthy()
     expect(screen.getByRole('region', { name: 'Anthropic subscription' })).toBeTruthy()
     expect(screen.getByRole('region', { name: 'Anthropic API key' })).toBeTruthy()
     expect(screen.getByText(/1 model · Catalog fetched/)).toBeTruthy()
@@ -142,6 +144,22 @@ describe('Account grant groups', () => {
   }
 
   function renderAccounts() {
+    vi.spyOn(api, 'services').mockResolvedValue([
+      {
+        slug: 'gmail',
+        title: 'Gmail',
+        description: 'Connect mailboxes.',
+        required: true,
+        connected: true,
+        connectedAt: account.connectedAt,
+        facts: {},
+        fields: [],
+        isOauth: true,
+        requiredScopes: [],
+        usedBy: ['inbox_manager'],
+        connections: [account],
+      },
+    ])
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     render(
       <QueryClientProvider client={queryClient}>
@@ -180,18 +198,20 @@ describe('Account grant groups', () => {
     const current = within(screen.getByRole('region', { name: 'Current accounts' }))
     const history = within(screen.getByRole('region', { name: 'Grant history' }))
     await current.findByText(/mailbox@example.invalid/)
+    expect(await current.findByRole('cell', { name: 'Gmail' })).toBeTruthy()
     expect(current.queryByText(/old@example.invalid/)).toBeNull()
     expect(history.getByText(/old@example.invalid/)).toBeTruthy()
     expect(history.queryByRole('button', { name: 'Disconnect' })).toBeNull()
     fireEvent.click(current.getByRole('button', { name: 'Disconnect' }))
     expect(confirm).toHaveBeenCalledWith(
-      'Disconnect mailbox@example.invalid from gmail? Its access will be revoked.',
+      'Disconnect mailbox@example.invalid from Gmail? Its access will be revoked.',
     )
     expect(disconnect).not.toHaveBeenCalled()
     confirm.mockReturnValue(true)
     fireEvent.click(current.getByRole('button', { name: 'Disconnect' }))
     await waitFor(() => expect(disconnect).toHaveBeenCalledWith('account-1'))
     expect(await current.findByText('No connected accounts.')).toBeTruthy()
+    expect(current.queryByRole('table')).toBeNull()
     expect(history.getByText(/mailbox@example.invalid/)).toBeTruthy()
     expect(current.getByRole('status').textContent).toContain('disconnected')
   })

--- a/frontend/src/components/ServicesPane.test.tsx
+++ b/frontend/src/components/ServicesPane.test.tsx
@@ -107,7 +107,7 @@ function renderPane() {
   )
 }
 async function openGithubForm() {
-  fireEvent.click(await screen.findByText('GitHub'))
+  fireEvent.click(await screen.findByRole('button', { name: 'Configure GitHub' }))
   fireEvent.click(await screen.findByText('Connect an existing GitHub App'))
 }
 
@@ -123,13 +123,13 @@ async function flush() {
 }
 
 describe('ServicesPane', () => {
-  it('shows compact cards with no credential fields on the overview', async () => {
+  it('shows compact rows with no credential fields on the overview', async () => {
     stubFetch([[disconnected, pasteOnly]])
     renderPane()
 
     expect(await screen.findByText('GitHub')).toBeTruthy()
     expect(screen.getByText('Google OAuth client')).toBeTruthy()
-    expect(screen.getAllByText('Not connected')).toHaveLength(2)
+    expect(screen.getAllByText('Not configured')).toHaveLength(2)
     expect(screen.queryByLabelText('App ID')).toBeNull()
     expect(screen.queryByLabelText('Client ID')).toBeNull()
     expect(document.body.textContent).not.toContain('service identity')
@@ -139,7 +139,7 @@ describe('ServicesPane', () => {
     stubFetch([[disconnected, pasteOnly]])
     renderPane()
 
-    fireEvent.click(await screen.findByText('Google OAuth client'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Configure Google OAuth client' }))
     expect(screen.getByText('← Services')).toBeTruthy()
     expect(screen.queryByLabelText('Client ID')).toBeNull()
 
@@ -155,7 +155,7 @@ describe('ServicesPane', () => {
     stubFetch([[disconnected]])
     renderPane()
 
-    fireEvent.click(await screen.findByText('GitHub'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Configure GitHub' }))
     expect(screen.getByText('Create GitHub App')).toBeTruthy()
     expect(screen.queryByLabelText('App ID')).toBeNull()
 
@@ -238,7 +238,7 @@ describe('ServicesPane', () => {
     stubFetch([[connected]])
     renderPane()
 
-    fireEvent.click(await screen.findByText('GitHub'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Configure GitHub' }))
     expect(screen.getByText('Connected')).toBeTruthy()
     expect(screen.getByText('12345')).toBeTruthy()
     expect(screen.queryByLabelText('Private key (PEM)')).toBeNull()
@@ -255,7 +255,7 @@ describe('ServicesPane', () => {
     vi.stubGlobal('open', open)
     renderPane()
 
-    fireEvent.click(await screen.findByText('GitHub'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Configure GitHub' }))
     fireEvent.click(screen.getByText('Create GitHub App'))
     expect(open).toHaveBeenCalledWith('/api/core/github/manifest')
 
@@ -270,7 +270,7 @@ describe('ServicesPane', () => {
     stubFetch([[connected]])
     renderPane()
 
-    fireEvent.click(await screen.findByText('GitHub'))
+    fireEvent.click(await screen.findByRole('button', { name: 'Configure GitHub' }))
     const link = screen.getByText('Manage installations')
 
     expect(link.getAttribute('href')).toBe(

--- a/frontend/src/components/SettingsPages.test.tsx
+++ b/frontend/src/components/SettingsPages.test.tsx
@@ -29,6 +29,7 @@ const harnesses = [
   { name: 'claude', provider: 'anthropic', billingOptions: ['api_key', 'subscription'] },
   { name: 'codex', provider: 'openai', billingOptions: ['api_key', 'subscription'] },
   { name: 'opencode', provider: null, billingOptions: ['api_key'] },
+  { name: 'pi', provider: null, billingOptions: ['api_key'] },
 ]
 
 const userSettings = {
@@ -564,11 +565,30 @@ describe('SettingsPages app fields', () => {
 })
 
 describe('SettingsPages agents', () => {
-  it('offers Agent defaults separately from General preferences', async () => {
+  it.each([false, true])('enables key-only harnesses only with a configured API key (key: %s)', async (hasKey) => {
+    stubFetch(false)
+    if (!hasKey) vi.spyOn(api, 'providerKeys').mockResolvedValue([])
+    renderSettings('/settings/agents')
+    await screen.findByLabelText('Harness')
+    for (const name of ['pi', 'opencode']) {
+      const choice = screen.getByRole('option', { name: new RegExp(`^${name}`) }) as HTMLOptionElement
+      expect(choice.disabled).toBe(!hasKey)
+    }
+    fireEvent.click(screen.getByRole('button', { name: 'Open Software Factory' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Agents' }))
+    const harness = await screen.findByRole('button', { name: /^harness:/ })
+    fireEvent.click(harness)
+    for (const name of ['pi', 'opencode']) {
+      const choice = screen.getByRole('button', { name: new RegExp(`^${name}`) }) as HTMLButtonElement
+      expect(choice.disabled).toBe(!hasKey)
+    }
+  })
+
+  it('offers Agents separately from General preferences', async () => {
     stubFetch()
     renderSettings()
 
-    expect(await screen.findByRole('link', { name: 'Agent defaults' })).toBeTruthy()
+    expect(await screen.findByRole('link', { name: 'Agents' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Harnesses' })).toBeNull()
     expect(screen.queryByText('default model')).toBeNull()
   })
@@ -576,9 +596,9 @@ describe('SettingsPages agents', () => {
   it('renders the defaults, the unattended-runs account, and every agent resolved', async () => {
     stubFetch()
     renderSettings()
-    fireEvent.click(await screen.findByRole('link', { name: 'Agent defaults' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Agents' }))
 
-    expect(await screen.findByRole('heading', { name: 'Agent defaults' })).toBeTruthy()
+    expect(await screen.findByRole('heading', { name: 'Agents' })).toBeTruthy()
     expect((screen.getByLabelText('Harness') as HTMLSelectElement).value).toBe('claude')
     expect((screen.getByLabelText('Billing') as HTMLSelectElement).value).toBe('subscription')
     expect((screen.getByLabelText('Unattended runs use') as HTMLSelectElement).value).toBe('acc-1')
@@ -595,8 +615,8 @@ describe('SettingsPages agents', () => {
   it('a key-only default harness locks billing to API key and Save sends the changed defaults', async () => {
     stubFetch()
     renderSettings()
-    fireEvent.click(await screen.findByRole('link', { name: 'Agent defaults' }))
-    await screen.findByRole('heading', { name: 'Agent defaults' })
+    fireEvent.click(await screen.findByRole('link', { name: 'Agents' }))
+    await screen.findByRole('heading', { name: 'Agents' })
 
     fireEvent.change(screen.getByLabelText('Harness'), { target: { value: 'opencode' } })
     const billing = screen.getByLabelText('Billing') as HTMLSelectElement
@@ -647,7 +667,7 @@ describe('SettingsPages agents', () => {
   it('selects a configured third-party OpenCode model', async () => {
     stubFetch()
     renderSettings()
-    fireEvent.click(await screen.findByRole('link', { name: 'Agent defaults' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Agents' }))
 
     fireEvent.change(screen.getByLabelText('Harness'), { target: { value: 'opencode' } })
     fireEvent.click(await screen.findByRole('button', { name: /^Model:/ }))
@@ -722,7 +742,7 @@ describe('SettingsPages agents', () => {
   it('closes the model chooser with Escape without closing settings', async () => {
     stubFetch()
     renderSettings()
-    fireEvent.click(await screen.findByRole('link', { name: 'Agent defaults' }))
+    fireEvent.click(await screen.findByRole('link', { name: 'Agents' }))
     fireEvent.click(await screen.findByRole('button', { name: /^Model:/ }))
 
     const search = screen.getByLabelText('Search models')
@@ -740,13 +760,13 @@ describe('settings drafts and navigation', () => {
     fireEvent.change(await screen.findByRole('combobox', { name: 'Timezone' }), {
       target: { value: 'Europe/Madrid' },
     })
-    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    fireEvent.click(screen.getByRole('link', { name: 'Agents' }))
     fireEvent.change(await screen.findByLabelText('Effort'), { target: { value: 'low' } })
     fireEvent.click(screen.getByRole('link', { name: 'General' }))
     expect((screen.getByLabelText('Timezone') as HTMLSelectElement).value).toBe('Europe/Madrid')
     fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
     await waitFor(() => expect(patched).toEqual([{ timezone: 'Europe/Madrid' }]))
-    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    fireEvent.click(screen.getByRole('link', { name: 'Agents' }))
     expect((screen.getByLabelText('Effort') as HTMLSelectElement).value).toBe('low')
     expect(
       (screen.getByRole('button', { name: 'Save changes' }) as HTMLButtonElement).disabled,
@@ -798,7 +818,7 @@ describe('settings drafts and navigation', () => {
     fireEvent.change(await screen.findByLabelText('Timezone'), {
       target: { value: 'Europe/Madrid' },
     })
-    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    fireEvent.click(screen.getByRole('link', { name: 'Agents' }))
     fireEvent.change(await screen.findByLabelText('Effort'), { target: { value: 'low' } })
     fireEvent.click(screen.getByRole('link', { name: 'Back to Druks' }))
     fireEvent.click(
@@ -899,7 +919,7 @@ describe('settings resource and keyboard behavior', () => {
   it('does not bypass model credential validation through the save shortcut', async () => {
     stubFetch(false)
     renderSettings()
-    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    fireEvent.click(screen.getByRole('link', { name: 'Agents' }))
     const harness = await screen.findByLabelText('Harness')
     fireEvent.change(harness, { target: { value: 'codex' } })
     fireEvent.keyDown(harness, { key: 'Enter', ctrlKey: true })
@@ -914,8 +934,8 @@ describe('settings resource and keyboard behavior', () => {
     renderSettings()
     fireEvent.click(screen.getByRole('button', { name: 'Open navigation' }))
     const drawer = screen.getByRole('dialog', { name: 'Druks navigation' })
-    fireEvent.click(within(drawer).getByRole('link', { name: 'Agent defaults' }))
-    const heading = await screen.findByRole('heading', { name: 'Agent defaults' })
+    fireEvent.click(within(drawer).getByRole('link', { name: 'Agents' }))
+    const heading = await screen.findByRole('heading', { name: 'Agents' })
     expect(document.activeElement).toBe(heading)
     expect(drawer.hasAttribute('open')).toBe(false)
   })
@@ -1148,8 +1168,8 @@ describe('canonical app settings', () => {
     renderSettings('/apps/software_factory/settings/agents')
     const settings = await screen.findByRole('link', { name: 'Software Factory settings' })
     expect(settings.getAttribute('aria-current')).toBe('page')
-    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
-    await screen.findByRole('heading', { name: 'Agent defaults' })
+    fireEvent.click(screen.getByRole('link', { name: 'Shared agents' }))
+    await screen.findByRole('heading', { name: 'Agents' })
     fireEvent.click(screen.getByRole('link', { name: 'Back to Druks' }))
     await screen.findByText('coder')
     expect(window.location.pathname).toBe('/apps/software_factory/settings/agents')
@@ -1157,13 +1177,13 @@ describe('canonical app settings', () => {
     fireEvent.change(screen.getByLabelText('Linear trigger status'), {
       target: { value: 'Agent Queue' },
     })
-    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    fireEvent.click(screen.getByRole('link', { name: 'Shared agents' }))
     expect(screen.getByRole('dialog', { name: 'Save your changes?' })).toBeTruthy()
   })
 })
 
 describe('settings resource read failures', () => {
-  it('uses a newly saved directory catalog in Agent defaults without remounting Settings', async () => {
+  it('uses a newly saved directory catalog in Agents without remounting Settings', async () => {
     stubFetch(false)
     const originalFetch = fetch
     let keySaved = false
@@ -1208,7 +1228,7 @@ describe('settings resource read failures', () => {
     fireEvent.change(resource.getByLabelText('API key'), { target: { value: 'local-test-key' } })
     fireEvent.click(resource.getByRole('button', { name: 'Save' }))
     await resource.findByText(/1 model · Catalog fetched/)
-    fireEvent.click(screen.getByRole('link', { name: 'Agent defaults' }))
+    fireEvent.click(screen.getByRole('link', { name: 'Agents' }))
     fireEvent.change(await screen.findByLabelText('Harness'), { target: { value: 'opencode' } })
     fireEvent.click(screen.getByRole('button', { name: /^Model:/ }))
     expect((await screen.findByRole('option', { name: /GPT OSS 120B/ }) as HTMLButtonElement).disabled).toBe(false)
@@ -1253,7 +1273,7 @@ describe('settings resource read failures', () => {
     'accounts',
     'agents',
   ] as const)(
-    'shows a failed %s read on Agent defaults and retries without false choices',
+    'shows a failed %s read on Agents and retries without false choices',
     async (method) => {
       stubFetch(false)
       const original = api[method]
@@ -1342,7 +1362,7 @@ it('finds model defaults, app overrides, and timezone with working field focus',
   const search = await screen.findByLabelText('Search settings')
   fireEvent.change(search, { target: { value: 'model' } })
   const results = screen.getByLabelText('Settings search results')
-  const defaultModel = within(results).getByRole('link', { name: 'Model Agent defaults · Field' })
+  const defaultModel = within(results).getByRole('link', { name: 'Model Agents · Field' })
   expect(within(results).getAllByRole('link').some((link) => link.getAttribute('href')?.includes('/settings/agents?field=agent.'))).toBe(true)
   fireEvent.click(defaultModel)
   await waitFor(() => expect(document.activeElement?.getAttribute('aria-label')).toMatch(/^Model:/))
@@ -1374,7 +1394,7 @@ it.each(Object.values(SETTINGS_FIELDS))('opens the shared $label field from sear
   mockScroll()
   renderSettings('/settings/general')
   fireEvent.change(await screen.findByLabelText('Search settings'), { target: { value: field.label } })
-  const owner = field.section === 'general' ? 'General' : 'Agent defaults'
+  const owner = field.section === 'general' ? 'General' : 'Agents'
   fireEvent.click(await screen.findByRole('link', { name: `${field.label} ${owner} · Field` }))
   await waitFor(() => expect(document.activeElement?.closest('[data-setting]')?.getAttribute('data-setting')).toBe(field.field))
 })

--- a/frontend/src/components/SettingsPages.tsx
+++ b/frontend/src/components/SettingsPages.tsx
@@ -40,7 +40,7 @@ import {
 
 const SECTIONS = [
   { id: 'providers', label: 'Providers', group: 'AI execution' },
-  { id: 'agents', label: 'Agent defaults', group: 'AI execution' },
+  { id: 'agents', label: 'Agents', group: 'AI execution' },
   { id: 'connections', label: 'Connections', group: 'Tools & access' },
   { id: 'mcp', label: 'MCP servers', group: 'Tools & access' },
   { id: 'skills', label: 'Skills', group: 'Tools & access' },
@@ -778,7 +778,7 @@ export function SettingsPages({
                     <aside className="app-settings-owner">
                       <p>Changes apply to {appLabel(entry.name)}. Unset agent fields inherit the shared defaults.</p>
                       <Link href="/settings/agents">
-                        Agent defaults <ArrowUpRight size={15} aria-hidden="true" />
+                        Shared agents <ArrowUpRight size={15} aria-hidden="true" />
                       </Link>
                     </aside>
                   </div>

--- a/frontend/src/components/SettingsPanes.tsx
+++ b/frontend/src/components/SettingsPanes.tsx
@@ -50,6 +50,9 @@ import { SETTINGS_FIELDS, isFieldVisible, type Catalog, type CatalogChoice, type
 const keyOnly = (harness: Harness | undefined) =>
   Boolean(harness) && !harness!.billingOptions.includes('subscription')
 
+const harnessNeedsKey = (harness: Harness, catalog: Catalog) =>
+  keyOnly(harness) && !catalog.hasApiKeyFor(harness)
+
 const BILLINGS: Billing[] = ['subscription', 'api_key']
 const billingLabel = (billing: string) => (billing === 'api_key' ? 'API key' : 'subscription')
 
@@ -157,15 +160,22 @@ function MenuOption({
   main,
   sub,
   onClick,
+  disabled,
 }: {
   selected: boolean
   harnessColor?: string
   main: string
   sub?: string
   onClick: () => void
+  disabled?: boolean
 }) {
   return (
-    <button type="button" className={'menu-opt' + (selected ? ' sel' : '')} onClick={onClick}>
+    <button
+      type="button"
+      className={'menu-opt' + (selected ? ' sel' : '')}
+      onClick={onClick}
+      disabled={disabled}
+    >
       <span className="mo-check">{selected ? '✓' : ''}</span>
       {harnessColor && <span className="mo-fam" style={{ background: harnessColor }} />}
       <span className="mo-main">
@@ -383,6 +393,8 @@ function InheritCell({
               selected={value === harness.name}
               harnessColor={harnessColor[harness.name]}
               main={harness.name}
+              sub={harnessNeedsKey(harness, catalog) ? 'Add a provider API key first' : undefined}
+              disabled={harnessNeedsKey(harness, catalog)}
               onClick={() => pick(harness.name)}
             />
           ))}
@@ -593,8 +605,13 @@ export function AgentsPane({
               disabled={busy}
             >
               {harnesses.map((harness) => (
-                <option key={harness.name} value={harness.name}>
+                <option
+                  key={harness.name}
+                  value={harness.name}
+                  disabled={harnessNeedsKey(harness, catalog)}
+                >
                   {harness.name}
+                  {harnessNeedsKey(harness, catalog) ? ' — add an API key' : ''}
                 </option>
               ))}
             </select>
@@ -850,32 +867,58 @@ export function ServicesPane() {
               Configure the services your apps use. Manage account access in Accounts.
             </p>
           </header>
-          <div className="svc-grid">
-            {services.map((service) => {
-              const identity = service.connected
-                ? (service.facts.slug ?? Object.values(service.facts)[0])
-                : undefined
-              return (
-                <button
-                  key={service.slug}
-                  type="button"
-                  className="set-card svc-card"
-                  onClick={() => setSelectedSlug(service.slug)}
-                >
-                  <span className="svc-card-top">
-                    <span className="svc-card-name">{service.title}</span>
-                    <ServiceStatus connected={service.connected} />
-                  </span>
-                  <span className="svc-card-desc">{service.description}</span>
-                  <span className="svc-card-foot">
-                    {identity && <span className="svc-card-id">{identity}</span>}
-                    <span className="svc-card-cue">Configure</span>
-                    <span className="chev" aria-hidden="true" />
-                  </span>
-                </button>
-              )
-            })}
-          </div>
+          <table className="connections-table" aria-label="Services">
+            <thead>
+              <tr>
+                <th scope="col">Service</th>
+                <th scope="col">Setup</th>
+                <th scope="col">Access</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {services.map((service) => {
+                const accounts = service.connections.filter((connection) => !connection.revokedAt)
+                return (
+                  <tr key={service.slug}>
+                    <th scope="row">
+                      <span className="connection-name">{service.title}</span>
+                      {service.usedBy.length > 0 && (
+                        <span className="connection-context">
+                          Used by {service.usedBy.map(appLabel).join(', ')}
+                        </span>
+                      )}
+                    </th>
+                    <td data-label="Setup">
+                      <ServiceStatus
+                        connected={service.connected}
+                        label={service.connected ? 'Configured' : 'Not configured'}
+                      />
+                    </td>
+                    <td data-label="Access">
+                      {service.isOauth
+                        ? accounts.length === 1
+                          ? (connectionIdentity(accounts[0]!) ?? '1 connected account')
+                          : accounts.length > 1
+                            ? `${accounts.length} connected accounts`
+                            : 'No connected accounts'
+                        : 'Service credentials'}
+                    </td>
+                    <td className="connection-actions">
+                      <button
+                        type="button"
+                        className="set-btn ghost"
+                        aria-label={`Configure ${service.title}`}
+                        onClick={() => setSelectedSlug(service.slug)}
+                      >
+                        Configure
+                      </button>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
         </>
       )}
     </div>
@@ -1118,7 +1161,7 @@ function ServiceAccess({ service }: { service: Service }) {
       {service.usedBy.length > 0 && (
         <div className="svc-fact">
           <span className="svc-fact-key">used by</span>
-          <span className="svc-fact-val">{service.usedBy.join(', ')}</span>
+          <span className="svc-fact-val">{service.usedBy.map(appLabel).join(', ')}</span>
         </div>
       )}
       {live.map((connection) => (
@@ -1182,15 +1225,24 @@ export function ConnectionsPane({ revokedOnly = false }: { revokedOnly?: boolean
     queryFn: () => api.listConnections(),
     staleTime: 60_000,
   })
+  const servicesQuery = useQuery({
+    queryKey: ['services'],
+    queryFn: api.services,
+    staleTime: 60_000,
+  })
+  const serviceTitles = Object.fromEntries(
+    (servicesQuery.data ?? []).map((service) => [service.slug, service.title]),
+  )
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [notice, setNotice] = useState('')
 
   const revoke = (connection: Connection) => {
     const identity = connectionIdentity(connection) ?? connection.provider
+    const service = serviceTitles[connection.provider] ?? connection.provider
     if (
       !window.confirm(
-        `Disconnect ${identity} from ${connection.provider}? Its access will be revoked.`,
+        `Disconnect ${identity} from ${service}? Its access will be revoked.`,
       )
     )
       return
@@ -1210,8 +1262,7 @@ export function ConnectionsPane({ revokedOnly = false }: { revokedOnly?: boolean
   }
 
   const connections = query.data ?? []
-  const live = connections.filter((connection) => !connection.revokedAt)
-  const revoked = connections.filter((connection) => connection.revokedAt)
+  const visible = connections.filter((connection) => Boolean(connection.revokedAt) === revokedOnly)
 
   return (
     <div className="set-pane mcp-pane svc-pane">
@@ -1239,44 +1290,72 @@ export function ConnectionsPane({ revokedOnly = false }: { revokedOnly?: boolean
       )}
       {busy && <p role="status">Disconnecting account…</p>}
       {notice && <p role="status">{notice}</p>}
-      {query.isSuccess && (revokedOnly ? revoked : live).length === 0 && (
+      {query.isSuccess && visible.length === 0 && (
         <p className="mcp-pane-sub">
           {revokedOnly ? 'No revoked accounts.' : 'No connected accounts.'}
         </p>
       )}
-      {connections.length > 0 && (
-        <div className="set-card svc-facts">
-          {!revokedOnly &&
-            live.map((connection) => (
-              <div className="svc-fact" key={connection.id}>
-                <span className="svc-fact-key">{connection.provider}</span>
-                <span className="svc-fact-val">
-                  {connectionIdentity(connection) ??
-                    (connection.scopes.join(', ') || 'unlabeled')}{' '}
-                  · {new Date(connection.connectedAt).toLocaleDateString()}
-                </span>
-                <button
-                  className="set-btn danger"
-                  onClick={() => revoke(connection)}
-                  disabled={busy}
-                >
-                  Disconnect
-                </button>
-              </div>
+      {visible.length > 0 && (
+        <table
+          className="connections-table"
+          aria-label={revokedOnly ? 'Revoked accounts' : 'Accounts'}
+        >
+          <thead>
+            <tr>
+              <th scope="col">Account</th>
+              <th scope="col">Service</th>
+              <th scope="col">Access</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visible.map((connection) => (
+              <tr key={connection.id}>
+                <th scope="row">
+                  <span className="connection-name">
+                    {connectionIdentity(connection) ?? 'Account identity unavailable'}
+                  </span>
+                  {revokedOnly && (
+                    <span className="connection-context">{revokedCopy(connection)}</span>
+                  )}
+                </th>
+                <td data-label="Service">
+                  {serviceTitles[connection.provider] ?? connection.provider}
+                </td>
+                <td>
+                  <details className="connection-details">
+                    <summary>Access details</summary>
+                    <dl>
+                      <dt>Connected</dt>
+                      <dd>
+                        <time dateTime={connection.connectedAt}>
+                          {new Date(connection.connectedAt).toLocaleString()}
+                        </time>
+                      </dd>
+                      <dt>Permissions</dt>
+                      <dd>
+                        {connection.scopes.length > 0
+                          ? connection.scopes.join(', ')
+                          : 'No scopes recorded'}
+                      </dd>
+                    </dl>
+                  </details>
+                </td>
+                <td className="connection-actions">
+                  {!revokedOnly && (
+                    <button
+                      className="set-btn danger"
+                      onClick={() => revoke(connection)}
+                      disabled={busy}
+                    >
+                      Disconnect
+                    </button>
+                  )}
+                </td>
+              </tr>
             ))}
-          {revokedOnly &&
-            revoked.map((connection) => (
-              <div className="svc-fact svc-revoked" key={connection.id}>
-                <span className="svc-fact-key">{connection.provider}</span>
-                <span className="svc-fact-val">
-                  {connectionIdentity(connection) ??
-                    (connection.scopes.join(', ') || 'unlabeled')}{' '}
-                  · connected {new Date(connection.connectedAt).toLocaleDateString()} ·{' '}
-                  {revokedCopy(connection)}
-                </span>
-              </div>
-            ))}
-        </div>
+          </tbody>
+        </table>
       )}
     </div>
   )
@@ -1664,7 +1743,6 @@ export function ProviderConnect({
   })
   const acceptsSubscription = provider.billingOptions.includes('subscription')
   const acceptsApiKey = provider.billingOptions.includes('api_key')
-  const weekly = usage?.weeks.find((week) => week.model === null)
 
   const run = (action: () => Promise<unknown>, after: () => Promise<unknown>, done: string) => {
     setBusy(true)
@@ -1759,16 +1837,11 @@ export function ProviderConnect({
                 {usage?.planTier ? `${usage.planTier} · ` : ''}
                 {subscription.providerEmail}
               </p>
-              <div className="provider-quotas">
-                {usage?.unlimited ? (
-                  <p>Quota: unmetered</p>
-                ) : (
-                  <>
-                    {usage?.fiveHour && <QuotaRow label="5-hour" metric={usage.fiveHour} />}
-                    {weekly && <QuotaRow label="Weekly" metric={weekly} />}
-                  </>
-                )}
-              </div>
+              {usage?.fiveHour && !usage.unlimited && (
+                <div className="provider-quotas">
+                  <QuotaRow label="5-hour" metric={usage.fiveHour} />
+                </div>
+              )}
             </>
           ) : (
             <p className="provider-account">Not connected</p>

--- a/frontend/src/components/settings.ts
+++ b/frontend/src/components/settings.ts
@@ -30,6 +30,7 @@ export interface CatalogChoice extends CatalogModel {
 
 export interface Catalog {
   modelsOf: (harness: string, billing: Billing) => CatalogChoice[]
+  hasApiKeyFor: (harness: Harness) => boolean
 }
 
 export function knownProviders(providers: Provider[], catalogs: ProviderCatalog[]): Provider[] {
@@ -71,6 +72,12 @@ export function buildCatalog(
     }))
   }
   return {
+    hasApiKeyFor: (harness) =>
+      keys.some(
+        (key) =>
+          (!harness.provider || harness.provider === key.provider) &&
+          providersById.get(key.provider)?.billingOptions.includes('api_key'),
+      ),
     modelsOf: (name, billing) => {
       const harness = harnesses.find((entry) => entry.name === name)
       if (!harness) return []

--- a/frontend/src/settings.css
+++ b/frontend/src/settings.css
@@ -15,7 +15,7 @@
 .settings-search-results a:hover { background: var(--surface-2); }
 .settings-search-results small { color: var(--text-dim); font-size: 13px; text-transform: capitalize; }
 .settings-search-results p { padding-inline: 16px; color: var(--text-dim); }
-.settings-pane > .set-pane { padding: 0; max-width: none; }
+.settings-pane .set-pane { padding: 0; max-width: none; }
 .settings-pane .mcp-pane > * { max-width: none; }
 .settings-pane .set-pane-sub { font-size: 15px; }
 .settings-pane .mcp-pane-title { font-size: 18px; }
@@ -82,7 +82,9 @@
 
 .settings-pane .mcp-pane-sub { font-size: 15px; }
 .settings-pane :is(.mcp-help, .provider-state, .provider-empty, .provider-save-note, .provider-directory-note, .provider-source, .provider-source p, .provider-account, .provider-key-details, .hr-quota, .hr-quota-reset, .svc-meta, .mcp-url, .mcp-tok, .browser-session-format, .browser-session-site, .browser-session-times, .browser-session-undeclared) { font-size: 13px; }
-.settings-pane :is(.mcp-h, .mcp-name, .mcp-conn, .provider-result-select strong, .provider-add-head label, .svc-card-name, .svc-card-desc, .svc-card-cue, .svc-back, .svc-alt, .browser-session-name) { font-family: var(--font-sans); font-size: 15px; letter-spacing: 0; text-transform: none; }
+.settings-pane :is(.mcp-h, .mcp-name, .mcp-conn, .provider-result-select strong, .provider-add-head label, .svc-back, .svc-alt, .browser-session-name) { font-family: var(--font-sans); font-size: 15px; letter-spacing: 0; text-transform: none; }
+.settings-pane .provider-add-panel { width: 100%; padding: 20px; gap: 16px; }
+.settings-pane .provider-results { max-height: min(480px, 50dvh); }
 .settings-pane .hr-conn-input { font-size: 15px; }
 .settings-pane .provider-section { padding: 20px 0; gap: 20px; }
 .provider-summary { display: grid; grid-template-columns: minmax(160px, 1fr) minmax(150px, .8fr) minmax(260px, 1.6fr) auto; align-items: center; gap: 24px; }
@@ -99,12 +101,23 @@
 .provider-details { padding: 24px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); }
 .provider-details .provider-source { margin-bottom: 24px; }
 .provider-catalog { margin: 24px 0 0; color: var(--text-dim); font-size: 13px; }
-.settings-pane .svc-grid { grid-template-columns: minmax(0, 1fr); gap: 0; }
-.settings-pane .svc-card { display: grid; grid-template-columns: minmax(220px, 1fr) minmax(180px, 1.5fr) auto; align-items: center; gap: 24px; padding: 20px 0; border: 0; border-bottom: 1px solid var(--border); border-radius: 0; background: transparent; }
-.settings-pane .svc-card-top { justify-content: flex-start; gap: 20px; }
-.settings-pane .svc-card-desc { white-space: normal; }
-.settings-pane .svc-card-foot { margin: 0; justify-content: flex-end; }
-.settings-pane .svc-card-id { max-width: 180px; font-size: 13px; }
+.connections-table { width: 100%; table-layout: fixed; border-collapse: collapse; text-align: left; font-size: 15px; }
+.connections-table th, .connections-table td { padding: 20px 16px; border-bottom: 1px solid var(--border); vertical-align: top; overflow-wrap: anywhere; }
+.connections-table :is(th, td):first-child { padding-left: 0; }
+.connections-table :is(th, td):last-child { padding-right: 0; text-align: right; }
+.connections-table thead th { padding-top: 0; padding-bottom: 12px; color: var(--text-dim); font-size: 13px; font-weight: 400; }
+.connections-table thead th:first-child { width: 32%; }
+.connections-table thead th:nth-child(2) { width: 18%; }
+.connections-table thead th:last-child { width: 124px; }
+.connections-table tbody th { font-weight: 400; }
+.connections-table td { color: var(--text-mid); }
+.connection-name { display: block; color: var(--text); font-weight: 500; }
+.connection-context { display: block; margin-top: 6px; color: var(--text-dim); font-size: 13px; }
+.connection-actions .set-btn { white-space: nowrap; }
+.connection-details summary { display: list-item; width: fit-content; min-height: 40px; cursor: pointer; color: var(--text); }
+.connection-details dl { margin: 8px 0 0; font-size: 13px; }
+.connection-details dt { margin-top: 12px; color: var(--text-dim); }
+.connection-details dd { margin: 4px 0 0; overflow-wrap: anywhere; }
 .settings-pane .svc-fact { align-items: center; flex-wrap: wrap; padding: 8px 0; font-family: var(--font-sans); font-size: 15px; }
 .settings-pane .svc-fact-key { flex-shrink: 1; overflow-wrap: anywhere; }
 .settings-pane .svc-fact-val { flex: 1; min-width: 160px; white-space: normal; overflow-wrap: anywhere; font-size: 13px; }
@@ -115,9 +128,6 @@
   .provider-access { grid-column: 1; grid-row: 2; }
   .provider-summary-usage { grid-column: 2; grid-row: 1 / 3; }
   .provider-summary > button { grid-column: 3; grid-row: 1 / 3; }
-  .settings-pane .svc-card { grid-template-columns: minmax(0, 1fr) auto; gap: 12px 20px; }
-  .settings-pane .svc-card-desc { grid-column: 1; }
-  .settings-pane .svc-card-foot { grid-column: 2; grid-row: 1 / 3; flex-wrap: wrap; }
 }
 @media (max-width: 649px) {
   .provider-summary { grid-template-columns: minmax(0, 1fr) auto; gap: 12px; }
@@ -125,11 +135,17 @@
   .provider-summary > button { grid-column: 2; grid-row: 1 / 3; }
   .provider-details { padding: 16px; }
   .settings-pane .hr-conn-input { font-size: 16px; }
-  .settings-pane .svc-card-top { flex-direction: column; align-items: flex-start; gap: 8px; }
-  .settings-pane .svc-card-foot { flex-direction: column; align-items: flex-end; max-width: 100px; }
-  .settings-pane .svc-card-id { max-width: 100%; }
+  .connections-table thead { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); }
+  .connections-table, .connections-table tbody { display: block; }
+  .connections-table tr { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 12px 16px; padding: 20px 0; border-bottom: 1px solid var(--border); }
+  .connections-table th, .connections-table td { display: block; padding: 0; border: 0; }
+  .connections-table tbody th { grid-column: 1; }
+  .connections-table td { grid-column: 1 / -1; }
+  .connections-table td[data-label]::before { content: attr(data-label) ': '; color: var(--text-dim); }
+  .connections-table .connection-actions { grid-column: 2; grid-row: 1; }
+  .connection-details summary { min-height: 44px; }
 }
-.settings-pane .settings-agents > * { max-width: 880px; }
+.settings-pane .settings-default-execution { max-width: 880px; }
 .settings-default-execution { padding: 24px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); }
 .settings-default-execution h2 { margin: 0 0 6px; font-size: 18px; font-weight: 500; }
 .settings-default-execution > p { margin: 0 0 24px; color: var(--text-mid); }
@@ -185,6 +201,7 @@
 .settings-pane .agent-record .cell-arrow { margin-left: auto; flex-shrink: 0; }
 .settings-pane .set-menu { max-width: calc(100vw - 24px); }
 .settings-pane .menu-opt { min-height: 44px; font-size: 15px; }
+.settings-pane .menu-opt:disabled { color: var(--text-dim); cursor: default; background: transparent; }
 @media (max-width: 649px) {
   .agent-record { grid-template-columns: minmax(0, 1fr); gap: 20px; }
   .agent-field-model { grid-column: 1; }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -971,17 +971,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .mcp-enable-label { font-size: 12.5px; color: var(--text-mid); }
 .mcp-actions { display: flex; align-items: center; justify-content: flex-end; flex-wrap: wrap; gap: 8px; }
 
-.svc-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
-.svc-card { display: flex; flex-direction: column; gap: 8px; min-width: 0; padding: 13px 14px; cursor: pointer; text-align: left; font: inherit; color: inherit; transition: border-color 120ms, background 120ms; }
-.svc-card:hover { border-color: var(--border-loud); background: var(--surface-3); }
-.svc-card:active { background: var(--surface); }
-.svc-card-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
-.svc-card-name { font-size: 13.5px; font-weight: 600; color: var(--text); }
-.svc-card-desc { font-size: 12px; line-height: 1.45; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.svc-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: auto; }
-.svc-card-id { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.svc-card-cue { font-size: 12px; color: var(--text-dim); }
-.svc-card .chev { flex-shrink: 0; }
 
 .svc-back { padding: 0; border: none; background: none; font: inherit; font-size: 12.5px; color: var(--text-mid); cursor: pointer; }
 .svc-back:hover { color: var(--text); }
@@ -1031,7 +1020,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 
 @media (max-width: 720px) {
   .set-app-toggles { grid-template-columns: 1fr; }
-  .svc-grid { grid-template-columns: 1fr; }
   .set-thead { display: none; }
   .set-trow { grid-template-columns: 1fr 1fr; gap: 8px; padding: 12px 14px; }
   .skill-add { flex-direction: column; align-items: stretch; }


### PR DESCRIPTION
## What changed

Settings use the available page width: Add provider expands with the page, and Resolved agents is no longer capped at 880 px. Rename Agent defaults to Agents. Manage keeps weekly quota in the provider row and shows the extra 5-hour quota with credential controls.

Pi and OpenCode stay disabled until a compatible provider API key is configured, in both shared defaults and app overrides. Both menus use the same credential rule.

Connections now uses aligned Service, Setup, Access, and Actions columns. Rows show the apps that use each service and the connected account or account count. Configure holds setup text and technical IDs. Accounts and Revoked use the same table layout, canonical service titles, and expandable access details. Phone rows stack within the shared page gutters.

The compact list and focused detail pattern follows [GitHub](https://docs.github.com/en/apps/using-github-apps/reviewing-and-modifying-installed-github-apps) and [Notion](https://www.notion.com/help/add-and-manage-connections-with-the-api). App titles and subtitles remain left-aligned.

Fixes [DRU-467](https://linear.app/fellaworks/issue/DRU-467/refine-providers-agents-and-connections-settings).

## Risk

Frontend and documentation only. No API contract, credential storage, migration, or execution changes. Rebuild the dashboard to apply the change.

## Verification

- `npm --prefix frontend run lint` — passed.
- `npm --prefix frontend test` — 392 tests passed.
- `npm --prefix frontend run build` — passed.
- Chrome with local API fixtures at 1600, 1000, and 390 px: provider expansion, single weekly quota, retained key draft, harness availability with and without a key, aligned Connections columns, detail disclosures, and revoked accounts. No page overflow or browser errors. The resolved table keeps its contained horizontal scroll on narrow screens.
- Backend tests and live provider/OAuth flows were not run; backend code is unchanged.
