### PR TITLE
Add proven API-key entries for Codex, Pi, and OpenCode (DRU-480)

### DIFF
--- a/backend/druks/harnesses/base.py
+++ b/backend/druks/harnesses/base.py
@@ -21,7 +21,7 @@ from .datastructures import (
     HarnessRunResult,
     SandboxSettings,
 )
-from .providers import Provider
+from .providers import Provider, get_provider, is_registered
 
 if TYPE_CHECKING:
     from druks.sandbox.datastructures import McpServer
@@ -106,8 +106,17 @@ class Harness(ABC):
         return bool(cls.billing_options & provider.billing_options)
 
     @classmethod
-    def get_secrets(cls, key: str) -> dict[str, Secret]:
-        return {}
+    def get_secrets(cls, provider: str, key: str) -> dict[str, Secret]:
+        """The Drukbox entries a box gets for the pasted key of ``provider``,
+        the one the model names. The CLI reads the placeholder from the
+        variable the entry names. A provider without a proven transport
+        refuses: no raw key enters a box."""
+        if is_registered(provider):
+            return {provider: get_provider(provider).get_secret(key)}
+        raise exceptions.ProfileSettingsError(
+            f"Druks has no proven API-key transport for provider {provider!r}. "
+            "Use an Anthropic or OpenAI key."
+        )
 
     @classmethod
     def get_secret_refs(cls, subscription: VaultSecret) -> list[SecretRef]:

--- a/backend/druks/harnesses/claude.py
+++ b/backend/druks/harnesses/claude.py
@@ -5,8 +5,6 @@ import shlex
 from pathlib import Path
 from typing import Any
 
-from drukbox_sdk import Secret
-
 from druks.sandbox.datastructures import (
     AgentInvocation,
     Credentials,
@@ -69,10 +67,9 @@ class ClaudeHarness(Harness):
         skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
-        # Both accepted for signature parity. The sandbox holds a placeholder
-        # for the subscription token or the key. Drukbox delivers it.
+        # Accepted for signature parity. The sandbox holds a placeholder for
+        # the subscription token or the key. Drukbox delivers it.
         subscription: VaultSecret | None = None,
-        key: str | None = None,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
         if not self.sandbox:
@@ -192,18 +189,6 @@ class ClaudeHarness(Harness):
         # The catalog entry puts the placeholder in ANTHROPIC_AUTH_TOKEN, which
         # the CLI sends as a bearer. It never refreshes a token from there.
         return [SecretRef(name=AnthropicProvider.id, secret_id=subscription.id)]
-
-    @classmethod
-    def get_secrets(cls, key: str) -> dict[str, Secret]:
-        return {
-            AnthropicProvider.id: Secret(
-                key,
-                host="api.anthropic.com",
-                auth_variable="ANTHROPIC_API_KEY",
-                auth_header="x-api-key",
-                auth_prefix="",
-            )
-        }
 
     def _command_args(self) -> tuple[str, ...]:
         args = (self.command,)

--- a/backend/druks/harnesses/codex.py
+++ b/backend/druks/harnesses/codex.py
@@ -9,6 +9,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
+from drukbox_sdk import Secret
+
 from druks.sandbox.datastructures import (
     AgentInvocation,
     Credentials,
@@ -366,7 +368,6 @@ class CodexHarness(Harness):
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
         subscription: VaultSecret | None = None,
-        key: str | None = None,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
         sandbox = self.sandbox
@@ -397,7 +398,6 @@ class CodexHarness(Harness):
                 sandbox,
                 skills=skills,
                 subscription=subscription,
-                key=key,
             ),
             env=extra_env,
             extra_artifact_filenames=("output.json", "session.jsonl"),
@@ -478,11 +478,12 @@ class CodexHarness(Harness):
         *,
         skills: tuple[str, ...] = (),
         subscription: VaultSecret | None,
-        key: str | None,
     ) -> Credentials:
         config_dir = sandbox.harness_config_root / self.name
