### PR TITLE
DRU-486 - Make the ticket page save in place

### DIFF
--- a/backend/druks/contrib/software_factory/issues/models.py
+++ b/backend/druks/contrib/software_factory/issues/models.py
@@ -161,6 +161,11 @@ class Ticket(StoredSubject):
         )
         session.add(ticket)
         await session.flush()
+        # Creating already in Ready for Agent is arriving at the trigger, the
+        # same as a later move into it. Todo and the rest stay quiet: drafting
+        # is not a funnel event.
+        if status == Status.READY_FOR_AGENT:
+            await ticket._emit_transitioned(status)
         return ticket
 
     def get_label(self) -> str:
@@ -211,6 +216,9 @@ class Ticket(StoredSubject):
         if self.status == status:
             return
         await self.set_status(status)
+        await self._emit_transitioned(status)
+
+    async def _emit_transitioned(self, status: Status) -> None:
         project = await IssuesProject.get(self.project_id)
         assignee = await Account.get(self.assignee_id) if self.assignee_id else None
         await publish(

--- a/backend/druks/contrib/software_factory/issues/pages.py
+++ b/backend/druks/contrib/software_factory/issues/pages.py
@@ -33,16 +33,6 @@ PRIORITY_LABELS: dict[Priority, str] = {
     Priority.MEDIUM: "Medium",
     Priority.LOW: "Low",
 }
-# How a status reads as a chip. Presentation only — the workflow is the enum.
-STATUS_TONES: dict[Status, str] = {
-    Status.BACKLOG: "neutral",
-    Status.TODO: "neutral",
-    Status.READY_FOR_AGENT: "warning",
-    Status.IN_PROGRESS: "active",
-    Status.IN_REVIEW: "active",
-    Status.DONE: "success",
-    Status.CANCELLED: "danger",
-}
 
 UNASSIGNED = "Unassigned"
 # An account that has since gone, or druks' own system actor: the row still
@@ -133,6 +123,27 @@ def _create_actions(projects: list[IssuesProject], accounts: list[Account]) -> l
 
 def _ticket_link(ticket: Ticket, label: str) -> ui.Link:
     return ui.Link(label, page="ticket", arguments={"identifier": ticket.identifier})
+
+
+def _live_form(
+    ticket: Ticket,
+    field: ui.Field,
+    *,
+    operation: str,
+    layout: str,
+    refresh: str,
+) -> ui.Form:
+    return ui.Form(
+        fields=[field],
+        action=ui.Action(
+            label=f"Save {field.label.lower()}",
+            operation=operation,
+            arguments={"identifier": ticket.identifier},
+            refresh=refresh,
+        ),
+        submit="change",
+        layout=layout,
+    )
 
 
 def _ticket_card(ticket: Ticket, account_names: dict[str, str]) -> ui.Card:
@@ -235,111 +246,139 @@ async def ticket(identifier: str):
 
     projects = await IssuesProject.list()
     accounts = await Account.list_all()
-    project_names = {project.id: project.name for project in projects}
     account_names = {account.id: account.username for account in accounts}
-    status = Status(found.status)
     comments = await found.list_comments()
     thread = _comment_blocks(comments, account_names) or [
         ui.EmptyState("No comments yet", description="Say something about this ticket.")
     ]
 
     return ui.Page(
-        found.title,
-        description=found.identifier,
+        found.identifier,
         # The whole page follows the ticket, so a status write from anywhere —
         # Software Factory included — redraws it without a navigation.
         follows=found,
-        controls=[
-            ui.Action(
-                label="Move",
-                operation="set_status",
-                arguments={"identifier": found.identifier},
-                fields=[
-                    ui.SelectField(
-                        name="status",
-                        label="Status",
-                        options=_status_options(),
-                        value=status.value,
-                        is_required=True,
-                    )
-                ],
-            )
-        ],
         blocks=[
-            ui.Markdown(found.description or "_No description._"),
-            ui.Facts(
+            ui.Columns(
                 [
-                    ui.Fact(
-                        "Status", value=ui.StatusValue(status.label, tone=STATUS_TONES[status])
+                    ui.Stack(
+                        [
+                            ui.Form(
+                                fields=[
+                                    ui.TextField(
+                                        name="title",
+                                        label="Title",
+                                        value=found.title,
+                                        is_required=True,
+                                        placeholder="Title",
+                                    ),
+                                    ui.TextAreaField(
+                                        name="description",
+                                        label="Description",
+                                        value=found.description,
+                                        placeholder="Add a description…",
+                                        rows=12,
+                                    ),
+                                ],
+                                action=ui.Action(
+                                    label="Save",
+                                    operation="update_ticket",
+                                    arguments={"identifier": found.identifier},
+                                    refresh="none",
+                                ),
+                                submit="change",
+                                layout="prose",
+                            ),
+                            ui.Section(
+                                title="Comments",
+                                # Named, so the comment below replaces this section alone and
+                                # the thread grows in place.
+                                name="comments",
+                                blocks=[
+                                    *thread,
+                                    ui.Form(
+                                        title="Add a comment",
+                                        fields=[
+                                            ui.TextAreaField(
+                                                name="body", label="Comment", is_required=True
+                                            )
+                                        ],
+                                        action=ui.Action(
+                                            label="Comment",
+                                            operation="add_comment",
+                                            arguments={"identifier": found.identifier},
+                                            tone="primary",
+                                            refresh="region",
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ],
+                        gap="large",
                     ),
-                    ui.Fact(
-                        "Priority",
-                        value=ui.TextValue(PRIORITY_LABELS[Priority(found.priority)]),
+                    ui.Stack(
+                        [
+                            _live_form(
+                                found,
+                                ui.SelectField(
+                                    name="status",
+                                    label="Status",
+                                    options=_status_options(),
+                                    value=found.status,
+                                    is_required=True,
+                                ),
+                                operation="set_status",
+                                layout="row",
+                                refresh="page",
+                            ),
+                            _live_form(
+                                found,
+                                ui.SelectField(
+                                    name="priority",
+                                    label="Priority",
+                                    options=_priority_options(),
+                                    value=found.priority,
+                                ),
+                                operation="update_ticket",
+                                layout="row",
+                                refresh="page",
+                            ),
+                            _live_form(
+                                found,
+                                ui.SelectField(
+                                    name="assignee_id",
+                                    label="Assignee",
+                                    options=_assignee_options(accounts),
+                                    value=found.assignee_id or "",
+                                ),
+                                operation="update_ticket",
+                                layout="row",
+                                refresh="page",
+                            ),
+                            _live_form(
+                                found,
+                                ui.SelectField(
+                                    name="project_id",
+                                    label="Project",
+                                    options=_project_options(projects),
+                                    value=str(found.project_id),
+                                ),
+                                operation="update_ticket",
+                                layout="row",
+                                refresh="page",
+                            ),
+                            ui.Facts(
+                                [
+                                    ui.Fact("Identifier", value=ui.TextValue(found.identifier)),
+                                    ui.Fact("Created", value=ui.TimeValue(found.created_at)),
+                                    ui.Fact("Updated", value=ui.TimeValue(found.updated_at)),
+                                ]
+                            ),
+                        ],
+                        gap="small",
                     ),
-                    ui.Fact(
-                        "Assignee",
-                        value=ui.TextValue(_assignee_name(found.assignee_id, account_names)),
-                    ),
-                    ui.Fact(
-                        "Project",
-                        value=ui.TextValue(project_names.get(found.project_id, "")),
-                    ),
-                    ui.Fact("Identifier", value=ui.TextValue(found.identifier)),
                 ],
-                title="Details",
-            ),
-            ui.Form(
-                title="Edit",
-                fields=[
-                    ui.TextField(name="title", label="Title", value=found.title, is_required=True),
-                    ui.TextAreaField(
-                        name="description", label="Description", value=found.description
-                    ),
-                    ui.SelectField(
-                        name="priority",
-                        label="Priority",
-                        options=_priority_options(),
-                        value=found.priority,
-                    ),
-                    ui.SelectField(
-                        name="assignee_id",
-                        label="Assignee",
-                        options=_assignee_options(accounts),
-                        value=found.assignee_id or "",
-                    ),
-                    ui.SelectField(
-                        name="project_id",
-                        label="Project",
-                        options=_project_options(projects),
-                        value=str(found.project_id),
-                    ),
-                ],
-                action=ui.Action(
-                    label="Save",
-                    operation="update_ticket",
-                    arguments={"identifier": found.identifier},
-                ),
-            ),
-            ui.Section(
-                title="Comments",
-                # Named, so the comment below replaces this section alone and
-                # the thread grows in place.
-                name="comments",
-                blocks=[
-                    *thread,
-                    ui.Form(
-                        title="Add a comment",
-                        fields=[ui.TextAreaField(name="body", label="Comment", is_required=True)],
-                        action=ui.Action(
-                            label="Comment",
-                            operation="add_comment",
-                            arguments={"identifier": found.identifier},
-                            tone="primary",
-                            refresh="region",
-                        ),
-                    ),
-                ],
-            ),
+                layout="sidebar",
+            )
         ],
     )
 

--- a/backend/druks/contrib/software_factory/issues/routes.py
+++ b/backend/druks/contrib/software_factory/issues/routes.py
@@ -127,9 +127,9 @@ async def create_ticket(
     priority: Priority = Body(Priority.NONE, embed=True),
     assignee_id: str | None = Body(None, embed=True),
 ) -> TicketDetail:
-    """Write a ticket down. It lands in Todo and takes the next number in its
-    project's sequence. Creating is quiet: moving a ticket into Ready for Agent
-    is what opens a build, so a new ticket publishes nothing."""
+    """Write a ticket down. It takes the next number in its project's sequence.
+    Creating in Ready for Agent is a transition into the trigger, so a build
+    can open. Creating in Todo publishes nothing."""
     title = required_text(title, "title")
     if not await IssuesProject.get(project_id):
         raise HTTPException(http_status.HTTP_404_NOT_FOUND, f"no project {project_id}")

--- a/backend/druks/ui/blocks.py
+++ b/backend/druks/ui/blocks.py
@@ -187,13 +187,16 @@ class Action(PageBlock):
 
 class Form(PageBlock):
     """Inputs and the action that submits them. The shell sends the action's
-    arguments and the field values as one object."""
+    arguments and the field values as one object. ``submit="change"`` sends
+    on blur for text and on change for a select, with no button."""
 
     block: Literal["form"] = "form"
     title: str = ""
     description: str = ""
     fields: list[FormField] = Field(default_factory=list)
     action: Action
+    submit: Literal["button", "change"] = "button"
+    layout: Literal["stack", "prose", "row"] = "stack"
 
     def iter_actions(self) -> "Iterable[Action]":
         yield self.action
@@ -206,6 +209,11 @@ class Form(PageBlock):
         if self.action.fields:
             raise ValueError(
                 f"form {self.title!r} has fields on its action. Put all form fields on the form."
+            )
+        if self.submit == "change" and self.action.confirm:
+            raise ValueError(
+                f"form {self.title!r} submits on change and also asks to confirm. "
+                "A confirm is a press; give the form a button, or drop confirm."
             )
         _check_field_names(
             owner=f"form {self.title!r}",
@@ -578,10 +586,11 @@ class Stack(BlockParent):
 
 
 class Columns(BlockParent):
-    """Blocks across the page. Each child is one column; they share the width
-    and stack on a narrow screen."""
+    """Blocks across the page. ``even`` shares the width. ``sidebar`` keeps
+    the last column a rail. They stack on a narrow screen."""
 
     block: Literal["columns"] = "columns"
+    layout: Literal["even", "sidebar"] = "even"
 
     def __init__(self, blocks=(), **data):
         super().__init__(blocks=blocks, **data)

--- a/backend/tests/software_factory/test_issues_pages.py
+++ b/backend/tests/software_factory/test_issues_pages.py
@@ -50,6 +50,11 @@ def _tables(page: dict) -> list[dict]:
     return page["blocks"][0]["blocks"]
 
 
+def _comments(page: dict) -> dict:
+    left = page["blocks"][0]["blocks"][0]["blocks"]
+    return next(block for block in left if block.get("name") == "comments")
+
+
 async def test_empty_board_shows_columns_and_create_actions(druks_client):
     page = (await druks_client.get(f"{_PAGES}/board")).json()
 
@@ -141,10 +146,21 @@ async def test_ticket_page_follows_the_row_and_comments_refresh_the_region(druks
 
     page = (await druks_client.get(f"{_PAGES}/tickets/{created['identifier']}")).json()
 
-    assert page["title"] == "Follow me"
+    assert page["title"] == created["identifier"]
     assert page["follows"] == {"subjectType": "ticket", "subjectId": str(row.id)}
-    assert page["controls"][0]["operation"] == "set_status"
-    comments = next(block for block in page["blocks"] if block.get("name") == "comments")
+    assert page["controls"] == []
+    columns = page["blocks"][0]
+    assert columns["layout"] == "sidebar"
+    left = columns["blocks"][0]["blocks"]
+    prose = left[0]
+    assert prose["submit"] == "change"
+    assert prose["layout"] == "prose"
+    assert prose["fields"][0]["value"] == "Follow me"
+    assert prose["action"]["operation"] == "update_ticket"
+    status = columns["blocks"][1]["blocks"][0]
+    assert status["action"]["operation"] == "set_status"
+    assert status["submit"] == "change"
+    comments = _comments(page)
     assert comments["title"] == "Comments"
     assert comments["blocks"][0]["title"] == "No comments yet"
     comment_form = comments["blocks"][1]
@@ -158,7 +174,7 @@ async def test_ticket_page_follows_the_row_and_comments_refresh_the_region(druks
     assert written.status_code == 201
 
     after = (await druks_client.get(f"{_PAGES}/tickets/{created['identifier']}")).json()
-    thread = next(block for block in after["blocks"] if block.get("name") == "comments")
+    thread = _comments(after)
     assert thread["blocks"][0]["blocks"][0]["text"] == "looks good"
 
 

--- a/backend/tests/software_factory/test_issues_routes.py
+++ b/backend/tests/software_factory/test_issues_routes.py
@@ -41,17 +41,41 @@ def test_get_and_comment_are_agent_operations():
     assert add_comment["operationId"] in {"add_comment", "software_factory_add_comment"}
 
 
-async def test_create_does_not_publish(druks_client, monkeypatch):
+async def test_create_as_todo_does_not_publish(druks_client, monkeypatch):
     events = _published(monkeypatch)
     project = await _open_project(druks_client)
-    ticket = await _open_ticket(
-        druks_client, project["id"], status="ready_for_agent", title="quiet"
-    )
+    ticket = await _open_ticket(druks_client, project["id"], title="quiet")
 
     assert ticket["identifier"] == "DRU-1"
-    assert ticket["status"] == "ready_for_agent"
+    assert ticket["status"] == "todo"
     assert ticket["comments"] == []
     assert events == []
+
+
+async def test_create_as_ready_for_agent_publishes_the_trigger(druks_client, monkeypatch):
+    events = _published(monkeypatch)
+    project = await _open_project(druks_client, name="acme-app")
+    ticket = await _open_ticket(druks_client, project["id"], status="ready_for_agent", title="go")
+
+    assert ticket["status"] == "ready_for_agent"
+    assert events == [
+        (
+            "ticket.transitioned",
+            {
+                "source": "issues",
+                "identifier": "DRU-1",
+                "status": Status.READY_FOR_AGENT.label,
+                "title": "go",
+                "url": "/software_factory/tickets/DRU-1",
+                "project_name": "acme-app",
+                "labels": [],
+                "assignee_email": None,
+                "assignee_name": None,
+                "completed": False,
+                "terminal": False,
+            },
+        )
+    ]
 
 
 async def test_set_status_publishes_one_transition_with_display_labels(druks_client, monkeypatch):

--- a/backend/tests/test_ui_actions.py
+++ b/backend/tests/test_ui_actions.py
@@ -73,6 +73,8 @@ def test_a_form_carries_its_fields_and_the_action_that_sends_them():
         }
     ]
     assert block["action"]["operation"] == "write_note"
+    assert block["submit"] == "button"
+    assert block["layout"] == "stack"
     assert "presentation" not in block
 
 
@@ -210,6 +212,15 @@ def test_a_form_keeps_all_fields_on_the_form():
                 fields=[TextField(name="tag", label="Tag")],
             ),
             fields=[TextField(name="body", label="Body")],
+        )
+
+
+def test_a_form_that_submits_on_change_cannot_also_confirm():
+    with pytest.raises(ValueError, match="submits on change"):
+        Form(
+            action=Action(label="Save", operation="write_note", confirm="Sure?"),
+            fields=[TextField(name="body", label="Note")],
+            submit="change",
         )
 
 

--- a/docs/druks-ui.md
+++ b/docs/druks-ui.md
@@ -863,6 +863,8 @@ class Form:
     description: str = ""
     fields: list[Field] = []
     action: Action
+    submit: Literal["button", "change"] = "button"
+    layout: Literal["stack", "prose", "row"] = "stack"
 ```
 
 ```python
@@ -905,9 +907,15 @@ Druks refuses the form when the page function builds it.
     "confirm": "",
     "refresh": "page",
     "link": null
-  }
+  },
+  "submit": "button",
+  "layout": "stack"
 }
 ```
+
+`submit="change"` sends the form when a select changes or a text field blurs.
+The shell draws no button. `layout="prose"` is a title and body. `layout="row"`
+is a labelled property. A form cannot both submit on change and set `confirm`.
 
 ### Timeline
 
@@ -1258,15 +1266,16 @@ class Stack:
 ```python
 class Columns:
     block: Literal["columns"] = "columns"
+    layout: Literal["even", "sidebar"] = "even"
     blocks: list[Block] = []
 ```
 
 ```json
-{"block": "columns", "blocks": []}
+{"block": "columns", "layout": "even", "blocks": []}
 ```
 
-Each child block is one column. The columns share the width. On a narrow
-screen they stack.
+Each child block is one column. `even` shares the width. `sidebar` keeps the
+last column a rail. On a narrow screen they stack.
 
 `Stack` and `Columns` hold every V1 block, including each other. They have no
 special cases.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -434,7 +434,7 @@ export type Block =
     }
   | { block: 'list'; title: string; items: Value[] }
   | { block: 'stack'; gap: 'small' | 'medium' | 'large'; blocks: Block[] }
-  | { block: 'columns'; blocks: Block[] }
+  | { block: 'columns'; layout?: 'even' | 'sidebar'; blocks: Block[] }
   | Action
   | {
       block: 'form'
@@ -442,6 +442,8 @@ export type Block =
       description: string
       fields: Field[]
       action: Action
+      submit?: 'button' | 'change'
+      layout?: 'stack' | 'prose' | 'row'
     }
   | CardBlock
   | { block: 'cards'; title: string; cards: CardBlock[]; empty: EmptyStateBlock | null }

--- a/frontend/src/druksui/Blocks.tsx
+++ b/frontend/src/druksui/Blocks.tsx
@@ -43,6 +43,8 @@ function BlockContent({ block }: { block: Block }) {
           description={block.description}
           fields={block.fields}
           action={block.action}
+          submit={block.submit ?? 'button'}
+          layout={block.layout ?? 'stack'}
         />
       )
     case 'gate_controls':
@@ -103,7 +105,7 @@ function BlockContent({ block }: { block: Block }) {
     case 'columns':
       if (!block.blocks.length) return null
       return (
-        <div className="dui-columns">
+        <div className={`dui-columns${block.layout === 'sidebar' ? ' dui-columns-sidebar' : ''}`}>
           {block.blocks.map((column, index) => (
             <div key={index} className="dui-column">
               <BlockContent block={column} />

--- a/frontend/src/druksui/Fields.tsx
+++ b/frontend/src/druksui/Fields.tsx
@@ -10,12 +10,14 @@ export function Fields({
   errors,
   resets,
   onChange,
+  onBlur,
 }: {
   fields: Field[]
   values: Record<string, unknown>
   errors: Record<string, string>
   resets: number
   onChange: (name: string, value: unknown) => void
+  onBlur?: () => void
 }) {
   // A page can hold two forms that both take a "body", so the id a label points
   // at belongs to this form, not to the field name alone.
@@ -52,6 +54,9 @@ export function Fields({
               id={id}
               value={values[field.name]}
               onChange={onChange}
+              onBlur={
+                ['text', 'text_area', 'number', 'secret'].includes(field.field) ? onBlur : undefined
+              }
               describedBy={describedBy}
               isInvalid={Boolean(errors[field.name])}
               resets={resets}
@@ -78,6 +83,7 @@ function Input({
   id,
   value,
   onChange,
+  onBlur,
   describedBy,
   isInvalid,
   resets,
@@ -86,6 +92,7 @@ function Input({
   id: string
   value: unknown
   onChange: (name: string, value: unknown) => void
+  onBlur?: () => void
   describedBy?: string
   isInvalid: boolean
   resets: number
@@ -115,6 +122,7 @@ function Input({
           placeholder={field.placeholder}
           value={String(value ?? '')}
           onChange={(event) => onChange(field.name, event.target.value)}
+          onBlur={onBlur}
         />
       )
     case 'text_area':
@@ -126,6 +134,7 @@ function Input({
           placeholder={field.placeholder}
           value={String(value ?? '')}
           onChange={(event) => onChange(field.name, event.target.value)}
+          onBlur={onBlur}
         />
       )
     case 'number':
@@ -141,6 +150,7 @@ function Input({
           onChange={(event) =>
             onChange(field.name, event.target.value === '' ? null : Number(event.target.value))
           }
+          onBlur={onBlur}
         />
       )
     case 'select':
@@ -226,6 +236,7 @@ function Input({
           data-lpignore="true"
           value={String(value ?? '')}
           onChange={(event) => onChange(field.name, event.target.value)}
+          onBlur={onBlur}
         />
       )
     case 'upload':

--- a/frontend/src/druksui/Form.test.tsx
+++ b/frontend/src/druksui/Form.test.tsx
@@ -370,18 +370,83 @@ describe('submitting a form', () => {
     await waitFor(() => expect(callOperation).toHaveBeenCalledTimes(1))
   })
 
-  it('calls the resolved operation with the arguments and the values as one object', async () => {
-    renderBlocks([form([BODY], action({ arguments: { source: 'dashboard' }, refresh: 'none' }))])
+    it('calls the resolved operation with the arguments and the values as one object', async () => {
+      renderBlocks([form([BODY], action({ arguments: { source: 'dashboard' }, refresh: 'none' }))])
 
-    fireEvent.change(screen.getByLabelText(/Note/), { target: { value: 'Fan noise.' } })
-    fireEvent.click(screen.getByText('Save'))
+      fireEvent.change(screen.getByLabelText(/Note/), { target: { value: 'Fan noise.' } })
+      fireEvent.click(screen.getByText('Save'))
 
-    await waitFor(() => expect(callOperation).toHaveBeenCalled())
-    expect(callOperation).toHaveBeenCalledWith('POST', '/api/field_notes/notes', {
-      source: 'dashboard',
-      body: 'Fan noise.',
+      await waitFor(() => expect(callOperation).toHaveBeenCalled())
+      expect(callOperation).toHaveBeenCalledWith('POST', '/api/field_notes/notes', {
+        source: 'dashboard',
+        body: 'Fan noise.',
+      })
     })
-  })
+
+    it('sends a live form when a text field blurs, with no Save button', async () => {
+      renderBlocks([
+        {
+          ...form([BODY], action({ refresh: 'none' })),
+          submit: 'change',
+          layout: 'prose',
+        },
+      ])
+
+      expect(screen.queryByRole('button', { name: 'Save' })).toBeNull()
+      fireEvent.change(screen.getByLabelText(/Note/), { target: { value: 'Fan noise.' } })
+      fireEvent.blur(screen.getByLabelText(/Note/))
+
+      await waitFor(() => expect(callOperation).toHaveBeenCalled())
+      expect(callOperation).toHaveBeenCalledWith('POST', '/api/field_notes/notes', {
+        body: 'Fan noise.',
+      })
+    })
+
+    it('does not send a live form that nobody changed', () => {
+      renderBlocks([
+        {
+          ...form([BODY], action({ refresh: 'none' })),
+          submit: 'change',
+          layout: 'prose',
+        },
+      ])
+
+      fireEvent.blur(screen.getByLabelText(/Note/))
+      expect(callOperation).not.toHaveBeenCalled()
+    })
+
+    it('sends a live select as soon as it changes', async () => {
+      renderBlocks([
+        {
+          ...form(
+            [
+              {
+                field: 'select',
+                name: 'severity',
+                label: 'Severity',
+                options: [
+                  { value: 'low', label: 'Low' },
+                  { value: 'high', label: 'High' },
+                ],
+                value: 'low',
+                helpText: '',
+                isRequired: false,
+              },
+            ],
+            action({ refresh: 'none' }),
+          ),
+          submit: 'change',
+          layout: 'row',
+        },
+      ])
+
+      fireEvent.change(screen.getByLabelText(/Severity/), { target: { value: 'high' } })
+
+      await waitFor(() => expect(callOperation).toHaveBeenCalled())
+      expect(callOperation).toHaveBeenCalledWith('POST', '/api/field_notes/notes', {
+        severity: 'high',
+      })
+    })
 
   it('fills the path from the payload and sends what is left as the body', async () => {
     renderBlocks([

--- a/frontend/src/druksui/Form.test.tsx
+++ b/frontend/src/druksui/Form.test.tsx
@@ -121,13 +121,18 @@ function action(overrides: Partial<Action> = {}): Action {
   }
 }
 
-function form(fields: Field[], sends = action()): Block {
+function form(
+  fields: Field[],
+  sends = action(),
+  extras: { submit?: 'button' | 'change'; layout?: 'stack' | 'prose' | 'row' } = {},
+): Extract<Block, { block: 'form' }> {
   return {
     block: 'form',
     title: 'New note',
     description: 'What did you see?',
     fields,
     action: sends,
+    ...extras,
   }
 }
 
@@ -370,83 +375,72 @@ describe('submitting a form', () => {
     await waitFor(() => expect(callOperation).toHaveBeenCalledTimes(1))
   })
 
-    it('calls the resolved operation with the arguments and the values as one object', async () => {
-      renderBlocks([form([BODY], action({ arguments: { source: 'dashboard' }, refresh: 'none' }))])
+  it('calls the resolved operation with the arguments and the values as one object', async () => {
+    renderBlocks([form([BODY], action({ arguments: { source: 'dashboard' }, refresh: 'none' }))])
 
-      fireEvent.change(screen.getByLabelText(/Note/), { target: { value: 'Fan noise.' } })
-      fireEvent.click(screen.getByText('Save'))
+    fireEvent.change(screen.getByLabelText(/Note/), { target: { value: 'Fan noise.' } })
+    fireEvent.click(screen.getByText('Save'))
 
-      await waitFor(() => expect(callOperation).toHaveBeenCalled())
-      expect(callOperation).toHaveBeenCalledWith('POST', '/api/field_notes/notes', {
-        source: 'dashboard',
-        body: 'Fan noise.',
-      })
+    await waitFor(() => expect(callOperation).toHaveBeenCalled())
+    expect(callOperation).toHaveBeenCalledWith('POST', '/api/field_notes/notes', {
+      source: 'dashboard',
+      body: 'Fan noise.',
     })
+  })
 
-    it('sends a live form when a text field blurs, with no Save button', async () => {
-      renderBlocks([
-        {
-          ...form([BODY], action({ refresh: 'none' })),
-          submit: 'change',
-          layout: 'prose',
-        },
-      ])
+  it('sends a live form when a text field blurs, with no Save button', async () => {
+    renderBlocks([
+      form([BODY], action({ refresh: 'none' }), { submit: 'change', layout: 'prose' }),
+    ])
 
-      expect(screen.queryByRole('button', { name: 'Save' })).toBeNull()
-      fireEvent.change(screen.getByLabelText(/Note/), { target: { value: 'Fan noise.' } })
-      fireEvent.blur(screen.getByLabelText(/Note/))
+    expect(screen.queryByRole('button', { name: 'Save' })).toBeNull()
+    fireEvent.change(screen.getByLabelText(/Note/), { target: { value: 'Fan noise.' } })
+    fireEvent.blur(screen.getByLabelText(/Note/))
 
-      await waitFor(() => expect(callOperation).toHaveBeenCalled())
-      expect(callOperation).toHaveBeenCalledWith('POST', '/api/field_notes/notes', {
-        body: 'Fan noise.',
-      })
+    await waitFor(() => expect(callOperation).toHaveBeenCalled())
+    expect(callOperation).toHaveBeenCalledWith('POST', '/api/field_notes/notes', {
+      body: 'Fan noise.',
     })
+  })
 
-    it('does not send a live form that nobody changed', () => {
-      renderBlocks([
-        {
-          ...form([BODY], action({ refresh: 'none' })),
-          submit: 'change',
-          layout: 'prose',
-        },
-      ])
+  it('does not send a live form that nobody changed', () => {
+    renderBlocks([
+      form([BODY], action({ refresh: 'none' }), { submit: 'change', layout: 'prose' }),
+    ])
 
-      fireEvent.blur(screen.getByLabelText(/Note/))
-      expect(callOperation).not.toHaveBeenCalled()
-    })
+    fireEvent.blur(screen.getByLabelText(/Note/))
+    expect(callOperation).not.toHaveBeenCalled()
+  })
 
-    it('sends a live select as soon as it changes', async () => {
-      renderBlocks([
-        {
-          ...form(
-            [
-              {
-                field: 'select',
-                name: 'severity',
-                label: 'Severity',
-                options: [
-                  { value: 'low', label: 'Low' },
-                  { value: 'high', label: 'High' },
-                ],
-                value: 'low',
-                helpText: '',
-                isRequired: false,
-              },
+  it('sends a live select as soon as it changes', async () => {
+    renderBlocks([
+      form(
+        [
+          {
+            field: 'select',
+            name: 'severity',
+            label: 'Severity',
+            options: [
+              { value: 'low', label: 'Low' },
+              { value: 'high', label: 'High' },
             ],
-            action({ refresh: 'none' }),
-          ),
-          submit: 'change',
-          layout: 'row',
-        },
-      ])
+            value: 'low',
+            helpText: '',
+            isRequired: false,
+          },
+        ],
+        action({ refresh: 'none' }),
+        { submit: 'change', layout: 'row' },
+      ),
+    ])
 
-      fireEvent.change(screen.getByLabelText(/Severity/), { target: { value: 'high' } })
+    fireEvent.change(screen.getByLabelText(/Severity/), { target: { value: 'high' } })
 
-      await waitFor(() => expect(callOperation).toHaveBeenCalled())
-      expect(callOperation).toHaveBeenCalledWith('POST', '/api/field_notes/notes', {
-        severity: 'high',
-      })
+    await waitFor(() => expect(callOperation).toHaveBeenCalled())
+    expect(callOperation).toHaveBeenCalledWith('POST', '/api/field_notes/notes', {
+      severity: 'high',
     })
+  })
 
   it('fills the path from the payload and sends what is left as the body', async () => {
     renderBlocks([

--- a/frontend/src/druksui/Form.tsx
+++ b/frontend/src/druksui/Form.tsx
@@ -19,20 +19,37 @@ export function Form({
   description,
   fields,
   action,
+  submit = 'button',
+  layout = 'stack',
 }: {
   title: string
   description: string
   fields: Field[]
   action: Action
+  submit?: 'button' | 'change'
+  layout?: 'stack' | 'prose' | 'row'
 }) {
   const fieldState = useFieldState(fields)
-  const run = useAction(action, fields, fieldState.clear)
+  const live = submit === 'change'
+  const run = useAction(action, fields, live ? undefined : fieldState.clear)
+  const declared = Object.fromEntries(fields.map(startingValue))
+  const immediate = new Set(
+    fields
+      .filter((field) => !['text', 'text_area', 'number', 'secret'].includes(field.field))
+      .map((field) => field.name),
+  )
+
+  function commit(values: Payload) {
+    if (JSON.stringify(values) === JSON.stringify(declared)) return
+    void run.call(values)
+  }
 
   return (
     <form
-      className="dui-form"
+      className={`dui-form dui-form-${layout}${live ? ' dui-form-live' : ''}`}
       onSubmit={(event) => {
         event.preventDefault()
+        if (live) return
         void run.call(fieldState.values)
       }}
     >
@@ -43,29 +60,36 @@ export function Form({
         values={fieldState.values}
         errors={run.fieldErrors}
         resets={fieldState.resets}
-        onChange={fieldState.change}
+        onChange={(name, value) => {
+          const next = { ...fieldState.values, [name]: value }
+          fieldState.change(name, value)
+          if (live && immediate.has(name)) commit(next)
+        }}
+        onBlur={live ? () => commit(fieldState.values) : undefined}
       />
       {run.problem && (
         <div className="dui-form-error" role="alert">
           {run.problem}
         </div>
       )}
-      <div className="dui-form-submit">
-        {run.confirming ? (
-          <Confirm action={action} run={run} />
-        ) : (
-          <button
-            type="submit"
-            className={`dui-action dui-action-${action.tone}`}
-            disabled={run.blocked}
-            aria-busy={run.pending}
-          >
-            {action.label}
-          </button>
-        )}
-      </div>
+      {live ? null : (
+        <div className="dui-form-submit">
+          {run.confirming ? (
+            <Confirm action={action} run={run} />
+          ) : (
+            <button
+              type="submit"
+              className={`dui-action dui-action-${action.tone}`}
+              disabled={run.blocked}
+              aria-busy={run.pending}
+            >
+              {action.label}
+            </button>
+          )}
+        </div>
+      )}
       <p className="dui-action-note" role="status">
-        {run.note}
+        {live ? '' : run.note}
       </p>
     </form>
   )

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2117,6 +2117,8 @@ a.dui-card:hover .dui-card-title { text-decoration: underline; text-underline-of
 .dui-stack-large { gap: 32px; }
 .dui-columns { display: flex; gap: 24px; margin: 16px 0; }
 .dui-column { flex: 1 1 0; min-width: 0; }
+.dui-columns-sidebar { align-items: start; }
+.dui-columns-sidebar > .dui-column:last-child { flex: 0 0 280px; }
 
 .dui-metric-row { display: flex; flex-wrap: wrap; gap: 32px; margin: 16px 0; }
 .dui-metric { margin: 0; }
@@ -2178,6 +2180,7 @@ a.dui-card:hover .dui-card-title { text-decoration: underline; text-underline-of
    the values without knowing what they are. */
 @media (max-width: 720px) {
   .dui-columns { flex-direction: column; }
+  .dui-columns-sidebar > .dui-column:last-child { flex: 1 1 auto; }
   .dui-table { font-size: 13px; }
   .dui-table thead th { padding: 10px 12px; }
   .dui-table :is(td, tbody th) { padding: 12px; }
@@ -2191,6 +2194,31 @@ a.dui-card:hover .dui-card-title { text-decoration: underline; text-underline-of
 
 .dui-form { margin: 16px 0; max-width: 520px; }
 .dui-form-desc { font-size: 13px; line-height: 18px; margin: 0 0 16px; }
+.dui-form-live .dui-action-note:empty { display: none; }
+.dui-form-prose { max-width: none; margin: 0; }
+.dui-form-prose .dui-field { margin-bottom: 8px; }
+.dui-form-prose .dui-field-label {
+  position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0);
+}
+.dui-form-prose .dui-field:first-child .dui-input {
+  font-size: 28px; line-height: 36px; font-weight: 600; min-height: 0;
+  padding: 4px 0; border: none; background: transparent; border-radius: 0;
+}
+.dui-form-prose textarea.dui-input {
+  min-height: 12em; padding: 8px 0; border: none; background: transparent; border-radius: 0;
+  resize: vertical;
+}
+.dui-form-prose .dui-input:hover, .dui-form-prose .dui-input:focus {
+  background: transparent; border: none; outline: none;
+}
+.dui-form-prose .dui-input:focus { box-shadow: 0 1px 0 var(--border-loud); }
+.dui-form-row { max-width: none; margin: 0; }
+.dui-form-row .dui-field {
+  display: grid; grid-template-columns: 7.5rem minmax(0, 1fr); gap: 8px 12px;
+  align-items: center; margin: 0; padding: 4px 0;
+}
+.dui-form-row .dui-field-label { margin: 0; }
+.dui-form-row .dui-input { min-height: 32px; padding: 6px 10px; }
 .dui-field { margin-bottom: 16px; }
 .dui-field-label { display: block; font-size: 12px; line-height: 16px; font-weight: 500; color: var(--text-mid); margin-bottom: 8px; }
 .dui-field-required { color: var(--decision-request-revision); }


### PR DESCRIPTION
Linear ticket: [DRU-486](https://linear.app/fellaworks/issue/DRU-486/issues-inline-ticket-detail)

Stacked on [DRU-485](https://github.com/czpython/druks/pull/470).

## Summary
- Ticket detail is a Linear-style page: title and description on the left, status/priority/assignee/project on the right. Typing or picking a value saves. There is no Move action and no Save button.
- `Form` grows `submit="change"` and `layout` (`prose` / `row`). `Columns` grows `layout="sidebar"`.
- Creating a ticket already in Ready for Agent publishes `ticket.transitioned`, so the funnel can open a build. Creating in Todo stays quiet.

## Test plan
- [ ] `uv run ruff check backend`
- [ ] `uv run ruff format --check backend`
- [ ] `uv pip install -e backend/tests/druks-field_notes`
- [ ] `uv run pytest backend/tests/software_factory/test_issues_pages.py backend/tests/software_factory/test_issues_routes.py backend/tests/test_ui_actions.py`
- [ ] `npm --prefix frontend test -- src/druksui/Form.test.tsx`
- [ ] On a ticket page, edit the title and tab away; it persists without Save.
- [ ] Change status in the sidebar dropdown; no Move action. Ready for Agent still opens a build.
- [ ] Create a ticket as Ready for Agent; a build can start without a later move.
- [ ] Create a ticket as Todo; nothing publishes.


Made with [Cursor](https://cursor.com)