### PR TITLE
Deliver MCP credentials as box entries (DRU-475)

### DIFF
--- a/backend/druks/contrib/software_factory/workflows.py
+++ b/backend/druks/contrib/software_factory/workflows.py
@@ -40,16 +40,23 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True, kw_only=True)
 class BuildWorkspace(RepoWorkspace):
     skills: tuple[str, ...]
-    # Installation token for build's github MCP server, minted per repo from
-    # the identity reviews act as. Required — there is no build without github.
-    mcp_token: str
 
     @property
     def workspace_root(self) -> str:
         return get_work_root(self.host.ssh_username)
 
-    def get_required_mcp_servers(self) -> tuple[RequiredMcpServer, ...]:
-        return (RequiredMcpServer(name=GITHUB_MCP_NAME, url=GITHUB_MCP_URL, token=self.mcp_token),)
+    @classmethod
+    async def get_required_mcp_servers(cls, subject: Any) -> tuple[RequiredMcpServer, ...]:
+        # GitHub MCP acts as the review actor; the clone acts as the operator.
+        actor = await get_review_actor()
+        return (
+            RequiredMcpServer(
+                name=GITHUB_MCP_NAME,
+                url=GITHUB_MCP_URL,
+                secret_id=(await actor.service.get()).id,
+                resource=cls.get_repo(subject),
+            ),
+        )
 
     async def run_agent(self, *, account_id: str | None, **kwargs: Any):
         # Agents clone related repos on demand; Claude's --add-dir target must exist first.
@@ -183,22 +190,10 @@ class Build(Workflow):
 
     async def get_workspace_kwargs(self, host: "Host") -> dict[str, Any]:
         kwargs = await super().get_workspace_kwargs(host)
-        repo = kwargs["subject"].repo
-        try:
-            mcp_token, _ = await (await get_review_actor()).client.token_for_repo(repo)
-        except Exception as error:
-            # There is no build without github: agents push and review through
-            # the github MCP, so a run that can't mint its token fails here,
-            # loudly, instead of degrading mid-run.
-            raise FatalError(
-                f"Could not mint the GitHub token for {repo}; build requires it "
-                "for its github MCP server."
-            ) from error
         return {
             **kwargs,
             # None until the first implement provisions the PR branch.
             "branch": self.branch,
-            "mcp_token": mcp_token,
             "skills": tuple(self._profile.get("recommended_skills", [])),
         }
 

--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -125,7 +125,6 @@ class Harness(ABC):
         *,
         mcp_servers: tuple["McpServer", ...],
         skills: Collection[str],
-        extra_env: dict[str, str] | None,
     ) -> dict:
         """The capability manifest for one AgentCall: what this harness was
         handed. Presence only — a token records as a boolean, never its value,
@@ -138,15 +137,13 @@ class Harness(ABC):
         is a stable digest of the canonicalised record, so an identical
         capability set always hashes the same and an eval report can bucket
         calls by it."""
-        delivered_env = extra_env or {}
         # Declared = the enabled registry view; delivered = what actually
         # reached this call (a workspace's required server owns its name — see
-        # Workspace.with_mcp_servers). The delivered server is what
+        # Workspace.get_mcp_delivery). The delivered server is what
         # this harness ran against, so record its url + env var; fall back to
         # the declared values only for a declared-but-not-delivered entry.
-        # token_present reads the delivered env: a server's bearer env var is
-        # set iff its token was found at delivery, for a static or an
-        # app-minted token alike.
+        # token_present reads the delivered shape: it names a bearer env var
+        # iff the box holds an entry behind it.
         declared = {server["name"]: server for server in await mcp_models.McpServer.list_enabled()}
         delivered_by_name = {server.name: server for server in mcp_servers}
         mcp = []
@@ -160,7 +157,7 @@ class Harness(ABC):
                     "bearer_token_env_var": env_var,
                     "declared": name in declared,
                     "delivered": name in delivered_by_name,
