### PR TITLE
Deliver Claude's API key through Drukbox secrets (DRU-471)

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -24,7 +24,7 @@ from druks.harnesses.exceptions import (
 from druks.harnesses.profiles import Profile, get_profile
 from druks.prompts import render_prompt
 from druks.sandbox import gate as sandbox_gate
-from druks.sandbox.client import sandbox_client
+from druks.sandbox.client import provisioning_key, sandbox_client
 from druks.sandbox.templates import get_template_id
 from druks.settings import load_settings
 from druks.usage.models import UsageScrape
@@ -43,7 +43,7 @@ _REAP_BEFORE_WAIT_SECONDS = 120
 
 @contextlib.asynccontextmanager
 async def _runner(
-    workflow: "Workflow", host_id: str | None, workflow_id: str, step: str | None
+    workflow: "Workflow", host_id: str | None, workflow_id: str, step: str, profile: Profile
 ) -> AsyncIterator["Workspace"]:
     # The agent always runs in a Workspace. A warm run attaches the run's held VM; the
     # rest get a fresh ephemeral VM. Either way workflow.get_workspace() turns the VM into
@@ -56,7 +56,8 @@ async def _runner(
             template = await get_template_id(workflow.sandbox)
             await set_run_phase("provisioning_vm")
         vm = sandbox_client.ephemeral(
-            idempotency_key=f"{workflow_id}:{step}",
+            idempotency_key=provisioning_key(workflow_id, step, profile.secrets_id),
+            secrets=profile.secrets,
             template=template,
         )
     async with vm as box:
@@ -283,14 +284,14 @@ class Agent:
         )
         async with gate:
             await set_run_phase("provisioning_vm")
-            host_id = await workflow._lease_host()
+            host_id = await workflow._lease_host(profile)
 
             # Record the call RUNNING once it has a host to run on (its id names
             # the on-disk transcript dir) so the live step shows while the agent
             # works, then finish it — or fail it if the run raised after
             # starting. A provisioning failure happens before this and records
             # no call.
-            async with _runner(workflow, host_id, workflow_id, self.id) as runner:
+            async with _runner(workflow, host_id, workflow_id, self.id, profile) as runner:
                 context = await runner.prepare_context(context, agent_call_id=call_id)
                 # Templates read the live workflow + the workspace the agent runs in,
                 # alongside whatever the workflow's get_prompt_context composes.

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -7,6 +7,8 @@ from collections.abc import Collection
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
+from drukbox_sdk import Secret
+
 from druks.mcp import models as mcp_models
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.skills.models import Skill
@@ -101,6 +103,10 @@ class Harness(ABC):
         if cls.provider:
             return cls.provider == provider.id
         return bool(cls.billing_options & provider.billing_options)
+
+    @classmethod
+    def get_secrets(cls, key: str) -> dict[str, Secret]:
+        return {}
 
     @property
     def model_id(self) -> str:

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -5,6 +5,8 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from drukbox_sdk import Secret
+
 from druks.sandbox.datastructures import (
     AgentInvocation,
     Credentials,
@@ -68,6 +70,7 @@ class ClaudeHarness(Harness):
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
         subscription: ProviderSubscription | None = None,
+        # Accepted for signature parity. The sandbox entry carries the key.
         key: str | None = None,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
@@ -120,9 +123,6 @@ class ClaudeHarness(Harness):
             f'if [ -n "$sf" ]; then cp "$sf" {session_q}; fi; '
             "exit $ec"
         )
-        env = dict(extra_env or {})
-        if key:
-            env["ANTHROPIC_API_KEY"] = key
         return AgentInvocation(
             name="claude",
             args=("sh", "-c", wrapper),
@@ -134,7 +134,7 @@ class ClaudeHarness(Harness):
                 skills=skills,
                 subscription=subscription,
             ),
-            env=env,
+            env=extra_env,
             extra_artifact_filenames=("debug.log", "session.jsonl"),
         )
 
@@ -191,6 +191,18 @@ class ClaudeHarness(Harness):
     @classmethod
     def auth_file(cls, subscription: ProviderSubscription) -> HomeFile:
         return HomeFile(".claude/.credentials.json", json.dumps(dict(subscription.payload)))
+
+    @classmethod
+    def get_secrets(cls, key: str) -> dict[str, Secret]:
+        return {
+            AnthropicProvider.id: Secret(
+                key,
+                host="api.anthropic.com",
+                auth_variable="ANTHROPIC_API_KEY",
+                auth_header="x-api-key",
+                auth_prefix="",
+            )
+        }
 
     def _command_args(self) -> tuple[str, ...]:
         args = (self.command,)

--- a/backend/druks/harnesses/profiles.py
+++ b/backend/druks/harnesses/profiles.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from drukbox_sdk import Secret
+
 from druks.accounts.models import Account
 from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
 from druks.user_settings.models import SettingsOverride, SettingsProfile
