### PR TITLE
Pin the subscription handoff contract on rotate_token (DRU-473)

### DIFF
--- a/backend/tests/test_provider_auth.py
+++ b/backend/tests/test_provider_auth.py
@@ -322,6 +322,51 @@ async def test_rotation_lock_is_released_after_refresh(monkeypatch, druks_db):
     assert not await druks.redis.get_client().get(f"druks:harness:refresh:{connection.id}")
 
 
+async def test_two_mints_inside_the_margin_rotate_once_and_read_the_same_token(
+    monkeypatch, druks_db
+):
+    # Two boxes mint at once inside the margin: the lock elects one grant, and
+    # the second mint reloads and answers with the token the first one stored.
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30)
+    )
+    calls = _mock_post(
+        monkeypatch,
+        _resp(200, {"access_token": "new", "refresh_token": "R1", "expires_in": 28800}),
+    )
+    first = await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    second = await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert (first.action, second.action) == ("refreshed", "fresh")
+    assert len(calls) == 1
+    token = AnthropicProvider.load_token(await ProviderSubscription.reload(connection.id), now=_NOW)
+    assert token.access_token == "new"
+    assert token.expires_at == second.expires_at == _NOW + timedelta(seconds=28800)
+
+
+async def test_a_failed_refresh_keeps_a_live_token_to_serve(monkeypatch, druks_db):
+    # The mint answers a box with the stored token while it is valid. A refresh
+    # that fails inside the margin changes nothing the box can see.
+    soon = _NOW + timedelta(minutes=30)
+    connection = await _seed_claude(access="old", refresh="R0", expires_at=soon)
+    _mock_post(monkeypatch, httpx.ConnectError("boom"))
+    result = await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    assert (result.action, result.error) == ("failed", "network")
+    token = AnthropicProvider.load_token(await ProviderSubscription.reload(connection.id), now=_NOW)
+    assert (token.access_token, token.expires_at) == ("old", soon)
+
+
+async def test_a_failed_refresh_of_an_expired_token_leaves_nothing_to_serve(monkeypatch, druks_db):
+    # Nothing valid is left, so the mint answers 503 and the exchange retries.
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_NOW - timedelta(minutes=1)
+    )
+    _mock_post(monkeypatch, httpx.ConnectError("boom"))
+    await AnthropicProvider.rotate_token(connection.id, now=_NOW)
+    with pytest.raises(OAuthTokenError) as error:
+        AnthropicProvider.load_token(await ProviderSubscription.reload(connection.id), now=_NOW)
+    assert error.value.tag == "token_expired"
+
+
 async def test_disconnect_removes_only_the_addressed_login(druks_db):
     mine = await _seed_claude(provider_email="a@example.com")
     other = await _seed_claude(provider_email="b@example.com")


### PR DESCRIPTION
## What changed

Three tests on the real `rotate_token` pin the subscription handoff contract of ADR 0030 in `druks-adrs`: two mints inside the margin rotate once and read the same token, a failed refresh keeps a live token to serve, and a failed refresh of an expired token leaves nothing to serve.

The record holds the evidence. Anthropic revokes the previous access token at the refresh, at once. OpenAI keeps it valid. Both were measured on the production host on 2026-09-07. The contract: Druks rotates only while the subscription is idle or the token is urgent, then orders a refresh for every live grant through the exchange endpoint that drukbox added in czpython/drukbox#46. DRU-474 and DRU-476 carry the contract.

Fixes [DRU-473](https://linear.app/fellaworks/issue/DRU-473/spike-determine-subscription-token-validity-after-refresh-and-exchange).

## Risk

Tests only. No production behavior, API contract, migration, or documentation change in this repository.

## Verification

- `uv run ruff check backend` and `uv run ruff format --check backend` — passed.
- `uv run pytest backend/` after the proof app install — see the checks on this PR for the full suite; the touched file's tests pass locally.
- Frontend gates were not run; the frontend is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