-                    "token_present": env_var in delivered_env,
+                    "token_present": bool(server and server.bearer_token_env_var),
                 }
             )
         # Only the delivered skill set is reachable in either CLI home, so the

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -228,8 +228,15 @@ async def _get_credentials(
     operator's plugin state, for prompts that use no MCP server and would
     otherwise die on a misconfigured plugin."""
     config_dir = sandbox.harness_config_root / ClaudeHarness.name
-    home: list[HomeFile | HomeCopy] = [
-        HomeCopy(".claude.json", config_dir / ".claude.json"),
+    home: list[HomeFile | HomeCopy] = []
+    claude_json = config_dir / ".claude.json"
+    if claude_json.is_file():
+        # The operator's own MCP servers stay out of the box: Druks delivers
+        # every server it manages, and a copied entry could carry a token.
+        config = json.loads(claude_json.read_text())
+        config.pop("mcpServers", None)
+        home.append(HomeFile(".claude.json", json.dumps(config)))
+    home += [
         HomeCopy(".claude/settings.json", config_dir / "settings.json"),
         HomeCopy(".claude/CLAUDE.md", config_dir / "CLAUDE.md"),
     ]

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -484,7 +484,6 @@ class CodexHarness(Harness):
         home: list[HomeFile | HomeCopy] = [
             self.auth_file(subscription, key=key),
             HomeCopy(".codex/config.toml", config_dir / "config.toml"),
-            HomeCopy(".codex/.credentials.json", config_dir / ".credentials.json"),
             HomeCopy(".codex/AGENTS.md", config_dir / "AGENTS.md"),
         ]
         skills_dir = sandbox.skills_dir or config_dir / "skills"

--- a/backend/druks/harnesses/opencode.py
+++ b/backend/druks/harnesses/opencode.py
@@ -78,6 +78,9 @@ class OpenCodeHarness(Harness):
             }
             if headers:
                 entry["headers"] = headers
+            if server.bearer_token_env_var or server.env_headers:
+                # Druks owns this server's credential; opencode starts no OAuth for it.
+                entry["oauth"] = False
             mcp[server.name] = entry
 
         provider, _, model = self.model.partition("/")

--- a/backend/druks/mcp/constants.py
+++ b/backend/druks/mcp/constants.py
@@ -11,8 +11,10 @@ TOKEN_ENV_SUFFIX = "_TOKEN"
 # two names never collapse to one env var.
 NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 
-# The header a server's bearer fills. A secret header keeps its own name.
+# The header a server's bearer fills, and its prefix. A secret header keeps
+# its own name and no prefix.
 BEARER_HEADER = "Authorization"
+BEARER_PREFIX = "Bearer "
 
 # The official MCP registry the picker resolves against; search results
 # cache briefly in Redis so typing in the picker doesn't hammer it.

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -137,8 +137,8 @@ class AgentInvocation:
 class McpServer:
     """A streamable-HTTP MCP server the agent talks to. Config-safe by
     construction: no secret value appears here — the bearer token and every
-    secret header value ride the run's env, and this shape names only their
-    env vars; the harness reads them at runtime. Only non-secret declared
+    secret header value are box entries behind the named env vars, and the
+    harness reads the placeholders at runtime. Only non-secret declared
     header values are carried inline."""
 
     name: str
@@ -154,14 +154,15 @@ class McpServer:
 
 @dataclass(frozen=True)
 class RequiredMcpServer:
-    """An MCP server a workspace requires for its runs and credentials itself —
-    a run-scoped token the operator registry can't hold (Software Factory's per-repo
-    reviewer token). It owns its name: a same-named registry entry is not
-    delivered."""
+    """An MCP server a workspace requires for its runs. ``secret_id`` names
+    the vault row the box's entry issues from, and ``resource`` what the token
+    is for: Software Factory's review identity and the repo. It owns its
+    name: a same-named registry entry is not delivered."""
 
     name: str
     url: str
-    token: str = field(repr=False)
+    secret_id: str
+    resource: str = ""
 
 
 @dataclass(frozen=True)

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -303,11 +303,7 @@ class Host:
         persist_manifest(
             artifact_dir,
             call_id=run_id,
-            manifest=await harness.get_manifest(
-                mcp_servers=mcp_servers,
-                skills=skills,
-                extra_env=extra_env,
-            ),
+            manifest=await harness.get_manifest(mcp_servers=mcp_servers, skills=skills),
         )
 
         invocation = await harness.build_invocation(

--- a/backend/druks/sandbox/models.py
+++ b/backend/druks/sandbox/models.py
@@ -10,7 +10,9 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship, selectinload
 
 from druks.core.models import Uuid7Pk
 from druks.database import db_session, get_session
+from druks.mcp.constants import BEARER_HEADER, BEARER_PREFIX
 from druks.models import Base
+from druks.secrets.enums import SecretKind
 from druks.secrets.models import VaultSecret
 from druks.settings import load_settings
 
@@ -23,6 +25,9 @@ if TYPE_CHECKING:
 # The lifetime the exchange gives an answer without expires_at. A
 # subscription answer always carries one. Nothing polls on it.
 _ISSUER_REFRESH = "1h"
+# A pasted value never expires, so the exchange fetches it again on this
+# cadence: a new paste reaches a running box within it.
+_STATIC_REFRESH = "5m"
 
 
 class SecretRef(Base):
@@ -39,13 +44,16 @@ class SecretRef(Base):
     secret_id: Mapped[str] = mapped_column(ForeignKey("vault.id", ondelete="CASCADE"))
     # What the token is for: the repo. Empty for a subscription.
     resource: Mapped[str] = mapped_column(default="")
+    # The host the box's placeholder is swapped at, for a custom entry such
+    # as an MCP server. Empty for a Drukbox catalog entry.
+    host: Mapped[str] = mapped_column(default="")
 
     identity: Mapped["SandboxIdentity"] = relationship(back_populates="secret_refs")
     secret: Mapped[VaultSecret] = relationship(lazy="selectin")
 
     @property
-    def key(self) -> tuple[str, str, str]:
-        return (self.name, self.secret_id, self.resource or "")
+    def key(self) -> tuple[str, str, str, str]:
+        return (self.name, self.secret_id, self.resource or "", self.host or "")
 
 
 class SandboxIdentity(Base, Uuid7Pk):
@@ -82,7 +90,12 @@ class SandboxIdentity(Base, Uuid7Pk):
             scoped_to=scoped_to,
             # Own rows: the caller's values stay values.
             secret_refs=[
-                SecretRef(name=ref.name, secret_id=ref.secret_id, resource=ref.resource or "")
+                SecretRef(
+                    name=ref.name,
+                    secret_id=ref.secret_id,
+                    resource=ref.resource or "",
+                    host=ref.host or "",
+                )
                 for ref in secret_refs
             ],
             token_hash=hashlib.sha256(bearer.encode()).digest(),
@@ -94,14 +107,27 @@ class SandboxIdentity(Base, Uuid7Pk):
         session.add(identity)
         await session.commit()
         issuer_url = load_settings().sandbox.issuer_url.rstrip("/")
-        entries = {
-            ref.name: Issuer(
+        entries = {}
+        for ref in secret_refs:
+            secret = await VaultSecret.get(ref.secret_id)
+            # A custom entry binds the host the proxy swaps at, the variable
+            # the box exports, and the header the value fills. A catalog entry
+            # leaves those to Drukbox.
+            fields = {}
+            if ref.host:
+                header = secret.header or BEARER_HEADER
+                fields = {
+                    "host": ref.host,
+                    "auth_variable": ref.name.upper(),
+                    "auth_header": header,
+                    "auth_prefix": BEARER_PREFIX if header == BEARER_HEADER else "",
+                }
+            entries[ref.name] = Issuer(
                 url=f"{issuer_url}/api/secrets/{identity.id}/{ref.name}",
                 headers={"Authorization": f"Bearer {bearer}"},
-                refresh=_ISSUER_REFRESH,
+                refresh=_STATIC_REFRESH if secret.kind == SecretKind.STATIC else _ISSUER_REFRESH,
+                **fields,
             )
-            for ref in secret_refs
-        }
         return identity, entries
 
     @classmethod

--- a/backend/druks/workflows.py
+++ b/backend/druks/workflows.py
@@ -835,8 +835,10 @@ class Workflow:
 
     async def get_secret_refs(self) -> list[SecretRef]:
         # The secrets a box of this run fetches beyond its profile's: the
-        # workspace's, read before the box exists.
-        return await self.workspace_class.get_secret_refs(await self.subject)
+        # workspace's and its MCP servers', read before the box exists.
+        subject = await self.subject
+        _, mcp = await self.workspace_class.get_mcp_delivery(subject, self.account_id)
+        return [*await self.workspace_class.get_secret_refs(subject), *mcp]
 
     async def _lease_host(self, profile: "Profile") -> str | None:
         # The warm VM, provisioned once per segment; state is carried in git, so

--- a/backend/druks/workspaces.py
+++ b/backend/druks/workspaces.py
@@ -5,6 +5,7 @@ import shlex
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, ClassVar
+from urllib.parse import urlsplit
 
 from druks.accounts.models import Account
 from druks.core.apis.github import get_github_client
@@ -20,7 +21,7 @@ from druks.mcp import models as mcp_models
 from druks.mcp import oauth
 from druks.mcp.constants import TOKEN_ENV_PREFIX
 from druks.mcp.enums import IdentityMode, TokenSource
-from druks.mcp.exceptions import MissingTokenError
+from druks.mcp.exceptions import MissingGrantError, MissingTokenError
 from druks.mcp.helpers import get_bearer_token_env_var, get_grant_account
 from druks.sandbox import repo as checkout
 from druks.sandbox.datastructures import AgentResult, McpServer, RequiredMcpServer
@@ -47,9 +48,10 @@ class Workspace:
         # Override to add what the run needs on this workspace (add_dirs, skills).
         return kwargs
 
-    def get_required_mcp_servers(self) -> tuple[RequiredMcpServer, ...]:
-        # Override to declare the servers this workspace requires and
-        # credentials itself. Base: none.
+    @classmethod
+    async def get_required_mcp_servers(cls, subject: Any) -> tuple[RequiredMcpServer, ...]:
+        # Override to declare the servers this workspace requires and the vault
+        # row each one issues through. Read before the box exists. Base: none.
         return ()
 
     @classmethod
@@ -148,79 +150,84 @@ class Workspace:
         return await self.host.run_agent(**run_kwargs)
 
     async def with_mcp_servers(self, account_id: str | None, **kwargs: Any) -> dict[str, Any]:
-        # Fold every MCP server into this call — the workspace's required
-        # servers, then the operator registry's enabled entries. Each becomes a
-        # wire shape on ``mcp_servers`` (url + derived env var, never the
-        # token); each token rides ``extra_env`` under that var.
-        required = self.get_required_mcp_servers()
+        # The harness names each server's url, variables, and plain headers.
+        # Every credential is a box entry, so nothing rides ``extra_env``.
+        wire, _ = await self.get_mcp_delivery(self.subject, account_id)
+        if wire:
+            kwargs["mcp_servers"] = wire
+        return kwargs
+
+    @classmethod
+    async def get_mcp_delivery(
+        cls, subject: Any, account_id: str | None
+    ) -> tuple[tuple[McpServer, ...], list[SecretRef]]:
+        """The MCP servers a box of this workspace reaches: the wire shapes for
+        the harness and the secret refs for the box's entries, one per bearer
+        and per secret header. The workspace's required servers come first
+        and own their names: a same-named registry entry is neither resolved
+        nor delivered. A server that cannot authenticate fails here, before
+        the box."""
+        required = await cls.get_required_mcp_servers(subject)
         required_names = {server.name for server in required}
         if len(required_names) != len(required):
             # One config key per name in the emitted harness config — a dupe
             # would break the VM's config parse mid-run.
             raise ValueError(f"duplicate required MCP server names: {sorted(required_names)}")
-        enabled = await mcp_models.McpServer.list_enabled()
-        if not required and not enabled:
-            return kwargs
-        run_account = account_id
-        # ``extra_env`` may be omitted or an explicit ``None`` (both valid for the
-        # underlying run_agent); treat them the same so the merge never unpacks None.
-        env = dict(kwargs.get("extra_env") or {})
         wire = []
+        refs = []
         for server in required:
-            env[get_bearer_token_env_var(server.name)] = server.token
-            wire.append(
-                McpServer(
-                    name=server.name,
-                    url=server.url,
-                    bearer_token_env_var=get_bearer_token_env_var(server.name),
+            variable = get_bearer_token_env_var(server.name)
+            wire.append(McpServer(name=server.name, url=server.url, bearer_token_env_var=variable))
+            refs.append(
+                SecretRef(
+                    name=variable.lower(),
+                    secret_id=server.secret_id,
+                    resource=server.resource,
+                    host=urlsplit(server.url).hostname,
                 )
             )
-        for server in enabled:
-            if server["name"] in required_names:
-                # A required server owns its name: the registry twin is neither
-                # resolved (no raise, no env clobber) nor delivered.
+        run_account = account_id
+        for server in await mcp_models.McpServer.list_enabled():
+            name = server["name"]
+            if name in required_names:
                 continue
-            # Per-strategy bearer resolution, loud when a server can't
-            # authenticate — delivery never ships a header the harness
-            # can't fill.
+            host = urlsplit(server["url"]).hostname
+            # The bearer's vault row, by source, loud when the server cannot
+            # authenticate. A bearerless server rides its declared headers.
             source = server["token_source"]
-            if not source:
-                # No bearer; auth, if any, rides the declared headers below.
-                token = ""
-            elif source == TokenSource.STATIC:
-                # A stored token is ciphertext everywhere else; it is read only
-                # here, entering the run env.
-                if not server["token"]:
-                    raise MissingTokenError(server["name"])
-                token = server["token"].secrets["value"]
-            else:  # oauth
+            bearer_token_env_var = ""
+            if source == TokenSource.STATIC:
+                secret = server["token"]
+                if not secret:
+                    raise MissingTokenError(name)
+            elif source:
                 if server["identity_mode"] == IdentityMode.PER_USER and not run_account:
                     account = await Account.get_default()
                     run_account = account.id if account else None
                 grant_account = get_grant_account(server["identity_mode"], run_account)
-                token, _ = await oauth.get_access_token(server["name"], grant_account)
-            bearer_token_env_var = ""
-            if token:
-                bearer_token_env_var = get_bearer_token_env_var(server["name"])
-                env[bearer_token_env_var] = token
+                secret = await oauth.get_connection(name, grant_account)
+                if not secret:
+                    raise MissingGrantError(name, grant_account)
+            if source:
+                bearer_token_env_var = get_bearer_token_env_var(name)
+                refs.append(
+                    SecretRef(name=bearer_token_env_var.lower(), secret_id=secret.id, host=host)
+                )
             env_headers = {}
             for index, (header, secret) in enumerate(server["secret_headers"].items()):
-                env_var = f"{TOKEN_ENV_PREFIX}{server['name'].upper()}_HEADER_{index}"
-                env[env_var] = secret.secrets["value"]
-                env_headers[header] = env_var
+                variable = f"{TOKEN_ENV_PREFIX}{name.upper()}_HEADER_{index}"
+                env_headers[header] = variable
+                refs.append(SecretRef(name=variable.lower(), secret_id=secret.id, host=host))
             wire.append(
                 McpServer(
-                    name=server["name"],
+                    name=name,
                     url=server["url"],
                     bearer_token_env_var=bearer_token_env_var,
                     headers=dict(server["headers"]),
                     env_headers=env_headers,
                 )
             )
-        kwargs["mcp_servers"] = tuple(wire)
-        if env:
-            kwargs["extra_env"] = env
-        return kwargs
+        return tuple(wire), refs
 
 
 @dataclass(frozen=True)

--- a/backend/migrations/versions/a3c9e7f1b5d2_secret_ref_host.py
+++ b/backend/migrations/versions/a3c9e7f1b5d2_secret_ref_host.py
@@ -1,0 +1,25 @@
+"""A secret ref binds its entry's host.
+
+Revision ID: a3c9e7f1b5d2
+Revises: f1a6d3e8c2b7
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a3c9e7f1b5d2"
+down_revision: str | Sequence[str] | None = "f1a6d3e8c2b7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sandbox_secret_refs", sa.Column("host", sa.String(), nullable=False, server_default="")
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sandbox_secret_refs", "host")