@@ -14,14 +16,13 @@ from .registry import get_harness
 @dataclass(frozen=True)
 class Profile:
     """How an agent runs for one account: harness, model, effort, billing, read from
-    Settings → Agents at call time. ``key`` rides here because an app driving its
-    own CLI in the VM builds that CLI's environment; the harness fills only the
-    calling agent's."""
+    Settings → Agents at call time."""
 
     harness_class: type[Harness]
     model: str
     subscription: ProviderSubscription | None
     api_key: ProviderKey | None
+    secrets: dict[str, Secret]
     billing: str
     effort: str
     timeout: int
@@ -38,7 +39,15 @@ class Profile:
 
     @property
     def key(self) -> str | None:
-        return self.api_key.value.decrypt() if self.api_key else None
+        # Codex, Pi, and OpenCode read the key from their invocation.
+        if self.api_key and not self.secrets:
+            return self.api_key.value.decrypt()
+
+    @property
+    def secrets_id(self) -> str:
+        if self.secrets:
+            return f"{self.api_key.provider}.{self.api_key.updated_at:%Y%m%dT%H%M%S}"
+        return ""
 
     @property
     def charged_account_id(self) -> str | None:
@@ -91,11 +100,13 @@ async def get_profile(agent_name: str, account_id: str | None) -> Profile:
     provider_id = model.partition("/")[0]
     subscription = None
     provider_key = None
+    secrets: dict[str, Secret] = {}
     if billing == "api_key":
         provider_key = await ProviderKey.get(provider_id)
         if not provider_key:
             label = await provider_label(provider_id)
             raise HarnessNotConnectedError(f"add the {label} API key in Settings → Providers.")
+        secrets = harness_class.get_secrets(provider_key.value.decrypt())
     else:
         subscription = await ProviderSubscription.lookup(provider_id, account_id)
     timeout = (
@@ -106,6 +117,7 @@ async def get_profile(agent_name: str, account_id: str | None) -> Profile:
         model=model,
         subscription=subscription,
         api_key=provider_key,
+        secrets=secrets,
         billing=billing,
         effort=(await SettingsOverride.agent_effort(agent_name, settings=settings)).value,
         # Capped so a single call always fits inside a fresh sandbox lease.

--- a/backend/druks/sandbox/client.py
+++ b/backend/druks/sandbox/client.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import asyncssh
-from drukbox_sdk import SandboxAPI, SandboxHost
+from drukbox_sdk import SandboxAPI, SandboxHost, Secret
 from drukbox_sdk.exceptions import (
     SandboxAPIError,
     SandboxNotFoundError,
@@ -53,10 +53,10 @@ class Client:
         image_override: str | None = None,
         provider: str | None = None,
         sandbox_env: dict[str, str] | None = None,
+        secrets: dict[str, Secret] | None = None,
         template: str | None = None,
     ) -> AsyncIterator[Host]:
-        """One-shot lifecycle: acquire → yield → release. For callers
-        whose sandbox is bound to a single context manager body."""
+        """Acquire, yield, release: for a sandbox bound to one context manager body."""
         host_id: str | None = None
 
         try:
@@ -65,6 +65,7 @@ class Client:
                 image_override=image_override,
                 provider=provider,
                 sandbox_env=sandbox_env,
+                secrets=secrets,
                 template=template,
             ) as host:
                 host_id = host.id
@@ -81,6 +82,7 @@ class Client:
         image_override: str | None = None,
         provider: str | None = None,
         sandbox_env: dict[str, str] | None = None,
+        secrets: dict[str, Secret] | None = None,
         template: str | None = None,
     ) -> AsyncIterator[Host]:
         """Create a new host (or reuse one matching ``idempotency_key``)
@@ -102,6 +104,7 @@ class Client:
                     idempotency_key=key,
                     image=image or None,
                     provider=provider,
+                    secrets=secrets,
                     template=template,
                 )
             except (SandboxProvisioningError, SandboxUnavailableError) as exc:
@@ -221,6 +224,7 @@ class Client:
         image_override: str | None = None,
         provider: str | None = None,
         sandbox_env: dict[str, str] | None = None,
+        secrets: dict[str, Secret] | None = None,
         template: str | None = None,
     ) -> Host:
         """Create a host and return its handle without holding an SSH connection —
@@ -231,6 +235,7 @@ class Client:
             image_override=image_override,
             provider=provider,
             sandbox_env=sandbox_env,
+            secrets=secrets,
             template=template,
         ) as host:
             return host
@@ -267,6 +272,10 @@ class Client:
             token=settings.sandbox.service_token,
             timeout=settings.sandbox.timeout,
         )
+
+
+def provisioning_key(*parts: str) -> str:
+    return ":".join(part for part in parts if part)
 
 
 async def _upload_helper_script(host: Host) -> None:

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -13,9 +13,10 @@ import asyncssh
 from drukbox_sdk import SandboxHost as SandboxHostRecord
 from drukbox_sdk.exceptions import SandboxAPIError, SandboxUnavailableError
 
-from druks.accounts.models import Account
 from druks.core.utils.time import ensure_utc
+from druks.durable.enums import AgentCallStatus
 from druks.harnesses.artifacts import persist_manifest, persist_prompt, read_cost
+from druks.harnesses.datastructures import SandboxSettings
 from druks.harnesses.exceptions import (
     HarnessError,
     HarnessFirstByteTimeoutError,
@@ -225,19 +226,12 @@ class Host:
         ``include_plugins=False`` (Claude only) skips uploading the operator's plugin
         state — for prompts that hit no MCP server; a no-op for codex.
         """
-        # cycle: the harnesses package eagerly imports claude/codex, which
-        # import this package's siblings — so the factory can't load while
-        # druks.sandbox is mid-init.
-        from druks.durable.enums import AgentCallStatus
-        from druks.harnesses.datastructures import SandboxSettings
-
-        settings = load_settings()
         model, timeout = profile.model, profile.timeout
         harness = profile.harness_class(
             model=model,
             fast_mode=profile.fast_mode,
             effort=profile.effort,
-            sandbox=SandboxSettings.maybe_from_settings(settings),
+            sandbox=SandboxSettings.maybe_from_settings(load_settings()),
         )
 
         # Names the artifact subdir and is the AgentCall.id — supplied by the
