### PR TITLE
Deploy the secrets exchange and proxy with internal HTTP mint routing (DRU-472)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,8 +37,9 @@ docker compose ps
 curl -fsS http://127.0.0.1:8001/health
 ```
 
-Verification: `web`, `postgres`, `redis`, and `drukbox` operate without
-restarts. The health endpoint returns `{"status":"ok"}`.
+Verification: `docker compose ps` lists `web`, `postgres`, `redis`, `drukbox`,
+`drukbox-exchange`, and `drukbox-proxy` as up, and none of them restarts. The
+health endpoint returns `{"status":"ok"}`.
 
 ## 4. Preflight
 

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -156,6 +156,14 @@ class Sandbox(BaseModel):
     service_token: str = ""
     # Empty → drukbox decides.
     image: str = ""
+    # The mint base URL the secrets exchange dials for an issuer value. It is
+    # the web process on the host loopback, over plain HTTP, on every shape.
+    # It never derives from the dashboard, webhook, ingress, or provider
+    # settings. Only an explicit value changes it.
+    issuer_url: str = "http://127.0.0.1:8001"
+    # The secrets exchange, for refresh orders and the doctor probe. The
+    # exchange binds the host loopback.
+    exchange_url: str = "http://127.0.0.1:8781"
     # The browser home: browser containers boot on this provider with this image.
     browser_sandbox_provider: str = "docker"
     browser_sandbox_image: str = "ghcr.io/czpython/druks/browser:latest"

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -7,6 +7,7 @@ import tomllib
 from collections.abc import Callable, Mapping, MutableMapping
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import tomlkit
 
@@ -48,6 +49,13 @@ _OWNED_ENV_KEYS = frozenset(
         "DRUKS_SANDBOX_SERVICE_URL",
         "DRUKS_SANDBOX_SERVICE_TOKEN",
         "DRUKS_SANDBOX_IMAGE",
+        "SECRETS_KEY",
+        "SECRETS_PROXY_URL",
+        "SECRETS_PROXY_CA_FILE",
+        "SECRETS_EXCHANGE_URL",
+        "SECRETS_EXCHANGE_BIND_HOST",
+        "SECRETS_EXCHANGE_PORT",
+        "DRUKS_SECRETS_PROXY_BIND_HOST",
     }
 )
 _KNOWN_TOML_KEYS = {
@@ -63,6 +71,7 @@ _KNOWN_TOML_KEYS = {
     "secrets": (
         "postgres_password",
         "secrets_key",
+        "drukbox_secrets_key",
     ),
     "paths": ("data_dir", "harness_config_root"),
     "sandbox": (
@@ -70,6 +79,9 @@ _KNOWN_TOML_KEYS = {
         "service_url",
         "service_token",
         "image",
+        "proxy_url",
+        "issuer_url",
+        "exchange_url",
         "browser_login_proxy",
         "browser_login_tz",
         "timeout",
@@ -168,6 +180,7 @@ webhook_host = ""
 [secrets]
 postgres_password = ""
 secrets_key = ""
+drukbox_secrets_key = ""
 
 # Host paths.
 [paths]
@@ -180,6 +193,16 @@ provider = ""
 service_url = ""
 service_token = ""
 image = ""
+# The secrets proxy, at the address a sandbox dials. A sandbox sends its HTTPS
+# through it. The docker shape uses the Docker bridge gateway. A remote shape
+# names the address of this host that its sandboxes reach, for example the
+# tailnet address on exe. docker-sbx runs no proxy and leaves it empty.
+proxy_url = ""
+# The mint base URL the exchange dials, and the exchange address. Both default
+# to the host loopback. Leave them empty unless web or the exchange listens
+# elsewhere.
+issuer_url = ""
+exchange_url = ""
 # An HTTP proxy for the login window. The login then leaves from a different IP
 # than the box. Use it for sign-in flows that refuse the box IP. Examples:
 # http://172.17.0.1:8888, or http://user:pass@host:port for a proxy with a user
@@ -213,6 +236,8 @@ def _fresh_values(*, provider: str, home: str) -> tuple[tuple[tuple[str, ...], s
             (("sandbox", "service_url"), "http://127.0.0.1:8780"),
             (("sandbox", "service_token"), "dev-token"),
             (("sandbox", "image"), "ghcr.io/czpython/druks/sandbox:latest"),
+            # Sandbox containers reach the host at the bridge gateway.
+            (("sandbox", "proxy_url"), "http://172.17.0.1:8880"),
         )
     elif provider == "exe":
         shape = (
@@ -244,6 +269,7 @@ def _fresh_values(*, provider: str, home: str) -> tuple[tuple[tuple[str, ...], s
         (("sandbox", "provider"), provider),
         (("secrets", "postgres_password"), _hex_secret()),
         (("secrets", "secrets_key"), _secrets_key()),
+        (("secrets", "drukbox_secrets_key"), _secrets_key()),
         (("paths", "data_dir"), f"{home.rstrip('/')}/druks-data"),
         (("paths", "harness_config_root"), f"{home.rstrip('/')}/.config/druks/harnesses"),
         *shape,
@@ -357,6 +383,7 @@ def _render_env(
     # start without it. A compose-side default would replace that safe stop
     # with a known token.
     service_tokens = _get_string(config, ("sandbox", "service_token"))
+    proxy_url = _get_string(config, ("sandbox", "proxy_url"))
 
     sections = (
         (
@@ -383,6 +410,10 @@ def _render_env(
             (
                 ("DEFAULT_HOST_PROVIDER", provider),
                 ("SERVICE_TOKENS", service_tokens),
+                ("SECRETS_KEY", _get_string(config, ("secrets", "drukbox_secrets_key"))),
+                ("SECRETS_PROXY_URL", proxy_url),
+                # The proxy binds the address sandboxes dial and nothing else.
+                ("DRUKS_SECRETS_PROXY_BIND_HOST", urlsplit(proxy_url).hostname or ""),
             ),
         ),
     )
@@ -467,6 +498,7 @@ def _collect_gaps(config: dict[str, Any]) -> list[str]:
         for path in (
             ("secrets", "postgres_password"),
             ("secrets", "secrets_key"),
+            ("secrets", "drukbox_secrets_key"),
             ("identity", "mode"),
             ("sandbox", "provider"),
             ("sandbox", "service_url"),
@@ -509,6 +541,8 @@ def _collect_gaps(config: dict[str, Any]) -> list[str]:
         for key in ("EXE_API_TOKEN", "TAILSCALE_TAILNET"):
             if not _get_string(config, ("sandbox", "exe", key)):
                 gaps.append(f"sandbox.exe.{key} is empty")
+        if not _get_string(config, ("sandbox", "proxy_url")):
+            gaps.append("sandbox.proxy_url is empty")
     elif provider != "docker" and not any(
         value for key, value in provider_environment.items() if not _is_reserved_env_key(key)
     ):

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -94,6 +94,16 @@ timeout = 180
     assert settings.sandbox.timeout == 180.0
 
 
+def test_only_an_explicit_issuer_url_changes_the_mint_base(tmp_path):
+    public = {"endpoint": "https://druks.example.com", "webhook_host": "hooks.example.com"}
+    assert make_settings(tmp_path, urls=public).sandbox.issuer_url == "http://127.0.0.1:8001"
+
+    settings = make_settings(tmp_path, urls=public, sandbox={"issuer_url": "http://10.0.0.5:8001"})
+
+    assert settings.sandbox.issuer_url == "http://10.0.0.5:8001"
+    assert settings.sandbox.exchange_url == "http://127.0.0.1:8781"
+
+
 def test_auth_mode_environment_variable_is_ignored(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("DRUKS_CONFIG", raising=False)

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -35,6 +35,10 @@ def _read_toml(path: Path) -> dict:
         return tomllib.load(config_file)
 
 
+def drukbox_key(tmp_path: Path) -> str:
+    return _read_toml(tmp_path / "druks.toml")["secrets"]["drukbox_secrets_key"]
+
+
 def test_fresh_exe_render_matches_the_deployment_contract(tmp_path):
     env_path = tmp_path / ".env"
 
@@ -48,6 +52,9 @@ def test_fresh_exe_render_matches_the_deployment_contract(tmp_path):
     assert values["EXE_DEFAULT_IMAGE"] == "ghcr.io/boldsoftware/exeuntu:latest"
     assert values["DRUKS_AUTH_HEADER"] == "X-ExeDev-Email"
     assert values["SERVICE_TOKENS"] == config["sandbox"]["service_token"]
+    assert values["SECRETS_KEY"] == config["secrets"]["drukbox_secrets_key"]
+    assert "SECRETS_PROXY_URL" not in values
+    assert "DRUKS_SECRETS_PROXY_BIND_HOST" not in values
     assert values["DRUKS_DATA_DIR"] == "/home/op/druks-data"
     assert values["DRUKS_HARNESS_CONFIG_ROOT"] == "/home/op/.config/druks/harnesses"
     assert config["paths"]["harness_config_root"] == values["DRUKS_HARNESS_CONFIG_ROOT"]
@@ -57,6 +64,7 @@ def test_fresh_exe_render_matches_the_deployment_contract(tmp_path):
         assert config["sandbox"]["exe"][key] == ""
         assert key not in values
     assert len(config["secrets"]["postgres_password"]) == 64
+    assert len(config["secrets"]["drukbox_secrets_key"]) == 44
     assert len(config["sandbox"]["service_token"]) == 64
     assert (tmp_path / ".gitignore").read_text().splitlines() == [
         "druks.toml",
@@ -148,6 +156,12 @@ def test_docker_shape_matches_local_wiring_and_ignores_provider_environment(tmp_
     # Rendered on every shape. Without it, drukbox stops instead of falling
     # back to a known token.
     assert values["SERVICE_TOKENS"] == "dev-token"
+    assert values["SECRETS_KEY"] == drukbox_key(tmp_path)
+    # Sandbox containers reach the host at the bridge gateway. The proxy binds
+    # that address only.
+    assert values["SECRETS_PROXY_URL"] == "http://172.17.0.1:8880"
+    assert values["DRUKS_SECRETS_PROXY_BIND_HOST"] == "172.17.0.1"
+    assert "DRUKS_WEBHOOK_HOST" not in values
     assert "DOCKER_HOST" not in values
 
 
@@ -435,6 +449,9 @@ def test_setup_toml_is_the_settings_source(tmp_path, monkeypatch):
             "urls.endpoint=https://druks.example",
             "urls.webhook_host=hooks.druks.example",
             "sandbox.image=druks-sandbox:test",
+            "sandbox.proxy_url=http://100.64.0.10:8880",
+            "sandbox.issuer_url=http://10.0.0.5:8001",
+            "sandbox.exchange_url=http://10.0.0.5:8781",
             "sandbox.timeout=240",
             "sandbox.exe.EXE_API_TOKEN=exe-token",
             "sandbox.exe.TAILSCALE_TAILNET=tail.ts.net",
@@ -453,7 +470,99 @@ def test_setup_toml_is_the_settings_source(tmp_path, monkeypatch):
     assert settings.sandbox.service_token == config["sandbox"]["service_token"]
     assert settings.sandbox.service_url == config["sandbox"]["service_url"]
     assert settings.sandbox.image == config["sandbox"]["image"]
+    assert settings.sandbox.issuer_url == config["sandbox"]["issuer_url"]
+    assert settings.sandbox.exchange_url == config["sandbox"]["exchange_url"]
     assert settings.sandbox.timeout == float(config["sandbox"]["timeout"])
+
+
+def test_a_hosted_install_keeps_the_internal_issuer_url(tmp_path, monkeypatch):
+    env_path = tmp_path / ".env"
+    _run(
+        env_path,
+        set_values=(
+            "urls.endpoint=https://druks.example",
+            "urls.webhook_host=hooks.druks.example",
+            "sandbox.proxy_url=http://100.64.0.10:8880",
+            "sandbox.exe.EXE_API_TOKEN=exe-token",
+            "sandbox.exe.TAILSCALE_TAILNET=tail.ts.net",
+        ),
+    )
+    monkeypatch.setenv("DRUKS_CONFIG", str(tmp_path / "druks.toml"))
+
+    settings = Settings()
+
+    assert settings.sandbox.issuer_url == "http://127.0.0.1:8001"
+    assert settings.sandbox.exchange_url == "http://127.0.0.1:8781"
+
+
+def test_exe_shape_requires_the_proxy_address(tmp_path):
+    env_path = tmp_path / ".env"
+    printed = []
+
+    rc = _run(
+        env_path,
+        set_values=(
+            "sandbox.exe.EXE_API_TOKEN=exe-token",
+            "sandbox.exe.TAILSCALE_TAILNET=tail.ts.net",
+        ),
+        print_fn=printed.append,
+    )
+
+    assert rc == GAPS_EXIT_CODE
+    assert "sandbox.proxy_url is empty" in "\n".join(printed)
+    assert _run(env_path, set_values=("sandbox.proxy_url=http://100.64.0.10:8880",)) == 0
+    values = read_env(env_path)
+    assert values["SECRETS_PROXY_URL"] == "http://100.64.0.10:8880"
+    assert values["DRUKS_SECRETS_PROXY_BIND_HOST"] == "100.64.0.10"
+
+
+def test_a_remote_shape_without_a_proxy_renders_no_proxy_address(tmp_path):
+    """docker-sbx swaps its own placeholders. Setup knows no provider names, so
+    the generic shape has no proxy gap. Drukbox names the fix at the first box."""
+    env_path = tmp_path / ".env"
+
+    rc = _run(
+        env_path,
+        provider="docker-sbx",
+        set_values=(
+            "identity.header=X-Forwarded-Email",
+            "sandbox.docker-sbx.GATEWAY_SSH_HOST=10.0.0.5",
+        ),
+    )
+
+    assert rc == 0
+    values = read_env(env_path)
+    assert values["GATEWAY_SSH_HOST"] == "10.0.0.5"
+    assert "SECRETS_PROXY_URL" not in values
+    assert "DRUKS_SECRETS_PROXY_BIND_HOST" not in values
+
+
+@pytest.mark.parametrize(
+    ("assignment", "gap"),
+    [
+        ("env.SECRETS_KEY=wrong", "env.SECRETS_KEY is reserved by druks"),
+        (
+            "sandbox.exoscale.SECRETS_PROXY_URL=http://elsewhere:8880",
+            "sandbox.exoscale.SECRETS_PROXY_URL is reserved by druks",
+        ),
+    ],
+)
+def test_a_copy_of_a_secrets_setting_is_a_named_gap(tmp_path, assignment, gap):
+    env_path = tmp_path / ".env"
+    printed = []
+
+    rc = _run(
+        env_path,
+        provider="exoscale",
+        set_values=("sandbox.exoscale.EXOSCALE_API_KEY=key", assignment),
+        print_fn=printed.append,
+    )
+
+    assert rc == GAPS_EXIT_CODE
+    assert gap in "\n".join(printed)
+    values = read_env(env_path)
+    assert values["SECRETS_KEY"] == drukbox_key(tmp_path)
+    assert "SECRETS_PROXY_URL" not in values
 
 
 @pytest.mark.parametrize("repository", ["ghcr.io/acme/templates", "docker.io/acme/templates"])
@@ -465,6 +574,7 @@ def test_exe_template_registry_uses_existing_provider_contract(tmp_path, reposit
             env_path,
             print_fn=printed.append,
             set_values=(
+                "sandbox.proxy_url=http://100.64.0.10:8880",
                 "sandbox.exe.EXE_API_TOKEN=exe-token",
                 "sandbox.exe.TAILSCALE_TAILNET=tail.ts.net",
                 f"sandbox.exe.EXE_IMAGE_REGISTRY={repository}",

--- a/deploy/compose.docker-sbx.yaml
+++ b/deploy/compose.docker-sbx.yaml
@@ -1,8 +1,10 @@
-# The Docker Sandboxes overlay. It connects the drukbox services, and the
-# gateway that compose.yaml declares behind the "gateway" profile, to the
-# sandboxd daemon on the host. sandboxd runs as one user. The overlay mounts
-# four things: the daemon socket, the sbx CLI of the host, the CLI auth store,
-# and the workspace root. The mount of the host CLI keeps the CLI version and
+# The Docker Sandboxes overlay. It connects the drukbox services, the secrets
+# exchange, and the gateway that compose.yaml declares behind the "gateway"
+# profile, to the sandboxd daemon on the host. This provider runs no secrets
+# proxy. sbx swaps the placeholders itself, and the exchange pushes each issuer
+# value into the sandbox through the sbx CLI. sandboxd runs as one user. The
+# overlay mounts four things: the daemon socket, the sbx CLI of the host, the
+# CLI auth store, and the workspace root. The mount of the host CLI keeps the CLI version and
 # the daemon version equal. The auth store and the workspace root keep the
 # same path inside and outside the container, because the daemon resolves
 # paths on its own filesystem. The services run with the uid of the daemon
@@ -41,6 +43,11 @@ services:
       <<: *sbx-env
 
   drukbox-janitor:
+    <<: *sbx-rig
+    environment:
+      <<: *sbx-env
+
+  drukbox-exchange:
     <<: *sbx-rig
     environment:
       <<: *sbx-env

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,10 +1,11 @@
-# The Druks stack: web, Postgres, Redis, and the drukbox sandbox control plane.
-# This one file applies to all install shapes. install.sh writes COMPOSE_PROFILES
-# to .env. The "hosted" profile starts the Caddy edge and the janitor. The
-# docker-sbx provider adds one overlay file, because its drukbox has different
-# mounts. All services use the host network. Services connect to Postgres and
-# Redis on 127.0.0.1. drukbox connects to each sandbox at the address the
-# provider returns.
+# The Druks stack: web, Postgres, Redis, the drukbox sandbox control plane, its
+# secrets exchange, and the secrets proxy. This one file applies to all install
+# shapes. install.sh writes COMPOSE_PROFILES to .env. The "hosted" profile
+# starts the Caddy edge and the janitor. The "proxy" profile starts the secrets
+# proxy, on every provider but docker-sbx. The docker-sbx provider adds one
+# overlay file, because its drukbox has different mounts. All services use the
+# host network. Services connect to Postgres and Redis on 127.0.0.1. drukbox
+# connects to each sandbox at the address the provider returns.
 
 x-druks: &druks
   image: ghcr.io/czpython/druks:${DRUKS_TAG:-latest}
@@ -68,8 +69,13 @@ x-drukbox: &drukbox
     TAILSCALE_ENABLED: ${TAILSCALE_ENABLED:-false}
     # Browser-login containers run sshd for the druks user, not for root.
     DOCKER_SSH_USERNAME: druks
+    # The public certificate of the secrets proxy, delivered into each sandbox
+    # with secrets. The proxy writes its CA into the volume at its first start.
+    # The key file is readable by the proxy user only.
+    SECRETS_PROXY_CA_FILE: /secrets-proxy-ca/mitmproxy-ca-cert.pem
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
+    - secrets_proxy_ca:/secrets-proxy-ca:ro
   depends_on:
     postgres:
       condition: service_healthy
@@ -128,6 +134,38 @@ services:
     # that API.
     healthcheck:
       disable: true
+
+  # The secrets exchange. The proxy asks it for the value behind a placeholder.
+  # On docker-sbx it pushes issuer values into each sandbox. Every shape runs it.
+  # It binds the host loopback, its default, so only the proxy and web reach it.
+  # It fetches issuer values from web over plain HTTP on the loopback.
+  drukbox-exchange:
+    <<: *drukbox
+    entrypoint: [".venv/bin/python", "-m", "secrets_exchange"]
+    # The image HEALTHCHECK probes the drukbox HTTP API. This service is not
+    # that API.
+    healthcheck:
+      disable: true
+
+  # The secrets proxy. A sandbox sends its HTTPS through it. The proxy swaps the
+  # placeholder for the value. Every provider but docker-sbx needs it, since sbx
+  # swaps its own placeholders. install.sh enables the profile. The proxy binds
+  # the host of [sandbox].proxy_url and no other address. A proxy on a public
+  # address accepts requests from anyone. druks setup renders the bind host. The
+  # CA lives in a volume. It survives a restart, so a sandbox that installed it
+  # still trusts the proxy.
+  drukbox-proxy:
+    image: ${DRUKS_SECRETS_PROXY_IMAGE:-ghcr.io/czpython/drukbox/proxy:latest}
+    profiles: ["proxy"]
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      SECRETS_EXCHANGE_URL: http://127.0.0.1:8781
+      SECRETS_PROXY_BIND_HOST: ${DRUKS_SECRETS_PROXY_BIND_HOST:-127.0.0.1}
+    volumes:
+      - secrets_proxy_ca:/home/mitmproxy/.mitmproxy
+    depends_on:
+      - drukbox-exchange
 
   # The identity edge and webhook TLS. Only hosted installs run it. A local
   # box gets the dashboard directly on 127.0.0.1:8001. Stock image with no
@@ -198,5 +236,6 @@ volumes:
   redis_data:
   postgres_data:
   druks_sandbox_keys:
+  secrets_proxy_ca:
   caddy_data:
   caddy_config:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ host-run development template for that environment plane.
 | `[urls]` | Dashboard callback base URL and public webhook hostname |
 | `[secrets]` | Generated deployment secrets |
 | `[paths]` | Host data and harness configuration paths |
-| `[sandbox]` | Drukbox provider, service URL, token behavior, and image override |
+| `[sandbox]` | Drukbox provider, service URL and token, image override, and the proxy, mint, and exchange addresses |
 | `[sandbox.<provider>]` | Provider environment passed through to the remote stack |
 | `[env]` | Additional deployment environment settings rendered verbatim |
 
@@ -310,9 +310,11 @@ An API key for `claude` never enters the sandbox. Druks gives the key to
 Drukbox as a secret entry when it creates the sandbox. The sandbox holds a
 placeholder in `ANTHROPIC_API_KEY`. The Drukbox secrets proxy swaps the
 placeholder for the key in the `x-api-key` header of each request to
-`api.anthropic.com`. The Drukbox deployment must run the secrets proxy. Without
-it, Drukbox refuses the sandbox and the call fails. Codex, Pi, and OpenCode
-still receive the key inside the sandbox.
+`api.anthropic.com`. The Compose stack runs the secrets proxy on every provider
+but docker-sbx. See
+[the secrets exchange and the secrets proxy](deployment.md#the-secrets-exchange-and-the-secrets-proxy).
+Without it, Drukbox refuses the sandbox and the call fails. Codex, Pi, and
+OpenCode still receive the key inside the sandbox.
 
 **Add provider** searches Models.dev for providers that use one API key.
 Druks caches the directory in Redis for one day for search and provider details.
@@ -370,6 +372,9 @@ credential is missing.
 | `sandbox.service_token` | Drukbox API token |
 | `sandbox.timeout` | Control-plane request timeout. The default is 180 seconds |
 | `sandbox.image` | Optional provider image override |
+| `sandbox.proxy_url` | The secrets proxy, at the address a sandbox dials. The docker shape sets `http://172.17.0.1:8880`. docker-sbx leaves it empty |
+| `sandbox.issuer_url` | The mint base URL the secrets exchange dials. The default is `http://127.0.0.1:8001` on every shape. Only an explicit value changes it |
+| `sandbox.exchange_url` | The secrets exchange, for refresh orders and the doctor probe. The default is `http://127.0.0.1:8781` |
 | `sandbox.browser_login_proxy` | Login-window egress proxy. An empty value keeps the box IP |
 | `sandbox.browser_login_tz` | Login-window timezone (IANA zone). An empty value keeps the container default |
 