--- a/backend/tests/druks-field_notes/tests/test_workflows.py
+++ b/backend/tests/druks-field_notes/tests/test_workflows.py
@@ -46,6 +46,7 @@ async def test_survey_writes_the_repository_gist(druks_db, monkeypatch):
 async def test_survey_workspace_clones_the_subject_repo(druks_db):
     workflow = Survey()
     workflow.subject = await Repository.create(repo="acme/widgets")
+    workflow.account_id = None
     host = SimpleNamespace(id="h1", ssh_username="exedev")
 
     workspace = await workflow.get_workspace(host)
@@ -57,4 +58,4 @@ async def test_survey_workspace_clones_the_subject_repo(druks_db):
         "github", identity={"app_id": "1", "slug": "druks-operator"}, secrets={"private_key": "pem"}
     )
     [secret] = await workflow.get_secret_refs()
-    assert secret.key == ("github", row.id, "acme/widgets")
+    assert secret.key == ("github", row.id, "acme/widgets", "")

--- a/backend/tests/software_factory/test_build_workspace.py
+++ b/backend/tests/software_factory/test_build_workspace.py
@@ -1,6 +1,5 @@
 import shlex
 import subprocess
-from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -15,7 +14,6 @@ from druks.core.services import Github
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.sandbox import host as host_mod
 from druks.sandbox.layout import get_related_root, get_repo_root
-from druks.workflows import FatalError
 from druks.workspaces import RepoWorkspace
 
 
@@ -31,7 +29,6 @@ def test_build_workspace_grants_related_root_add_dir():
         host=_FakeSandbox(),  # type: ignore[arg-type]
         subject=SimpleNamespace(repo="o/main"),
         branch="b",
-        mcp_token="ghs_review",
         skills=("python-house-rules",),
     )
     kwargs = workspace.get_agent_run_kwargs(model="m")
@@ -59,7 +56,6 @@ async def test_build_workspace_makes_the_related_root_before_the_clone(
         host=host_mod.Host(record=SimpleNamespace(id="h1", ssh_username="exedev")),  # type: ignore[arg-type]
         subject=SimpleNamespace(repo="o/main"),
         branch="b",
-        mcp_token="ghs_review",
         skills=(),
     )
     monkeypatch.setattr(host_mod.Host, "exec", fake_exec)