@@ -305,18 +299,7 @@ class Host:
         key: str | None = None,
     ) -> Any:
         """Drive one prompt through ``harness`` on this VM: the harness
-        builds the invocation and parses the result; this sandbox executes it.
-        One-shot callers with a hand-built harness use this directly;
-        ``run_agent`` adds the harness factory + cost capture on top."""
-        # A one-shot caller with a hand-built harness runs on the default
-        # account's subscription.
-        from druks.harnesses.models import ProviderSubscription
-
-        if not (subscription or key):
-            account = await Account.get_default()
-            subscription = await ProviderSubscription.lookup(
-                harness.model.partition("/")[0], account.id if account else None
-            )
+        builds the invocation and parses the result; this sandbox executes it."""
         run_id = harness.mint_run_id(call_id)
         artifact_dir.mkdir(parents=True, exist_ok=True)
         persist_prompt(artifact_dir, call_id=run_id, prompt=prompt)

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -52,7 +52,7 @@ from druks.events.models import Event
 from druks.harnesses.exceptions import HarnessError
 from druks.models import StoredSubject, snake_name
 from druks.notifications.outbox import notifications_queue, send_notification
-from druks.sandbox.client import sandbox_client
+from druks.sandbox.client import provisioning_key, sandbox_client
 from druks.sandbox.constants import SANDBOX_HOST_ROTATE_BEFORE_SECONDS
 from druks.sandbox.datastructures import Sandbox
 from druks.sandbox.templates import get_template_id
@@ -85,6 +85,7 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:
+    from druks.harnesses.profiles import Profile
     from druks.sandbox.host import Host
 
 # A human gate can park for days; a long recv TTL still caps zombie parks.
@@ -166,9 +167,8 @@ class _DeclaredSubject:
         async def resolve() -> Any:
             if "subject" in run.__dict__:
                 return run.__dict__["subject"]
-            if not run._subject:
-                return None
-            return await self.subject_class.get_for_subject_id(str(run._subject["id"]))
+            if run._subject:
+                return await self.subject_class.get_for_subject_id(str(run._subject["id"]))
 
         return resolve()
 
@@ -775,6 +775,7 @@ class Workflow:
         # The run's warm VM, provisioned lazily and reaped at segment boundaries;
         # its lease expiry decides when it must rotate.
         self._host: Host | None = None
+        self._host_secrets_id = ""
 
     async def announce(self, topic: str, **facts: Any) -> None:
         # The workflow announcing a domain event in its app's vocabulary
@@ -831,7 +832,7 @@ class Workflow:
         # Built per agent call, so nothing is held across steps.
         return self.workspace_class(**await self.get_workspace_kwargs(host))
 
-    async def _lease_host(self) -> str | None:
+    async def _lease_host(self, profile: "Profile") -> str | None:
         # The warm VM, provisioned once per segment; state is carried in git, so
         # only the host-id matters across steps — held-across-steps never fights replay.
         if not self.steps_reuse_sandbox:
@@ -843,15 +844,21 @@ class Workflow:
                 # host. Safe because each call rebuilds its workspace on whatever
                 # host it lands on (state lives in git), so a bare VM is fine.
                 await self._reap_run()
+        if self._host and self._host_secrets_id != profile.secrets_id:
+            # Drukbox binds entries at creation.
+            await self._reap_run()
         if not self._host:
             template = None
             if self.sandbox:
                 template = await get_template_id(self.sandbox)
                 await set_run_phase("provisioning_vm")
             self._host = await sandbox_client.provision(
-                idempotency_key=f"{self._workflow_id}:sandbox",
+                # The key names the pasted key the VM holds, so a replay finds its VM.
+                idempotency_key=provisioning_key(self._workflow_id, "sandbox", profile.secrets_id),
+                secrets=profile.secrets,
                 template=template,
             )
+            self._host_secrets_id = profile.secrets_id
         return self._host.id
 
     async def _reap_run(self) -> None:

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -798,9 +799,10 @@ async def test_reused_host_retry_presents_a_stable_idempotency_key(monkeypatch, 
 
     monkeypatch.setattr("druks.sandbox.client.Client.provision", fake_provision)
 
+    profile = SimpleNamespace(secrets={}, secrets_id="")
     with pytest.raises(HarnessSandboxProvisioningError):
-        await current_run._lease_host()
-    host_id = await current_run._lease_host()
+        await current_run._lease_host(profile)
+    host_id = await current_run._lease_host(profile)
 
     assert host_id == "warm-host"
     assert keys == ["wf-9:sandbox", "wf-9:sandbox"]
@@ -834,16 +836,70 @@ async def test_provisioning_failure_exhausts_retries_with_classified_code(
     assert current_run._reap_run.await_count == 1
 
 
+async def test_api_key_billing_hands_claude_a_placeholder(
+    druks_db, tmp_path, monkeypatch, current_run
+):
+    """Under api_key billing the VM is created with the key as a Drukbox entry. The
+    profile the sandbox runs carries no key, and the durable call records none."""
+    import json
+
+    from drukbox_sdk import Secret
+
+    pasted = await installation_key()
+    key = pasted.value.decrypt()
+    await SettingsOverride.set_agent_billing(DUMMY_AGENT.id, "api_key")
+    sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
+    seen: list[dict] = []
+    keys: list[str] = []
+
+    @asynccontextmanager
+    async def fake_ephemeral(self, *, idempotency_key, secrets, **_kwargs):
+        keys.append(idempotency_key)
+        seen.append(secrets)
+        yield sandbox
+
+    monkeypatch.setattr("druks.sandbox.client.Client.ephemeral", fake_ephemeral)
+
+    await DUMMY_AGENT._run(workflow_id="wf-9")
+
+    assert seen == [
+        {
+            "anthropic": Secret(
+                key,
+                host="api.anthropic.com",
+                auth_variable="ANTHROPIC_API_KEY",
+                auth_header="x-api-key",
+                auth_prefix="",
+            )
+        }
+    ]
+    # The VM's key names the pasted key, never its value.
+    assert keys == [f"wf-9:dummy:anthropic.{pasted.updated_at:%Y%m%dT%H%M%S}"]
+    profile = sandbox.run_agent.await_args.kwargs["profile"]
+    assert (profile.billing, profile.key, profile.subscription) == ("api_key", None, None)
+    [call] = await AgentCall.list_for_run("wf-9")
+    assert (call.subscription_id, call.api_key_provider) == (None, "anthropic")
+    row = {column.key: getattr(call, column.key) for column in AgentCall.__table__.columns}
+    assert key not in json.dumps(row, default=str)
+
+
+@pytest.mark.parametrize(
+    "fatal_name",
+    [
+        pytest.param("SandboxValidationError", id="422"),
+        pytest.param("SandboxConflictError", id="409"),
+    ],
+)
 async def test_fatal_sdk_error_does_not_trigger_agent_retry(
-    druks_db, tmp_path, monkeypatch, current_run, _inline_agent_steps
+    druks_db, tmp_path, monkeypatch, current_run, _inline_agent_steps, fatal_name
 ):
     """A non-transient SDK failure surfacing from acquire is not a HarnessError,
     so it propagates on the first attempt with no retry sleep — auth/validation
     failures can't recover without changed inputs."""
-    from drukbox_sdk.exceptions import SandboxValidationError
+    from drukbox_sdk import exceptions as sdk_exceptions
 
     _patch_runtime(monkeypatch, tmp_path, {"ok": True})
-    fatal = SandboxValidationError("bad image")
+    fatal = getattr(sdk_exceptions, fatal_name)("drukbox refused the entries")
     attempts = 0
 
     @asynccontextmanager
@@ -857,7 +913,7 @@ async def test_fatal_sdk_error_does_not_trigger_agent_retry(
     current_run._reap_run = AsyncMock()
     _, sleep = _inline_agent_steps
 
-    with pytest.raises(SandboxValidationError) as excinfo:
+    with pytest.raises(type(fatal)) as excinfo:
         await DUMMY_AGENT()
 
     assert excinfo.value is fatal

--- a/backend/tests/test_declared_sandboxes.py
+++ b/backend/tests/test_declared_sandboxes.py
@@ -241,10 +241,11 @@ async def test_warm_lease_uses_workflow_template(monkeypatch):
     monkeypatch.setattr(workflow_module, "get_template_id", resolve)
     monkeypatch.setattr(workflow_module, "set_run_phase", AsyncMock())
 
-    assert await workflow._lease_host() == "host-1"
+    assert await workflow._lease_host(SimpleNamespace(secrets={}, secrets_id="")) == "host-1"
     resolve.assert_awaited_once_with(sandbox)
     provision.assert_awaited_once_with(
         idempotency_key="run-1:sandbox",
+        secrets={},
         template="template-1",
     )
 
@@ -271,11 +272,14 @@ async def test_ephemeral_lease_uses_workflow_template(monkeypatch):
     )
     monkeypatch.setattr(agent_module, "get_template_id", resolve)
 