@@ -512,6 +517,11 @@ While a stored row depends on the old key, keep that key. If you lose each key f
 row, you cannot recover that secret. Reconnect the OAuth grants. Enter the
 static tokens again. Log in to the affected browser sessions again. Validation
 and API errors do not include submitted secret values.
+
+`secrets.drukbox_secrets_key` encrypts the secret entries of each sandbox in
+the Drukbox database. The installer generates it and renders it as
+`SECRETS_KEY` for the Drukbox API and the secrets exchange. Rotate it as you
+rotate `secrets_key`, with the new key first.
 
 The encryption envelope does **not** currently cover harness subscription
 payloads or notification webhook URLs. Postgres stores them as

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,26 +6,28 @@ icon: "server"
 ---
 
 `compose.yaml` holds the full stack. It includes Druks, Postgres, Redis,
-Drukbox, the janitor, the SSH gateway, and the Caddy edge. The `web` service
-contains the DBOS durable engine and serves the dashboard SPA. The `drukbox`
-service is the sandbox control plane. `install.sh` writes `COMPOSE_PROFILES` to
-`.env`. Then plain
-`docker compose` commands in the install directory do the correct thing.
+Drukbox, its secrets exchange, the secrets proxy, the janitor, the SSH gateway,
+and the Caddy edge. The `web` service contains the DBOS durable engine and
+serves the dashboard SPA. The `drukbox` service is the sandbox control plane.
+`install.sh` writes `COMPOSE_PROFILES` to `.env`. After that, `docker compose`
+in the install directory starts the services of the selected shape.
 
