### PR TITLE
Add box grants and issue Claude subscription tokens (DRU-474)

### DIFF
--- a/backend/druks/agents.py
+++ b/backend/druks/agents.py
@@ -25,6 +25,7 @@ from druks.harnesses.profiles import Profile, get_profile
 from druks.prompts import render_prompt
 from druks.sandbox import gate as sandbox_gate
 from druks.sandbox.client import provisioning_key, sandbox_client
+from druks.sandbox.models import SandboxGrant
 from druks.sandbox.templates import get_template_id
 from druks.settings import load_settings
 from druks.usage.models import UsageScrape
@@ -50,15 +51,29 @@ async def _runner(
     # the runner — fresh per call, so nothing (connection or credential) is held across steps.
     if host_id:
         vm = sandbox_client.attach(host_id=host_id)
+    elif profile.services and (
+        grant := await SandboxGrant.lookup(workflow_id, step, profile.services)
+    ):
+        # A crashed attempt left its box behind. Its grant finds it again.
+        vm = sandbox_client.resume(host_id=grant.host_id)
     else:
         template = None
         if workflow.sandbox:
             template = await get_template_id(workflow.sandbox)
             await set_run_phase("provisioning_vm")
+        # A box that fetches gets its own grant, and the key names it. A replay
+        # finds the box through the grant, above.
+        grant, entries, key = None, {}, profile.secrets_id
+        if profile.services:
+            grant, entries = await SandboxGrant.create(
+                run_id=workflow_id, scoped_to=step, services=profile.services
+            )
+            key = grant.id
         vm = sandbox_client.ephemeral(
-            idempotency_key=provisioning_key(workflow_id, step, profile.secrets_id),
-            secrets=profile.secrets,
+            idempotency_key=provisioning_key(workflow_id, step, key),
+            secrets={**profile.secrets, **entries},
             template=template,
+            grant=grant,
         )
     async with vm as box:
         yield await workflow.get_workspace(box)

--- a/backend/druks/api/server.py
+++ b/backend/druks/api/server.py
@@ -43,6 +43,7 @@ from druks.mcp.routes import router as mcp_router
 from druks.notifications.routes import external_router as notifications_external_router
 from druks.notifications.routes import router as notifications_router
 from druks.redis import close_client
+from druks.sandbox.routes import router as secrets_router
 from druks.services.exceptions import OauthPageError, ServiceNotConnectedError
 from druks.services.routes import oauth_router
 from druks.services.routes import router as service_identities_router
@@ -281,7 +282,8 @@ async def _unhandled_exception_handler(
 # boundary test pins the split. The auth and harness-connection routers mount
 # ungated because each of their routes carries its own resolver (/me and the
 # connection flow must answer during none/zero setup; capability management
-# admits only the session identity).
+# admits only the session identity). The secrets router authenticates a box's
+# grant bearer and nothing else.
 _identity_gate = [Depends(current_account)]
 app.include_router(health_router)
 # Before the webhook catch-all ({hook_path:path}): declaration order is match order.
@@ -289,6 +291,7 @@ app.include_router(notifications_external_router)
 app.include_router(webhooks_router)
 app.include_router(auth_router)
 app.include_router(providers_router)
+app.include_router(secrets_router)
 app.include_router(browser_sessions_router)
 app.include_router(settings_router, dependencies=_identity_gate)
 app.include_router(agents_router, dependencies=_identity_gate)

--- a/backend/druks/core/tasks.py
+++ b/backend/druks/core/tasks.py
@@ -36,11 +36,10 @@ async def refresh_catalogs() -> None:
 async def _refresh() -> dict[str, object]:
     subscriptions = await ProviderSubscription.list_all()
 
-    # A refresh 401s a VM mid-call holding the old token, so a due rotation
-    # runs only while its subscription is idle — busy defers to the next tick;
-    # urgent rotates regardless. rotate_token no-ops rows outside their
-    # margin. Snapshot plain values: each refresh commits and expires the
-    # session's ORM objects mid-loop.
+    # A rotation ends the token every box holds, so a due rotation runs only
+    # while its subscription is idle, or once urgent. rotate_token no-ops
+    # outside the margin and requests a refresh for every live box. Snapshot
+    # plain values: each refresh commits and expires the session's ORM objects.
     rows = [
         (
             subscription.provider,

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -108,6 +108,12 @@ class Harness(ABC):
     def get_secrets(cls, key: str) -> dict[str, Secret]:
         return {}
 
+    @classmethod
+    def get_services(cls, subscription: ProviderSubscription) -> dict[str, str]:
+        """The subscription a box fetches, by Drukbox catalog service name.
+        Empty for a CLI that reads its credential from a file."""
+        return {}
+
     @property
     def model_id(self) -> str:
         """The model as the CLI names it, without the provider namespace."""

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -69,8 +69,9 @@ class ClaudeHarness(Harness):
         skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
+        # Both accepted for signature parity. The sandbox holds a placeholder
+        # for the subscription token or the key. Drukbox delivers it.
         subscription: ProviderSubscription | None = None,
-        # Accepted for signature parity. The sandbox entry carries the key.
         key: str | None = None,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
@@ -132,7 +133,6 @@ class ClaudeHarness(Harness):
                 github_token=github_token,
                 include_plugins=include_plugins,
                 skills=skills,
-                subscription=subscription,
             ),
             env=extra_env,
             extra_artifact_filenames=("debug.log", "session.jsonl"),
@@ -189,8 +189,10 @@ class ClaudeHarness(Harness):
         return ("--mcp-config", json.dumps({"mcpServers": entries}))
 
     @classmethod
-    def auth_file(cls, subscription: ProviderSubscription) -> HomeFile:
-        return HomeFile(".claude/.credentials.json", json.dumps(dict(subscription.payload)))
+    def get_services(cls, subscription: ProviderSubscription) -> dict[str, str]:
+        # The catalog entry puts the placeholder in ANTHROPIC_AUTH_TOKEN, which
+        # the CLI sends as a bearer. It never refreshes a token from there.
+        return {AnthropicProvider.id: subscription.id}
 
     @classmethod
     def get_secrets(cls, key: str) -> dict[str, Secret]:
@@ -221,17 +223,14 @@ async def _get_credentials(
     github_token: str | None,
     include_plugins: bool = True,
     skills: tuple[str, ...] = (),
-    subscription: ProviderSubscription | None,
 ) -> Credentials:
-    """The Credentials bundle the runner pushes into the sandbox: the rendered
-    credentials file, plus any local config, plugins, and skills.
-    ``include_plugins=False`` skips the operator's plugin state, for prompts
-    that use no MCP server and would otherwise die on a misconfigured plugin."""
+    """The Credentials bundle the runner pushes into the sandbox: the local
+    config, plugins, and skills. No credential file: the sandbox holds a
+    placeholder for its token or key. ``include_plugins=False`` skips the
+    operator's plugin state, for prompts that use no MCP server and would
+    otherwise die on a misconfigured plugin."""
     config_dir = sandbox.harness_config_root / ClaudeHarness.name
-    home: list[HomeFile | HomeCopy] = []
-    if subscription:
-        home.append(ClaudeHarness.auth_file(subscription))
-    home += [
+    home: list[HomeFile | HomeCopy] = [
         HomeCopy(".claude.json", config_dir / ".claude.json"),
         HomeCopy(".claude/settings.json", config_dir / "settings.json"),
         HomeCopy(".claude/CLAUDE.md", config_dir / "CLAUDE.md"),

--- a/backend/druks/harnesses/profiles.py
+++ b/backend/druks/harnesses/profiles.py
@@ -23,6 +23,8 @@ class Profile:
     subscription: ProviderSubscription | None
     api_key: ProviderKey | None
     secrets: dict[str, Secret]
+    # Service name → the subscription the box fetches.
+    services: dict[str, str]
     billing: str
     effort: str
     timeout: int
@@ -45,8 +47,12 @@ class Profile:
 
     @property
     def secrets_id(self) -> str:
+        """What a box created for this profile holds: the pasted key, or the
+        subscription its grant fetches."""
         if self.secrets:
             return f"{self.api_key.provider}.{self.api_key.updated_at:%Y%m%dT%H%M%S}"
+        if self.services:
+            return ".".join(self.services.values())
         return ""
 
     @property
@@ -101,6 +107,7 @@ async def get_profile(agent_name: str, account_id: str | None) -> Profile:
     subscription = None
     provider_key = None
     secrets: dict[str, Secret] = {}
+    services: dict[str, str] = {}
     if billing == "api_key":
         provider_key = await ProviderKey.get(provider_id)
         if not provider_key:
@@ -109,6 +116,7 @@ async def get_profile(agent_name: str, account_id: str | None) -> Profile:
         secrets = harness_class.get_secrets(provider_key.value.decrypt())
     else:
         subscription = await ProviderSubscription.lookup(provider_id, account_id)
+        services = harness_class.get_services(subscription)
     timeout = (
         await SettingsOverride.agent_timeout(agent_name, agent.timeout, settings=settings)
     ).value
@@ -118,6 +126,7 @@ async def get_profile(agent_name: str, account_id: str | None) -> Profile:
         subscription=subscription,
         api_key=provider_key,
         secrets=secrets,
+        services=services,
         billing=billing,
         effort=(await SettingsOverride.agent_effort(agent_name, settings=settings)).value,
         # Capped so a single call always fits inside a fresh sandbox lease.

--- a/backend/druks/harnesses/providers.py
+++ b/backend/druks/harnesses/providers.py
@@ -1,9 +1,11 @@
+import asyncio
 import base64
 import hashlib
 import json
 import logging
 import re
 import secrets
+import time
 import urllib.parse
 from datetime import UTC, datetime, timedelta
 from typing import ClassVar
@@ -15,6 +17,8 @@ from pydantic import TypeAdapter
 from druks.core.utils.time import ensure_utc
 from druks.database import db_session
 from druks.redis import get_client
+from druks.sandbox import gate
+from druks.sandbox.client import sandbox_client
 from druks.sandbox.constants import MAX_AGENT_TIMEOUT_SECONDS
 from druks.usage.models import UsageScrape
 
@@ -33,7 +37,7 @@ from .models import ProviderCatalog, ProviderKey, ProviderSubscription
 
 logger = logging.getLogger(__name__)
 
-_GRANT_TIMEOUT_SECONDS = 30.0
+_TOKEN_REQUEST_TIMEOUT_SECONDS = 30.0
 _USAGE_TIMEOUT_SECONDS = 20.0
 _CATALOG_TIMEOUT_SECONDS = 20.0
 _OPENAI_MODELS_URL = "https://api.openai.com/v1/models"
@@ -53,9 +57,11 @@ _OPENAI_NON_CHAT_MARKERS = (
 # long — enough to authorize and paste, short enough that an abandoned attempt
 # clears.
 _CONNECT_PENDING_TTL_SECONDS = 600
-# Per-row refresh lock: five minutes outlives the provider grant timeout and
+# Per-row refresh lock: five minutes outlives the token request timeout and
 # expires before the next 15-minute cron tick if the holder dies mid-refresh.
 _REFRESH_LOCK_TTL_SECONDS = 300
+# How often a fetch asks again while another refresher holds the row lock.
+_LOCK_POLL_SECONDS = 0.5
 
 Token = OAuthToken | CodexToken
 
@@ -161,16 +167,45 @@ class Provider:
         raise NotImplementedError
 
     @classmethod
+    async def issue_token(cls, subscription_id: str, *, except_host_id: str = "") -> Token:
+        """The token a box can use now. A due token rotates first, while the
+        subscription is idle or the token is urgent. The gate holds every other
+        fetch and every new call until the rotation and its refresh requests end.
+        Raises :class:`OAuthTokenError` when the row holds nothing valid."""
+        row = await ProviderSubscription.reload(subscription_id)
+        if row and cls.refresh_is_due(row):
+            async with gate.shut(subscription_id) as is_idle:
+                if is_idle or cls.refresh_is_urgent(row):
+                    # A refresher that holds the row lock keeps it for its token
+                    # request. Wait for it, then read the row it advanced.
+                    deadline = time.monotonic() + _TOKEN_REQUEST_TIMEOUT_SECONDS
+                    rotation = await cls.rotate_token(
+                        subscription_id, except_host_id=except_host_id
+                    )
+                    while rotation.action == "locked" and time.monotonic() < deadline:
+                        await asyncio.sleep(_LOCK_POLL_SECONDS)
+                        rotation = await cls.rotate_token(
+                            subscription_id, except_host_id=except_host_id
+                        )
+            row = await ProviderSubscription.reload(subscription_id)
+        if not row:
+            raise exceptions.OAuthTokenError("no_credentials", "the subscription is disconnected")
+        return cls.load_token(row)
+
+    @classmethod
     async def rotate_token(
         cls,
         subscription_id: str,
         *,
         now: datetime | None = None,
         margin: timedelta | None = None,
+        except_host_id: str = "",
     ) -> RotationResult:
         """Refresh one subscription's token when it is inside the expiry margin.
         A Redis lock elects one refresher per row; the loser reports ``locked``
-        and never presents the refresh token a concurrent grant may have burned."""
+        and never presents the refresh token a concurrent token request may have burned.
+        A refresh that succeeds requests a refresh for every live box on the
+        subscription, except ``except_host_id``, whose answer carries it."""
         moment = now or _utc_now()
         row = await ProviderSubscription.reload(subscription_id)
         if not row:
@@ -239,11 +274,20 @@ class Provider:
             # the step's own commit would let a concurrent refresher take the
             # freed lock and re-present the superseded token.
             await db_session().commit()
+            # The refresh requests go out before the lock releases: a rotation
+            # ends the value every box on this subscription holds.
+            await sandbox_client.request_refreshes(row.id, except_host_id=except_host_id)
             return RotationResult(
                 cls.id, "refreshed", expires_at=new_expiry, subscription_id=row.id
             )
         finally:
             await redis.delete(lock_key)
+
+    @classmethod
+    def refresh_is_due(cls, subscription: ProviderSubscription) -> bool:
+        """Expiry inside the refresh margin, or past."""
+        _, expires_at = cls._refresh_state(dict(subscription.payload))
+        return bool(expires_at) and expires_at - _utc_now() <= cls.REFRESH_MARGIN
 
     @classmethod
     def refresh_is_urgent(cls, subscription: ProviderSubscription) -> bool:
@@ -517,7 +561,7 @@ async def _post_grant(url: str, body: dict) -> dict:
     """POST a refresh grant and return the parsed grant dict. Raises
     :class:`GrantError` tagged with why no usable grant came back."""
     try:
-        async with httpx.AsyncClient(timeout=_GRANT_TIMEOUT_SECONDS) as client:
+        async with httpx.AsyncClient(timeout=_TOKEN_REQUEST_TIMEOUT_SECONDS) as client:
             response = await client.post(url, json=body)
     except httpx.HTTPError as exc:
         logger.warning("token refresh request failed (%s): %s", url, exc, exc_info=True)
@@ -567,7 +611,7 @@ async def post_token(url: str, body: dict, *, form: bool) -> dict:
     parsed grant. Raises :class:`ConnectError` with the provider's error text on
     any failure, so the operator sees why the connect didn't take."""
     try:
-        async with httpx.AsyncClient(timeout=_GRANT_TIMEOUT_SECONDS) as client:
+        async with httpx.AsyncClient(timeout=_TOKEN_REQUEST_TIMEOUT_SECONDS) as client:
             if form:
                 response = await client.post(url, data=body)
             else:

--- a/backend/druks/sandbox/client.py
+++ b/backend/druks/sandbox/client.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import shlex
 from collections.abc import AsyncIterator
@@ -6,7 +7,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import asyncssh
-from drukbox_sdk import SandboxAPI, SandboxHost, Secret
+import httpx
+from drukbox_sdk import Issuer, SandboxAPI, SandboxHost, Secret
 from drukbox_sdk.exceptions import (
     SandboxAPIError,
     SandboxNotFoundError,
@@ -15,6 +17,7 @@ from drukbox_sdk.exceptions import (
 )
 from uuid_utils import uuid7
 
+from druks.durable.engine import _step_engine
 from druks.harnesses.exceptions import HarnessSandboxProvisioningError
 from druks.settings import load_settings
 
@@ -22,8 +25,13 @@ from .constants import SANDBOX_HOST_LEASE_SECONDS
 from .exceptions import HostGone, SandboxError, SandboxUnreachable, TemplateNotFound
 from .host import Host
 from .layout import get_helper_script_path, get_remote_home
+from .models import SandboxGrant
 
 logger = logging.getLogger(__name__)
+
+# The exchange answers a refresh request after it fetched the value again, so
+# one request takes one fetch round trip.
+_REQUEST_TIMEOUT_SECONDS = 5.0
 
 _DRUKS_SANDBOX_LOCAL_SCRIPT = Path(__file__).parent / "druks-sandbox.sh"
 
@@ -53,8 +61,9 @@ class Client:
         image_override: str | None = None,
         provider: str | None = None,
         sandbox_env: dict[str, str] | None = None,
-        secrets: dict[str, Secret] | None = None,
+        secrets: dict[str, Secret | Issuer] | None = None,
         template: str | None = None,
+        grant: SandboxGrant | None = None,
     ) -> AsyncIterator[Host]:
         """Acquire, yield, release: for a sandbox bound to one context manager body."""
         host_id: str | None = None
@@ -67,6 +76,7 @@ class Client:
                 sandbox_env=sandbox_env,
                 secrets=secrets,
                 template=template,
+                grant=grant,
             ) as host:
                 host_id = host.id
                 yield host
@@ -82,13 +92,15 @@ class Client:
         image_override: str | None = None,
         provider: str | None = None,
         sandbox_env: dict[str, str] | None = None,
-        secrets: dict[str, Secret] | None = None,
+        secrets: dict[str, Secret | Issuer] | None = None,
         template: str | None = None,
+        grant: SandboxGrant | None = None,
     ) -> AsyncIterator[Host]:
         """Create a new host (or reuse one matching ``idempotency_key``)
         and yield it with SSH connected. Closes SSH on exit but does NOT
         release the VM — pair with ``release`` for long-lived flows or
-        use ``ephemeral`` for one-shots."""
+        use ``ephemeral`` for one-shots. ``grant`` is the box's credential at
+        the issuer: bound to the box once it exists, revoked when no box comes."""
         key = idempotency_key or str(uuid7())
         api = self._api()
         try:
@@ -98,27 +110,35 @@ class Client:
             # worker dies frees its VM without a druks-side reconciler.
             expires_at = datetime.now(UTC) + timedelta(seconds=SANDBOX_HOST_LEASE_SECONDS)
             try:
-                record = await api.create_host(
-                    expires_at=expires_at,
-                    env=sandbox_env,
-                    idempotency_key=key,
-                    image=image or None,
-                    provider=provider,
-                    secrets=secrets,
-                    template=template,
-                )
-            except (SandboxProvisioningError, SandboxUnavailableError) as exc:
-                # Transient control-plane failures — a 502 the service raises
-                # when the provider/Tailscale/keyscan step fails, or a
-                # transport/503 SandboxUnavailableError. Classify them into the
-                # in-run retry path so a slow provider window recovers instead
-                # of dead-ending the run. Fatal SDK errors (auth, validation,
-                # conflict, not-found, generic response) are subclasses of the
-                # untouched SandboxAPIError base and fall through unretried.
-                raise HarnessSandboxProvisioningError(
-                    f"sandbox host provisioning failed: {exc}"
-                ) from exc
+                try:
+                    record = await api.create_host(
+                        expires_at=expires_at,
+                        env=sandbox_env,
+                        idempotency_key=key,
+                        image=image or None,
+                        provider=provider,
+                        secrets=secrets,
+                        template=template,
+                    )
+                except (SandboxProvisioningError, SandboxUnavailableError) as exc:
+                    # Transient control-plane failures — a 502 the service raises
+                    # when the provider/Tailscale/keyscan step fails, or a
+                    # transport/503 SandboxUnavailableError. Classify them into the
+                    # in-run retry path so a slow provider window recovers instead
+                    # of dead-ending the run. Fatal SDK errors (auth, validation,
+                    # conflict, not-found, generic response) are subclasses of the
+                    # untouched SandboxAPIError base and fall through unretried.
+                    raise HarnessSandboxProvisioningError(
+                        f"sandbox host provisioning failed: {exc}"
+                    ) from exc
+            except BaseException:
+                # The next attempt presents a new grant and a new key.
+                if grant:
+                    await grant.revoke()
+                raise
             logger.info("sandbox host created id=%s", record.id)
+            if grant:
+                await grant.bind(record.id)
             key_path = settings.sandbox_keys_dir / record.id
             if record.private_key:
                 settings.sandbox_keys_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -180,7 +200,17 @@ class Client:
         raise TemplateNotFound(f"sandbox template {setup_script_hash} does not exist")
 
     @staticmethod
+    async def _revoke_grant(host_id: str) -> None:
+        """The denial comes first, and its failure must not stop the cleanup
+        behind it."""
+        try:
+            await SandboxGrant.revoke_for_host(_step_engine(), host_id)
+        except Exception:  # noqa: BLE001 — a cleanup surface; log and move on
+            logger.exception("failed to revoke the grant of sandbox host %s", host_id)
+
+    @staticmethod
     async def _best_effort_delete(api: SandboxAPI, host_id: str) -> None:
+        await Client._revoke_grant(host_id)
         try:
             await api.delete_host(host_id)
         except SandboxNotFoundError:
@@ -224,8 +254,9 @@ class Client:
         image_override: str | None = None,
         provider: str | None = None,
         sandbox_env: dict[str, str] | None = None,
-        secrets: dict[str, Secret] | None = None,
+        secrets: dict[str, Secret | Issuer] | None = None,
         template: str | None = None,
+        grant: SandboxGrant | None = None,
     ) -> Host:
         """Create a host and return its handle without holding an SSH connection —
         the handle reconnects lazily when used (its id and lease expiry are readable
@@ -237,17 +268,68 @@ class Client:
             sandbox_env=sandbox_env,
             secrets=secrets,
             template=template,
+            grant=grant,
         ) as host:
             return host
+
+    async def reattach(self, *, host_id: str) -> Host:
+        """The handle of a box a crashed process left behind, found through its
+        grant. A box that is gone loses the grant, and the retry provisions anew."""
+        try:
+            async with self.attach(host_id=host_id) as host:
+                return host
+        except HostGone as exc:
+            await self._revoke_grant(host_id)
+            raise HarnessSandboxProvisioningError(f"sandbox host {host_id} is gone") from exc
+
+    @asynccontextmanager
+    async def resume(self, *, host_id: str) -> AsyncIterator[Host]:
+        """``ephemeral`` for a box that exists: reattach, then release on exit."""
+        host = await self.reattach(host_id=host_id)
+        try:
+            yield host
+        finally:
+            await host.aclose()
+            await self.release(host_id=host_id)
+
+    async def request_refreshes(self, subscription_id: str, *, except_host_id: str = "") -> None:
+        """Tell the exchange to fetch again for every live box on the
+        subscription: a rotation ended the value they hold. One attempt per
+        box, side by side, and a failure is a log line. The exchange refreshes
+        at expiry in any case. The box whose answer carries the new token
+        needs no request."""
+        boxes = [
+            (grant.host_id, service)
+            for grant in await SandboxGrant.list_live_for_subscription(subscription_id)
+            if grant.host_id != except_host_id
+            for service, held in grant.services.items()
+            if held == subscription_id
+        ]
+        exchange_url = load_settings().sandbox.exchange_url.rstrip("/")
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_SECONDS) as client:
+            answers = await asyncio.gather(
+                *(
+                    client.post(f"{exchange_url}/refresh/{host_id}/{service}")
+                    for host_id, service in boxes
+                ),
+                return_exceptions=True,
+            )
+        for (host_id, service), answer in zip(boxes, answers, strict=True):
+            if isinstance(answer, BaseException) or answer.status_code != 200:
+                logger.warning(
+                    "refresh request for box %s service %s failed: %s", host_id, service, answer
+                )
 
     async def release(self, *, host_id: str) -> None:
         """Terminate the VM. Idempotent and infallible — already-gone hosts
         no-op silently; any other failure is logged but not surfaced so
-        cleanup paths don't have to handle SDK errors at every call site."""
+        cleanup paths don't have to handle SDK errors at every call site.
+        The box's grant dies first, so the denial never waits on the VM."""
         api = self._api()
         settings = load_settings()
 
         try:
+            await self._revoke_grant(host_id)
             try:
                 await api.delete_host(host_id)
             except SandboxNotFoundError:

--- a/backend/druks/sandbox/exceptions.py
+++ b/backend/druks/sandbox/exceptions.py
@@ -34,6 +34,10 @@ class ExecFailed(SandboxError):
         self.exit_code = exit_code
 
 
+class GrantDenied(SandboxError):
+    """A fetch names no live grant for its bearer and service."""
+
+
 class HostGone(SandboxError):
     """The provider says this host no longer exists.
 

--- a/backend/druks/sandbox/gate.py
+++ b/backend/druks/sandbox/gate.py
@@ -12,9 +12,9 @@ from .constants import GATE_USERS_PREFIX, MAX_AGENT_TIMEOUT_SECONDS, ROTATING_PR
 # register in a zset scored by expiry, so a crashed caller ages out.
 _RUN_HORIZON = MAX_AGENT_TIMEOUT_SECONDS  # a sandbox run never outlives this; caps every wait
 _POLL = 2.0
-# The gate is only shut for the seconds a refresh takes; a short TTL means a
-# crashed holder frees the subscription fast instead of blocking it for the horizon.
-_SHUT_TTL_SECONDS = 60
+# The gate is shut for a rotation, a wait on another refresher's row lock, and
+# the refresh requests. A crashed holder frees the subscription when this lapses.
+_SHUT_TTL_SECONDS = 90
 
 
 @asynccontextmanager
@@ -43,11 +43,13 @@ async def use(subscription_id: str, call_id: str) -> AsyncIterator[None]:
 @asynccontextmanager
 async def shut(subscription_id: str) -> AsyncIterator[bool]:
     """Shut the connection's gate; yield True when idle — rotate now — else
-    defer to the next tick. Reopens on exit either way."""
+    defer. One holder at a time: a later rotator waits for the gate to reopen,
+    then holds it. Reopens on exit either way."""
     client = get_client()
     rotating = f"{ROTATING_PREFIX}{subscription_id}"
     users = f"{GATE_USERS_PREFIX}{subscription_id}"
-    await client.set(rotating, "1", ex=_SHUT_TTL_SECONDS)
+    while not await client.set(rotating, "1", nx=True, ex=_SHUT_TTL_SECONDS):
+        await asyncio.sleep(_POLL)
     try:
         await client.zremrangebyscore(users, "-inf", time.time())
         yield not await client.zcard(users)

--- a/backend/druks/sandbox/models.py
+++ b/backend/druks/sandbox/models.py
@@ -1,0 +1,149 @@
+import hashlib
+import hmac
+import secrets
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+from drukbox_sdk import Issuer
+from sqlalchemy import ForeignKey, LargeBinary, select, update
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship, selectinload
+
+from druks.core.models import Uuid7Pk
+from druks.database import db_session, get_session
+from druks.models import Base
+from druks.settings import load_settings
+
+from .constants import SANDBOX_HOST_LEASE_SECONDS
+from .exceptions import GrantDenied
+
+if TYPE_CHECKING:
+    from druks.durable.models import Run
+
+# The lifetime the exchange gives an answer without expires_at. A
+# subscription answer always carries one. Nothing polls on it.
+_ISSUER_REFRESH = "1h"
+
+
+class SandboxGrant(Base, Uuid7Pk):
+    """One box's credential at the issuer. The bearer rides only in the box's
+    issuer headers. The row keeps its hash, the run, and the services the box
+    can fetch."""
+
+    __tablename__ = "sandbox_grants"
+
+    run_id: Mapped[str] = mapped_column(ForeignKey("durable_runs.id", ondelete="CASCADE"))
+    run: Mapped["Run"] = relationship()
+    # What the box serves in its run: ``workflow`` for the warm box, the agent
+    # id for an ephemeral one. A replay finds the box through it.
+    scoped_to: Mapped[str]
+    # Bound once Drukbox returns the box. One box holds one grant.
+    host_id: Mapped[str | None] = mapped_column(unique=True)
+    token_hash: Mapped[bytes] = mapped_column(LargeBinary)
+    # Service name → the subscription the box fetches.
+    services: Mapped[dict[str, str]] = mapped_column(JSONB)
+    created_at: Mapped[datetime] = mapped_column(default=Base.utc_now)
+    expires_at: Mapped[datetime]
+    revoked_at: Mapped[datetime | None]
+
+    @classmethod
+    async def create(
+        cls, *, run_id: str, scoped_to: str, services: dict[str, str]
+    ) -> tuple["SandboxGrant", dict[str, Issuer]]:
+        """The committed grant and the issuer entries for its box. Committed
+        before the box exists: Drukbox fetches an issuer during provisioning."""
+        bearer = secrets.token_urlsafe(32)
+        now = Base.utc_now()
+        grant = cls(
+            run_id=run_id,
+            scoped_to=scoped_to,
+            services=services,
+            token_hash=hashlib.sha256(bearer.encode()).digest(),
+            created_at=now,
+            # The box lease bounds the grant: a box never outlives it.
+            expires_at=now + timedelta(seconds=SANDBOX_HOST_LEASE_SECONDS),
+        )
+        session = db_session()
+        session.add(grant)
+        await session.commit()
+        issuer_url = load_settings().sandbox.issuer_url.rstrip("/")
+        entries = {
+            service: Issuer(
+                url=f"{issuer_url}/api/secrets/{grant.id}/{service}",
+                headers={"Authorization": f"Bearer {bearer}"},
+                refresh=_ISSUER_REFRESH,
+            )
+            for service in services
+        }
+        return grant, entries
+
+    @classmethod
+    async def lookup(
+        cls, run_id: str, scoped_to: str, services: dict[str, str]
+    ) -> "SandboxGrant | None":
+        """The live grant bound to the box scoped to a workflow or an agent, for
+        these services. A replay finds the box a crashed process left behind."""
+        rows = await db_session().scalars(
+            select(cls)
+            .where(
+                cls.run_id == run_id,
+                cls.scoped_to == scoped_to,
+                cls.host_id.is_not(None),
+                cls.revoked_at.is_(None),
+            )
+            .order_by(cls.id.desc())
+        )
+        return next((grant for grant in rows if grant.is_live and grant.services == services), None)
+
+    @classmethod
+    async def authenticate(cls, grant_id: str, bearer: str, service: str) -> "SandboxGrant":
+        """The live grant of an active run that a fetch presents, read fresh,
+        or GrantDenied."""
+        grant = await db_session().scalar(
+            select(cls)
+            .options(selectinload(cls.run))
+            .where(cls.id == grant_id)
+            .execution_options(populate_existing=True)
+        )
+        if (
+            grant
+            and hmac.compare_digest(hashlib.sha256(bearer.encode()).digest(), grant.token_hash)
+            and service in grant.services
+            and grant.is_live
+            and grant.run.is_active
+        ):
+            return grant
+        raise GrantDenied(f"no live grant {grant_id} for service {service}")
+
+    @property
+    def is_live(self) -> bool:
+        return not self.revoked_at and self.expires_at > Base.utc_now()
+
+    async def bind(self, host_id: str) -> None:
+        self.host_id = host_id
+        await db_session().commit()
+
+    async def revoke(self) -> None:
+        self.revoked_at = Base.utc_now()
+        await db_session().commit()
+
+    @classmethod
+    async def revoke_for_host(cls, engine, host_id: str) -> None:
+        # Own transaction: a box release can run outside a step session.
+        async with get_session(engine) as session:
+            await session.execute(
+                update(cls)
+                .where(cls.host_id == host_id, cls.revoked_at.is_(None))
+                .values(revoked_at=Base.utc_now())
+            )
+            await session.commit()
+
+    @classmethod
+    async def list_live_for_subscription(cls, subscription_id: str) -> list["SandboxGrant"]:
+        """The live grants with a bound box that name the subscription."""
+        rows = await db_session().scalars(
+            select(cls).where(cls.host_id.is_not(None), cls.revoked_at.is_(None))
+        )
+        return [
+            grant for grant in rows if grant.is_live and subscription_id in grant.services.values()
+        ]

--- a/backend/druks/sandbox/routes.py
+++ b/backend/druks/sandbox/routes.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from druks.harnesses.exceptions import OAuthTokenError
+from druks.harnesses.models import ProviderSubscription
+from druks.harnesses.providers import get_provider
+
+from .exceptions import GrantDenied
+from .models import SandboxGrant
+
+# The grant bearer is the one credential here. Dashboard cookies, personal
+# access tokens, and the edge identity do not authorize a fetch.
+_bearer_scheme = HTTPBearer(auto_error=False, scheme_name="sandboxGrant")
+
+router = APIRouter(prefix="/api/secrets", tags=["secrets"])
+
+
+@router.get("/{grant_id}/{service}", include_in_schema=False)
+async def secret(
+    grant_id: str,
+    service: str,
+    bearer: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> JSONResponse:
+    """The value behind a box's placeholder. A 403 carries no reason. A 503
+    says the source holds nothing valid now, and the exchange retries."""
+    credential = bearer.credentials if bearer else ""
+    try:
+        grant = await SandboxGrant.authenticate(grant_id, credential, service)
+        subscription = await ProviderSubscription.get(grant.services[service])
+        if not subscription:
+            raise HTTPException(status_code=503)
+        token = await get_provider(subscription.provider).issue_token(
+            subscription.id, except_host_id=grant.host_id or ""
+        )
+        # The grant can die during the source I/O.
+        await SandboxGrant.authenticate(grant_id, credential, service)
+    except GrantDenied:
+        raise HTTPException(status_code=403) from None
+    except OAuthTokenError:
+        raise HTTPException(status_code=503) from None
+    expires_at = token.expires_at.isoformat() if token.expires_at else None
+    return JSONResponse(
+        {"value": token.access_token, "expires_at": expires_at},
+        headers={"Cache-Control": "no-store"},
+    )

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -156,12 +156,12 @@ class Sandbox(BaseModel):
     service_token: str = ""
     # Empty → drukbox decides.
     image: str = ""
-    # The mint base URL the secrets exchange dials for an issuer value. It is
+    # The issuer base URL the secrets exchange dials for a value. It is
     # the web process on the host loopback, over plain HTTP, on every shape.
     # It never derives from the dashboard, webhook, ingress, or provider
     # settings. Only an explicit value changes it.
     issuer_url: str = "http://127.0.0.1:8001"
-    # The secrets exchange, for refresh orders and the doctor probe. The
+    # The secrets exchange, for refresh requests and the doctor probe. The
     # exchange binds the host loopback.
     exchange_url: str = "http://127.0.0.1:8781"
     # The browser home: browser containers boot on this provider with this image.

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -55,6 +55,7 @@ from druks.notifications.outbox import notifications_queue, send_notification
 from druks.sandbox.client import provisioning_key, sandbox_client
 from druks.sandbox.constants import SANDBOX_HOST_ROTATE_BEFORE_SECONDS
 from druks.sandbox.datastructures import Sandbox
+from druks.sandbox.models import SandboxGrant
 from druks.sandbox.templates import get_template_id
 from druks.signals import publish
 from druks.user_settings.models import SettingsOverride, SettingsProfile
@@ -837,6 +838,16 @@ class Workflow:
         # only the host-id matters across steps — held-across-steps never fights replay.
         if not self.steps_reuse_sandbox:
             return
+        # A crashed process left its box behind. Its grant finds it again.
+        if (
+            not self._host
+            and profile.services
+            and (
+                grant := await SandboxGrant.lookup(self._workflow_id, "workflow", profile.services)
+            )
+        ):
+            self._host = await sandbox_client.reattach(host_id=grant.host_id)
+            self._host_secrets_id = profile.secrets_id
         if self._host and self._host.expires_at:
             remaining = (self._host.expires_at - datetime.now(UTC)).total_seconds()
             if remaining < SANDBOX_HOST_ROTATE_BEFORE_SECONDS:
@@ -852,11 +863,20 @@ class Workflow:
             if self.sandbox:
                 template = await get_template_id(self.sandbox)
                 await set_run_phase("provisioning_vm")
+            # The key names the pasted key the VM holds, so a replay finds its VM.
+            # A box that fetches gets its own grant, and the key names that instead.
+            # A replay finds the box through the grant, above.
+            grant, entries, key = None, {}, profile.secrets_id
+            if profile.services:
+                grant, entries = await SandboxGrant.create(
+                    run_id=self._workflow_id, scoped_to="workflow", services=profile.services
+                )
+                key = grant.id
             self._host = await sandbox_client.provision(
-                # The key names the pasted key the VM holds, so a replay finds its VM.
-                idempotency_key=provisioning_key(self._workflow_id, "sandbox", profile.secrets_id),
-                secrets=profile.secrets,
+                idempotency_key=provisioning_key(self._workflow_id, "workflow", key),
+                secrets={**profile.secrets, **entries},
                 template=template,
+                grant=grant,
             )
             self._host_secrets_id = profile.secrets_id
         return self._host.id

--- a/backend/migrations/versions/c5e2a7b19d43_add_sandbox_grants.py
+++ b/backend/migrations/versions/c5e2a7b19d43_add_sandbox_grants.py
@@ -1,0 +1,39 @@
+"""Add sandbox grants.
+
+Revision ID: c5e2a7b19d43
+Revises: a8d4c1e63f92
+Create Date: 2026-09-07
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "c5e2a7b19d43"
+down_revision: str | Sequence[str] | None = "a8d4c1e63f92"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sandbox_grants",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("run_id", sa.String(), nullable=False),
+        sa.Column("scoped_to", sa.String(), nullable=False),
+        sa.Column("host_id", sa.String(), nullable=True),
+        sa.Column("token_hash", sa.LargeBinary(), nullable=False),
+        sa.Column("services", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["run_id"], ["durable_runs.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("host_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("sandbox_grants")

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -7,11 +7,14 @@ import pytest
 from conftest import installation_key, make_agent_result
 from druks import agents
 from druks.accounts.models import Account
+from druks.database import db_session
 from druks.durable import AgentCall, WorkflowError
 from druks.files import File
 from druks.sandbox.exceptions import SandboxDownloadError
+from druks.sandbox.models import SandboxGrant
 from druks.usage.models import UsageScrape
 from druks.user_settings.models import SettingsOverride
+from sqlalchemy import select
 
 
 class DummyOutput(agents.AgentOutput):
@@ -72,6 +75,13 @@ def _patch_runtime(monkeypatch, tmp_path, payload):
     sandbox.id = "host-test"
     sandbox.run_agent = AsyncMock(return_value=make_agent_result(payload, agent="dummy"))
     return sandbox
+
+
+async def _grants(run_id: str) -> list[SandboxGrant]:
+    rows = await db_session().scalars(
+        select(SandboxGrant).where(SandboxGrant.run_id == run_id).order_by(SandboxGrant.id)
+    )
+    return list(rows)
 
 
 def _patch_ephemeral(monkeypatch, box):
@@ -212,7 +222,7 @@ async def test_ephemeral_acquisition_keys_idempotency_to_workflow_step(
     druks_db, tmp_path, monkeypatch, current_run
 ):
     """Without a warm context the runtime acquires a throwaway VM, keyed for
-    idempotency to ``<workflow_id>:<step>``."""
+    idempotency to ``<workflow_id>:<step>:<grant>``."""
     sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
     seen: list[str | None] = []
 
@@ -226,7 +236,8 @@ async def test_ephemeral_acquisition_keys_idempotency_to_workflow_step(
     result = await DUMMY_AGENT._run(workflow_id="wf-9")
 
     assert result == DummyOutput(ok=True)
-    assert seen == ["wf-9:dummy"]
+    [grant] = await _grants("wf-9")
+    assert seen == [f"wf-9:dummy:{grant.id}"]
 
 
 @pytest.mark.parametrize("billing", ["subscription", "api_key"])
@@ -710,8 +721,8 @@ async def test_provisioning_failure_recovers_through_durable_retry(
     druks_db, tmp_path, monkeypatch, current_run, _inline_agent_steps
 ):
     """A transient provisioning failure at acquire time is retried by the
-    body-level durable path with backoff; a later attempt succeeds, and every
-    attempt for the one logical acquire presents the same ephemeral key."""
+    body-level durable path with backoff; a later attempt succeeds, and each
+    attempt presents a fresh grant, so a fresh ephemeral key."""
     from druks.harnesses.exceptions import HarnessSandboxProvisioningError
 
     sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
@@ -731,8 +742,9 @@ async def test_provisioning_failure_recovers_through_durable_retry(
     assert result == DummyOutput(ok=True)
     # First delay off the schedule HarnessSandboxProvisioningError inherits (60, 300).
     assert [awaited.args[0] for awaited in sleep.await_args_list] == [60.0]
-    # Each attempt re-enters _run with the same workflow/agent identity → same key.
-    assert keys == ["wf-9:dummy", "wf-9:dummy"]
+    # Each attempt re-enters _run and asks for a fresh box under a fresh grant.
+    first, second = await _grants("wf-9")
+    assert keys == [f"wf-9:dummy:{first.id}", f"wf-9:dummy:{second.id}"]
     # A 60s wait is under the reap-before threshold, so the (never-acquired) VM
     # isn't reaped between attempts.
     current_run._reap_run.assert_not_awaited()
@@ -745,7 +757,7 @@ async def test_provisioning_failure_recovers_in_step_retry(
 ):
     """An agent invoked inside an enclosing @step retries the same transient
     provisioning failure in memory (plain asyncio.sleep, no durable sleep) and
-    recovers, holding the ephemeral key stable across attempts."""
+    recovers, with a fresh grant and key per attempt."""
     from druks.harnesses.exceptions import HarnessSandboxProvisioningError
     from druks.workflows import _in_step
 
@@ -772,7 +784,8 @@ async def test_provisioning_failure_recovers_in_step_retry(
     assert result == DummyOutput(ok=True)
     memory_sleep.assert_awaited_once_with(60.0)
     durable_sleep.assert_not_awaited()
-    assert keys == ["wf-9:dummy", "wf-9:dummy"]
+    first, second = await _grants("wf-9")
+    assert keys == [f"wf-9:dummy:{first.id}", f"wf-9:dummy:{second.id}"]
 
 
 async def test_reused_host_retry_presents_a_stable_idempotency_key(monkeypatch, current_run):
@@ -799,13 +812,13 @@ async def test_reused_host_retry_presents_a_stable_idempotency_key(monkeypatch, 
 
     monkeypatch.setattr("druks.sandbox.client.Client.provision", fake_provision)
 
-    profile = SimpleNamespace(secrets={}, secrets_id="")
+    profile = SimpleNamespace(secrets={}, services={}, secrets_id="")
     with pytest.raises(HarnessSandboxProvisioningError):
         await current_run._lease_host(profile)
     host_id = await current_run._lease_host(profile)
 
     assert host_id == "warm-host"
-    assert keys == ["wf-9:sandbox", "wf-9:sandbox"]
+    assert keys == ["wf-9:workflow", "wf-9:workflow"]
 
 
 async def test_provisioning_failure_exhausts_retries_with_classified_code(
@@ -953,3 +966,38 @@ async def test_recovery_supersedes_the_orphaned_running_call(druks_db):
     assert by_id["a"].status == "abandoned"
     assert by_id["a"].finished_at is not None
     assert by_id["b"].status == "running"
+
+
+async def test_a_replay_resumes_the_ephemeral_box_through_its_grant(
+    druks_db, tmp_path, monkeypatch, current_run
+):
+    """A crashed attempt left a bound box under a live grant. The replay resumes
+    that box and creates no grant."""
+    from druks.harnesses.models import ProviderSubscription
+
+    sandbox = _patch_runtime(monkeypatch, tmp_path, {"ok": True})
+    subscription = await db_session().scalar(select(ProviderSubscription))
+    grant, _ = await SandboxGrant.create(
+        run_id="wf-9", scoped_to="dummy", services={"anthropic": subscription.id}
+    )
+    await grant.bind("host-crashed")
+    resumed: list[str] = []
+
+    @asynccontextmanager
+    async def fake_resume(self, *, host_id):
+        resumed.append(host_id)
+        yield sandbox
+
+    @asynccontextmanager
+    async def fake_ephemeral(self, **_kwargs):
+        pytest.fail("the replay provisioned a new box")
+        yield
+
+    monkeypatch.setattr("druks.sandbox.client.Client.resume", fake_resume)
+    monkeypatch.setattr("druks.sandbox.client.Client.ephemeral", fake_ephemeral)
+
+    result = await DUMMY_AGENT._run(workflow_id="wf-9")
+
+    assert result == DummyOutput(ok=True)
+    assert resumed == ["host-crashed"]
+    assert [row.id for row in await _grants("wf-9")] == [grant.id]

--- a/backend/tests/test_auth_boundary.py
+++ b/backend/tests/test_auth_boundary.py
@@ -16,6 +16,7 @@ EXEMPT_API_PATHS = {
     "/api/providers",
     "/api/providers/{provider_id}/connection/start",
     "/api/providers/{provider_id}/connection/complete",
+    "/api/secrets/{grant_id}/{service}",  # a box's grant bearer, nothing else
     "/api/{path:path}",  # the JSON-404 catch-all
 }
 

--- a/backend/tests/test_declared_sandboxes.py
+++ b/backend/tests/test_declared_sandboxes.py
@@ -241,12 +241,16 @@ async def test_warm_lease_uses_workflow_template(monkeypatch):
     monkeypatch.setattr(workflow_module, "get_template_id", resolve)
     monkeypatch.setattr(workflow_module, "set_run_phase", AsyncMock())
 
-    assert await workflow._lease_host(SimpleNamespace(secrets={}, secrets_id="")) == "host-1"
+    assert (
+        await workflow._lease_host(SimpleNamespace(secrets={}, services={}, secrets_id=""))
+        == "host-1"
+    )
     resolve.assert_awaited_once_with(sandbox)
     provision.assert_awaited_once_with(
-        idempotency_key="run-1:sandbox",
+        idempotency_key="run-1:workflow",
         secrets={},
         template="template-1",
+        grant=None,
     )
 
 
@@ -272,13 +276,18 @@ async def test_ephemeral_lease_uses_workflow_template(monkeypatch):
     )
     monkeypatch.setattr(agent_module, "get_template_id", resolve)
 
-    profile = SimpleNamespace(secrets={}, secrets_id="")
+    profile = SimpleNamespace(secrets={}, services={}, secrets_id="")
     async with agent_module._runner(workflow, None, "run-1", "summarize", profile) as runner:
         assert runner == "workspace"
 
     resolve.assert_awaited_once_with(sandbox)
     assert calls == [
-        {"idempotency_key": "run-1:summarize", "secrets": {}, "template": "template-1"}
+        {
+            "idempotency_key": "run-1:summarize",
+            "secrets": {},
+            "template": "template-1",
+            "grant": None,
+        }
     ]
 
 

--- a/backend/tests/test_gate.py
+++ b/backend/tests/test_gate.py
@@ -48,6 +48,22 @@ async def test_new_calls_wait_out_a_shut_gate_then_proceed():
     assert ran == ["call-9"]
 
 
+async def test_a_second_shut_waits_for_the_first_to_reopen():
+    order: list[str] = []
+
+    async def second() -> None:
+        async with gate.shut("subscription-1"):
+            order.append("second")
+
+    async with gate.shut("subscription-1"):
+        pending = asyncio.create_task(second())
+        await asyncio.sleep(0.05)
+        assert not pending.done()  # one rotator at a time
+        order.append("first")
+    await asyncio.wait_for(pending, timeout=1.0)
+    assert order == ["first", "second"]
+
+
 async def test_expired_registrations_never_defer_a_rotation():
     # A crashed caller's registration ages out (score in the past) — shut
     # prunes it and grants instead of deferring forever.

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -12,7 +12,7 @@ from druks.harnesses.datastructures import SandboxSettings
 from druks.harnesses.exceptions import HarnessNotConnectedError
 from druks.harnesses.models import ProviderSubscription
 from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
-from druks.sandbox.datastructures import HomeCopy
+from druks.sandbox.datastructures import HomeCopy, HomeFile
 
 
 async def _seed_claude(
@@ -31,8 +31,9 @@ async def _seed_claude(
     )
 
 
-async def test_claude_builder_puts_db_credentials_on_the_bundle(druks_db):
-    subscription = await _seed_claude(access="live", refresh="R0")
+async def test_claude_bundle_carries_no_credential_file(druks_db):
+    """The sandbox holds a placeholder for the token. No file carries it."""
+    await _seed_claude(access="live", refresh="R0")
     sandbox = SandboxSettings(
         service_url="x",
         service_token="x",
@@ -40,14 +41,12 @@ async def test_claude_builder_puts_db_credentials_on_the_bundle(druks_db):
         image="x",
         harness_config_root=Path("/harnesses"),
     )
-    bundle = await _get_credentials(sandbox, github_token=None, subscription=subscription)
-    auth = bundle.home[0]
-    assert auth.path == ".claude/.credentials.json"
-    assert json.loads(auth.content)["claudeAiOauth"]["accessToken"] == "live"
+    bundle = await _get_credentials(sandbox, github_token=None)
+    assert not any(type(entry) is HomeFile for entry in bundle.home)
+    assert bundle.home[0] == HomeCopy(".claude.json", Path("/harnesses/claude/.claude.json"))
 
 
 async def test_credentials_builders_read_their_harness_config_directories(druks_db):
-    claude_subscription = await _seed_claude()
     far_future_expiration = 4_102_444_800
     jwt_header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
     jwt_payload = (
@@ -76,11 +75,7 @@ async def test_credentials_builders_read_their_harness_config_directories(druks_
         harness_config_root=config_root,
     )
 
-    claude_bundle = await _get_credentials(
-        sandbox,
-        github_token=None,
-        subscription=claude_subscription,
-    )
+    claude_bundle = await _get_credentials(sandbox, github_token=None)
     codex_bundle = await CodexHarness(
         model=CodexHarness.default_model,
         fast_mode=False,
@@ -93,7 +88,6 @@ async def test_credentials_builders_read_their_harness_config_directories(druks_
         key=None,
     )
 
-    assert claude_bundle.home[0].path == ".claude/.credentials.json"
     assert codex_bundle.home[0].path == ".codex/auth.json"
     assert HomeCopy(".claude/settings.json", config_root / "claude/settings.json") in (
         claude_bundle.home
@@ -131,8 +125,7 @@ async def test_credentials_builders_read_their_harness_config_directories(druks_
     assert codex_bundle.home[-1].source == config_root / "codex/skills"
 
 
-async def test_missing_config_root_keeps_the_db_credential(druks_db, tmp_path):
-    subscription = await _seed_claude(access="live")
+async def test_missing_config_root_keeps_the_github_token(druks_db, tmp_path):
     sandbox = SandboxSettings(
         service_url="x",
         service_token="x",
@@ -140,9 +133,8 @@ async def test_missing_config_root_keeps_the_db_credential(druks_db, tmp_path):
         image="x",
         harness_config_root=tmp_path / "missing",
     )
-    bundle = await _get_credentials(sandbox, github_token="gh", subscription=subscription)
-    auth = bundle.home[0]
-    assert json.loads(auth.content)["claudeAiOauth"]["accessToken"] == "live"
+    bundle = await _get_credentials(sandbox, github_token="gh")
+    assert not any(type(entry) is HomeFile for entry in bundle.home)
     assert bundle.github_token == "gh"
 
 
@@ -213,19 +205,6 @@ async def test_credential_without_any_row_raises(druks_db):
     account = await Account.get_or_create("a@example.com")
     with pytest.raises(HarnessNotConnectedError, match="connect your Anthropic subscription"):
         await ProviderSubscription.lookup("anthropic", account.id)
-
-
-async def test_credential_renders_only_the_selected_row(druks_db):
-    mine = await _seed_claude(access="mine-token", provider_email="a@example.com")
-    other = await _seed_claude(access="other-token", provider_email="b@example.com")
-
-    selected = await ProviderSubscription.lookup("anthropic", None, subscription_id=other.id)
-    rendered = json.loads(ClaudeHarness.auth_file(selected).content)
-    assert rendered["claudeAiOauth"]["accessToken"] == "other-token"
-    assert "mine-token" not in json.dumps(rendered)
-    selected = await ProviderSubscription.lookup("anthropic", None, subscription_id=mine.id)
-    rendered = json.loads(ClaudeHarness.auth_file(selected).content)
-    assert rendered["claudeAiOauth"]["accessToken"] == "mine-token"
 
 
 async def test_credential_for_a_deleted_row_raises(druks_db):

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -131,7 +131,8 @@ async def test_a_subscription_agent_runs_as_its_actor_or_the_default_account(dru
     assert as_actor.subscription.id == actor.id
     assert as_actor.charged_account_id == actor.account_id
     assert unattended.subscription.id == default_subscription.id
-    assert (as_actor.secrets, as_actor.secrets_id, as_actor.key) == ({}, "", None)
+    assert (as_actor.secrets, as_actor.secrets_id, as_actor.key) == ({}, actor.id, None)
+    assert as_actor.services == {"anthropic": actor.id}
     assert as_actor.harness_class is ClaudeHarness
     assert as_actor.model == "anthropic/claude-opus-4-7"
     assert (as_actor.effort, as_actor.timeout, as_actor.fast_mode) == ("high", 1800, False)

--- a/backend/tests/test_provider_auth.py
+++ b/backend/tests/test_provider_auth.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 from datetime import UTC, datetime, timedelta
@@ -8,12 +9,18 @@ import httpx
 import pytest
 from conftest import connect_provider
 from druks.accounts.models import Account
+from druks.core import tasks
 from druks.database import db_session
 from druks.harnesses import providers as pbase
 from druks.harnesses.datastructures import ParsedUsage
 from druks.harnesses.exceptions import HarnessNotConnectedError, OAuthTokenError
 from druks.harnesses.models import ProviderKey, ProviderSubscription
 from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
+from druks.sandbox import gate
+from druks.sandbox.models import SandboxGrant
+from druks.testing import seed_run
+from druks_field_notes.workflows import Summarize
+from sqlalchemy import update
 
 _NOW = datetime(2026, 6, 4, 20, 0, tzinfo=UTC)
 
@@ -322,11 +329,11 @@ async def test_rotation_lock_is_released_after_refresh(monkeypatch, druks_db):
     assert not await druks.redis.get_client().get(f"druks:harness:refresh:{connection.id}")
 
 
-async def test_two_mints_inside_the_margin_rotate_once_and_read_the_same_token(
+async def test_two_fetches_inside_the_margin_rotate_once_and_read_the_same_token(
     monkeypatch, druks_db
 ):
-    # Two boxes mint at once inside the margin: the lock elects one grant, and
-    # the second mint reloads and answers with the token the first one stored.
+    # Two boxes fetch at once inside the margin: the lock elects one grant, and
+    # the second fetch reloads and answers with the token the first one stored.
     connection = await _seed_claude(
         access="old", refresh="R0", expires_at=_NOW + timedelta(minutes=30)
     )
@@ -344,7 +351,7 @@ async def test_two_mints_inside_the_margin_rotate_once_and_read_the_same_token(
 
 
 async def test_a_failed_refresh_keeps_a_live_token_to_serve(monkeypatch, druks_db):
-    # The mint answers a box with the stored token while it is valid. A refresh
+    # The issuer answers a box with the stored token while it is valid. A refresh
     # that fails inside the margin changes nothing the box can see.
     soon = _NOW + timedelta(minutes=30)
     connection = await _seed_claude(access="old", refresh="R0", expires_at=soon)
@@ -356,7 +363,7 @@ async def test_a_failed_refresh_keeps_a_live_token_to_serve(monkeypatch, druks_d
 
 
 async def test_a_failed_refresh_of_an_expired_token_leaves_nothing_to_serve(monkeypatch, druks_db):
-    # Nothing valid is left, so the mint answers 503 and the exchange retries.
+    # Nothing valid is left, so the issuer answers 503 and the exchange retries.
     connection = await _seed_claude(
         access="old", refresh="R0", expires_at=_NOW - timedelta(minutes=1)
     )
@@ -563,3 +570,232 @@ async def test_minimal_provider_reports_unsupported_usage(monkeypatch):
         ok=False, error="unsupported"
     )
     assert calls == []
+
+
+async def _bound_grant(subscription, *, host_id: str, run_id: str) -> SandboxGrant:
+    await seed_run(db_session(), kind=Summarize.kind, run_id=run_id)
+    grant, _ = await SandboxGrant.create(
+        run_id=run_id,
+        scoped_to="workflow",
+        services={"anthropic": subscription.id},
+    )
+    await grant.bind(host_id)
+    return grant
+
+
+def _no_gate(subscription_id: str):
+    raise AssertionError(f"a fresh token shut the gate of {subscription_id}")
+
+
+_REFRESHED = {"access_token": "new", "refresh_token": "R1", "expires_in": 28800}
+_REFRESH_URL = "http://127.0.0.1:8781/refresh/{host_id}/anthropic"
+
+
+def _in(delta: timedelta) -> datetime:
+    return datetime.now(UTC) + delta
+
+
+async def test_a_fetch_answers_a_fresh_token_without_a_provider_call_or_the_gate(
+    monkeypatch, druks_db
+):
+    connection = await _seed_claude(access="live", expires_at=_in(timedelta(hours=6)))
+    calls = _mock_post(monkeypatch, _resp(200, _REFRESHED))
+    monkeypatch.setattr(pbase.gate, "shut", _no_gate)
+
+    token = await AnthropicProvider.issue_token(connection.id)
+
+    assert token.access_token == "live"
+    assert calls == []
+
+
+async def test_two_fetches_inside_the_margin_rotate_once_request_once_and_answer_the_same_token(
+    monkeypatch, druks_db
+):
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_in(timedelta(minutes=30))
+    )
+    await _bound_grant(connection, host_id="host-other", run_id="run-other")
+    calls = _mock_post(monkeypatch, _resp(200, _REFRESHED))
+
+    first = await AnthropicProvider.issue_token(connection.id, except_host_id="host-mine")
+    second = await AnthropicProvider.issue_token(connection.id, except_host_id="host-mine")
+
+    assert first.access_token == second.access_token == "new"
+    assert [call["url"] for call in calls] == [
+        AnthropicProvider._TOKEN_URL,
+        _REFRESH_URL.format(host_id="host-other"),
+    ]
+
+
+async def test_a_fetch_on_a_busy_subscription_answers_the_current_token(monkeypatch, druks_db):
+    # Inside the margin, above the call horizon: the call in flight keeps its token.
+    connection = await _seed_claude(
+        access="current", refresh="R0", expires_at=_in(timedelta(minutes=90))
+    )
+    calls = _mock_post(monkeypatch, _resp(200, _REFRESHED))
+
+    async with gate.use(connection.id, "call-1"):
+        token = await AnthropicProvider.issue_token(connection.id)
+
+    assert token.access_token == "current"
+    assert calls == []
+
+
+async def test_a_fetch_rotates_a_busy_subscription_once_urgent(monkeypatch, druks_db):
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_in(timedelta(minutes=30))
+    )
+    calls = _mock_post(monkeypatch, _resp(200, _REFRESHED))
+
+    async with gate.use(connection.id, "call-1"):
+        token = await AnthropicProvider.issue_token(connection.id)
+
+    assert token.access_token == "new"
+    assert calls[0]["json"]["refresh_token"] == "R0"
+
+
+async def test_a_fetch_waits_out_a_shut_gate_then_answers_the_stored_token(monkeypatch, druks_db):
+    monkeypatch.setattr(gate, "_POLL", 0.01)
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_in(timedelta(minutes=30))
+    )
+    calls = _mock_post(monkeypatch, _resp(200, _REFRESHED))
+    client = druks.redis.get_client()
+    rotating = f"druks:sandbox:rotating:{connection.id}"
+    await client.set(rotating, "1", ex=60)
+    session = db_session()
+
+    async def other_rotator() -> None:
+        # The holder advances the row, then reopens the gate.
+        await asyncio.sleep(0.03)
+        await session.execute(
+            update(ProviderSubscription)
+            .where(ProviderSubscription.id == connection.id)
+            .values(
+                payload=_claude_payload(
+                    access="stored", refresh="R1", expires_at=_in(timedelta(hours=8))
+                )
+            )
+        )
+        await client.delete(rotating)
+
+    holder = asyncio.create_task(other_rotator())
+    token = await AnthropicProvider.issue_token(connection.id)
+    await holder
+
+    assert token.access_token == "stored"
+    assert calls == []
+
+
+async def test_a_rotation_requests_a_refresh_for_every_other_live_bound_grant(
+    monkeypatch, druks_db
+):
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_in(timedelta(minutes=30))
+    )
+    await _bound_grant(connection, host_id="host-a", run_id="run-a")
+    await _bound_grant(connection, host_id="host-mine", run_id="run-mine")
+    await seed_run(db_session(), kind=Summarize.kind, run_id="run-unbound")
+    await SandboxGrant.create(
+        run_id="run-unbound",
+        scoped_to="workflow",
+        services={"anthropic": connection.id},
+    )
+    revoked = await _bound_grant(connection, host_id="host-revoked", run_id="run-revoked")
+    await revoked.revoke()
+    other = await _seed_claude(
+        access="x", refresh="RX", expires_at=_in(timedelta(hours=6)), provider_email="b@example.com"
+    )
+    await _bound_grant(other, host_id="host-elsewhere", run_id="run-elsewhere")
+    calls = _mock_post(monkeypatch, _resp(200, _REFRESHED))
+
+    result = await AnthropicProvider.rotate_token(connection.id, except_host_id="host-mine")
+
+    assert result.action == "refreshed"
+    assert [call["url"] for call in calls] == [
+        AnthropicProvider._TOKEN_URL,
+        _REFRESH_URL.format(host_id="host-a"),
+    ]
+
+
+async def test_a_failed_refresh_request_is_a_log_line_and_the_rotation_stands(
+    monkeypatch, druks_db, caplog
+):
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_in(timedelta(minutes=30))
+    )
+    await _bound_grant(connection, host_id="host-a", run_id="run-a")
+
+    async def fake_post(self, url, *, json=None, **_kwargs):
+        if "/refresh/" in url:
+            raise httpx.ConnectError("the exchange is down")
+        return _resp(200, _REFRESHED)
+
+    monkeypatch.setattr(pbase.httpx.AsyncClient, "post", fake_post)
+
+    result = await AnthropicProvider.rotate_token(connection.id)
+
+    assert result.action == "refreshed"
+    assert (await _payload("anthropic"))["claudeAiOauth"]["accessToken"] == "new"
+    assert "refresh request for box host-a service anthropic failed" in caplog.text
+
+
+async def test_a_failed_rotation_answers_the_live_token(monkeypatch, druks_db):
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_in(timedelta(minutes=30))
+    )
+    _mock_post(monkeypatch, httpx.ConnectError("boom"))
+
+    token = await AnthropicProvider.issue_token(connection.id)
+
+    assert token.access_token == "old"
+
+
+async def test_an_expired_token_with_a_failed_rotation_answers_nothing(monkeypatch, druks_db):
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_in(-timedelta(minutes=1))
+    )
+    _mock_post(monkeypatch, httpx.ConnectError("boom"))
+
+    with pytest.raises(OAuthTokenError) as error:
+        await AnthropicProvider.issue_token(connection.id)
+    assert error.value.tag == "token_expired"
+
+
+async def test_the_cron_requests_refreshes_after_a_rotation(monkeypatch, druks_db):
+    connection = await _seed_claude(
+        access="old", refresh="R0", expires_at=_in(timedelta(minutes=30))
+    )
+    await _bound_grant(connection, host_id="host-a", run_id="run-a")
+    calls = _mock_post(monkeypatch, _resp(200, _REFRESHED))
+
+    await tasks._refresh()
+
+    assert [call["url"] for call in calls] == [
+        AnthropicProvider._TOKEN_URL,
+        _REFRESH_URL.format(host_id="host-a"),
+    ]
+
+
+async def test_the_usage_fetch_requests_refreshes_after_its_rotation(monkeypatch, druks_db):
+    connection = await _seed_claude(access="dead", refresh="R0", expires_at=_in(timedelta(hours=6)))
+    await _bound_grant(connection, host_id="host-a", run_id="run-a")
+    posts = _mock_post(monkeypatch, _resp(200, _REFRESHED))
+    usage = {
+        "five_hour": {"utilization": 16.0, "resets_at": "2026-06-04T23:19:59+00:00"},
+        "seven_day": {"utilization": 48.0, "resets_at": "2026-06-07T16:00:00+00:00"},
+    }
+    answers = [_resp(401, {"error": "revoked"}), _resp(200, usage)]
+
+    async def fake_get(self, url, *, headers=None, **_kwargs):
+        return answers.pop(0)
+
+    monkeypatch.setattr(pbase.httpx.AsyncClient, "get", fake_get)
+
+    parsed = await AnthropicProvider.fetch_usage(connection)
+
+    assert parsed.ok
+    assert [call["url"] for call in posts] == [
+        AnthropicProvider._TOKEN_URL,
+        _REFRESH_URL.format(host_id="host-a"),
+    ]

--- a/backend/tests/test_sandbox_grants.py
+++ b/backend/tests/test_sandbox_grants.py
@@ -1,0 +1,223 @@
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from conftest import connect_provider
+from druks.database import db_session
+from druks.durable.engine import _step_engine
+from druks.harnesses import providers as pbase
+from druks.harnesses.providers import AnthropicProvider
+from druks.sandbox.constants import SANDBOX_HOST_LEASE_SECONDS
+from druks.sandbox.models import SandboxGrant
+from druks.testing import asgi_client, configure_app_for_test, make_settings, seed_run
+from druks_field_notes.workflows import Summarize
+from sqlalchemy.exc import IntegrityError
+
+
+def _payload(*, access: str = "live", life: timedelta = timedelta(hours=6)) -> dict:
+    expires_at = datetime.now(UTC) + life
+    return {
+        "claudeAiOauth": {
+            "accessToken": access,
+            "refreshToken": "R0",
+            "scopes": ["user:profile"],
+            "expiresAt": int(expires_at.timestamp() * 1000),
+        }
+    }
+
+
+async def _subscription(**kwargs):
+    return await connect_provider(AnthropicProvider, _payload(**kwargs))
+
+
+def _services(subscription) -> dict:
+    return {"anthropic": subscription.id}
+
+
+async def _bound_grant(subscription, *, state: str = "running") -> tuple[SandboxGrant, str]:
+    await seed_run(db_session(), kind=Summarize.kind, run_id="run-1", state=state)
+    grant, entries = await SandboxGrant.create(
+        run_id="run-1", scoped_to="workflow", services=_services(subscription)
+    )
+    await grant.bind("host-1")
+    return grant, entries["anthropic"].headers["Authorization"].removeprefix("Bearer ")
+
+
+def _resp(status: int, body: object) -> httpx.Response:
+    return httpx.Response(status, text=json.dumps(body), request=httpx.Request("POST", "https://x"))
+
+
+def _mock_post(monkeypatch, response):
+    calls = []
+
+    async def fake_post(self, url, *, json=None, **_kwargs):
+        calls.append(url)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(pbase.httpx.AsyncClient, "post", fake_post)
+    return calls
+
+
+def _no_gate(subscription_id: str):
+    raise AssertionError(f"a fresh token shut the gate of {subscription_id}")
+
+
+async def _fetch(
+    tmp_path, grant_id: str, bearer: str, service: str = "anthropic"
+) -> httpx.Response:
+    api = configure_app_for_test(settings=make_settings(tmp_path), authenticated=False)
+    async with asgi_client(api) as client:
+        return await client.get(
+            f"/api/secrets/{grant_id}/{service}", headers={"Authorization": f"Bearer {bearer}"}
+        )
+
+
+async def test_a_grant_keeps_the_hash_and_puts_the_bearer_in_the_issuer_entry(druks_db):
+    subscription = await _subscription()
+    await seed_run(db_session(), kind=Summarize.kind, run_id="run-1")
+
+    grant, entries = await SandboxGrant.create(
+        run_id="run-1", scoped_to="workflow", services=_services(subscription)
+    )
+
+    [entry] = entries.values()
+    bearer = entry.headers["Authorization"].removeprefix("Bearer ")
+    assert entry.entry() == {
+        "issuer": {
+            "url": f"http://127.0.0.1:8001/api/secrets/{grant.id}/anthropic",
+            "headers": {"Authorization": f"Bearer {bearer}"},
+            "refresh": "1h",
+        }
+    }
+    assert grant.token_hash == hashlib.sha256(bearer.encode()).digest()
+    assert grant.expires_at - grant.created_at == timedelta(seconds=SANDBOX_HOST_LEASE_SECONDS)
+    columns = {
+        column.name: getattr(grant, column.name) for column in SandboxGrant.__table__.columns
+    }
+    assert bearer not in repr(columns)
+    assert not grant.host_id
+
+
+async def test_one_box_holds_one_grant(druks_db):
+    subscription = await _subscription()
+    await seed_run(db_session(), kind=Summarize.kind, run_id="run-1")
+    first, _ = await SandboxGrant.create(
+        run_id="run-1", scoped_to="workflow", services=_services(subscription)
+    )
+    second, _ = await SandboxGrant.create(
+        run_id="run-1", scoped_to="workflow", services=_services(subscription)
+    )
+
+    await first.bind("host-1")
+    with pytest.raises(IntegrityError):
+        await second.bind("host-1")
+
+
+async def test_a_grant_needs_its_run(druks_db):
+    subscription = await _subscription()
+
+    with pytest.raises(IntegrityError):
+        await SandboxGrant.create(
+            run_id="no-such-run", scoped_to="workflow", services=_services(subscription)
+        )
+
+
+async def test_the_issuer_answers_a_fresh_token_with_its_expiry(druks_db, tmp_path, monkeypatch):
+    subscription = await _subscription(access="live")
+    grant, bearer = await _bound_grant(subscription)
+    posts = _mock_post(monkeypatch, _resp(200, {}))
+    monkeypatch.setattr(pbase.gate, "shut", _no_gate)
+
+    response = await _fetch(tmp_path, grant.id, bearer)
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    expiry = AnthropicProvider.load_token(subscription).expires_at
+    assert response.json() == {"value": "live", "expires_at": expiry.isoformat()}
+    assert posts == []
+
+
+@pytest.mark.parametrize("wrong", ["bearer", "service", "grant", "revoked", "expired", "run"])
+async def test_the_issuer_denies_a_wrong_bearer_service_or_dead_grant(druks_db, tmp_path, wrong):
+    subscription = await _subscription(access="live")
+    state = "finished" if wrong == "run" else "running"
+    grant, bearer = await _bound_grant(subscription, state=state)
+    grant_id, service = grant.id, "anthropic"
+    if wrong == "bearer":
+        bearer = "not-it"
+    if wrong == "service":
+        service = "github"
+    if wrong == "grant":
+        grant_id = "no-such-grant"
+    if wrong == "revoked":
+        await grant.revoke()
+    if wrong == "expired":
+        grant.expires_at = datetime.now(UTC) - timedelta(minutes=1)
+        await db_session().commit()
+
+    response = await _fetch(tmp_path, grant_id, bearer, service)
+
+    assert response.status_code == 403
+    assert "live" not in response.text
+
+
+async def test_the_issuer_denies_a_grant_revoked_during_the_source_io(
+    druks_db, tmp_path, monkeypatch
+):
+    subscription = await _subscription(access="live")
+    grant, bearer = await _bound_grant(subscription)
+    answer = AnthropicProvider.issue_token
+
+    async def revoke_then_answer(self, subscription_id, **kwargs):
+        await SandboxGrant.revoke_for_host(_step_engine(), grant.host_id)
+        return await answer(subscription_id, **kwargs)
+
+    monkeypatch.setattr(AnthropicProvider, "issue_token", revoke_then_answer)
+
+    response = await _fetch(tmp_path, grant.id, bearer)
+
+    assert response.status_code == 403
+    assert "live" not in response.text
+
+
+async def test_the_issuer_answers_503_when_the_source_holds_nothing_valid(
+    druks_db, tmp_path, monkeypatch
+):
+    subscription = await _subscription(access="old", life=-timedelta(minutes=1))
+    grant, bearer = await _bound_grant(subscription)
+    _mock_post(monkeypatch, httpx.ConnectError("boom"))
+
+    response = await _fetch(tmp_path, grant.id, bearer)
+
+    assert response.status_code == 503
+    assert "old" not in response.text
+
+
+async def test_lookup_finds_the_live_bound_grant_of_a_scope() -> None:
+    await seed_run(db_session(), kind=Summarize.kind, run_id="run-1")
+    services = {"anthropic": "sub-1"}
+    await SandboxGrant.create(run_id="run-1", scoped_to="workflow", services=services)
+    revoked, _ = await SandboxGrant.create(run_id="run-1", scoped_to="workflow", services=services)
+    await revoked.bind("host-revoked")
+    await revoked.revoke()
+    other_scope, _ = await SandboxGrant.create(
+        run_id="run-1", scoped_to="reviewer", services=services
+    )
+    await other_scope.bind("host-reviewer")
+    other_services, _ = await SandboxGrant.create(
+        run_id="run-1", scoped_to="workflow", services={"anthropic": "sub-2"}
+    )
+    await other_services.bind("host-other")
+    live, _ = await SandboxGrant.create(run_id="run-1", scoped_to="workflow", services=services)
+    await live.bind("host-live")
+
+    found = await SandboxGrant.lookup("run-1", "workflow", services)
+
+    assert found is not None
+    assert found.id == live.id
+    assert await SandboxGrant.lookup("run-1", "workflow", {"anthropic": "sub-3"}) is None
+    assert await SandboxGrant.lookup("run-2", "workflow", services) is None

--- a/backend/tests/test_sandbox_lifecycle.py
+++ b/backend/tests/test_sandbox_lifecycle.py
@@ -14,6 +14,7 @@ from drukbox_sdk.exceptions import (
     SandboxUnavailableError,
     SandboxValidationError,
 )
+from druks.database import db_session
 from druks.harnesses.exceptions import HarnessSandboxProvisioningError, Retry
 from druks.sandbox import credentials as creds_module
 from druks.sandbox import layout, repo
@@ -22,6 +23,9 @@ from druks.sandbox.constants import SANDBOX_HOST_LEASE_SECONDS
 from druks.sandbox.datastructures import Credentials, HomeCopy, HomeFile
 from druks.sandbox.exceptions import ExecFailed, HostGone, SandboxUnreachable
 from druks.sandbox.host import ExecResult
+from druks.sandbox.models import SandboxGrant
+from druks.testing import seed_run
+from druks_field_notes.workflows import Summarize
 
 
 @dataclass
@@ -489,6 +493,7 @@ async def test_acquire_uploads_helper_and_closes_ssh_without_releasing(
 
 
 async def test_acquire_releases_host_when_helper_upload_fails(
+    druks_db,
     patched_real_sandbox: list[_FakeSandbox],
     patched_sandbox_api: list[_FakeAPI],
 ):
@@ -585,6 +590,7 @@ async def test_provision_hands_the_entries_to_drukbox(
 
 
 async def test_ephemeral_hands_the_entries_to_drukbox_and_releases(
+    druks_db,
     patched_real_sandbox: list[_FakeSandbox],
     patched_sandbox_api: list[_FakeAPI],
 ):
@@ -645,6 +651,7 @@ async def test_acquire_passes_through_fatal_create_failure(
 
 
 async def test_acquire_classifies_setup_reachability_failure_after_rollback(
+    druks_db,
     patched_real_sandbox: list[_FakeSandbox],
     patched_sandbox_api: list[_FakeAPI],
 ):
@@ -672,6 +679,7 @@ async def test_acquire_classifies_setup_reachability_failure_after_rollback(
 
 
 async def test_acquire_setup_cancellation_propagates_unclassified(
+    druks_db,
     patched_real_sandbox: list[_FakeSandbox],
     patched_sandbox_api: list[_FakeAPI],
 ):
@@ -746,7 +754,7 @@ async def test_attach_raises_host_gone_on_not_found(
             pass
 
 
-async def test_release_calls_sdk_delete(patched_sandbox_api: list[_FakeAPI]):
+async def test_release_calls_sdk_delete(druks_db, patched_sandbox_api: list[_FakeAPI]):
 
     api = _FakeAPI(create_record=None)
     patched_sandbox_api.append(api)
@@ -757,6 +765,7 @@ async def test_release_calls_sdk_delete(patched_sandbox_api: list[_FakeAPI]):
 
 
 async def test_release_swallows_sdk_delete_failure(
+    druks_db,
     patched_sandbox_api: list[_FakeAPI],
 ):
 
@@ -772,3 +781,142 @@ async def test_release_swallows_sdk_delete_failure(
     await sandbox_client.release(host_id="host-xyz")
 
     assert api.deleted_ids == ["host-xyz"]
+
+
+async def _grant() -> SandboxGrant:
+    await seed_run(db_session(), kind=Summarize.kind, run_id="run-1")
+    grant, _ = await SandboxGrant.create(
+        run_id="run-1",
+        scoped_to="workflow",
+        services={"anthropic": "sub-1"},
+    )
+    return grant
+
+
+async def test_acquire_binds_the_grant_to_the_box(
+    druks_db,
+    patched_real_sandbox: list[_FakeSandbox],
+    patched_sandbox_api: list[_FakeAPI],
+):
+    api = _FakeAPI(create_record=_record(status="active"))
+    patched_sandbox_api.append(api)
+    grant = await _grant()
+
+    async with sandbox_client.acquire(grant=grant):
+        pass
+
+    assert grant.host_id == "host-xyz"
+    assert not grant.revoked_at
+
+
+async def test_a_failed_create_revokes_the_unbound_grant(
+    druks_db,
+    patched_real_sandbox: list[_FakeSandbox],
+    patched_sandbox_api: list[_FakeAPI],
+):
+    api = _FakeAPI(create_raises=SandboxProvisioningError("create timed out"))
+    patched_sandbox_api.append(api)
+    grant = await _grant()
+
+    with pytest.raises(HarnessSandboxProvisioningError):
+        async with sandbox_client.acquire(grant=grant):
+            pass
+
+    assert grant.revoked_at
+    assert not grant.host_id
+
+
+async def test_a_failed_setup_revokes_the_bound_grant(
+    druks_db,
+    patched_real_sandbox: list[_FakeSandbox],
+    patched_sandbox_api: list[_FakeAPI],
+):
+    api = _FakeAPI(create_record=_record(status="active"))
+    patched_sandbox_api.append(api)
+    grant = await _grant()
+
+    async def _fake_upload(sandbox: Any) -> None:
+        raise SandboxUnreachable("failed to write /root/.gitconfig")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("druks.sandbox.client._upload_helper_script", _fake_upload)
+        with pytest.raises(HarnessSandboxProvisioningError):
+            async with sandbox_client.acquire(grant=grant):
+                pass
+
+    await db_session().refresh(grant)
+    assert grant.host_id == "host-xyz"
+    assert grant.revoked_at
+    assert api.deleted_ids == ["host-xyz"]
+
+
+async def test_release_revokes_the_boxs_grant(druks_db, patched_sandbox_api: list[_FakeAPI]):
+    api = _FakeAPI(create_record=None)
+    patched_sandbox_api.append(api)
+    grant = await _grant()
+    await grant.bind("host-xyz")
+
+    await sandbox_client.release(host_id="host-xyz")
+
+    await db_session().refresh(grant)
+    assert grant.revoked_at
+    assert api.deleted_ids == ["host-xyz"]
+
+
+async def test_attach_reuses_a_bound_box_without_the_bearer(
+    druks_db,
+    patched_real_sandbox: list[_FakeSandbox],
+    patched_sandbox_api: list[_FakeAPI],
+):
+    """A process that reattaches never held the bearer. The box keeps its grant."""
+    api = _FakeAPI(get_host_responses=[_record(status="active")])
+    patched_sandbox_api.append(api)
+    grant = await _grant()
+    await grant.bind("host-xyz")
+
+    async with sandbox_client.attach(host_id="host-xyz") as host:
+        assert host.id == "host-xyz"
+
+    await db_session().refresh(grant)
+    assert grant.is_live
+
+
+async def test_resume_reattaches_the_box_and_releases_it_on_exit(
+    druks_db,
+    patched_real_sandbox: list[_FakeSandbox],
+    patched_sandbox_api: list[_FakeAPI],
+):
+    """A replay resumes the box a crashed attempt left behind. The exit releases
+    the box and revokes its grant, like an ephemeral box."""
+    api = _FakeAPI(get_host_responses=[_record(status="active")])
+    patched_sandbox_api.append(api)
+    grant = await _grant()
+    await grant.bind("host-xyz")
+
+    async with sandbox_client.resume(host_id="host-xyz") as host:
+        assert host.id == "host-xyz"
+        assert api.deleted_ids == []
+
+    assert api.deleted_ids == ["host-xyz"]
+    await db_session().refresh(grant)
+    assert not grant.is_live
+
+
+async def test_a_gone_box_loses_its_grant_and_the_retry_provisions_anew(
+    druks_db,
+    patched_real_sandbox: list[_FakeSandbox],
+    patched_sandbox_api: list[_FakeAPI],
+):
+    """The grant outlived its box. The reattach revokes the grant and fails as
+    transient, so the retry finds no grant and provisions anew."""
+    api = _FakeAPI(get_host_raises=SandboxNotFoundError("host-xyz not found"))
+    patched_sandbox_api.append(api)
+    grant = await _grant()
+    await grant.bind("host-xyz")
+
+    with pytest.raises(HarnessSandboxProvisioningError):
+        await sandbox_client.reattach(host_id="host-xyz")
+
+    await db_session().refresh(grant)
+    assert not grant.is_live
+    assert await SandboxGrant.lookup("run-1", "workflow", {"anthropic": "sub-1"}) is None

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -3,13 +3,13 @@ import functools
 import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from conftest import PROFILE_PROBE, installation_key
+from conftest import PROFILE_PROBE, connect_provider, installation_key
 from druks.durable.enums import AgentCallStatus
 from druks.harnesses.base import Harness
 from druks.harnesses.claude import ClaudeHarness
@@ -26,6 +26,7 @@ from druks.harnesses.exceptions import (
     Retry,
 )
 from druks.harnesses.profiles import Profile, get_profile
+from druks.harnesses.providers import AnthropicProvider
 from druks.sandbox.datastructures import (
     AgentInvocation,
     AgentResult,
@@ -532,6 +533,7 @@ def agent_profile():
         subscription=SimpleNamespace(id="subscription-1", account_id="acc"),
         api_key=None,
         secrets={},
+        services={},
         billing="subscription",
         effort="high",
         timeout=60,
@@ -639,3 +641,61 @@ async def test_claude_api_key_stays_on_the_server(
     for artifact in (ctx.artifact_dir / "call-9").iterdir():
         assert key not in artifact.read_text()
     assert key not in repr(result) and key not in repr(profile)
+
+
+async def test_claude_subscription_token_stays_on_the_server(
+    ctx: SimpleNamespace, druks_db, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Under subscription billing the VM holds a placeholder in ANTHROPIC_AUTH_TOKEN.
+    The token and its refresh token reach no invocation, VM file, artifact, or result."""
+    expires_at = int((datetime.now(UTC) + timedelta(hours=6)).timestamp() * 1000)
+    await connect_provider(
+        AnthropicProvider,
+        {
+            "claudeAiOauth": {
+                "accessToken": "oat-live",
+                "refreshToken": "rt-secret",
+                "expiresAt": expires_at,
+            }
+        },
+    )
+    await SettingsOverride.set_agent_billing(PROFILE_PROBE.id, "subscription")
+    profile = await get_profile(PROFILE_PROBE.id, None)
+    result_event = {
+        "type": "result",
+        "subtype": "success",
+        "structured_output": {"ok": True},
+        "total_cost_usd": 0.01,
+    }
+    run = _FakeRun(stdout_chunks=[json.dumps(result_event).encode() + b"\n"])
+    sandbox = _fake_sandbox(run)
+    sandbox.run_prompt = functools.partial(Host.run_prompt, sandbox)
+    sandbox._exec = functools.partial(Host._exec, sandbox)
+    settings = SimpleNamespace(
+        sandbox=SimpleNamespace(service_url="x", service_token="x", timeout=30.0, image="x"),
+        harness_config_root=tmp_path / "harnesses",
+        skills_dir=None,
+    )
+    monkeypatch.setattr("druks.sandbox.host.load_settings", lambda: settings)
+
+    result = await Host.run_agent(
+        sandbox,
+        agent="evaluate",
+        profile=profile,
+        prompt="p",
+        schema={"type": "object"},
+        artifact_dir=ctx.artifact_dir,
+        call_id="call-9",
+    )
+
+    assert result.status is AgentCallStatus.SUCCEEDED
+    assert profile.services == {"anthropic": profile.subscription.id}
+    [start] = sandbox.calls
+    assert not start.kwargs["extra_env"]
+    bundle = start.kwargs["credentials_bundle"]
+    assert not any(type(entry) is HomeFile for entry in bundle.home)
+    for secret in ("oat-live", "rt-secret"):
+        assert secret not in " ".join(start.kwargs["cmd"])
+        assert secret not in start.kwargs["stdin_data"].decode()
+        for artifact in (ctx.artifact_dir / "call-9").iterdir():
+            assert secret not in artifact.read_text()

--- a/backend/tests/test_warm_host_rotation.py
+++ b/backend/tests/test_warm_host_rotation.py
@@ -10,7 +10,7 @@ from druks.workflows import Workflow
 
 
 def _profile(secrets: dict[str, Secret], secrets_id: str = "") -> SimpleNamespace:
-    return SimpleNamespace(secrets=secrets, secrets_id=secrets_id)
+    return SimpleNamespace(secrets=secrets, services={}, secrets_id=secrets_id)
 
 
 _ENTRY = Secret(
@@ -36,11 +36,18 @@ class _FakeSandboxClient:
         self.provisions: list[str] = []
         self.secrets: list[dict[str, Secret]] = []
         self.released: list[str] = []
+        self.reattached: list[str] = []
 
     async def provision(
-        self, *, idempotency_key: str, secrets: dict[str, Secret], template: str | None
+        self,
+        *,
+        idempotency_key: str,
+        secrets: dict[str, Secret],
+        template: str | None,
+        grant: object = None,
     ) -> _FakeSandbox:
         assert template is None
+        assert grant is None
         self.provisions.append(idempotency_key)
         self.secrets.append(secrets)
         host_id = f"host-{len(self.provisions)}"
@@ -48,6 +55,10 @@ class _FakeSandboxClient:
 
     async def release(self, *, host_id: str) -> None:
         self.released.append(host_id)
+
+    async def reattach(self, *, host_id: str) -> _FakeSandbox:
+        self.reattached.append(host_id)
+        return _FakeSandbox(id=host_id, expires_at=datetime.now(UTC) + self.lease)
 
 
 def _warm_workflow(*, reuse: bool = True) -> Workflow:
@@ -71,7 +82,7 @@ async def test_warm_host_reused_while_lease_covers_another_call(monkeypatch):
     second = await flow._lease_host(_NONE)
 
     assert first == second == "host-1"
-    assert fake.provisions == ["wf-1:sandbox"]
+    assert fake.provisions == ["wf-1:workflow"]
     assert fake.released == []
 
 
@@ -89,7 +100,7 @@ async def test_warm_host_rotates_when_lease_cannot_cover_a_call(monkeypatch):
     assert first == "host-1"
     assert second == "host-2"
     assert fake.released == ["host-1"]
-    assert fake.provisions == ["wf-1:sandbox", "wf-1:sandbox"]
+    assert fake.provisions == ["wf-1:workflow", "wf-1:workflow"]
 
 
 @pytest.mark.asyncio
@@ -103,7 +114,7 @@ async def test_warm_host_keeps_its_entries_across_calls(monkeypatch):
     second = await flow._lease_host(_profile({"anthropic": _ENTRY}, _ANTHROPIC.secrets_id))
 
     assert first == second == "host-1"
-    assert fake.provisions == ["wf-1:sandbox:anthropic.20260907T110000"]
+    assert fake.provisions == ["wf-1:workflow:anthropic.20260907T110000"]
     assert fake.secrets == [{"anthropic": _ENTRY}]
     assert fake.released == []
 
@@ -122,7 +133,7 @@ async def test_warm_host_rotates_when_a_call_needs_other_entries(monkeypatch):
     assert first == "host-1"
     assert second == "host-2"
     assert fake.released == ["host-1"]
-    assert fake.provisions == ["wf-1:sandbox:anthropic.20260907T110000", "wf-1:sandbox"]
+    assert fake.provisions == ["wf-1:workflow:anthropic.20260907T110000", "wf-1:workflow"]
     assert fake.secrets == [{"anthropic": _ENTRY}, {}]
 
 
@@ -139,9 +150,9 @@ async def test_provisioning_key_names_the_pasted_key(monkeypatch):
     await _warm_workflow()._lease_host(replaced)
 
     assert fake.provisions == [
-        "wf-1:sandbox:anthropic.20260907T110000",
-        "wf-1:sandbox:anthropic.20260907T110000",
-        "wf-1:sandbox:anthropic.20260907T120000",
+        "wf-1:workflow:anthropic.20260907T110000",
+        "wf-1:workflow:anthropic.20260907T110000",
+        "wf-1:workflow:anthropic.20260907T120000",
     ]
 
 
@@ -155,3 +166,27 @@ async def test_no_warm_host_when_reuse_disabled(monkeypatch):
 
     assert await flow._lease_host(_NONE) is None
     assert fake.provisions == []
+
+
+async def test_a_replay_finds_the_warm_box_through_its_grant(
+    monkeypatch: pytest.MonkeyPatch, druks_db
+) -> None:
+    from druks.database import db_session
+    from druks.sandbox.models import SandboxGrant
+    from druks.testing import seed_run
+    from druks_field_notes.workflows import Summarize
+
+    await seed_run(db_session(), kind=Summarize.kind, run_id="wf-1")
+    grant, _ = await SandboxGrant.create(
+        run_id="wf-1", scoped_to="workflow", services={"anthropic": "sub-1"}
+    )
+    await grant.bind("host-crashed")
+    client = _FakeSandboxClient(lease=timedelta(hours=2))
+    monkeypatch.setattr(sdk, "sandbox_client", client)
+    flow = _warm_workflow()
+    profile = SimpleNamespace(secrets={}, services={"anthropic": "sub-1"}, secrets_id="sub-1")
+
+    assert await flow._lease_host(profile) == "host-crashed"
+
+    assert client.reattached == ["host-crashed"]
+    assert client.provisions == []

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -186,6 +186,21 @@ warm sandbox across a segment. Druks releases it before a gate and at workflow
 exit. Druks also rotates it before the lease becomes too short for another
 call. Store durable state in an external system such as Git, not only on the VM.
 
+A sandbox never holds a subscription token. Druks creates one grant for each
+sandbox that fetches one, before Drukbox provisions it. The grant names the run,
+the services the sandbox can fetch, and the workflow or agent the sandbox is
+scoped to. It keeps a hash of a random bearer. A replay after a crash finds the
+sandbox through the run's live grant with the same scope.
+Drukbox holds the bearer in the sandbox's issuer entry and fetches the token
+from the Druks issuer, `GET /api/secrets/<grant id>/<service>`. The issuer
+answers a fresh token at once. A token inside its refresh margin rotates first, while the
+subscription is idle or the token is urgent. One rotator runs at a time, and
+new calls wait for it. After a rotation, Druks requests a refresh from the secrets
+exchange for every live sandbox on that subscription. A provider can revoke
+the previous token at the rotation. Druks revokes the grant when it
+releases the sandbox, and a terminal run denies every fetch. The grant expires
+with the sandbox lease.
+
 ## Events, signals, webhooks, and subjects
 
 A subject is the object of a run. It is always a class that represents an app

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ host-run development template for that environment plane.
 | `[urls]` | Dashboard callback base URL and public webhook hostname |
 | `[secrets]` | Generated deployment secrets |
 | `[paths]` | Host data and harness configuration paths |
-| `[sandbox]` | Drukbox provider, service URL and token, image override, and the proxy, mint, and exchange addresses |
+| `[sandbox]` | Drukbox provider, service URL and token, image override, and the proxy, issuer, and exchange addresses |
 | `[sandbox.<provider>]` | Provider environment passed through to the remote stack |
 | `[env]` | Additional deployment environment settings rendered verbatim |
 
@@ -300,10 +300,15 @@ optional. It reports pending setup if the selected tracker lacks a connection.
 Druks registers two subscription providers, `anthropic` and `openai`. Each
 also accepts an API key. Both connect from **Settings → Providers**. The
 connection flow stores each credential in Postgres. Druks refreshes a
-subscription token on a schedule. It creates the CLI credential file inside
-each sandbox. It does not copy a host login. This is a capability connection
-for the requesting account. In a fresh `none`-mode install, the first
-completed subscription connection also creates the operator account. See
+subscription token on a schedule. A `claude` sandbox holds a placeholder in
+`ANTHROPIC_AUTH_TOKEN` and never the token. Drukbox fetches the token from the
+Druks issuer through the sandbox's grant, and the secrets proxy swaps the
+placeholder on each request. See
+[grants and the issuer](concepts.md#agents-harnesses-workspaces-and-sandboxes).
+Codex and Pi still receive their credential file inside the sandbox. Druks does
+not copy a host login. This is a capability connection for the requesting
+account. In a fresh `none`-mode install, the first completed subscription
+connection also creates the operator account. See
 [access control](#public-urls-and-access-control).
 
 An API key for `claude` never enters the sandbox. Druks gives the key to
@@ -373,8 +378,8 @@ credential is missing.
 | `sandbox.timeout` | Control-plane request timeout. The default is 180 seconds |
 | `sandbox.image` | Optional provider image override |
 | `sandbox.proxy_url` | The secrets proxy, at the address a sandbox dials. The docker shape sets `http://172.17.0.1:8880`. docker-sbx leaves it empty |
-| `sandbox.issuer_url` | The mint base URL the secrets exchange dials. The default is `http://127.0.0.1:8001` on every shape. Only an explicit value changes it |
-| `sandbox.exchange_url` | The secrets exchange, for refresh orders and the doctor probe. The default is `http://127.0.0.1:8781` |
+| `sandbox.issuer_url` | The issuer base URL the secrets exchange dials. The default is `http://127.0.0.1:8001` on every shape. Only an explicit value changes it |
+| `sandbox.exchange_url` | The secrets exchange, for refresh requests and the doctor probe. The default is `http://127.0.0.1:8781` |
 | `sandbox.browser_login_proxy` | Login-window egress proxy. An empty value keeps the box IP |
 | `sandbox.browser_login_tz` | Login-window timezone (IANA zone). An empty value keeps the container default |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -203,7 +203,14 @@ the hosts with a registered secret. No service in the deployment uses that CA.
 The exchange fetches an issuer value from the Druks web process at
 `[sandbox].issuer_url`, `http://127.0.0.1:8001` on every shape, over plain
 HTTP on the host loopback. The API and the exchange trust no extra CA. There
-is no public mint route.
+is no public issuer route.
+
+A subscription token is such a value. The issuer route is
+`GET /api/secrets/<grant id>/<service>`. It authenticates the sandbox's grant
+bearer and nothing else, and it answers `value` and the provider's
+`expires_at`. After every rotation Druks requests a refresh at
+`POST /refresh/<host id>/<service>` on `[sandbox].exchange_url`, one request for
+each live sandbox on the subscription.
 
 Drukbox encrypts the secret entries of each sandbox with `SECRETS_KEY`. The
 installer generates `[secrets].drukbox_secrets_key` and renders it as


### PR DESCRIPTION
## What changed

- `backend/druks/sandbox/models.py`: `SandboxGrant`, table `sandbox_grants`. A grant names its run, the workflow or agent it is scoped to, the services it can fetch, and its bearer's hash. `create` commits the row and returns the issuer entries with the bearer in their headers. `lookup` finds the run's live bound grant with a scope and its services. `authenticate` compares the hash in constant time and reads the grant's run through a relationship. `bind`, `revoke`, `revoke_for_host`, and `list_live_for_subscription`. The model holds queries and writes, no HTTP.
- Migration `c5e2a7b19d43` adds the table.
- `backend/druks/sandbox/routes.py`: `GET /api/secrets/<grant id>/<service>`, mounted ungated. One function authenticates the grant bearer, the service, the run state, revocation, and expiry, fetches the token, and repeats the check after the source I/O. It answers `value` and the provider's `expires_at` with `Cache-Control: no-store`, or 403 and 503 with no detail.
- `Provider.issue_token`: a fresh token answers at once. A due token, per `refresh_is_due`, shuts the gate. The rotation runs while the subscription is idle or the token is urgent, waits out another refresher's row lock, and reloads the row. `rotate_token` requests the refreshes after its commit and before the lock releases, except for the box whose answer carries the token. The cron and the usage fetch request them through the same path.
- `Client.request_refreshes` posts one refresh request per live bound box to `[sandbox].exchange_url`, in one `gather`, and logs the failures from the answers.
- `gate.shut` sets its flag with `NX` and waits for a holder to reopen. The flag lives 90 seconds.
- `Harness.get_services` and `Profile.services` map a Drukbox service to the subscription the box fetches. Claude names `anthropic`. `Profile.secrets_id` names the subscription, so a warm host rotates when the subscription changes.
- The two lease sites look up the run's live grant with their scope before they create one. The warm box is scoped to `workflow`, an ephemeral box to its agent id. A hit attaches the box: `Client.reattach` for the warm host, `Client.resume` for an ephemeral one, which releases on exit. A miss creates a grant, merges its entries into the box's secrets, and keys the box by the grant id. `Client.acquire` binds the grant after creation and revokes it when creation fails, on any exit. `release` and the rollback delete revoke the box's grant before the VM goes, and never raise.
- `ClaudeHarness` writes no credentials file. The box holds the placeholder in `ANTHROPIC_AUTH_TOKEN`.
- `docs/concepts.md`, `docs/configuration.md`, and `docs/deployment.md` describe the grant, the issuer, the rotation contract, and the replay.

## Where this differs from the ticket

- A box without issuer services has no grant. A Codex, Pi, OpenCode, or API-key box keeps its DRU-471 key. DRU-156 gives every box a service.
- The refresh requests live in `rotate_token`, not at three call sites. `except_host_id` names the box whose answer carries the token.
- The grant carries `scoped_to`. A replay after a crash finds the box through the run's live grant with the same scope and attaches it. A box that is gone loses its grant, and the retry provisions anew. A failed attempt leaves an unbound or revoked grant, which no lookup matches. The warm key literal is `workflow`, the same word as the scope.
- Druks is the issuer, as `sandbox.issuer_url` says. The route is `/api/secrets`, beside Drukbox's `/refresh`. Nothing mints: the route hands out the subscription's current token.

## Names

- `SandboxGrant`, `sandbox_grants`, `scoped_to`, `lookup`, `GrantDenied`.
- `Provider.issue_token`, `refresh_is_due`, `except_host_id`, `_LOCK_POLL_SECONDS`, `_SHUT_TTL_SECONDS`.
- `Harness.get_services`, `Profile.services`.
- `Client.request_refreshes`, `Client.reattach`, `Client.resume`, `Client._revoke_grant`, `_REQUEST_TIMEOUT_SECONDS`, and `grant`, the parameter on `Client.acquire`, `Client.provision`, and `Client.ephemeral`.
- Tests: `_bound_grant`, `_fetch`, `_no_gate`, `_grants`, `_in`, `_REFRESHED`, `_REFRESH_URL`.

## Gates

- `ruff check backend`: clean.
- `ruff format --check backend`: clean.
- `pytest backend/` with the proof app installed: 1692 passed.
- `alembic upgrade head` on a scratch database, then `alembic check`: no new upgrade operations.
- Rebased on main and squashed to one commit. CI: see the checks on this PR.

## Review

Own adversarial pass, then the review round: the model lost its HTTP and its helpers, the route and the provider lost their one-off functions, the grant got `scoped_to`, and the issuer got its one word. Nothing left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