@@ -69,44 +65,34 @@ async def test_build_workspace_makes_the_related_root_before_the_clone(
     assert execs == [["mkdir", "-p", get_related_root("exedev")], ["run_agent"]]
 
 
-async def test_build_workspace_declares_its_github_mcp(druks_db):
-    # The github MCP is build's own declaration, credentialed with the per-repo
-    # review-actor token — never an operator catalog entry, never optional (there
-    # is no build without github). Delivery ships it whole: wire shape + token
-    # in the run env.
-    workspace = BuildWorkspace(
-        host=_FakeSandbox(),  # type: ignore[arg-type]
-        subject=SimpleNamespace(repo="o/main"),
-        branch="b",
-        mcp_token="ghs_review",
-        skills=("python-house-rules",),
+async def test_build_workspace_declares_its_github_mcp_as_the_review_actor(druks_db):
+    # The github MCP is build's own declaration, issued through the review
+    # actor's vault row for the subject's repo — never an operator catalog
+    # entry, never optional (there is no build without github). The clone
+    # stays the operator's: two identities, two entries in the box.
+    operator = await connect_service(
+        "github", identity={"app_id": "1", "slug": "druks-operator"}, secrets={"private_key": "pem"}
     )
-    kwargs = await workspace.with_mcp_servers(None, **workspace.get_agent_run_kwargs())
+    reviewer = await connect_service(
+        "github_reviewer",
+        identity={"app_id": "2", "slug": "druks-reviewer"},
+        secrets={"private_key": "reviewer-pem"},
+    )
+    subject = SimpleNamespace(repo="o/main")
 
-    assert kwargs["extra_env"] == {get_bearer_token_env_var(GITHUB_MCP_NAME): "ghs_review"}
-    github = next(s for s in kwargs["mcp_servers"] if s.name == GITHUB_MCP_NAME)
+    wire, refs = await BuildWorkspace.get_mcp_delivery(subject, None)
+
+    github = next(s for s in wire if s.name == GITHUB_MCP_NAME)
     assert github.url == GITHUB_MCP_URL
-    assert "ghs_review" not in repr(github)
-
-
-def _review_actor_stub(monkeypatch: pytest.MonkeyPatch, *, review_actor) -> None:
-    async def _review_actor():
-        return review_actor()
-
-    monkeypatch.setattr("druks.contrib.software_factory.workflows.get_review_actor", _review_actor)
+    assert github.bearer_token_env_var == get_bearer_token_env_var(GITHUB_MCP_NAME)
+    [ref] = refs
+    assert ref.key == ("mcp_github_token", reviewer.id, "o/main", "api.githubcopilot.com")
+    [clone] = await BuildWorkspace.get_secret_refs(subject)
+    assert clone.key == ("github", operator.id, "o/main", "")
 
 
 @pytest.mark.asyncio
-async def test_get_workspace_kwargs_carries_the_build_fields(monkeypatch: pytest.MonkeyPatch):
-    async def _review_token(_repo: str) -> tuple[str, datetime]:
-        return "ghs_review", datetime(2026, 9, 7, 18, 0, tzinfo=UTC)
-
-    _review_actor_stub(
-        monkeypatch,
-        review_actor=lambda: SimpleNamespace(
-            client=SimpleNamespace(token_for_repo=_review_token), mode="approve"
-        ),
-    )
+async def test_get_workspace_kwargs_carries_the_build_fields():
     sandbox = host_mod.Host(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
 
     workflow = Build()
@@ -119,35 +105,15 @@ async def test_get_workspace_kwargs_carries_the_build_fields(monkeypatch: pytest
         "host": sandbox,
         "subject": workflow.__dict__["subject"],
         "branch": None,
-        "mcp_token": "ghs_review",
         "skills": ("python-house-rules",),
     }
 
 
-@pytest.mark.asyncio
-async def test_get_workspace_kwargs_fails_loudly_when_the_token_wont_mint(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    # There is no build without github: a run that can't mint its MCP token
-    # fails at workspace setup, never degrades mid-run.
-    async def _no_token(_repo: str) -> tuple[str, datetime]:
-        raise RuntimeError("app not installed on this repo")
+def _review_actor_stub(monkeypatch: pytest.MonkeyPatch, *, review_actor) -> None:
+    async def _review_actor():
+        return review_actor()
 
-    _review_actor_stub(
-        monkeypatch,
-        review_actor=lambda: SimpleNamespace(
-            client=SimpleNamespace(token_for_repo=_no_token), mode="comment"
-        ),
-    )
-    sandbox = host_mod.Host(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
-
-    workflow = Build()
-    workflow.input = Build._run_input_model()
-    workflow.subject = SimpleNamespace(repo="o/app")
-    workflow._profile = {"recommended_skills": ["python-house-rules"]}
-
-    with pytest.raises(FatalError, match="github MCP server"):
-        await workflow.get_workspace_kwargs(sandbox)
+    monkeypatch.setattr("druks.contrib.software_factory.workflows.get_review_actor", _review_actor)
 
 
 def test_the_build_clones_as_the_operator():
@@ -170,7 +136,7 @@ async def test_the_review_workspace_names_the_review_actors_identity(
 
     [secret] = await ReviewWorkspace.get_secret_refs(SimpleNamespace(repo="o/app"))
 
-    assert secret.key == ("github", row.id, "o/app")
+    assert secret.key == ("github", row.id, "o/app", "")
 
 
 class _IdentitySandbox:

--- a/backend/tests/test_declared_sandboxes.py
+++ b/backend/tests/test_declared_sandboxes.py
@@ -234,6 +234,7 @@ async def test_warm_lease_uses_workflow_template(monkeypatch):
     workflow._workflow_id = "run-1"
     workflow._host = None
     workflow._subject = None
+    workflow.account_id = None
     monkeypatch.setattr(
         workflow_module,
         "sandbox_client",

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -43,7 +43,39 @@ async def test_claude_bundle_carries_no_credential_file(druks_db):
     )
     bundle = await _get_credentials(sandbox)
     assert not any(type(entry) is HomeFile for entry in bundle.home)
-    assert bundle.home[0] == HomeCopy(".claude.json", Path("/harnesses/claude/.claude.json"))
+    assert bundle.home[0] == HomeCopy(
+        ".claude/settings.json", Path("/harnesses/claude/settings.json")
+    )
+
+
+async def test_the_operators_claude_config_reaches_the_box_without_its_mcp_servers(
+    druks_db, tmp_path
+):
+    # Druks delivers every server it manages; a copied entry could carry a
+    # token the vault never saw.
+    config_root = tmp_path / "harnesses"
+    (config_root / "claude").mkdir(parents=True)
+    (config_root / "claude" / ".claude.json").write_text(
+        json.dumps(
+            {
+                "theme": "dark",
+                "mcpServers": {"linear": {"headers": {"Authorization": "Bearer lin_secret"}}},
+            }
+        )
+    )
+    sandbox = SandboxSettings(
+        service_url="x",
+        service_token="x",
+        service_timeout=30.0,
+        image="x",
+        harness_config_root=config_root,
+    )
+
+    bundle = await _get_credentials(sandbox)
+
+    [config] = [entry for entry in bundle.home if entry.path == ".claude.json"]
+    assert json.loads(config.content) == {"theme": "dark"}
+    assert "lin_secret" not in repr(bundle)
 
 
 async def test_credentials_builders_read_their_harness_config_directories(druks_db):
@@ -92,7 +124,6 @@ async def test_credentials_builders_read_their_harness_config_directories(druks_
         claude_bundle.home
     )
     assert HomeCopy(".claude/CLAUDE.md", config_root / "claude/CLAUDE.md") in claude_bundle.home
-    assert HomeCopy(".claude.json", config_root / "claude/.claude.json") in claude_bundle.home
     assert (
         HomeCopy(
             ".claude/plugins/installed_plugins.json",
@@ -116,10 +147,9 @@ async def test_credentials_builders_read_their_harness_config_directories(druks_
     )
     assert claude_bundle.home[-1].source == config_root / "claude/skills"
     assert HomeCopy(".codex/config.toml", config_root / "codex/config.toml") in codex_bundle.home
-    assert (
-        HomeCopy(".codex/.credentials.json", config_root / "codex/.credentials.json")
-        in codex_bundle.home
-    )
+    # MCP credentials are box entries; a copied credentials file would carry a
+    # second, unmanaged set.
+    assert not any(file.path == ".codex/.credentials.json" for file in codex_bundle.home)
     assert HomeCopy(".codex/AGENTS.md", config_root / "codex/AGENTS.md") in codex_bundle.home
     assert codex_bundle.home[-1].source == config_root / "codex/skills"
 

--- a/backend/tests/test_manifest.py
+++ b/backend/tests/test_manifest.py
@@ -24,14 +24,13 @@ async def _build(
     harness: Harness | None = None,
     mcp_servers: tuple[McpServer, ...] = (),
     skills: tuple[str, ...] = (),
-    extra_env: dict[str, str] | None = None,
 ) -> dict:
     # get_manifest never touches the live sandbox, so the harness builds
     # without sandbox settings — the same shape argv unit tests use.
     harness = harness or ClaudeHarness(
         model="anthropic/claude-opus-4-8", fast_mode=False, effort=None
     )
-    return await harness.get_manifest(mcp_servers=mcp_servers, skills=skills, extra_env=extra_env)
+    return await harness.get_manifest(mcp_servers=mcp_servers, skills=skills)
 
 
 async def _seed_skills(*names: str, disabled: tuple[str, ...] = ()) -> None:
@@ -60,16 +59,9 @@ async def test_manifest_records_the_delivered_capability_set(druks_db):
         url="https://api.githubcopilot.com/mcp/",
         bearer_token_env_var=get_bearer_token_env_var("github"),
     )
-    # Both servers delivered with their token — github is SoftwareFactory's own
+    # Both servers delivered with a bearer entry — github is SoftwareFactory's own
     # requirement (get_required_mcp_servers), so it reads delivered but not declared.
-    manifest = await _build(
-        mcp_servers=(linear, github),
-        skills=("alpha",),
-        extra_env={
-            _LINEAR_ENV: _TOKEN,
-            get_bearer_token_env_var("github"): "ghs_from_build",
-        },
-    )
+    manifest = await _build(mcp_servers=(linear, github), skills=("alpha",))
 
     assert manifest["schema_version"] == 2
     assert manifest["model"] == "anthropic/claude-opus-4-8"
@@ -88,14 +80,11 @@ async def test_manifest_records_the_delivered_capability_set(druks_db):
 
 
 async def test_missing_mcp_token_records_absence(druks_db):
-    """A delivered server whose bearer var is absent from the run env reads
+    """A delivered server that names no bearer var holds no entry behind one:
     token_present False — recorded, not failed."""
     await models.McpServer.create(name="linear", url=_LINEAR_URL, token=_TOKEN)
 
-    manifest = await _build(
-        mcp_servers=(McpServer(name="linear", url=_LINEAR_URL, bearer_token_env_var=_LINEAR_ENV),),
-        extra_env={},
-    )
+    manifest = await _build(mcp_servers=(McpServer(name="linear", url=_LINEAR_URL),))
 
     linear_entry = next(s for s in manifest["mcp_servers"] if s["name"] == "linear")
     assert linear_entry["declared"] is True
@@ -127,7 +116,7 @@ async def test_records_the_delivered_server_not_the_registry_duplicate(druks_db)
         bearer_token_env_var="REQUIRED_LINEAR_TOKEN",
     )
 
-    manifest = await _build(mcp_servers=(required,), extra_env={"REQUIRED_LINEAR_TOKEN": "s"})
+    manifest = await _build(mcp_servers=(required,))
 
     linear_entry = next(s for s in manifest["mcp_servers"] if s["name"] == "linear")
     assert linear_entry["url"] == "https://required.internal/linear"
@@ -142,7 +131,7 @@ async def test_hash_is_stable_for_identical_capabilities(druks_db):
     availability, or the delivered skill set moves the hash."""
     await models.McpServer.create(name="linear", url=_LINEAR_URL, token=_TOKEN)
     linear = McpServer(name="linear", url=_LINEAR_URL, bearer_token_env_var=_LINEAR_ENV)
-    with_token = {"mcp_servers": (linear,), "extra_env": {_LINEAR_ENV: _TOKEN}}
+    with_token = {"mcp_servers": (linear,)}
 
     baseline = await _build(**with_token)
     assert (await _build(**with_token))["manifest_hash"] == baseline["manifest_hash"]
@@ -153,7 +142,7 @@ async def test_hash_is_stable_for_identical_capabilities(druks_db):
     )
     assert different_model["manifest_hash"] != baseline["manifest_hash"]
 
-    without_token = await _build(mcp_servers=(linear,), extra_env={})
+    without_token = await _build(mcp_servers=(McpServer(name="linear", url=_LINEAR_URL),))
     assert without_token["manifest_hash"] != baseline["manifest_hash"]
 
 
@@ -174,7 +163,7 @@ async def test_manifest_records_token_presence_never_the_value(druks_db):
     await models.McpServer.create(name="linear", url=_LINEAR_URL, token=_TOKEN)
     linear = McpServer(name="linear", url=_LINEAR_URL, bearer_token_env_var=_LINEAR_ENV)
 
-    manifest = await _build(mcp_servers=(linear,), extra_env={_LINEAR_ENV: _TOKEN})
+    manifest = await _build(mcp_servers=(linear,))
 
     serialized = json.dumps(manifest)
     assert _TOKEN not in serialized
@@ -199,10 +188,7 @@ async def test_manifest_stays_presence_only_for_a_declared_header_server(druks_d
         env_headers={"X-Api-Key": "MCP_GRAFANA_HEADER_X_API_KEY"},
     )
 
-    manifest = await _build(
-        mcp_servers=(delivered,),
-        extra_env={"MCP_GRAFANA_HEADER_X_API_KEY": "grafana-api-secret"},
-    )
+    manifest = await _build(mcp_servers=(delivered,))
 
     serialized = json.dumps(manifest)
     assert "grafana-api-secret" not in serialized

--- a/backend/tests/test_mcp_oauth.py
+++ b/backend/tests/test_mcp_oauth.py
@@ -21,7 +21,9 @@ from druks.mcp.exceptions import (
 from druks.mcp.helpers import get_bearer_token_env_var, get_grant_account
 from druks.mcp.models import McpServer
 from druks.redis import close_client, get_client
+from druks.sandbox.models import SecretRef
 from druks.secrets.datastructures import Audience
+from druks.secrets.exceptions import SecretRevokedError
 from druks.secrets.models import VaultSecret
 from druks.testing import configure_app_for_test, make_settings
 from druks.workspaces import Workspace
@@ -32,10 +34,6 @@ _SERVER_URL = "https://mcp.linear.test/sse"
 _AUTH_BASE = "https://auth.linear.test"
 _ENDPOINT = "https://druks.example"
 _CALLBACK = f"{_ENDPOINT}/api/mcp-servers/oauth/callback"
-
-
-class _FakeSandbox:
-    ssh_username = "exedev"
 
 
 class FakeAuthServer:
@@ -581,23 +579,32 @@ async def test_get_cache_and_refresh_lock_are_per_account(auth_server, druks_db)
     assert await redis.get(await _token_key(second.id)) == b"at-1"
 
 
-# --- delivery: the oauth branch of the fold ---------------------------------
+# --- delivery: the oauth ref and the row that issues -------------------------
 
 
-async def test_delivery_mints_and_injects_the_oauth_token(registry_state, auth_server, druks_db):
+async def _ref(account_id: str | None = None) -> SecretRef:
+    _, refs = await Workspace.get_mcp_delivery(None, account_id)
+    return next(ref for ref in refs if ref.name == get_bearer_token_env_var(_NAME).lower())
+
+
+async def test_delivery_binds_the_grant_and_the_row_issues_the_token(
+    registry_state, auth_server, druks_db
+):
     _register_oauth_server()
-    await _store_grant()
+    grant = await _store_grant()
 
-    kwargs = await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
-        None
-    )
+    wire, refs = await Workspace.get_mcp_delivery(None, None)
 
     var = get_bearer_token_env_var(_NAME)
-    assert kwargs["extra_env"][var] == "at-1"
-    entry = next(s for s in kwargs["mcp_servers"] if s.name == _NAME)
+    entry = next(s for s in wire if s.name == _NAME)
     assert entry.url == _SERVER_URL
     assert entry.bearer_token_env_var == var
-    assert "at-1" not in repr(entry)
+    [ref] = refs
+    assert ref.key == (var.lower(), grant.id, "", "mcp.linear.test")
+    token, expires_at = await grant.issue_token("")
+    assert token == "at-1"
+    assert expires_at > datetime.now(UTC)
+    assert "at-1" not in repr(wire) + repr(refs)
 
 
 async def test_delivery_fails_loudly_for_an_unconnected_enabled_oauth_server(
@@ -608,9 +615,7 @@ async def test_delivery_fails_loudly_for_an_unconnected_enabled_oauth_server(
     server.identity_mode = IdentityMode.SHARED
 
     with pytest.raises(MissingGrantError, match=_NAME):
-        await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
-            None
-        )
+        await Workspace.get_mcp_delivery(None, None)
 
 
 async def test_delivery_names_the_account_missing_its_per_user_grant(druks_db):
@@ -619,9 +624,7 @@ async def test_delivery_names_the_account_missing_its_per_user_grant(druks_db):
     server.identity_mode = IdentityMode.PER_USER
 
     with pytest.raises(MissingGrantError) as error:
-        await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
-            account.id
-        )
+        await Workspace.get_mcp_delivery(None, account.id)
 
     assert error.value.name == _NAME
     assert error.value.account_id == account.id
@@ -631,13 +634,11 @@ async def test_delivery_names_the_account_missing_its_per_user_grant(druks_db):
 
 async def test_delivery_without_a_run_account_uses_the_default_account(auth_server, druks_db):
     default_account = await Account.get_or_create("default@example.com")
-    await _store_grant(account_id=default_account.id, identity_mode=IdentityMode.PER_USER)
+    grant = await _store_grant(account_id=default_account.id, identity_mode=IdentityMode.PER_USER)
 
-    kwargs = await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
-        None
-    )
+    ref = await _ref()
 
-    assert kwargs["extra_env"][get_bearer_token_env_var(_NAME)] == "at-1"
+    assert ref.secret_id == grant.id
 
 
 async def test_delivery_with_a_named_account_does_not_use_the_default_account(
@@ -648,11 +649,32 @@ async def test_delivery_with_a_named_account_does_not_use_the_default_account(
     await _store_grant(account_id=default_account.id, identity_mode=IdentityMode.PER_USER)
 
     with pytest.raises(MissingGrantError) as error:
-        await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
-            named.id
-        )
+        await Workspace.get_mcp_delivery(None, named.id)
 
     assert error.value.account_id == named.id
+
+
+async def test_the_ref_binds_the_accounts_own_grant(auth_server, druks_db):
+    # The ref binds the grant row at creation: a held box keeps that account's
+    # grant whatever account asks later.
+    first = await Account.get_or_create("first@example.com")
+    second = await Account.get_or_create("second@example.com")
+    grant = await _store_grant(account_id=first.id, identity_mode=IdentityMode.PER_USER)
+    await _store_grant(account_id=second.id, identity_mode=IdentityMode.PER_USER)
+
+    ref = await _ref(first.id)
+
+    assert ref.secret_id == grant.id
+    assert (await VaultSecret.get(ref.secret_id)).account_id == first.id
+
+
+async def test_a_disconnected_grant_issues_nothing(auth_server, druks_db):
+    await _store_grant()
+    ref = await _ref()
+    await oauth.disconnect(_NAME, None)
+
+    with pytest.raises(SecretRevokedError, match=_NAME):
+        await (await VaultSecret.get(ref.secret_id)).issue_token("")
 
 
 # --- API: connect / callback / disconnect / badge ---------------------------

--- a/backend/tests/test_mcp_servers.py
+++ b/backend/tests/test_mcp_servers.py
@@ -2,11 +2,13 @@ import json
 from pathlib import Path
 
 import pytest
+from conftest import connect_service
 from druks.apps.registry import mcp_servers
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.datastructures import SandboxSettings
 from druks.mcp.catalog import load_mcp_catalog
+from druks.mcp.constants import BEARER_HEADER
 from druks.mcp.exceptions import (
     InvalidCatalogError,
     InvalidServerNameError,
@@ -15,6 +17,10 @@ from druks.mcp.exceptions import (
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.mcp.models import McpServer
 from druks.sandbox.datastructures import RequiredMcpServer
+from druks.sandbox.models import SecretRef
+from druks.secrets.datastructures import Audience
+from druks.secrets.enums import SecretKind
+from druks.secrets.models import VaultSecret
 from druks.settings import PACKAGED_MCP_CATALOG
 from druks.testing import asgi_client, configure_app_for_test, make_settings
 from druks.workspaces import Workspace
@@ -37,22 +43,37 @@ def _sandbox_config() -> SandboxSettings:
     )
 
 
-async def _delivery(**kwargs) -> dict:
-    # Delivery is resolved at the workspace seam: the enabled servers become wire
-    # shapes on ``mcp_servers`` and their tokens land in ``extra_env``.
-    return await Workspace(host=_FakeSandbox()).with_mcp_servers(  # type: ignore[arg-type]
-        None, **kwargs
+async def _delivery() -> dict:
+    # Delivery at the workspace seam: the enabled servers become wire shapes on
+    # ``mcp_servers``; their credentials are box entries, never env.
+    return await Workspace(host=_FakeSandbox()).with_mcp_servers(None)  # type: ignore[arg-type]
+
+
+async def _refs() -> dict[str, SecretRef]:
+    # The secret refs a box of a plain workspace binds, one per entry, by name.
+    _, refs = await Workspace.get_mcp_delivery(None, None)
+    return {ref.name: ref for ref in refs}
+
+
+async def _bearer_row(name: str) -> VaultSecret:
+    return await VaultSecret.lookup(SecretKind.STATIC, Audience.mcp(name), header=BEARER_HEADER)
+
+
+async def _github_row() -> VaultSecret:
+    return await connect_service(
+        "github", identity={"app_id": "1", "slug": "druks-operator"}, secrets={"private_key": "pem"}
     )
 
 
-def _requiring_workspace(*servers: RequiredMcpServer) -> Workspace:
-    # A workspace declaring the servers it requires and credentials itself,
-    # as SoftwareFactory does.
+def _requiring(*servers: RequiredMcpServer) -> type[Workspace]:
+    # A workspace declaring the servers it requires and the vault row each
+    # one issues through, as SoftwareFactory does.
     class _Requiring(Workspace):
-        def get_required_mcp_servers(self) -> tuple[RequiredMcpServer, ...]:
+        @classmethod
+        async def get_required_mcp_servers(cls, subject) -> tuple[RequiredMcpServer, ...]:
             return servers
 
-    return _Requiring(host=_FakeSandbox())  # type: ignore[arg-type]
+    return _Requiring
 
 
 # --- custom servers: CRUD + enable/disable -------------------------------
@@ -106,78 +127,87 @@ async def test_valid_name_derives_shell_safe_env_var(druks_db):
 # --- delivery at the workspace seam --------------------------------------
 
 
-async def test_delivery_carries_static_token_in_env(druks_db):
+async def test_delivery_names_the_variable_and_binds_the_static_row(druks_db):
     await McpServer.create(name="linear", url=_LINEAR_URL, token=_TOKEN)
+    row = await _bearer_row("linear")
 
     kwargs = await _delivery()
-    assert "linear" in {s.name for s in kwargs["mcp_servers"]}
-    # The token rides in env under the derived var; the wire shape names only the
-    # var, never the value.
-    assert kwargs["extra_env"][get_bearer_token_env_var("linear")] == _TOKEN
+    refs = await _refs()
+
+    # The wire shape names only the var. The value is a box entry the issuer
+    # answers from the bound row; nothing rides the run env.
     linear = next(s for s in kwargs["mcp_servers"] if s.name == "linear")
-    assert _TOKEN not in repr(linear)
+    assert linear.bearer_token_env_var == "MCP_LINEAR_TOKEN"
+    assert "extra_env" not in kwargs
+    [ref] = refs.values()
+    assert ref.key == ("mcp_linear_token", row.id, "", "mcp.linear.app")
+    assert _TOKEN not in repr(linear) + repr(refs)
+    assert await row.issue_token("") == (_TOKEN, None)
 
 
 async def test_required_server_delivers_beside_the_registry(druks_db):
-    # A workspace declares a server with a run-scoped token it minted itself
-    # (SoftwareFactory's per-repo reviewer token): wire shape + env var ride the same
-    # seam as every registry server.
+    # A workspace declares a server with its own vault row and resource
+    # (SoftwareFactory's review identity and repo): wire shape + entry ride
+    # the same seam as every registry server.
     await McpServer.create(name="linear", url=_LINEAR_URL, token=_TOKEN)
-    workspace = _requiring_workspace(
+    row = await _github_row()
+    workspace = _requiring(
         RequiredMcpServer(
-            name="github", url="https://api.githubcopilot.com/mcp/", token="ghs_minted"
+            name="github",
+            url="https://api.githubcopilot.com/mcp/",
+            secret_id=row.id,
+            resource="acme/widgets",
         )
     )
 
-    kwargs = await workspace.with_mcp_servers(None)
+    wire, refs = await workspace.get_mcp_delivery(None, None)
 
-    github = next(s for s in kwargs["mcp_servers"] if s.name == "github")
+    github = next(s for s in wire if s.name == "github")
     assert github.url == "https://api.githubcopilot.com/mcp/"
-    assert kwargs["extra_env"][github.bearer_token_env_var] == "ghs_minted"
-    assert "ghs_minted" not in repr(github)
-    assert "linear" in {s.name for s in kwargs["mcp_servers"]}
+    assert github.bearer_token_env_var == "MCP_GITHUB_TOKEN"
+    by_name = {ref.name: ref for ref in refs}
+    assert by_name["mcp_github_token"].key == (
+        "mcp_github_token",
+        row.id,
+        "acme/widgets",
+        "api.githubcopilot.com",
+    )
+    assert "linear" in {s.name for s in wire}
+    assert "mcp_linear_token" in by_name
 
 
 async def test_required_server_owns_its_name_against_a_registry_twin(druks_db):
     # Exactly one wire entry per name — the workspace's — and the registry twin
-    # is skipped whole: its token neither clobbers the required server's
-    # credential in env nor gets resolved at all (a tokenless twin would
-    # otherwise raise).
+    # is skipped whole: it is neither bound to an entry nor resolved at all (a
+    # tokenless twin would otherwise raise).
     await McpServer.create(name="linear", url=_LINEAR_URL, token=_TOKEN)
     await McpServer.create(name="notion", url="https://mcp.notion.com/sse", token="")
-    workspace = _requiring_workspace(
-        RequiredMcpServer(
-            name="linear", url="https://required.internal/linear", token="required-token"
-        ),
-        RequiredMcpServer(
-            name="notion", url="https://required.internal/notion", token="notion-token"
-        ),
+    row = await _github_row()
+    workspace = _requiring(
+        RequiredMcpServer(name="linear", url="https://required.internal/linear", secret_id=row.id),
+        RequiredMcpServer(name="notion", url="https://required.internal/notion", secret_id=row.id),
     )
 
-    kwargs = await workspace.with_mcp_servers(None)
+    wire, refs = await workspace.get_mcp_delivery(None, None)
 
-    delivered = [s for s in kwargs["mcp_servers"] if s.name == "linear"]
+    delivered = [s for s in wire if s.name == "linear"]
     assert len(delivered) == 1
     assert delivered[0].url == "https://required.internal/linear"
-    assert kwargs["extra_env"][get_bearer_token_env_var("linear")] == "required-token"
-    assert kwargs["extra_env"][get_bearer_token_env_var("notion")] == "notion-token"
+    by_name = {ref.name: ref for ref in refs}
+    assert by_name["mcp_linear_token"].host == "required.internal"
+    assert by_name["mcp_notion_token"].secret_id == row.id
 
 
 async def test_duplicate_required_names_are_refused(druks_db):
     # Two servers under one name would collide in the emitted harness config
     # (one TOML table / JSON key per name) — refused loudly at delivery.
-    workspace = _requiring_workspace(
-        RequiredMcpServer(name="github", url="https://a/", token="t1"),
-        RequiredMcpServer(name="github", url="https://b/", token="t2"),
+    workspace = _requiring(
+        RequiredMcpServer(name="github", url="https://a/", secret_id="one"),
+        RequiredMcpServer(name="github", url="https://b/", secret_id="two"),
     )
 
     with pytest.raises(ValueError, match="duplicate required"):
-        await workspace.with_mcp_servers(None)
-
-
-def test_required_server_token_stays_out_of_reprs():
-    required = RequiredMcpServer(name="github", url="https://a/", token="ghs_secret")
-    assert "ghs_secret" not in repr(required)
+        await workspace.get_mcp_delivery(None, None)
 
 
 async def test_enabled_static_server_without_token_raises_loudly(druks_db):
@@ -215,20 +245,7 @@ async def test_enabled_server_reaches_both_harness_configs_without_token(druks_d
     assert _LINEAR_URL in codex_config
     assert get_bearer_token_env_var("linear") in codex_config
     assert _TOKEN not in codex_config
-
-    # The token lives only in the run env, keyed by the same var the config names.
-    assert kwargs["extra_env"][get_bearer_token_env_var("linear")] == _TOKEN
-
-
-async def test_delivery_tolerates_explicit_none_extra_env(druks_db):
-    # ``extra_env=None`` is valid for the underlying run_agent; the fold must treat
-    # it like an omitted env, not unpack None (which would crash the call before it
-    # starts). A static server still rides via its own delivery env.
-    await McpServer.create(name="linear", url=_LINEAR_URL, token=_TOKEN)
-
-    kwargs = await _delivery(extra_env=None)
-    assert "linear" in {s.name for s in kwargs["mcp_servers"]}
-    assert kwargs["extra_env"][get_bearer_token_env_var("linear")] == _TOKEN
+    assert "extra_env" not in kwargs
 
 
 # --- declared headers: N per server, secret values via env refs -----------
@@ -246,22 +263,50 @@ async def _grafana_shaped_server() -> None:
     )
 
 
-async def test_declared_headers_deliver_inline_and_secret_values_ride_env(druks_db):
+async def test_declared_headers_deliver_inline_and_secret_values_are_entries(druks_db):
     await _grafana_shaped_server()
 
     kwargs = await _delivery()
+    refs = await _refs()
 
     grafana = next(s for s in kwargs["mcp_servers"] if s.name == "grafana")
-    # The wire shape names the env var carrying each secret header; the value
-    # rides only in the run env under that name, never inline.
+    # The wire shape names the env var behind each secret header; the value is
+    # a box entry for that header on the server's host, never inline.
     assert grafana.headers == {"X-Grafana-URL": "https://acme.grafana.net"}
-    assert set(grafana.env_headers) == {"X-Api-Key"}
-    header_env_var = grafana.env_headers["X-Api-Key"]
-    assert kwargs["extra_env"][header_env_var] == "grafana-api-secret"
-    assert "grafana-api-secret" not in repr(grafana)
-    # No bearer: neither the wire shape nor the env carries an Authorization var.
+    assert grafana.env_headers == {"X-Api-Key": "MCP_GRAFANA_HEADER_0"}
+    assert "grafana-api-secret" not in repr(grafana) + repr(refs)
+    assert "extra_env" not in kwargs
+    # No bearer: neither the wire shape nor the box carries an Authorization entry.
     assert grafana.bearer_token_env_var == ""
-    assert get_bearer_token_env_var("grafana") not in kwargs["extra_env"]
+    [ref] = refs.values()
+    row = await VaultSecret.get(ref.secret_id)
+    assert (ref.name, ref.host, row.header) == (
+        "mcp_grafana_header_0",
+        "mcp.grafana.com",
+        "X-Api-Key",
+    )
+    assert await row.issue_token("") == ("grafana-api-secret", None)
+
+
+async def test_two_secret_headers_bind_two_entries_beside_the_bearer(druks_db):
+    await McpServer.create(
+        name="acme",
+        url="https://mcp.acme.com/mcp",
+        token=_TOKEN,
+        secret_headers={"X-Api-Key": "key-secret", "X-Org": "org-secret"},
+    )
+
+    kwargs = await _delivery()
+    refs = await _refs()
+
+    acme = next(s for s in kwargs["mcp_servers"] if s.name == "acme")
+    assert acme.env_headers == {"X-Api-Key": "MCP_ACME_HEADER_0", "X-Org": "MCP_ACME_HEADER_1"}
+    assert set(refs) == {"mcp_acme_token", "mcp_acme_header_0", "mcp_acme_header_1"}
+    org = await VaultSecret.get(refs["mcp_acme_header_1"].secret_id)
+    assert org.header == "X-Org"
+    assert await org.issue_token("") == ("org-secret", None)
+    key = await VaultSecret.get(refs["mcp_acme_header_0"].secret_id)
+    assert await key.issue_token("") == ("key-secret", None)
 
 
 async def test_two_header_server_emits_both_headers_in_each_harness_config(druks_db):
@@ -312,7 +357,7 @@ async def test_bearer_and_declared_headers_combine_on_one_server(druks_db):
         "Authorization": f"Bearer ${{{get_bearer_token_env_var('acme')}}}",
         "X-Region": "eu",
     }
-    assert kwargs["extra_env"][get_bearer_token_env_var("acme")] == _TOKEN
+    assert "extra_env" not in kwargs
 
 
 async def test_bearerless_server_delivers_without_a_bearer(druks_db):

--- a/backend/tests/test_opencode.py
+++ b/backend/tests/test_opencode.py
@@ -135,6 +135,8 @@ async def test_build_invocation_uses_server_schema_and_env_auth(
         "Authorization": "Bearer {env:MCP_GITHUB_TOKEN}",
         "X-Trace-Key": "{env:MCP_TRACE_KEY}",
     }
+    # Druks owns the credential, so opencode must not start its own OAuth.
+    assert config["mcp"]["github"]["oauth"] is False
     assert _API_KEY not in wrapper
     assert "mcp-secret" not in env["OPENCODE_CONFIG_CONTENT"]
     assert "trace-secret" not in env["OPENCODE_CONFIG_CONTENT"]

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -136,7 +136,7 @@ async def test_a_subscription_agent_runs_as_its_actor_or_the_default_account(dru
     assert unattended.subscription.id == default_subscription.id
     assert (as_actor.secrets, as_actor.secrets_id, as_actor.key) == ({}, actor.id, None)
     [secret] = as_actor.secret_refs
-    assert secret.key == ("anthropic", actor.id, "")
+    assert secret.key == ("anthropic", actor.id, "", "")
     assert as_actor.harness_class is ClaudeHarness
     assert as_actor.model == "anthropic/claude-opus-4-7"
     assert (as_actor.effort, as_actor.timeout, as_actor.fast_mode) == ("high", 1800, False)

--- a/backend/tests/test_sandbox_identities.py
+++ b/backend/tests/test_sandbox_identities.py
@@ -10,9 +10,14 @@ from druks.database import db_session
 from druks.durable.engine import _step_engine
 from druks.harnesses import providers as pbase
 from druks.harnesses.providers import AnthropicProvider
+from druks.mcp.enums import IdentityMode
+from druks.mcp.models import McpServer
 from druks.sandbox.constants import SANDBOX_HOST_LEASE_SECONDS
 from druks.sandbox.models import SandboxIdentity, SecretRef
+from druks.secrets.datastructures import Audience
+from druks.secrets.models import VaultSecret
 from druks.testing import asgi_client, configure_app_for_test, make_settings, seed_run
+from druks.workspaces import Workspace
 from druks_field_notes.workflows import Summarize
 from sqlalchemy.exc import IntegrityError
 
@@ -99,7 +104,7 @@ async def test_an_identity_keeps_the_hash_and_puts_the_bearer_in_the_issuer_entr
         seconds=SANDBOX_HOST_LEASE_SECONDS
     )
     [secret] = identity.secret_refs
-    assert secret.key == ("anthropic", subscription.id, "")
+    assert secret.key == ("anthropic", subscription.id, "", "")
     rows = [identity, secret]
     columns = {
         column.name: getattr(row, column.name) for row in rows for column in row.__table__.columns
@@ -319,3 +324,79 @@ async def test_the_issuer_answers_503_when_github_refuses(druks_db, tmp_path, mo
 
     assert response.status_code == 503
     assert "installed" not in response.text
+
+
+async def _mcp_identity() -> tuple[SandboxIdentity, str, dict]:
+    # The one ref a box of a plain workspace binds for the enabled servers.
+    await seed_run(db_session(), kind=Summarize.kind, run_id="run-1")
+    [ref] = (await Workspace.get_mcp_delivery(None, None))[1]
+    identity, entries = await SandboxIdentity.create(
+        run_id="run-1", scoped_to="workflow", secret_refs=[ref]
+    )
+    await identity.bind("host-1")
+    bearer = entries[ref.name].headers["Authorization"].removeprefix("Bearer ")
+    return identity, bearer, entries[ref.name].entry()
+
+
+async def test_an_mcp_ref_binds_a_custom_entry_and_the_issuer_answers_the_stored_token(
+    druks_db, tmp_path
+):
+    await McpServer.create(name="linear", url="https://mcp.linear.app/mcp", token="lin_secret")
+    identity, bearer, entry = await _mcp_identity()
+
+    response = await _fetch(tmp_path, identity.id, bearer, "mcp_linear_token")
+
+    # The entry binds the host, the variable, the header, and the prefix. A
+    # pasted value has no expiry, so the static refresh bounds it.
+    assert entry == {
+        "host": "mcp.linear.app",
+        "auth_variable": "MCP_LINEAR_TOKEN",
+        "auth_header": "Authorization",
+        "auth_prefix": "Bearer ",
+        "issuer": {
+            "url": f"http://127.0.0.1:8001/api/secrets/{identity.id}/mcp_linear_token",
+            "headers": {"Authorization": f"Bearer {bearer}"},
+            "refresh": "5m",
+        },
+    }
+    assert response.json() == {"value": "lin_secret", "expires_at": None}
+    # A later server edit moves nothing: the row keeps the host its entry was made for.
+    [stored] = identity.secret_refs
+    assert stored.host == "mcp.linear.app"
+
+
+async def test_a_secret_header_entry_fills_its_own_header_with_no_prefix(druks_db, tmp_path):
+    await McpServer.create(
+        name="grafana",
+        url="https://mcp.grafana.com/mcp",
+        token_source="",
+        secret_headers={"X-Api-Key": "grafana-api-secret"},
+    )
+    identity, bearer, entry = await _mcp_identity()
+
+    response = await _fetch(tmp_path, identity.id, bearer, "mcp_grafana_header_0")
+
+    assert (entry["auth_header"], entry["auth_prefix"], entry["auth_variable"]) == (
+        "X-Api-Key",
+        "",
+        "MCP_GRAFANA_HEADER_0",
+    )
+    assert response.json() == {"value": "grafana-api-secret", "expires_at": None}
+
+
+async def test_the_issuer_answers_503_for_a_disconnected_mcp_grant(druks_db, tmp_path):
+    server = await McpServer.create(
+        name="linear", url="https://mcp.linear.app/mcp", token_source="oauth"
+    )
+    server.identity_mode = IdentityMode.SHARED
+    grant = await VaultSecret.connect(
+        Audience.mcp("linear"), account_id=None, refresh_token="rt", scopes=[]
+    )
+    identity, bearer, entry = await _mcp_identity()
+    assert entry["issuer"]["refresh"] == "1h"
+    await grant.revoke("user")
+
+    response = await _fetch(tmp_path, identity.id, bearer, "mcp_linear_token")
+
+    assert response.status_code == 503
+    assert "rt" not in response.text

--- a/backend/tests/test_sandboxed_harness.py
+++ b/backend/tests/test_sandboxed_harness.py
@@ -689,7 +689,7 @@ async def test_claude_subscription_token_stays_on_the_server(
 
     assert result.status is AgentCallStatus.SUCCEEDED
     [secret] = profile.secret_refs
-    assert secret.key == ("anthropic", profile.subscription.id, "")
+    assert secret.key == ("anthropic", profile.subscription.id, "", "")
     [start] = sandbox.calls
     assert not start.kwargs["extra_env"]
     bundle = start.kwargs["credentials_bundle"]

--- a/backend/tests/test_warm_host_rotation.py
+++ b/backend/tests/test_warm_host_rotation.py
@@ -69,6 +69,7 @@ def _warm_workflow(*, reuse: bool = True) -> Workflow:
     flow._host = None
     flow._subject = None
     flow._workflow_id = "wf-1"
+    flow.account_id = None
     return flow
 
 

--- a/backend/tests/test_workspaces.py
+++ b/backend/tests/test_workspaces.py
@@ -62,7 +62,7 @@ async def test_repo_workspace_names_its_github_secret_and_repo_before_the_box_ex
 
     [secret] = await RepoWorkspace.get_secret_refs(subject)
 
-    assert secret.key == ("github", row.id, "acme/widgets")
+    assert secret.key == ("github", row.id, "acme/widgets", "")
     assert await Workspace.get_secret_refs(subject) == []
 
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -245,7 +245,9 @@ backup access is credential access.
 
 Druks injects enabled MCP servers through the selected harness. A call receives
 the enabled skills it requests, or every enabled skill when it requests none.
-A workspace can also require an MCP server and supply its credentials.
+A workspace can also require an MCP server and name its vault row. Each MCP
+credential is a sandbox entry that the Druks issuer answers, so no token
+enters the sandbox environment.
 Each agent call records its declarations and delivery so later evaluation can
 distinguish capability sets without storing the tokens.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,8 +263,9 @@ A sandbox never holds an installation token. It holds a placeholder in
 secrets proxy swaps the placeholder for a token that Druks mints for the
 sandbox's repo, with the expiry GitHub gives it, and fetches a new one before
 it expires. The `software_factory` build clones and pushes as the operator App.
-A review clones as the reviewer App when one is connected. Its GitHub MCP
-server acts as the review identity. The identities stay separate.
+A review clones as the reviewer App when one is connected. The build's GitHub
+MCP server acts as the review identity through a second entry, for
+`api.githubcopilot.com`. The identities stay separate.
 
 **To upgrade an existing installation**, paste the credentials one time on each
 active host. Open **Settings → Connections → Services**. Connect GitHub with the
@@ -364,13 +365,14 @@ read-only at `/harnesses`. Claude and Codex each read their named directory:
 │   ├── settings.json
 │   └── plugins/
 └── codex/
-    ├── .credentials.json
     ├── AGENTS.md
     └── config.toml
 ```
 
-Missing files are optional. Codex uses `.credentials.json` for MCP credentials.
-Provider credentials do not belong in this root. OpenCode and Pi do not read it.
+Missing files are optional. Druks copies no credentials file, and it removes
+the `mcpServers` block from `.claude.json` before the copy. MCP credentials
+are sandbox entries. Provider credentials do not belong in this root. OpenCode
+and Pi do not read it.
 The default harness, model, billing, effort, and timeout live in
 **Settings → Agents**. Each agent can override any of them on its app's page.
 **Unattended runs use** names the default account. Its profile selects the
@@ -489,8 +491,14 @@ is one of:
 - An OAuth connection, which requires `urls.endpoint`.
 
 Druks delivers enabled servers through the selected harness unless an app
-workspace owns a required server with the same name. Tokens enter the agent
-environment under a derived variable and are never returned by the API.
+workspace owns a required server with the same name. Each bearer token and
+each secret header is a Drukbox entry behind a vault row. The sandbox holds a
+placeholder under a derived variable, and the harness configuration names that
+variable. The secrets proxy swaps the placeholder only for the server's host.
+The Druks issuer answers the value from the row that was bound when the
+sandbox was created. A pasted token reaches a running sandbox within five
+minutes. A server enabled after that gets no entry in a running sandbox. The
+API never returns a token.
 
 ## Skills
 

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -479,8 +479,35 @@ those two, so a request cannot select another repo or identity.
 Override `Workflow.get_workspace_kwargs()` to pass `branch` or the fields a
 subclass adds. Extend `RepoWorkspace` by adding fields, not by cloning again.
 Override `run_agent()` to prepare the VM before the call, `get_agent_run_kwargs()`
-to grant directories or skills, and `get_required_mcp_servers()` to require an
-MCP server the workspace credentials itself.
+to grant directories or skills, and `get_required_mcp_servers(subject)` to
+require an MCP server with its own vault row:
+
+```python
+from druks.sandbox.datastructures import RequiredMcpServer
+
+
+class BuildWorkspace(RepoWorkspace):
+    @classmethod
+    async def get_required_mcp_servers(cls, subject) -> tuple[RequiredMcpServer, ...]:
+        actor = await get_review_actor()
+        return (
+            RequiredMcpServer(
+                name="github",
+                url="https://api.githubcopilot.com/mcp/",
+                secret_id=(await actor.service.get()).id,
+                resource=cls.get_repo(subject),
+            ),
+        )
+```
+
+The server names the vault row the issuer answers from and what the token is
+for: here a connected GitHub service and its repo. Druks binds the server's
+host and the variable `MCP_GITHUB_TOKEN` to the entry when it creates the
+sandbox. The harness configuration names the variable, and the sandbox never
+holds the token. A required server owns its name, so a same-named registry
+server is not delivered. `Workspace.get_mcp_delivery(subject, account_id)`
+returns the wire shapes and the secret refs for every MCP server of a sandbox.
+Override it to deliver none.
 
 Keep durable state outside the VM. A workflow can set
 `steps_reuse_sandbox = True` to retain one host across a segment. Druks releases


### PR DESCRIPTION
Lands on #483 (DRU-494), merged. Linear: DRU-475.

## What changed

- Every MCP credential is a vault row, and a box holds one `SecretRef` per row it fetches: the pasted bearer, each secret header, the account's OAuth grant, or the review identity behind a required server. The ref binds `host`, the server's host at delivery. `SandboxIdentity.create` turns a ref with a host into a custom Drukbox entry. The entry names the host the proxy swaps at, the variable the box exports, the header the vault row names, and `Bearer ` for `Authorization`. The variable is the ref's name in upper case. A pasted value carries no expiry, so its entry refreshes every five minutes. The rest carry their expiry.
- `Workspace.get_mcp_delivery(subject, account_id)` resolves the required and enabled servers before the box exists. It returns the harness wire shapes and the refs, one per bearer and per secret header. `Workflow.get_secret_refs()` merges the refs with the workspace's own. `with_mcp_servers` keeps its signature, reads the wire shapes from the same method, and puts no value in `extra_env`.
- `RequiredMcpServer` holds `secret_id` and `resource` instead of `token`, and `get_required_mcp_servers(subject)` is an async classmethod. `BuildWorkspace` names the GitHub MCP server with the review actor's vault row and the repo. `mcp_token` and the per-call mint are gone. The box gets one custom entry for `api.githubcopilot.com` beside the operator's `github` entry.
- The issuer route is unchanged: `ref.secret.issue_token(ref.resource)` answers every kind. A revoked row answers 503 and the exchange retries.
- Codex no longer copies `.codex/.credentials.json`. Claude's `.claude.json` reaches the box without its `mcpServers` block. OpenCode sets `oauth: false` for a server whose credential Druks owns. The capability manifest reads token presence from the delivered wire shape, and `get_manifest` takes no environment.
- Migration `a3c9e7f1b5d2` adds `host` to `sandbox_secret_refs`.
- Docs: `configuration.md`, `writing-an-app.md`, `concepts.md`.

## Where this differs from the ticket

- The ticket predates the vault. A grant reference with a source, an account, and a minter is now a `SecretRef` to the vault row. `McpServer.mint` and the reference dicts do not exist: the row issues.
- The environment token source is gone since DRU-494, so its delivery and mint paths have no counterpart.
- The entry's header and prefix come from the vault row, not from the reference: a row under `Authorization` gets `Bearer `, a secret header row gets its own header and no prefix.
- One column, `host`, joins `sandbox_secret_refs`, so the ticket's "no new migration" no longer holds.
- Claude's `.claude.json` loses its `mcpServers` block on the way into the box. A copied entry could carry a token the vault never saw.

## Names

- `SecretRef.host`, `Workspace.get_mcp_delivery`, `RequiredMcpServer.secret_id`, `RequiredMcpServer.resource`, `BEARER_PREFIX`, `_STATIC_REFRESH`.
- Tests: `_refs`, `_bearer_row`, `_github_row`, `_requiring`, `_ref`, `_mcp_identity`.

## Removed tests

- `test_required_server_token_stays_out_of_reprs`: no token field.
- `test_delivery_tolerates_explicit_none_extra_env`: no env merge.
- `test_get_workspace_kwargs_fails_loudly_when_the_token_wont_mint`: no per-call mint.

## Gates

- `ruff check backend` and `ruff format --check backend`: clean.
- `pytest backend/` with the proof app installed: 1693 passed.
- By hand on a scratch database: `alembic upgrade head` through the new revision, `alembic check`, `downgrade e4b7c2d91a58`, `upgrade head`, `alembic check`. No drift either way.
- CI runs the full suite.

## Review

Real bed, Paulo's run. Enable one static MCP server and one OAuth server, and dispatch a run. From the box, run `env | grep MCP_` and one `curl` to the server through the proxy with `Authorization: Bearer $MCP_<NAME>_TOKEN`. Record the placeholder in the box environment and the proxy swap line. Record the issuer line in the Druks log, and a second issuer line about five minutes later for the static entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