-A **local** install (`DRUKS_PROVIDER=docker`) runs bare, with no profiles.
+A **local** install (`DRUKS_PROVIDER=docker`) enables `COMPOSE_PROFILES=proxy`.
 `drukbox` mounts the Docker socket of the host. Sandboxes are sibling
 containers on the host daemon. The dashboard is on `127.0.0.1:8001`, with no
 Caddy. See [Full local](full-local.md).
 
 A **remote** installation uses each other `DRUKS_PROVIDER` value. It enables
-`COMPOSE_PROFILES=hosted`. This profile includes a remote Drukbox control plane,
-the periodic janitor, and stock Caddy. Caddy supplies the identity edge and
-proxy with a bind-mounted Caddyfile.
+`COMPOSE_PROFILES=hosted,proxy`. The `hosted` profile includes a remote Drukbox
+control plane, the periodic janitor, and stock Caddy. Caddy supplies the
+identity edge and proxy with a bind-mounted Caddyfile. The `proxy` profile
+includes the secrets proxy.
 
-The **docker-sbx** provider also layers `compose.docker-sbx.yaml` and enables
-the `gateway` profile. The overlay connects the Drukbox services to the
-[Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) daemon of the host
-(microVM sandboxes). The gateway is the SSH path into them.
+The **docker-sbx** provider layers `compose.docker-sbx.yaml` and enables
+`COMPOSE_PROFILES=hosted,gateway`. The overlay connects the Drukbox services to
+the [Docker Sandboxes](https://docs.docker.com/ai/sandboxes/) daemon of the host
+(microVM sandboxes). The gateway is the SSH path into them. This provider runs
+no secrets proxy, because sbx swaps the placeholders itself.
 
 Prepare the host first. Install `docker-sbx`. Put the service user in the `kvm` group. Run
 `sbx login`. Then run `sbx daemon start -d --policy balanced`. The installer stops
@@ -170,6 +172,48 @@ Webhook URLs become
 `https://druks.example.com/mcp`
 ([Connect your agent](connect-your-agent.md)). Leave
 `[urls].webhook_host` blank to bring your own ingress instead.
+
+## The secrets exchange and the secrets proxy
+
+A sandbox holds a placeholder for each credential, never the value. Two
+Drukbox services put the value into the request:
+
+- `drukbox-exchange` runs `python -m secrets_exchange` from the Drukbox image
+  on every shape. It keeps each issuer value in memory. It binds
+  `127.0.0.1:8781`, so only the proxy and the Druks web process reach it.
+- `drukbox-proxy` runs `ghcr.io/czpython/drukbox/proxy` under the `proxy`
+  profile. A sandbox sends its HTTPS through it. The proxy swaps the
+  placeholder for the value. It binds port 8880 at the host of
+  `[sandbox].proxy_url` and no other address. A proxy on a public address
+  accepts requests from anyone.
+
+`[sandbox].proxy_url` is the address a sandbox dials. The docker shape sets
+`http://172.17.0.1:8880`, the Docker bridge gateway. A remote shape sets the
+address of the Druks host that its sandboxes reach. On exe that is the tailnet
+address of the Druks box, and the tailnet policy needs one grant from
+`tag:sandbox` to that box on `tcp:8880`. The proxy is the only connection from
+a sandbox to the Druks host. docker-sbx runs no proxy and leaves the value
+empty.
+
+The proxy writes its CA into the `secrets_proxy_ca` volume at its first start.
+The Drukbox API mounts the volume read-only and reads the public certificate
+at `SECRETS_PROXY_CA_FILE`. Only the proxy user can read the key file. A
+sandbox with secrets installs the certificate at boot and trusts the proxy for
+the hosts with a registered secret. No service in the deployment uses that CA.
+The exchange fetches an issuer value from the Druks web process at
+`[sandbox].issuer_url`, `http://127.0.0.1:8001` on every shape, over plain
+HTTP on the host loopback. The API and the exchange trust no extra CA. There
+is no public mint route.
+
+Drukbox encrypts the secret entries of each sandbox with `SECRETS_KEY`. The
+installer generates `[secrets].drukbox_secrets_key` and renders it as
+`SECRETS_KEY` for the API and the exchange. Pin the proxy image with
+`DRUKS_SECRETS_PROXY_IMAGE` in `[env]`, at the tag of
+`DRUKS_SANDBOX_SERVICE_IMAGE`.
+
+An install from before these services has `SECRETS_KEY` in `[env]` or in
+`[sandbox.<provider>]`. Move that value to `[secrets].drukbox_secrets_key`,
+set `[sandbox].proxy_url`, and run the installer again.
 
 ## Update / redeploy
 

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -10,12 +10,14 @@ The local shape keeps every component on one machine:
 browser -> Druks :8001 -> Drukbox :8780 -> Docker sandbox containers
                          \
                           -> SSH from Druks to each container
+sandbox container -> secrets proxy 172.17.0.1:8880 -> secrets exchange 127.0.0.1:8781
 ```
 
-Compose runs Druks, Postgres, Redis, and Drukbox. The Drukbox service holds the
-Docker socket of the host. Its `docker` provider starts sandboxes as sibling
-containers on the host daemon. Agent work stays in these isolated containers.
-It does not run in the Druks process.
+Compose runs Druks, Postgres, Redis, Drukbox, the secrets exchange, and the
+secrets proxy. The Drukbox service holds the Docker socket of the host. Its
+`docker` provider starts sandboxes as sibling containers on the host daemon.
+Agent work stays in these isolated containers. It does not run in the Druks
+process.
 
 ## Prerequisites
 
@@ -43,9 +45,12 @@ The local shape needs no authored values, so the first run goes all the way:
 - It creates `~/.config/druks/harnesses` for optional harness configuration.
 - It generates the database password and the stored-secret key.
 - It pulls images and applies migrations.
-- It starts Druks, Postgres, Redis, and Drukbox. Drukbox listens on `127.0.0.1:8780`.
-- It uses `COMPOSE_FILE=compose.yaml:compose.override.yaml` without Caddy or the
-  janitor profiles.
+- It starts Druks, Postgres, Redis, Drukbox, the secrets exchange, and the
+  secrets proxy. Drukbox listens on `127.0.0.1:8780`. The exchange listens on
+  `127.0.0.1:8781`. The proxy listens on `172.17.0.1:8880`, where sandbox
+  containers reach it.
+- It uses `COMPOSE_FILE=compose.yaml:compose.override.yaml` and
+  `COMPOSE_PROFILES=proxy`, without Caddy or the janitor.
 
 Drukbox controls sandboxes through the mounted `/var/run/docker.sock`. The
 installer records the group ID of the socket in `.env`. This value gives the
@@ -53,6 +58,10 @@ non-root service user access to the socket. Drukbox keeps its schema in a
 `drukbox` database in the same Postgres instance. It does not require a separate
 data store. If sandbox SSH is unreachable on macOS, enable host networking in
 the Docker Desktop settings.
+
+A sandbox holds a placeholder for each credential and sends its HTTPS through
+the secrets proxy. See
+[the secrets exchange and the secrets proxy](deployment.md#the-secrets-exchange-and-the-secrets-proxy).
 
 For the bundled `software_factory` app, connect its GitHub App after startup.
 Use **Settings → Connections → Services** in the dashboard. Create the app there, or paste the

--- a/druks.toml.example
+++ b/druks.toml.example
@@ -21,4 +21,6 @@ secrets_key = ""
 service_url = ""
 service_token = ""
 image = ""
+issuer_url = ""
+exchange_url = ""
 timeout = 180

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -145,17 +145,18 @@ main() {
     set_env_var DRUKS_DOCKER_GID "$(stat -c '%g' /var/run/docker.sock)"
   fi
 
-  # Shape selection, written to .env. Then a plain `docker compose` command in
-  # this directory does the correct thing. The `hosted` profile turns on the
-  # Caddy edge and the janitor. A `docker` box runs bare, with the dashboard
-  # directly on :8001. docker-sbx also layers the overlay (drukbox connected to
-  # the host sandboxd) and enables the SSH gateway. compose.override.yaml loads
-  # last. Operator additions thus win over the repo files, and the installer
-  # never overwrites them.
+  # Shape selection, written to .env. After that, `docker compose` in this
+  # directory starts the services of the shape. The `hosted` profile adds the
+  # Caddy edge and the janitor. The `proxy` profile adds the secrets proxy on
+  # every provider but docker-sbx, where sbx swaps the placeholders itself.
+  # A `docker` box runs without Caddy, with the dashboard on :8001. docker-sbx
+  # also layers the overlay, which connects drukbox to the host sandboxd, and
+  # enables the SSH gateway. compose.override.yaml loads last, so operator
+  # additions win over the repo files, and the installer never overwrites them.
   set_env_var COMPOSE_FILE "compose.yaml:compose.override.yaml"
   case "$PROVIDER" in
     docker)
-      set_env_var COMPOSE_PROFILES ""
+      set_env_var COMPOSE_PROFILES "proxy"
       ;;
     docker-sbx)
       set_env_var COMPOSE_FILE "compose.yaml:compose.docker-sbx.yaml:compose.override.yaml"
@@ -178,7 +179,7 @@ main() {
       fi
       ;;
     *)
-      set_env_var COMPOSE_PROFILES "hosted"
+      set_env_var COMPOSE_PROFILES "hosted,proxy"
       ;;
   esac
 


### PR DESCRIPTION
## What changed

- `deploy/compose.yaml`: `drukbox-exchange` runs `python -m secrets_exchange` from the drukbox image on every shape, bound to `127.0.0.1:8781`. `drukbox-proxy` runs `ghcr.io/czpython/drukbox/proxy` behind the `proxy` profile. It binds the host of `[sandbox].proxy_url` on port 8880, reads the exchange at `http://127.0.0.1:8781`, and keeps its CA in the `secrets_proxy_ca` volume. The drukbox image services mount that volume read-only and read the certificate at `SECRETS_PROXY_CA_FILE`.
- `deploy/compose.docker-sbx.yaml`: the exchange gets the sbx mounts and environment.
- `backend/druks/settings.py`: `sandbox.issuer_url`, default `http://127.0.0.1:8001`, and `sandbox.exchange_url`, default `http://127.0.0.1:8781`.
- `backend/druks/setup_env.py`: `[secrets] drukbox_secrets_key`, generated on the first write and rendered as `SECRETS_KEY`. `[sandbox] proxy_url`, rendered as `SECRETS_PROXY_URL` and, by its host, as `DRUKS_SECRETS_PROXY_BIND_HOST`. The docker shape seeds `http://172.17.0.1:8880`. A blank value is a gap on the exe shape. The exchange and proxy variables are reserved.
- `scripts/install.sh`: `COMPOSE_PROFILES` is `proxy` for docker, `hosted,gateway` for docker-sbx, and `hosted,proxy` for every other provider.
- `docs/configuration.md`, `docs/deployment.md`, `docs/full-local.md`, `INSTALL.md`, and `druks.toml.example` describe the two services, the proxy address, the CA, and the issuer transport.

## Where this differs from the ticket

- The proxy binds `127.0.0.1` when `.env` carries no bind host. A `:?` interpolation would break docker-sbx, where the proxy service is inactive but Compose still interpolates the file.
- `drukbox-exchange` inherits the anchor's Docker socket mount, like the janitor. It does not use it.

## Names

- `drukbox-exchange`, `drukbox-proxy` — the services, beside `drukbox-janitor` and `drukbox-gateway`.
- `proxy` — the profile, beside `hosted` and `gateway`.
- `secrets_proxy_ca` — the CA volume.
- `DRUKS_SECRETS_PROXY_IMAGE`, `DRUKS_SECRETS_PROXY_BIND_HOST` — the image knob beside `DRUKS_SANDBOX_SERVICE_IMAGE`, and the rendered bind host.
- `secrets.drukbox_secrets_key`, `sandbox.proxy_url`, `sandbox.issuer_url`, `sandbox.exchange_url` — the TOML keys.
- Tests: `drukbox_key`.

## Gates

- `ruff check backend`: clean.
- `ruff format --check backend`: clean.
- `pytest backend/` with the proof app installed: 1658 passed.
- `docker compose config` with `COMPOSE_PROFILES` at `proxy`, at `hosted,proxy`, and at `hosted,gateway` with the overlay: renders. The exchange carries `SECRETS_KEY`, the drukbox database, and the read-only CA mount. The proxy binds the rendered host and starts after the exchange. With the overlay the exchange carries the sandboxd socket and the sbx environment.

## Review

No Codex review. Own checklist pass over every touched file, end to end: reflowed three paragraphs and renamed the test helper. Nothing else found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