-        home: list[HomeFile | HomeCopy] = [
-            self.auth_file(subscription, key=key),
+        home: list[HomeFile | HomeCopy] = []
+        if subscription:
+            home.append(self.auth_file(subscription))
+        home += [
             HomeCopy(".codex/config.toml", config_dir / "config.toml"),
             HomeCopy(".codex/AGENTS.md", config_dir / "AGENTS.md"),
         ]
@@ -493,9 +494,19 @@ class CodexHarness(Harness):
         return Credentials(home=tuple(home))
 
     @classmethod
-    def auth_file(cls, subscription: VaultSecret | None, *, key: str | None = None) -> HomeFile:
-        if subscription:
-            auth = dict(subscription.secrets)
-        else:
-            auth = {"OPENAI_API_KEY": key}
-        return HomeFile(".codex/auth.json", json.dumps(auth))
+    def auth_file(cls, subscription: VaultSecret) -> HomeFile:
+        return HomeFile(".codex/auth.json", json.dumps(dict(subscription.secrets)))
+
+    @classmethod
+    def get_secrets(cls, provider: str, key: str) -> dict[str, Secret]:
+        # codex exec reads CODEX_API_KEY from the environment and ignores
+        # OPENAI_API_KEY there, so the key needs its own entry, not the catalog's.
+        return {
+            OpenAiProvider.id: Secret(
+                key,
+                host="api.openai.com",
+                auth_variable="CODEX_API_KEY",
+                auth_header="Authorization",
+                auth_prefix="Bearer ",
+            )
+        }

--- a/backend/druks/harnesses/opencode.py
+++ b/backend/druks/harnesses/opencode.py
@@ -37,11 +37,6 @@ class OpenCodeHarness(Harness):
     # owns an earlier deadline so it can abort the OpenCode session cleanly.
     first_byte_seconds = None
 
-    @classmethod
-    def auth_json(cls, provider: str, key: str) -> str:
-        """The auth store opencode reads from OPENCODE_AUTH_CONTENT."""
-        return json.dumps({provider: {"type": "api", "key": key}})
-
     async def build_invocation(
         self,
         *,
@@ -54,8 +49,9 @@ class OpenCodeHarness(Harness):
         skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
+        # Accepted for signature parity; opencode runs on an API key only, and
+        # the sandbox holds it as a placeholder in the provider's variable.
         subscription: VaultSecret | None = None,
-        key: str | None = None,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
         if not self.sandbox:
@@ -91,7 +87,6 @@ class OpenCodeHarness(Harness):
             credentials=Credentials(),
             env={
                 **(extra_env or {}),
-                "OPENCODE_AUTH_CONTENT": self.auth_json(provider, key),
                 "DRUKS_RUN_DIR": f"{get_runs_root(ssh_username)}/{run_id}",
                 "OPENCODE_CONFIG_CONTENT": json.dumps(
                     {"$schema": "https://opencode.ai/config.json", "mcp": mcp},

--- a/backend/druks/harnesses/opencode_wrapper.sh
+++ b/backend/druks/harnesses/opencode_wrapper.sh
@@ -1,9 +1,8 @@
 # One structured opencode call: start `opencode serve`, open a session, POST
 # the message with the contract schema, and print the POST response. Inputs
-# ride the environment (DRUKS_*, OPENCODE_AUTH_CONTENT,
-# OPENCODE_CONFIG_CONTENT); the prompt rides stdin. The message POST carries
-# the deadline — an unsatisfiable schema loops forever server-side, so on
-# expiry the wrapper aborts the session and exits 124.
+# ride the environment (DRUKS_*, OPENCODE_CONFIG_CONTENT); the prompt rides
+# stdin. The message POST carries the deadline — an unsatisfiable schema loops
+# forever server-side, so on expiry the wrapper aborts the session and exits 124.
 
 run_dir="$DRUKS_RUN_DIR"
 mkdir -p "$run_dir" &&

--- a/backend/druks/harnesses/pi.py
+++ b/backend/druks/harnesses/pi.py
@@ -8,7 +8,6 @@ from druks.sandbox.datastructures import (
     AgentInvocation,
     Credentials,
     HarnessRunResult,
-    HomeFile,
     McpServer,
 )
 from druks.sandbox.layout import get_runs_root
@@ -17,7 +16,6 @@ from druks.secrets.models import VaultSecret
 from . import exceptions
 from .artifacts import write_cost
 from .base import Harness
-from .providers import jwt_expiry
 from .subprocess import read_result_json
 
 _DRUKS_OUTPUT_TEMPLATE = Path(__file__).parent / "druks-output.ts"
@@ -38,27 +36,6 @@ class PiHarness(Harness):
     billing_options = frozenset({"api_key"})
     default_model = "openai/gpt-5.5"
 
-    @classmethod
-    def auth_file(
-        cls,
-        provider: str,
-        *,
-        subscription: VaultSecret | None = None,
-        key: str | None = None,
-    ) -> HomeFile:
-        if subscription:
-            tokens = subscription.secrets["tokens"]
-            entry = {
-                "type": "oauth",
-                "access": tokens["access_token"],
-                "refresh": tokens["refresh_token"],
-                "expires": int(jwt_expiry(tokens["access_token"]).timestamp() * 1000),
-                "accountId": tokens["account_id"],
-            }
-        else:
-            entry = {"type": "api_key", "key": key}
-        return HomeFile(".pi/agent/auth.json", json.dumps({provider: entry}))
-
     async def build_invocation(
         self,
         *,
@@ -74,8 +51,9 @@ class PiHarness(Harness):
         skills: tuple[str, ...] = (),
         extra_env: dict[str, str] | None = None,
         mcp_servers: tuple[McpServer, ...] = (),
+        # Accepted for signature parity; pi runs on an API key only, and the
+        # sandbox holds it as a placeholder in the provider's variable.
         subscription: VaultSecret | None = None,
-        key: str | None = None,
         timeout: int = Harness.default_timeout,
     ) -> AgentInvocation:
         if not self.sandbox:
@@ -85,8 +63,7 @@ class PiHarness(Harness):
             )
 
         model = self.model_id
-        # pi keeps the ChatGPT backend as its own provider name.
-        provider = "openai-codex" if subscription else self.model.partition("/")[0]
+        provider = self.model.partition("/")[0]
         in_vm_run_dir = f"{get_runs_root(ssh_username)}/{run_id}"
         in_vm_schema = f"{in_vm_run_dir}/schema.json"
         in_vm_extension = f"{in_vm_run_dir}/druks-output.ts"
@@ -140,12 +117,11 @@ class PiHarness(Harness):
         command_line = " ".join(shlex.quote(argument) for argument in command)
         wrapper = " && ".join((*writes, command_line))
 
-        auth_file = self.auth_file(provider, subscription=subscription, key=key)
         return AgentInvocation(
             name=self.name,
             args=("sh", "-c", wrapper),
             stdin=prompt.encode("utf-8"),
-            credentials=Credentials(home=(auth_file,)),
+            credentials=Credentials(),
             env={
                 **(extra_env or {}),
                 "DRUKS_SCHEMA_PATH": in_vm_schema,

--- a/backend/druks/harnesses/profiles.py
+++ b/backend/druks/harnesses/profiles.py
@@ -44,12 +44,6 @@ class Profile:
         return self.model.partition("/")[2]
 
     @property
-    def key(self) -> str | None:
-        # Codex, Pi, and OpenCode read the key from their invocation.
-        if self.api_key and not self.secrets:
-            return self.api_key.secrets["value"]
-
-    @property
     def secrets_id(self) -> str:
         """What a box created for this profile holds: the pasted key, or the
         subscriptions it fetches."""
@@ -115,7 +109,7 @@ async def get_profile(agent_name: str, account_id: str | None) -> Profile:
         if not provider_key:
             label = await provider_label(provider_id)
             raise HarnessNotConnectedError(f"add the {label} API key in Settings → Providers.")
-        secrets = harness_class.get_secrets(provider_key.secrets["value"])
+        secrets = harness_class.get_secrets(provider_id, provider_key.secrets["value"])
     else:
         subscription = await get_provider(provider_id).get_subscription(account_id)
         secret_refs = harness_class.get_secret_refs(subscription)

--- a/backend/druks/harnesses/providers.py
+++ b/backend/druks/harnesses/providers.py
@@ -12,6 +12,7 @@ from typing import ClassVar
 from urllib.parse import urlencode
 
 import httpx
+from drukbox_sdk import Secret
 from pydantic import TypeAdapter
 
 from druks.core.utils.time import ensure_utc
@@ -83,6 +84,12 @@ class Provider:
     REFRESH_MARGIN: ClassVar[timedelta]
     _TOKEN_URL: ClassVar[str]
     _CLIENT_ID: ClassVar[str]
+
+    @classmethod
+    def get_secret(cls, key: str) -> Secret:
+        """The Drukbox entry that puts ``key`` in a box as a placeholder: the
+        host, variable, header, and prefix this provider's API takes."""
+        raise NotImplementedError
 
     @classmethod
     async def connect_start(cls, *, account_id: str | None = None) -> tuple[str, str]:
@@ -675,6 +682,18 @@ class AnthropicProvider(Provider):
     redirect_uri = "https://console.anthropic.com/oauth/code/callback"
 
     @classmethod
+    def get_secret(cls, key: str) -> Secret:
+        # The API takes a key in x-api-key. The catalog entry is a bearer for a
+        # subscription token, so the key needs its own entry.
+        return Secret(
+            key,
+            host="api.anthropic.com",
+            auth_variable="ANTHROPIC_API_KEY",
+            auth_header="x-api-key",
+            auth_prefix="",
+        )
+
+    @classmethod
     def _token_from_credentials(cls, data: dict) -> OAuthToken:
         block = _oauth_block(data)
         if access := block.get("accessToken") or block.get("access_token"):
@@ -894,6 +913,11 @@ class OpenAiProvider(Provider):
     # Connect-flow (PKCE): authorize on auth.openai.com; the operator pastes the
     # failed localhost redirect URL back.
     redirect_uri = "http://localhost:1455/auth/callback"
+
+    @classmethod
+    def get_secret(cls, key: str) -> Secret:
+        # The catalog entry: OPENAI_API_KEY as a bearer on api.openai.com.
+        return Secret(key)
 
     @classmethod
     def _token_from_credentials(cls, data: dict) -> CodexToken:

--- a/backend/druks/sandbox/host.py
+++ b/backend/druks/sandbox/host.py
@@ -254,7 +254,6 @@ class Host:
                 mcp_servers=mcp_servers,
                 call_id=run_id,
                 subscription=profile.subscription,
-                key=profile.key,
             )
         except HarnessError as exc:
             error = exc
@@ -293,7 +292,6 @@ class Host:
         mcp_servers: tuple[McpServer, ...] = (),
         call_id: str | None = None,
         subscription: "VaultSecret | None" = None,
-        key: str | None = None,
     ) -> Any:
         """Drive one prompt through ``harness`` on this VM: the harness
         builds the invocation and parses the result; this sandbox executes it."""
@@ -317,7 +315,6 @@ class Host:
             extra_env=extra_env,
             mcp_servers=mcp_servers,
             subscription=subscription,
-            key=key,
             timeout=timeout,
         )
         result = await self._exec(

--- a/backend/tests/test_agents.py
+++ b/backend/tests/test_agents.py
@@ -893,7 +893,7 @@ async def test_api_key_billing_hands_claude_a_placeholder(
     # The VM's key names the pasted key, never its value.
     assert keys == [f"wf-9:dummy:anthropic.{pasted.updated_at:%Y%m%dT%H%M%S}"]
     profile = sandbox.run_agent.await_args.kwargs["profile"]
-    assert (profile.billing, profile.key, profile.subscription) == ("api_key", None, None)
+    assert (profile.billing, profile.subscription) == ("api_key", None)
     [call] = await AgentCall.list_for_run("wf-9")
     assert (call.subscription_id, call.api_key.audience_name) == (None, "anthropic")
     row = {column.key: getattr(call, column.key) for column in AgentCall.__table__.columns}

--- a/backend/tests/test_harness_auth.py
+++ b/backend/tests/test_harness_auth.py
@@ -5,11 +5,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 from conftest import connect_provider
+from drukbox_sdk import Secret
 from druks.accounts.models import Account
 from druks.harnesses.claude import ClaudeHarness, _get_credentials
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.datastructures import SandboxSettings
-from druks.harnesses.exceptions import HarnessNotConnectedError
+from druks.harnesses.exceptions import HarnessNotConnectedError, ProfileSettingsError
+from druks.harnesses.opencode import OpenCodeHarness
+from druks.harnesses.pi import PiHarness
 from druks.harnesses.providers import AnthropicProvider, OpenAiProvider
 from druks.sandbox.datastructures import HomeCopy, HomeFile
 from druks.secrets.models import VaultSecret
@@ -113,11 +116,7 @@ async def test_credentials_builders_read_their_harness_config_directories(druks_
         fast_mode=False,
         effort=None,
         sandbox=sandbox,
-    )._get_credentials(
-        sandbox,
-        subscription=codex_subscription,
-        key=None,
-    )
+    )._get_credentials(sandbox, subscription=codex_subscription)
 
     assert codex_bundle.home[0].path == ".codex/auth.json"
     assert HomeCopy(".claude/settings.json", config_root / "claude/settings.json") in (
@@ -155,16 +154,17 @@ async def test_credentials_builders_read_their_harness_config_directories(druks_
 
 
 @pytest.mark.parametrize(
-    ("harness", "config_name", "auth_name", "key"),
+    ("harness", "config_name", "auth_name"),
     [
-        # Claude reads the key from a placeholder in the VM, so its invocation gets none.
-        (ClaudeHarness, "settings.json", ".credentials.json", None),
-        (CodexHarness, "config.toml", "auth.json", "selected-key"),
+        # Each CLI reads its key from a placeholder in the VM, so its invocation
+        # carries no key and writes no credential file.
+        (ClaudeHarness, "settings.json", ".credentials.json"),
+        (CodexHarness, "config.toml", "auth.json"),
     ],
 )
 @pytest.mark.parametrize("config_exists", [False, True])
 async def test_config_delivery_does_not_copy_host_provider_credentials(
-    druks_db, tmp_path, harness, config_name, auth_name, key, config_exists
+    druks_db, tmp_path, harness, config_name, auth_name, config_exists
 ):
     config_root = tmp_path / "harnesses"
     config_dir = config_root / harness.name
@@ -187,7 +187,6 @@ async def test_config_delivery_does_not_copy_host_provider_credentials(
         schema={"type": "object"},
         run_id="run-1",
         ssh_username="druks",
-        key=key,
     )
     host = AsyncMock()
     for file in invocation.credentials.home:
@@ -201,14 +200,41 @@ async def test_config_delivery_does_not_copy_host_provider_credentials(
     else:
         host.upload_file.assert_not_awaited()
     host.upload_dir.assert_not_awaited()
-    if harness.name == "codex":
-        host.write_secret.assert_awaited_once_with(
-            secret=json.dumps({"OPENAI_API_KEY": "selected-key"}),
-            remote="/home/druks/.codex/auth.json",
+    host.write_secret.assert_not_awaited()
+    assert not invocation.env
+
+
+_ANTHROPIC_ENTRY = Secret(
+    "sk-1",
+    host="api.anthropic.com",
+    auth_variable="ANTHROPIC_API_KEY",
+    auth_header="x-api-key",
+    auth_prefix="",
+)
+
+
+def test_key_entries_follow_the_proven_transport_of_each_harness():
+    # Codex reads CODEX_API_KEY; every other CLI
+    # reads the provider's own variable, x-api-key for Anthropic and a bearer
+    # for OpenAI.
+    assert CodexHarness.get_secrets("openai", "sk-1") == {
+        "openai": Secret(
+            "sk-1",
+            host="api.openai.com",
+            auth_variable="CODEX_API_KEY",
+            auth_header="Authorization",
+            auth_prefix="Bearer ",
         )
-    else:
-        host.write_secret.assert_not_awaited()
-        assert not invocation.env
+    }
+    for harness in (ClaudeHarness, PiHarness, OpenCodeHarness):
+        assert harness.get_secrets("anthropic", "sk-1") == {"anthropic": _ANTHROPIC_ENTRY}
+    for harness in (PiHarness, OpenCodeHarness):
+        assert harness.get_secrets("openai", "sk-1") == {"openai": Secret("sk-1")}
+
+
+def test_an_unproven_provider_key_refuses_instead_of_entering_the_box():
+    with pytest.raises(ProfileSettingsError, match="'openrouter'"):
+        OpenCodeHarness.get_secrets("openrouter", "sk-1")
 
 
 async def test_credential_without_a_selection_reads_the_accounts_row(druks_db):

--- a/backend/tests/test_harness_reasoning_flags.py
+++ b/backend/tests/test_harness_reasoning_flags.py
@@ -157,7 +157,7 @@ async def test_codex_build_invocation_carries_every_flag():
 async def test_claude_reads_its_key_from_a_placeholder_in_the_vm():
     # Drukbox delivers the key as a placeholder under ANTHROPIC_API_KEY. The
     # invocation carries no key and no credentials file.
-    assert ClaudeHarness.get_secrets("sk-secret") == {
+    assert ClaudeHarness.get_secrets("anthropic", "sk-secret") == {
         "anthropic": Secret(
             "sk-secret",
             host="api.anthropic.com",
@@ -180,19 +180,27 @@ async def test_claude_reads_its_key_from_a_placeholder_in_the_vm():
     assert "sk-secret" not in inv.args[2]
 
 
-async def test_codex_runs_a_key_from_auth_json():
-    # The CLI reads OPENAI_API_KEY from auth.json for usage-based billing.
+async def test_codex_reads_its_key_from_a_placeholder_in_the_vm():
+    # Drukbox delivers the key as a placeholder under CODEX_API_KEY, the one
+    # variable codex exec reads. The invocation carries no key and no auth.json.
+    assert CodexHarness.get_secrets("openai", "sk-secret") == {
+        "openai": Secret(
+            "sk-secret",
+            host="api.openai.com",
+            auth_variable="CODEX_API_KEY",
+            auth_header="Authorization",
+            auth_prefix="Bearer ",
+        )
+    }
     inv = await CodexHarness(
         model=_CODEX_MODEL, fast_mode=False, effort=None, sandbox=_sandbox_config()
     ).build_invocation(
-        key="sk-secret",
         prompt="hello",
         schema={"type": "object"},
         run_id="run-1",
         ssh_username="exedev",
     )
-    [auth] = [file for file in inv.credentials.home if file.path == ".codex/auth.json"]
-    assert json.loads(auth.content) == {"OPENAI_API_KEY": "sk-secret"}
+    assert not any(file.path == ".codex/auth.json" for file in inv.credentials.home)
     assert inv.env is None
     assert "sk-secret" not in inv.args[2]
 

--- a/backend/tests/test_opencode.py
+++ b/backend/tests/test_opencode.py
@@ -90,7 +90,6 @@ async def test_build_invocation_uses_server_schema_and_env_auth(
         env_headers={"X-Trace-Key": "MCP_TRACE_KEY"},
     )
     invocation = await _harness().build_invocation(
-        key=_API_KEY,
         prompt="A large prompt stays on stdin.",
         schema={"type": "object", "properties": {"answer": {"type": "string"}}},
         run_id="run-1",
@@ -119,9 +118,8 @@ async def test_build_invocation_uses_server_schema_and_env_auth(
     assert invocation.credentials.home == ()
     env = invocation.env
     assert env is not None
-    assert json.loads(env["OPENCODE_AUTH_CONTENT"]) == {
-        "anthropic": {"type": "api", "key": _API_KEY}
-    }
+    # The key is a placeholder in the VM environment; opencode reads it from there.
+    assert "OPENCODE_AUTH_CONTENT" not in env
     assert env["DRUKS_RUN_DIR"].endswith("/run-1")
     assert env["DRUKS_PROVIDER"] == "anthropic"
     assert env["DRUKS_MODEL"] == "claude-sonnet-4-5"
@@ -149,12 +147,6 @@ async def test_build_invocation_uses_server_schema_and_env_auth(
     assert syntax.returncode == 0, syntax.stderr
 
 
-def test_auth_json_keys_the_provider() -> None:
-    rendered = OpenCodeHarness.auth_json("openai", _API_KEY)
-
-    assert json.loads(rendered) == {"openai": {"type": "api", "key": _API_KEY}}
-
-
 async def test_third_party_invocation_keeps_provider_key_and_model_namespace() -> None:
     harness = OpenCodeHarness(
         model="openrouter/anthropic/claude-sonnet-4",
@@ -164,7 +156,6 @@ async def test_third_party_invocation_keeps_provider_key_and_model_namespace() -
     )
 
     invocation = await harness.build_invocation(
-        key="sk-openrouter",
         prompt="Run it.",
         schema={"type": "object"},
         run_id="run-openrouter",
@@ -172,9 +163,7 @@ async def test_third_party_invocation_keeps_provider_key_and_model_namespace() -
     )
 
     assert invocation.env is not None
-    assert json.loads(invocation.env["OPENCODE_AUTH_CONTENT"]) == {
-        "openrouter": {"type": "api", "key": "sk-openrouter"}
-    }
+    assert "OPENCODE_AUTH_CONTENT" not in invocation.env
     assert invocation.env["DRUKS_PROVIDER"] == "openrouter"
     assert invocation.env["DRUKS_MODEL"] == "anthropic/claude-sonnet-4"
 

--- a/backend/tests/test_pi.py
+++ b/backend/tests/test_pi.py
@@ -1,11 +1,10 @@
-import base64
 import json
 import shlex
 import subprocess
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
+from drukbox_sdk import Secret
 from druks.harnesses.datastructures import SandboxSettings
 from druks.harnesses.exceptions import (
     HarnessAuthError,
@@ -16,7 +15,7 @@ from druks.harnesses.exceptions import (
 )
 from druks.harnesses.pi import PiHarness
 from druks.harnesses.registry import get_harness
-from druks.sandbox.datastructures import HarnessRunResult, HomeFile, McpServer
+from druks.sandbox.datastructures import HarnessRunResult, McpServer
 from druks.secrets.datastructures import Audience
 from druks.secrets.enums import SecretKind
 from druks.secrets.models import VaultSecret
@@ -75,36 +74,6 @@ def test_class_facts_and_registration() -> None:
     assert PiHarness.billing_options == {"api_key"}
 
 
-def test_auth_file_renders_a_key_under_the_vendor() -> None:
-    rendered = PiHarness.auth_file("anthropic", key=_API_KEY)
-    assert rendered.path == ".pi/agent/auth.json"
-    assert json.loads(rendered.content) == {"anthropic": {"type": "api_key", "key": _API_KEY}}
-
-
-def test_auth_file_renders_an_openai_subscription_as_pis_openai_codex() -> None:
-    # pi keeps the ChatGPT backend as its own provider name.
-    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode()
-    claims = base64.urlsafe_b64encode(b'{"exp": 1800000000}').rstrip(b"=").decode()
-    subscription = SimpleNamespace(
-        secrets={
-            "tokens": {
-                "access_token": f"{header}.{claims}.sig",
-                "refresh_token": "R0",
-                "account_id": "acc-1",
-            }
-        },
-    )
-    assert json.loads(PiHarness.auth_file("openai-codex", subscription=subscription).content) == {
-        "openai-codex": {
-            "type": "oauth",
-            "access": f"{header}.{claims}.sig",
-            "refresh": "R0",
-            "expires": 1800000000000,
-            "accountId": "acc-1",
-        }
-    }
-
-
 async def test_build_invocation_writes_the_run_files_and_pi_argv(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -118,7 +87,6 @@ async def test_build_invocation_writes_the_run_files_and_pi_argv(
     public = McpServer(name="public", url="https://public.example.test/mcp")
 
     invocation = await _harness().build_invocation(
-        key=_API_KEY,
         prompt="A large prompt stays on stdin.",
         schema={"type": "object"},
         run_id="run-1",
@@ -176,11 +144,8 @@ async def test_build_invocation_writes_the_run_files_and_pi_argv(
         "DRUKS_SCHEMA_PATH": f"{_RUN_DIR}/schema.json",
         "DRUKS_RESULT_PATH": f"{_RUN_DIR}/output.json",
     }
-    assert invocation.credentials.home == (
-        HomeFile(
-            ".pi/agent/auth.json", json.dumps({"openai": {"type": "api_key", "key": _API_KEY}})
-        ),
-    )
+    # The key is a placeholder in the VM environment; no home file carries it.
+    assert invocation.credentials.home == ()
     assert invocation.extra_artifact_filenames == ("output.json",)
     for secret in (_API_KEY, "mcp-secret", "trace-secret"):
         assert secret not in wrapper
@@ -194,7 +159,6 @@ async def test_build_invocation_without_servers_or_effort_is_bare(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     invocation = await _harness(effort=None).build_invocation(
-        key=_API_KEY,
         prompt="Prompt",
         schema={"type": "object"},
         run_id="run-1",
@@ -298,11 +262,8 @@ def test_parse_treats_a_broken_stream_as_invalid_output(tmp_path: Path) -> None:
         _parse(b"not json", tmp_path)
 
 
-async def test_a_pasted_key_renders_under_its_provider(client, druks_db) -> None:
+async def test_a_pasted_key_becomes_the_catalog_entry(client, druks_db) -> None:
     assert client.post("/api/providers/openai/key", json={"key": _API_KEY}).status_code == 200
     stored = await VaultSecret.lookup(SecretKind.STATIC, Audience.provider("openai"))
 
-    auth = PiHarness.auth_file("openai", key=stored.secrets["value"])
-
-    assert auth.path == ".pi/agent/auth.json"
-    assert json.loads(auth.content) == {"openai": {"type": "api_key", "key": _API_KEY}}
+    assert PiHarness.get_secrets("openai", stored.secrets["value"]) == {"openai": Secret(_API_KEY)}

--- a/backend/tests/test_profiles.py
+++ b/backend/tests/test_profiles.py
@@ -134,7 +134,7 @@ async def test_a_subscription_agent_runs_as_its_actor_or_the_default_account(dru
     assert as_actor.subscription.id == actor.id
     assert as_actor.charged_account_id == actor.account_id
     assert unattended.subscription.id == default_subscription.id
-    assert (as_actor.secrets, as_actor.secrets_id, as_actor.key) == ({}, actor.id, None)
+    assert (as_actor.secrets, as_actor.secrets_id) == ({}, actor.id)
     [secret] = as_actor.secret_refs
     assert secret.key == ("anthropic", actor.id, "", "")
     assert as_actor.harness_class is ClaudeHarness
@@ -161,11 +161,7 @@ async def test_a_key_agent_runs_on_the_installations_key_for_anyone(druks_db):
     unattended = await get_profile(PROFILE_PROBE.id, None)
 
     # Claude reads the key from a placeholder in the VM, never from its invocation.
-    assert (as_actor.secrets, as_actor.key, as_actor.subscription) == (
-        {"anthropic": _SHARED_ENTRY},
-        None,
-        None,
-    )
+    assert (as_actor.secrets, as_actor.subscription) == ({"anthropic": _SHARED_ENTRY}, None)
     assert unattended.secrets == {"anthropic": _SHARED_ENTRY}
     # The entries' identity is the pasted key, with no secret material.
     assert as_actor.secrets_id == f"anthropic.{pasted.updated_at:%Y%m%dT%H%M%S}"
@@ -182,7 +178,8 @@ async def test_a_key_agent_refuses_without_the_key(druks_db):
         await get_profile(PROFILE_PROBE.id, actor.account_id)
 
 
-async def test_opencode_runs_an_added_provider_with_its_key_and_model(druks_db):
+async def test_an_added_provider_refuses_until_its_transport_is_proven(druks_db):
+    # A Models.dev provider has no proven transport, so no raw key enters a box.
     await ProviderCatalog.create(
         "openrouter",
         [{"id": "openrouter/anthropic/claude-sonnet-4", "label": "Claude Sonnet 4"}],
@@ -197,12 +194,8 @@ async def test_opencode_runs_an_added_provider_with_its_key_and_model(druks_db):
     await SettingsOverride.set_agent_model(PROFILE_PROBE.id, "openrouter/anthropic/claude-sonnet-4")
     await SettingsOverride.set_agent_billing(PROFILE_PROBE.id, "api_key")
 
-    profile = await get_profile(PROFILE_PROBE.id, None)
-
-    assert profile.harness_class is OpenCodeHarness
-    assert profile.model == "openrouter/anthropic/claude-sonnet-4"
-    # OpenCode still reads the key from its invocation.
-    assert (profile.secrets, profile.key) == ({}, "sk-openrouter")
+    with pytest.raises(ProfileSettingsError, match="'openrouter'"):
+        await get_profile(PROFILE_PROBE.id, None)
 
 
 async def test_an_added_provider_without_a_key_names_it(druks_db):
@@ -238,7 +231,7 @@ async def test_a_key_only_harness_bills_the_key(druks_db):
     profile = await get_profile(PROFILE_PROBE.id, None)
 
     assert profile.harness_class is OpenCodeHarness
-    assert (profile.secrets, profile.key) == ({}, "sk-shared")
+    assert profile.secrets == {"anthropic": _SHARED_ENTRY}
 
 
 async def test_a_stored_triple_no_harness_runs_refuses(druks_db):
@@ -278,12 +271,8 @@ async def test_an_agent_reads_its_own_profile(druks_db):
         await PROFILE_PROBE.get_profile()
 
     assert (subscribed.harness, subscribed.model_id) == ("claude", "claude-opus-4-7")
-    assert (subscribed.billing, subscribed.secrets, subscribed.key) == ("subscription", {}, None)
-    assert (keyed.billing, keyed.secrets, keyed.key) == (
-        "api_key",
-        {"anthropic": _SHARED_ENTRY},
-        None,
-    )
+    assert (subscribed.billing, subscribed.secrets) == ("subscription", {})
+    assert (keyed.billing, keyed.secrets) == ("api_key", {"anthropic": _SHARED_ENTRY})
 
 
 async def test_an_unregistered_agent_is_named(druks_db):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -314,21 +314,27 @@ subscription token on a schedule. A `claude` sandbox holds a placeholder in
 Druks issuer through the sandbox's identity, and the secrets proxy swaps the
 placeholder on each request. See
 [sandbox identities and the issuer](concepts.md#agents-harnesses-workspaces-and-sandboxes).
-Codex and Pi still receive their credential file inside the sandbox. Druks does
+Codex still receives its subscription file inside the sandbox. Druks does
 not copy a host login. This is a capability connection for the requesting
 account. In a fresh `none`-mode install, the first completed subscription
 connection also creates the operator account. See
 [access control](#public-urls-and-access-control).
 
-An API key for `claude` never enters the sandbox. Druks gives the key to
-Drukbox as a secret entry when it creates the sandbox. The sandbox holds a
-placeholder in `ANTHROPIC_API_KEY`. The Drukbox secrets proxy swaps the
-placeholder for the key in the `x-api-key` header of each request to
-`api.anthropic.com`. The Compose stack runs the secrets proxy on every provider
-but docker-sbx. See
+An API key never enters the sandbox. Druks gives the key to Drukbox as a
+secret entry when it creates the sandbox. The sandbox holds a placeholder in
+the variable the entry names, and the CLI reads it from the environment. The
+Drukbox secrets proxy swaps the placeholder for the key in the entry's header
+on each request to the entry's host.
+
+| Harness | Provider | Variable | Host | Header |
+| --- | --- | --- | --- | --- |
+| `claude`, `pi`, `opencode` | Anthropic | `ANTHROPIC_API_KEY` | `api.anthropic.com` | `x-api-key` |
+| `pi`, `opencode` | OpenAI | `OPENAI_API_KEY` | `api.openai.com` | `Authorization: Bearer` |
+| `codex` | OpenAI | `CODEX_API_KEY` | `api.openai.com` | `Authorization: Bearer` |
+
+The Compose stack runs the secrets proxy on every provider but docker-sbx. See
 [the secrets exchange and the secrets proxy](deployment.md#the-secrets-exchange-and-the-secrets-proxy).
-Without it, Drukbox refuses the sandbox and the call fails. Codex, Pi, and
-OpenCode still receive the key inside the sandbox.
+Without it, Drukbox refuses the sandbox and the call fails.
 
 **Add provider** searches Models.dev for providers that use one API key.
 Druks caches the directory in Redis for one day for search and provider details.
@@ -348,9 +354,10 @@ Anthropic and OpenAI fetch separate model lists.
 Added providers use the cached Models.dev directory.
 
 The `claude` and `codex` CLIs run on their own vendor's subscription or key.
-`opencode` and `pi` run on an API key only. OpenCode can run a supported
-Models.dev provider after its key is stored. A model ID is `provider/model`
-for each harness, for example `openai/gpt-5.5`.
+`opencode` and `pi` run on an API key only, for Anthropic or OpenAI. A key for
+a Models.dev provider stores, but an agent on that provider refuses to run: no
+proven transport carries its placeholder through the secrets proxy. A model ID
+is `provider/model` for each harness, for example `openai/gpt-5.5`.
 The harness menus disable `opencode` and `pi` until a provider API key is configured.
 
 `paths.harness_config_root` points at optional CLI configuration that Druks

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -399,7 +399,6 @@ profile.model     # "provider/model"
 profile.effort
 profile.billing   # "subscription" | "api_key"
 profile.secrets   # the Drukbox entries that put the key in the VM as a placeholder
-profile.key       # an API key the CLI reads from its invocation, else None
 ```
 
 `get_profile()` runs inside a workflow and reads the settings at call time for
@@ -407,9 +406,11 @@ the run's own actor, the same read Druks makes for the calling agent. A
 missing login or key raises before any sandbox work. Under subscription
 billing there is no key. The VM home holds the login of the calling agent's
 subscription only, so a nested CLI on another provider needs `api_key` billing.
-Under `api_key` billing on `claude`, the VM holds the key as a placeholder in
-`ANTHROPIC_API_KEY`, the variable the entry names. A nested CLI reads it from
-the environment. Codex, Pi, and OpenCode read the key from `profile.key`.
+Under `api_key` billing, the VM holds the key as a placeholder in the variable
+the entry names: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `CODEX_API_KEY` for
+Codex. A nested CLI reads it from the environment. The
+[configuration guide](configuration.md#harnesses) lists the variable, host, and
+header per harness.
 
 Do not ask the framework to infer domain side effects from agent prose.
 The prompt or a subsequent explicit step owns those actions.


### PR DESCRIPTION
Lands on main after #466 (DRU-475). Linear: DRU-480. The entry contracts come from the API-key transport proof, ADR 0031.

## What changed

- `Harness.get_secrets(provider, key)` takes the model's provider. The base returns the provider's own entry for a registered provider and raises `ProfileSettingsError` for any other. `Provider.get_secret(key)` holds each entry: Anthropic is a custom entry on `api.anthropic.com` with `ANTHROPIC_API_KEY` in `x-api-key`; OpenAI is the catalog `openai` entry, `OPENAI_API_KEY` as a bearer. Claude now uses the base method, so its entry has one definition.
- Codex overrides `get_secrets` with a custom entry on `api.openai.com`, variable `CODEX_API_KEY`, `Authorization: Bearer`. `codex exec` reads that variable and ignores `OPENAI_API_KEY` from the environment. Codex writes `auth.json` for a subscription only.
- Pi loses `auth_file` and its dead subscription branch. OpenCode loses `auth_json` and `OPENCODE_AUTH_CONTENT`. Both read the placeholder from the box environment.
- `Profile.key` and the `key` parameter of `build_invocation`, `Host.run_agent`, and `Host.run_prompt` go away. No raw key reaches an invocation, a home file, or the environment.
- A key for a Models.dev provider still stores. An agent on that provider refuses at profile time, by name. No feature flag, no raw-key fallback.
- Docs: `configuration.md` carries the variable, host, and header matrix per harness and provider and the Models.dev refusal. `writing-an-app.md` drops `profile.key`.

## Where this differs from the ticket

- `get_secrets` gained a `provider` parameter. Pi and OpenCode run whichever provider the model names, so the key alone cannot select the entry.
- The entry shapes live on `Provider.get_secret`, not on each harness. Three harnesses share the Anthropic entry, so it has one definition.
- Models.dev providers lose API-key mode until a transport is proven. The ticket forbids a raw-key fallback and a Bearer contract inferred from Models.dev, and the proof covers Anthropic and OpenAI only. `docs/configuration.md` says so.
- Reused boxes, changed entry sets, and SDK 422 and 409 errors keep their existing coverage in `test_warm_host_rotation.py` and `test_sandbox_lifecycle.py`. This PR adds no second copy.

## Names

- `Provider.get_secret` beside `Harness.get_secrets`: one entry per provider, a set per harness.
- `CODEX_API_KEY` is Codex's own name for the variable.

## Removed tests

- `test_auth_file_renders_a_key_under_the_vendor`, `test_auth_file_renders_an_openai_subscription_as_pis_openai_codex`, and `test_auth_json_keys_the_provider`: the files and the store are gone.
- `test_codex_runs_a_key_from_auth_json` became `test_codex_reads_its_key_from_a_placeholder_in_the_vm`. `test_opencode_runs_an_added_provider_with_its_key_and_model` became `test_an_added_provider_refuses_until_its_transport_is_proven`.

## Gates

- `uv run ruff check backend` and `uv run ruff format --check backend` pass.
- `pytest backend/` with the proof app installed, rebased on main after the vault: 1691 passed.
- CI runs the full suite. No migration.

## Review

Real bed, Paulo's run, after the four checks in `docs/api-key-transport.md`. Set an agent to `codex` with `api_key` billing and one to `pi` or `opencode` on each provider, dispatch a run each, and from the box run `env | grep -E 'API_KEY'`. Record the placeholder in each variable, the proxy swap line per request, and the provider's status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