-    async with agent_module._runner(workflow, None, "run-1", "summarize") as runner:
+    profile = SimpleNamespace(secrets={}, secrets_id="")
+    async with agent_module._runner(workflow, None, "run-1", "summarize", profile) as runner:
         assert runner == "workspace"
 
     resolve.assert_awaited_once_with(sandbox)
-    assert calls == [{"idempotency_key": "run-1:summarize", "template": "template-1"}]
+    assert calls == [
+        {"idempotency_key": "run-1:summarize", "secrets": {}, "template": "template-1"}
+    ]
 
 
 async def test_client_template_primitives_use_sdk_contract(monkeypatch):

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -147,15 +147,16 @@ async def test_missing_config_root_keeps_the_db_credential(druks_db, tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("harness", "config_name", "auth_name"),
+    ("harness", "config_name", "auth_name", "key"),
     [
-        (ClaudeHarness, "settings.json", ".credentials.json"),
-        (CodexHarness, "config.toml", "auth.json"),
+        # Claude reads the key from a placeholder in the VM, so its invocation gets none.
+        (ClaudeHarness, "settings.json", ".credentials.json", None),
+        (CodexHarness, "config.toml", "auth.json", "selected-key"),
     ],
 )
 @pytest.mark.parametrize("config_exists", [False, True])
 async def test_config_delivery_does_not_copy_host_provider_credentials(
-    druks_db, tmp_path, harness, config_name, auth_name, config_exists
+    druks_db, tmp_path, harness, config_name, auth_name, key, config_exists
 ):
     config_root = tmp_path / "harnesses"
     config_dir = config_root / harness.name
@@ -178,7 +179,7 @@ async def test_config_delivery_does_not_copy_host_provider_credentials(
         schema={"type": "object"},
         run_id="run-1",
         ssh_username="druks",
-        key="selected-key",
+        key=key,
     )
     host = AsyncMock()
     for file in invocation.credentials.home:
@@ -199,7 +200,7 @@ async def test_config_delivery_does_not_copy_host_provider_credentials(
         )
     else:
         host.write_secret.assert_not_awaited()
-        assert invocation.env["ANTHROPIC_API_KEY"] == "selected-key"
+        assert not invocation.env
 
 
 async def test_credential_without_a_selection_reads_the_accounts_row(druks_db):

--- a/backend/tests/test_harness_reasoning_flags.py
+++ b/backend/tests/test_harness_reasoning_flags.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from conftest import connect_provider
+from drukbox_sdk import Secret
 from druks.accounts.models import Account
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
@@ -149,19 +150,28 @@ async def test_codex_build_invocation_carries_every_flag():
     assert inv.extra_artifact_filenames == ("output.json", "session.jsonl")
 
 
-async def test_claude_runs_a_key_from_the_environment():
-    # A key ships as ANTHROPIC_API_KEY; no credentials file lands in the home.
+async def test_claude_reads_its_key_from_a_placeholder_in_the_vm():
+    # Drukbox delivers the key as a placeholder under ANTHROPIC_API_KEY. The
+    # invocation carries no key and no credentials file.
+    assert ClaudeHarness.get_secrets("sk-secret") == {
+        "anthropic": Secret(
+            "sk-secret",
+            host="api.anthropic.com",
+            auth_variable="ANTHROPIC_API_KEY",
+            auth_header="x-api-key",
+            auth_prefix="",
+        )
+    }
     inv = await ClaudeHarness(
         model="anthropic/claude-x", fast_mode=False, effort=None, sandbox=_sandbox_config()
     ).build_invocation(
-        key="sk-secret",
         prompt="hello",
         schema={"type": "object"},
         run_id="run-1",
         ssh_username="exedev",
         extra_env={"TOK": "secret"},
     )
-    assert inv.env == {"TOK": "secret", "ANTHROPIC_API_KEY": "sk-secret"}
+    assert inv.env == {"TOK": "secret"}
     assert not any(file.path == ".claude/.credentials.json" for file in inv.credentials.home)
     assert "sk-secret" not in inv.args[2]
 

--- a/backend/tests/test_personal_settings.py
+++ b/backend/tests/test_personal_settings.py
@@ -110,7 +110,7 @@ async def test_unattended_api_key_uses_installation_profile_without_a_default_ac
 
     profile = await get_profile(PROFILE_PROBE.id, None)
 
-    assert profile.key == "test-api-key"
+    assert profile.api_key.value.decrypt() == "test-api-key"
     assert profile.subscription is None
     assert profile.effort == "low"
 

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 from conftest import PROFILE_PROBE, ProfileOutput, connect_anthropic_subscription
+from drukbox_sdk import Secret
 from druks import agents
 from druks.accounts.models import Account
 from druks.apps import App
@@ -56,6 +57,15 @@ async def _key() -> ProviderKey:
         key="sk-shared",
         account=await Account.get_or_create("ops@example.com"),
     )
+
+
+_SHARED_ENTRY = Secret(
+    "sk-shared",
+    host="api.anthropic.com",
+    auth_variable="ANTHROPIC_API_KEY",
+    auth_header="x-api-key",
+    auth_prefix="",
+)
 
 
 @pytest.mark.parametrize("billing", ["subscription", "api_key"])
@@ -121,7 +131,7 @@ async def test_a_subscription_agent_runs_as_its_actor_or_the_default_account(dru
     assert as_actor.subscription.id == actor.id
     assert as_actor.charged_account_id == actor.account_id
     assert unattended.subscription.id == default_subscription.id
-    assert as_actor.key is None
+    assert (as_actor.secrets, as_actor.secrets_id, as_actor.key) == ({}, "", None)
     assert as_actor.harness_class is ClaudeHarness
     assert as_actor.model == "anthropic/claude-opus-4-7"
     assert (as_actor.effort, as_actor.timeout, as_actor.fast_mode) == ("high", 1800, False)
@@ -139,14 +149,22 @@ async def test_a_subscription_agent_refuses_without_the_actors_own_subscription(
 
 async def test_a_key_agent_runs_on_the_installations_key_for_anyone(druks_db):
     actor = await connect_anthropic_subscription("a@example.com")
-    await _key()
+    pasted = await _key()
     await SettingsOverride.set_agent_billing(PROFILE_PROBE.id, "api_key")
 
     as_actor = await get_profile(PROFILE_PROBE.id, actor.account_id)
     unattended = await get_profile(PROFILE_PROBE.id, None)
 
-    assert (as_actor.key, as_actor.subscription) == ("sk-shared", None)
-    assert unattended.key == "sk-shared"
+    # Claude reads the key from a placeholder in the VM, never from its invocation.
+    assert (as_actor.secrets, as_actor.key, as_actor.subscription) == (
+        {"anthropic": _SHARED_ENTRY},
+        None,
+        None,
+    )
+    assert unattended.secrets == {"anthropic": _SHARED_ENTRY}
+    # The entries' identity is the pasted key, with no secret material.
+    assert as_actor.secrets_id == f"anthropic.{pasted.updated_at:%Y%m%dT%H%M%S}"
+    assert "sk-shared" not in as_actor.secrets_id
     # The key is nobody's, so its calls are charged to the installation.
     assert as_actor.charged_account_id is None
 
@@ -178,7 +196,8 @@ async def test_opencode_runs_an_added_provider_with_its_key_and_model(druks_db):
 
     assert profile.harness_class is OpenCodeHarness
     assert profile.model == "openrouter/anthropic/claude-sonnet-4"
-    assert profile.key == "sk-openrouter"
+    # OpenCode still reads the key from its invocation.
+    assert (profile.secrets, profile.key) == ({}, "sk-openrouter")
 
 
 async def test_an_added_provider_without_a_key_names_it(druks_db):
@@ -214,7 +233,7 @@ async def test_a_key_only_harness_bills_the_key(druks_db):
     profile = await get_profile(PROFILE_PROBE.id, None)
 
     assert profile.harness_class is OpenCodeHarness
-    assert profile.key == "sk-shared"
+    assert (profile.secrets, profile.key) == ({}, "sk-shared")
 
 
 async def test_a_stored_triple_no_harness_runs_refuses(druks_db):
@@ -254,8 +273,12 @@ async def test_an_agent_reads_its_own_profile(druks_db):
         await PROFILE_PROBE.get_profile()
 
     assert (subscribed.harness, subscribed.model_id) == ("claude", "claude-opus-4-7")
-    assert (subscribed.billing, subscribed.key) == ("subscription", None)
-    assert (keyed.billing, keyed.key) == ("api_key", "sk-shared")
+    assert (subscribed.billing, subscribed.secrets, subscribed.key) == ("subscription", {}, None)
+    assert (keyed.billing, keyed.secrets, keyed.key) == (
+        "api_key",
+        {"anthropic": _SHARED_ENTRY},
+        None,
+    )
 
 
 async def test_an_unregistered_agent_is_named(druks_db):

--- a/backend/tests/test_sandbox_lifecycle.py
+++ b/backend/tests/test_sandbox_lifecycle.py
@@ -5,11 +5,14 @@ from typing import Any
 
 import pytest
 from drukbox_sdk import SandboxHost as SandboxHostRecord
+from drukbox_sdk import Secret
 from drukbox_sdk.exceptions import (
     SandboxAuthError,
+    SandboxConflictError,
     SandboxNotFoundError,
     SandboxProvisioningError,
     SandboxUnavailableError,
+    SandboxValidationError,
 )
 from druks.harnesses.exceptions import HarnessSandboxProvisioningError, Retry
 from druks.sandbox import credentials as creds_module
@@ -82,6 +85,7 @@ class _FakeSandbox:
 @dataclass
 class _FakeAPI:
     created_envs: list[dict[str, str] | None] = field(default_factory=list)
+    created_secrets: list[dict[str, Secret] | None] = field(default_factory=list)
     created_expires_at: list[datetime | None] = field(default_factory=list)
     deleted_ids: list[str] = field(default_factory=list)
     get_host_responses: list[SandboxHostRecord] = field(default_factory=list)
@@ -102,9 +106,11 @@ class _FakeAPI:
         idempotency_key: str | None = None,
         expires_at: datetime | None = None,
         provider: str | None = None,
+        secrets: dict[str, Secret] | None = None,
         template: str | None = None,
     ) -> SandboxHostRecord:
         self.created_envs.append(env)
+        self.created_secrets.append(secrets)
         self.created_expires_at.append(expires_at)
         if self.create_raises is not None:
             raise self.create_raises
@@ -537,6 +543,85 @@ async def test_acquire_translates_transient_create_failures(
     # The schedule is inherited from HarnessSandboxError, not re-declared.
     assert error.retry_delays == (60, 300)
     assert error.__cause__ is sdk_error
+
+
+_ENTRIES = {
+    "anthropic": Secret(
+        "sk-real",
+        host="api.anthropic.com",
+        auth_variable="ANTHROPIC_API_KEY",
+        auth_header="x-api-key",
+        auth_prefix="",
+    )
+}
+
+
+async def test_acquire_hands_the_entries_to_drukbox(
+    patched_real_sandbox: list[_FakeSandbox],
+    patched_sandbox_api: list[_FakeAPI],
+):
+    api = _FakeAPI(create_record=_record(status="active"))
+    patched_sandbox_api.append(api)
+
+    async with sandbox_client.acquire(secrets=_ENTRIES):
+        pass
+
+    assert api.created_secrets == [_ENTRIES]
+    # The VM gets a placeholder from Drukbox. Druks writes no key into it.
+    assert patched_real_sandbox[0].secrets == []
+
+
+async def test_provision_hands_the_entries_to_drukbox(
+    patched_real_sandbox: list[_FakeSandbox],
+    patched_sandbox_api: list[_FakeAPI],
+):
+    api = _FakeAPI(create_record=_record(status="active"))
+    patched_sandbox_api.append(api)
+
+    host = await sandbox_client.provision(secrets=_ENTRIES)
+
+    assert host.id == "host-xyz"
+    assert api.created_secrets == [_ENTRIES]
+
+
+async def test_ephemeral_hands_the_entries_to_drukbox_and_releases(
+    patched_real_sandbox: list[_FakeSandbox],
+    patched_sandbox_api: list[_FakeAPI],
+):
+    api = _FakeAPI(create_record=_record(status="active"))
+    patched_sandbox_api.append(api)
+
+    async with sandbox_client.ephemeral(secrets=_ENTRIES):
+        pass
+
+    assert api.created_secrets == [_ENTRIES]
+    assert api.deleted_ids == ["host-xyz"]
+
+
+@pytest.mark.parametrize(
+    "sdk_error",
+    [
+        pytest.param(SandboxValidationError("unknown secret service"), id="422"),
+        pytest.param(SandboxConflictError("secrets need the secrets proxy"), id="409"),
+    ],
+)
+async def test_acquire_refuses_entries_drukbox_rejects(
+    sdk_error: Exception,
+    patched_real_sandbox: list[_FakeSandbox],
+    patched_sandbox_api: list[_FakeAPI],
+):
+    """Drukbox refuses the entries: the call fails on that answer. There is no
+    second attempt without them, and no key reaches a VM."""
+    api = _FakeAPI(create_raises=sdk_error)
+    patched_sandbox_api.append(api)
+
+    with pytest.raises(type(sdk_error)) as excinfo:
+        async with sandbox_client.acquire(secrets=_ENTRIES):
+            pass
+
+    assert excinfo.value is sdk_error
+    assert api.created_secrets == [_ENTRIES]
+    assert patched_real_sandbox == []
 
 
 async def test_acquire_passes_through_fatal_create_failure(

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -8,6 +9,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from conftest import PROFILE_PROBE, installation_key
 from druks.durable.enums import AgentCallStatus
 from druks.harnesses.base import Harness
 from druks.harnesses.claude import ClaudeHarness
@@ -23,14 +25,17 @@ from druks.harnesses.exceptions import (
     HarnessUsageLimitError,
     Retry,
 )
+from druks.harnesses.profiles import Profile, get_profile
 from druks.sandbox.datastructures import (
     AgentInvocation,
     AgentResult,
     Credentials,
     HarnessRunResult,
+    HomeFile,
 )
 from druks.sandbox.exceptions import SandboxUnreachable
 from druks.sandbox.host import Host
+from druks.user_settings.models import SettingsOverride
 
 
 @dataclass
@@ -521,13 +526,12 @@ def test_agent_result_names_the_agent_in_its_failure():
 
 @pytest.fixture
 def agent_profile():
-    from druks.harnesses.profiles import Profile
-
     return Profile(
         harness_class=ClaudeHarness,
         model="anthropic/claude-opus-4-7",
         subscription=SimpleNamespace(id="subscription-1", account_id="acc"),
         api_key=None,
+        secrets={},
         billing="subscription",
         effort="high",
         timeout=60,
@@ -586,3 +590,52 @@ async def test_run_agent_carries_a_taxonomy_failure_as_itself(ctx: SimpleNamespa
     )
 
     assert result.error is timeout
+
+
+async def test_claude_api_key_stays_on_the_server(
+    ctx: SimpleNamespace, druks_db, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Under api_key billing the VM is created with the key as a Drukbox entry and
+    holds a placeholder. The key reaches no invocation, VM file, artifact, or result."""
+    key = (await installation_key()).value.decrypt()
+    await SettingsOverride.set_agent_billing(PROFILE_PROBE.id, "api_key")
+    profile = await get_profile(PROFILE_PROBE.id, None)
+    result_event = {
+        "type": "result",
+        "subtype": "success",
+        "structured_output": {"ok": True},
+        "total_cost_usd": 0.01,
+    }
+    run = _FakeRun(stdout_chunks=[json.dumps(result_event).encode() + b"\n"])
+    sandbox = _fake_sandbox(run)
+    sandbox.run_prompt = functools.partial(Host.run_prompt, sandbox)
+    sandbox._exec = functools.partial(Host._exec, sandbox)
+    settings = SimpleNamespace(
+        sandbox=SimpleNamespace(service_url="x", service_token="x", timeout=30.0, image="x"),
+        harness_config_root=tmp_path / "harnesses",
+        skills_dir=None,
+    )
+    monkeypatch.setattr("druks.sandbox.host.load_settings", lambda: settings)
+
+    result = await Host.run_agent(
+        sandbox,
+        agent="evaluate",
+        profile=profile,
+        prompt="p",
+        schema={"type": "object"},
+        artifact_dir=ctx.artifact_dir,
+        call_id="call-9",
+    )
+
+    assert result.status is AgentCallStatus.SUCCEEDED
+    assert result.output == {"ok": True}
+    [start] = sandbox.calls
+    assert not start.kwargs["extra_env"]
+    assert key not in " ".join(start.kwargs["cmd"])
+    assert key not in start.kwargs["stdin_data"].decode()
+    bundle = start.kwargs["credentials_bundle"]
+    assert not bundle.github_token
+    assert not any(type(entry) is HomeFile for entry in bundle.home)
+    for artifact in (ctx.artifact_dir / "call-9").iterdir():
+        assert key not in artifact.read_text()
+    assert key not in repr(result) and key not in repr(profile)

--- a/backend/tests/test_warm_host_rotation.py
+++ b/backend/tests/test_warm_host_rotation.py
@@ -1,10 +1,27 @@
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 import druks.workflows as sdk
 import pytest
+from drukbox_sdk import Secret
 from druks.sandbox.constants import SANDBOX_HOST_ROTATE_BEFORE_SECONDS
 from druks.workflows import Workflow
+
+
+def _profile(secrets: dict[str, Secret], secrets_id: str = "") -> SimpleNamespace:
+    return SimpleNamespace(secrets=secrets, secrets_id=secrets_id)
+
+
+_ENTRY = Secret(
+    "sk-real",
+    host="api.anthropic.com",
+    auth_variable="ANTHROPIC_API_KEY",
+    auth_header="x-api-key",
+    auth_prefix="",
+)
+_NONE = _profile({})
+_ANTHROPIC = _profile({"anthropic": _ENTRY}, "anthropic.20260907T110000")
 
 
 @dataclass
@@ -17,11 +34,15 @@ class _FakeSandboxClient:
     def __init__(self, *, lease: timedelta) -> None:
         self.lease = lease
         self.provisions: list[str] = []
+        self.secrets: list[dict[str, Secret]] = []
         self.released: list[str] = []
 
-    async def provision(self, *, idempotency_key: str, template: str | None) -> _FakeSandbox:
+    async def provision(
+        self, *, idempotency_key: str, secrets: dict[str, Secret], template: str | None
+    ) -> _FakeSandbox:
         assert template is None
         self.provisions.append(idempotency_key)
+        self.secrets.append(secrets)
         host_id = f"host-{len(self.provisions)}"
         return _FakeSandbox(id=host_id, expires_at=datetime.now(UTC) + self.lease)
 
@@ -46,8 +67,8 @@ async def test_warm_host_reused_while_lease_covers_another_call(monkeypatch):
     monkeypatch.setattr(sdk, "sandbox_client", fake)
     flow = _warm_workflow()
 
-    first = await flow._lease_host()
-    second = await flow._lease_host()
+    first = await flow._lease_host(_NONE)
+    second = await flow._lease_host(_NONE)
 
     assert first == second == "host-1"
     assert fake.provisions == ["wf-1:sandbox"]
@@ -62,13 +83,66 @@ async def test_warm_host_rotates_when_lease_cannot_cover_a_call(monkeypatch):
     monkeypatch.setattr(sdk, "sandbox_client", fake)
     flow = _warm_workflow()
 
-    first = await flow._lease_host()
-    second = await flow._lease_host()
+    first = await flow._lease_host(_NONE)
+    second = await flow._lease_host(_NONE)
 
     assert first == "host-1"
     assert second == "host-2"
     assert fake.released == ["host-1"]
     assert fake.provisions == ["wf-1:sandbox", "wf-1:sandbox"]
+
+
+@pytest.mark.asyncio
+async def test_warm_host_keeps_its_entries_across_calls(monkeypatch):
+    """Calls with the same entries keep the host created with those entries."""
+    fake = _FakeSandboxClient(lease=timedelta(hours=2))
+    monkeypatch.setattr(sdk, "sandbox_client", fake)
+    flow = _warm_workflow()
+
+    first = await flow._lease_host(_ANTHROPIC)
+    second = await flow._lease_host(_profile({"anthropic": _ENTRY}, _ANTHROPIC.secrets_id))
+
+    assert first == second == "host-1"
+    assert fake.provisions == ["wf-1:sandbox:anthropic.20260907T110000"]
+    assert fake.secrets == [{"anthropic": _ENTRY}]
+    assert fake.released == []
+
+
+@pytest.mark.asyncio
+async def test_warm_host_rotates_when_a_call_needs_other_entries(monkeypatch):
+    """A host holds only the entries it was created with. A call that needs other
+    entries gets a fresh host under a new provisioning key."""
+    fake = _FakeSandboxClient(lease=timedelta(hours=2))
+    monkeypatch.setattr(sdk, "sandbox_client", fake)
+    flow = _warm_workflow()
+
+    first = await flow._lease_host(_ANTHROPIC)
+    second = await flow._lease_host(_NONE)
+
+    assert first == "host-1"
+    assert second == "host-2"
+    assert fake.released == ["host-1"]
+    assert fake.provisions == ["wf-1:sandbox:anthropic.20260907T110000", "wf-1:sandbox"]
+    assert fake.secrets == [{"anthropic": _ENTRY}, {}]
+
+
+@pytest.mark.asyncio
+async def test_provisioning_key_names_the_pasted_key(monkeypatch):
+    """A replay after a crash starts with no held host and presents its key again.
+    The same pasted key finds the host. A replaced key asks for a fresh host."""
+    fake = _FakeSandboxClient(lease=timedelta(hours=2))
+    monkeypatch.setattr(sdk, "sandbox_client", fake)
+    replaced = _profile({"anthropic": _ENTRY}, "anthropic.20260907T120000")
+
+    await _warm_workflow()._lease_host(_ANTHROPIC)
+    await _warm_workflow()._lease_host(_ANTHROPIC)
+    await _warm_workflow()._lease_host(replaced)
+
+    assert fake.provisions == [
+        "wf-1:sandbox:anthropic.20260907T110000",
+        "wf-1:sandbox:anthropic.20260907T110000",
+        "wf-1:sandbox:anthropic.20260907T120000",
+    ]
 
 
 @pytest.mark.asyncio
@@ -79,5 +153,5 @@ async def test_no_warm_host_when_reuse_disabled(monkeypatch):
     monkeypatch.setattr(sdk, "sandbox_client", fake)
     flow = _warm_workflow(reuse=False)
 
-    assert await flow._lease_host() is None
+    assert await flow._lease_host(_NONE) is None
     assert fake.provisions == []

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -301,10 +301,18 @@ Druks registers two subscription providers, `anthropic` and `openai`. Each
 also accepts an API key. Both connect from **Settings → Providers**. The
 connection flow stores each credential in Postgres. Druks refreshes a
 subscription token on a schedule. It creates the CLI credential file inside
-each sandbox, or passes the key in the CLI environment. It does not copy a
-host login. This is a capability connection for the requesting account. In a
-fresh `none`-mode install, the first completed subscription connection also
-creates the operator account. See [access control](#public-urls-and-access-control).
+each sandbox. It does not copy a host login. This is a capability connection
+for the requesting account. In a fresh `none`-mode install, the first
+completed subscription connection also creates the operator account. See
+[access control](#public-urls-and-access-control).
+
+An API key for `claude` never enters the sandbox. Druks gives the key to
+Drukbox as a secret entry when it creates the sandbox. The sandbox holds a
+placeholder in `ANTHROPIC_API_KEY`. The Drukbox secrets proxy swaps the
+placeholder for the key in the `x-api-key` header of each request to
+`api.anthropic.com`. The Drukbox deployment must run the secrets proxy. Without
+it, Drukbox refuses the sandbox and the call fails. Codex, Pi, and OpenCode
+still receive the key inside the sandbox.
 
 **Add provider** searches Models.dev for providers that use one API key.
 Druks caches the directory in Redis for one day for search and provider details.

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -398,7 +398,8 @@ profile.model_id  # the model as that CLI names it, provider prefix stripped
 profile.model     # "provider/model"
 profile.effort
 profile.billing   # "subscription" | "api_key"
-profile.key       # the provider API key under api_key billing, else None
+profile.secrets   # the Drukbox entries that put the key in the VM as a placeholder
+profile.key       # an API key the CLI reads from its invocation, else None
 ```
 
 `get_profile()` runs inside a workflow and reads the settings at call time for
@@ -406,6 +407,9 @@ the run's own actor, the same read Druks makes for the calling agent. A
 missing login or key raises before any sandbox work. Under subscription
 billing there is no key. The VM home holds the login of the calling agent's
 subscription only, so a nested CLI on another provider needs `api_key` billing.
+Under `api_key` billing on `claude`, the VM holds the key as a placeholder in
+`ANTHROPIC_API_KEY`, the variable the entry names. A nested CLI reads it from
+the environment. Codex, Pi, and OpenCode read the key from `profile.key`.
 
 Do not ask the framework to infer domain side effects from agent prose.
 The prompt or a subsequent explicit step owns those actions.
@@ -451,7 +455,8 @@ MCP server the workspace credentials itself.
 
 Keep durable state outside the VM. A workflow can set
 `steps_reuse_sandbox = True` to retain one host across a segment. Druks releases
-the host at a gate and at workflow exit. It rotates the host near lease expiry.
+the host at a gate and at workflow exit. It rotates the host near lease expiry,
+and when the next agent call needs other secret entries.
 
 ### Borrow a browser session
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "asyncssh>=2.22",
-    "drukbox-python-sdk>=0.1.0",
+    "drukbox-python-sdk>=0.2.0",
     # 0.138 adds app.frontend(), which serves an app's shipped dist/.
     "fastapi>=0.138.0",
     "githubkit[auth-app]>=0.15.5",

--- a/uv.lock
+++ b/uv.lock
@@ -522,14 +522,14 @@ wheels = [
 
 [[package]]
 name = "drukbox-python-sdk"
-version = "0.1.0"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/01/73e978566c3c6670ec2f5fcbd4829508f4f3edb992fa01856a120ef4f7b0/drukbox_python_sdk-0.1.0.tar.gz", hash = "sha256:d81cb31f865f67c01b28d531989525f9367bbbae0a335835aa61ad4400756715", size = 18394, upload-time = "2026-08-26T19:44:28.841Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/b1/3e9e802bc3421eb190fb41804112d13bfc75c1515bc0c34a31e23a38f35f/drukbox_python_sdk-0.2.0.tar.gz", hash = "sha256:08e64c2318b55bcd52fad8dda08ac69f76e4e1d1fe2e7bbc73c1186e51fe7789", size = 20035, upload-time = "2026-09-07T10:51:49.012Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/f7/70dc580b901cbb6eec1fd6aa12cfa5c87f9ba8854840793ce59c534b8a11/drukbox_python_sdk-0.1.0-py3-none-any.whl", hash = "sha256:9a72cc443404d40bbdb23b08e691ff89746130b88e5bc2ac2e375f93eafebe04", size = 12186, upload-time = "2026-08-26T19:44:27.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/4f/695698ffe986138cc1a7c796228dd447bda8cb45777d467798cc0df76df9/drukbox_python_sdk-0.2.0-py3-none-any.whl", hash = "sha256:2651dbff2642730e02a56ff3be99e4ae532df3ba4bb6077674f636d2d6699711", size = 13068, upload-time = "2026-09-07T10:51:47.797Z" },
 ]
 
 [[package]]
@@ -580,7 +580,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "dbos", specifier = ">=2.30" },
-    { name = "drukbox-python-sdk", specifier = ">=0.1.0" },
+    { name = "drukbox-python-sdk", specifier = ">=0.2.0" },
     { name = "fastapi", specifier = ">=0.138.0" },
     { name = "fastmcp", specifier = ">=3.4.4,<4" },
     { name = "githubkit", extras = ["auth-app"], specifier = ">=0.15.5" },


### PR DESCRIPTION
## What changes

- `drukbox-python-sdk>=0.2.0`. The lockfile follows.
- `Client.acquire`, `Client.provision`, and `Client.ephemeral` take `secrets` and hand the map to `SandboxAPI.create_host`.
- An agent call resolves its profile once. `Agent._run` passes it to `Workflow._lease_host`, `_runner`, and `Host.run_agent`. `Host.run_agent` no longer resolves the profile a second time.
- `Harness.get_secrets(key)` returns the Drukbox entries for an API key. The base returns none. `ClaudeHarness` returns a custom entry on `api.anthropic.com` with `ANTHROPIC_API_KEY`, `x-api-key`, and an empty prefix.
- `Profile.secrets` carries those entries. `Profile.key` is `None` when an entry carries the key. Codex, Pi, and OpenCode keep the key in `Profile.key` and in their invocation. Rebased on #459: the profile keeps its `api_key` row, and `key` stays a property.
- `ClaudeHarness.build_invocation` no longer sets `ANTHROPIC_API_KEY`. The sandbox receives the placeholder from Drukbox at creation.
- A warm host keeps the entries it was created with. When the next call needs other entries, the run releases the host and provisions a fresh one. The provisioning key of a warm host and of an ephemeral host names the pasted key the host holds: the provider and the key row's `updated_at`. A replay with the same key finds its host, and a replaced key asks for a fresh one. No secret material enters the key.
- `Host.run_prompt` no longer looks up the fallback account's subscription when a call carries no credential.
- `docs/configuration.md` describes the Claude API-key path and the secrets proxy requirement. `docs/writing-an-app.md` documents `profile.secrets` and the new meaning of `profile.key`.

## Where this differs from the ticket

- The ticket asks to pass the placeholder variable to Claude's invocation. The Claude CLI reads `ANTHROPIC_API_KEY` from the sandbox environment, so the invocation needs no variable and none is passed. `build_invocation` keeps the `key` parameter for signature parity with the other harnesses and never reads it.
- The ticket asks for a fresh provisioning key when the entries change. The key names the pasted key, not a random value. A random key would leave a duplicate host after a step retry or a replay.
- The ticket does not mention the fallback lookup in `Host.run_prompt`. With no key in the invocation, that lookup would have pushed the fallback account's subscription into an API-key sandbox. This PR removes it.
- The ticket names `test_sandbox_host.py`. Nothing there changes. The `Host.run_agent` tests live in `test_sandboxed_harness.py`, which got the changes.
- Drukbox never serves a request with secrets from its warm pool. A Claude API-key call always provisions a fresh sandbox.

## Names

- `Harness.get_secrets` — the Drukbox entries that put an API key in the sandbox as a placeholder.
- `Profile.secrets` — the entries of the resolved profile.
- `secrets` — the same map as a parameter on `Client.acquire`, `Client.provision`, `Client.ephemeral`, `Workflow._lease_host`, and `agents._runner`.
- `profile` — the resolved profile as a parameter on `Host.run_agent`. It replaces `account_id`.
- `Profile.secrets_id` — which pasted key the entries carry, as provider and `updated_at`. Empty without entries.
- `Workflow._host_secrets_id` — the `secrets_id` the warm host was created with.
- `provisioning_key` — Drukbox's idempotency key from the parts that name a host. An empty part is left out.
- `value` — the decrypted key inside `get_profile`.
- Tests: `_claude_profile`, `_ENTRIES`, `_ANTHROPIC`, `_SHARED_ENTRY`.

## Gates

- `uv run ruff check backend`: clean.
- `uv run ruff format --check backend`: clean.
- The touched test files pass locally with the proof app installed. CI runs the full suite.

## Review

Codex adversarial review, one finding.

- Applied (medium): after a worker crash, a replay presented a provisioning key that named only the entry names. Drukbox returned the pre-crash host, and a key the operator replaced in between stayed in use. The key now names the pasted key on the warm path and on the ephemeral path, and tests cover replay with the same key and with a replaced key.
