### PR TITLE
DRU-488 - Issues: markdown ticket editor

### DIFF
--- a/backend/druks/contrib/software_factory/issues/pages.py
+++ b/backend/druks/contrib/software_factory/issues/pages.py
@@ -111,7 +111,7 @@ def _create_actions(repos: list[ProjectRepo], accounts: list[Account]) -> list[u
                     is_required=True,
                     help_text="The GitHub repo this ticket's pull request will target.",
                 ),
-                ui.TextAreaField(name="description", label="Description"),
+                ui.TextAreaField(name="description", label="Description", markdown=True, rows=3),
                 ui.SelectField(
                     name="status",
                     label="Status",
@@ -444,6 +444,8 @@ async def ticket(identifier: str):
                                         label="Description",
                                         value=found.description,
                                         placeholder="Add a description…",
+                                        rows=12,
+                                        markdown=True,
                                     ),
                                 ],
                                 action=ui.Action(
@@ -469,6 +471,8 @@ async def ticket(identifier: str):
                                                 name="body",
                                                 label="Comment",
                                                 is_required=True,
+                                                markdown=True,
+                                                rows=3,
                                             )
                                         ],
                                         action=ui.Action(

--- a/backend/druks/ui/fields.py
+++ b/backend/druks/ui/fields.py
@@ -39,6 +39,8 @@ class TextAreaField(PageField):
     value: str = ""
     placeholder: str = ""
     rows: int = 4
+    # The value is markdown source. The shell renders it as formatted text.
+    markdown: bool = False
 
 
 class NumberField(PageField):

--- a/backend/tests/test_ui_actions.py
+++ b/backend/tests/test_ui_actions.py
@@ -14,6 +14,7 @@ from druks.ui import (
     SecretField,
     Section,
     SelectField,
+    TextAreaField,
     TextField,
 )
 from druks.ui.fields import PageField
@@ -78,6 +79,29 @@ def test_a_form_carries_its_fields_and_the_action_that_sends_them():
     assert block["submit"] == "button"
     assert block["layout"] == "stack"
     assert "presentation" not in block
+
+
+def test_a_markdown_text_area_stays_source_on_the_wire():
+    (block,) = wire(
+        Form(
+            action=Action(label="Save", operation="write_note"),
+            fields=[TextAreaField(name="body", label="Note", markdown=True, rows=8)],
+        )
+    )
+
+    assert block["fields"] == [
+        {
+            "field": "text_area",
+            "name": "body",
+            "label": "Note",
+            "value": "",
+            "placeholder": "",
+            "helpText": "",
+            "isRequired": False,
+            "rows": 8,
+            "markdown": True,
+        }
+    ]
 
 
 def test_an_action_can_collect_fields_before_it_runs():

--- a/docs/druks-ui.md
+++ b/docs/druks-ui.md
@@ -1424,11 +1424,17 @@ class TextAreaField:
     help_text: str = ""
     is_required: bool = False
     rows: int = 4
+    markdown: bool = False
 ```
 
 ```json
-{"field": "text_area", "name": "body", "label": "Note", "value": "", "placeholder": "", "helpText": "", "isRequired": false, "rows": 4}
+{"field": "text_area", "name": "body", "label": "Note", "value": "", "placeholder": "", "helpText": "", "isRequired": false, "rows": 4, "markdown": false}
 ```
+
+`markdown=True` keeps the value as markdown source. The shell renders formatted
+text in place. A selection toolbar applies marks, headings, lists, and links.
+Submit still sends markdown. There is no HTML roundtrip. Read-only `Markdown`
+blocks still use the GFM renderer.
 
 ### NumberField
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,8 +29,10 @@ runs lint, tests, and build for PRs into `main` and `codex/` stack branches.
 - Shared routing and fallback behavior.
 
 Bundled app UI lives under `src/apps/<name>/`. Its module calls
-`registerAppUI()` with routes and an optional home path. The backend app class
-declares the subnav tabs. The roster supplies these tabs to the frontend.
+`registerAppUI()` with routes and an optional home path. A Python-page app
+declares subnav tabs on its backend class; the roster supplies them. An app
+that ships its own JavaScript sets `navigation` on the registration, or
+`navigationFor` when the tabs depend on settings.
 Import the module one time from `src/apps/index.ts`. The shell finds the
 registration and does not hardcode the app name.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,12 @@
       "dependencies": {
         "@novnc/novnc": "1.7.0",
         "@tanstack/react-query": "^5.102.6",
+        "@tiptap/extension-bubble-menu": "^3.31.3",
+        "@tiptap/extension-placeholder": "^3.31.3",
+        "@tiptap/markdown": "^3.31.3",
+        "@tiptap/pm": "^3.31.3",
+        "@tiptap/react": "^3.31.3",
+        "@tiptap/starter-kit": "^3.31.3",
         "lucide-react": "^1.34.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -650,6 +656,31 @@
         }
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1226,6 +1257,465 @@
         }
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.31.3.tgz",
+      "integrity": "sha512-Cz50pvciQrxdSxgTkHOVz0uD0Yl/8Xt0QatGD6ILm47jW8EzyHR9RkUGs/D5IqzXKuVPntfw1ttaT926vXfiRg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.31.3.tgz",
+      "integrity": "sha512-fyY2XMbyDDDfOTQ1Qdrnqa1qwC9DWE4n7AfE0EKQI0G8MfLV8RaDlLDcOZDJ9JbMPY7/Gx7EjyK4NKxSW9n2hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.31.3.tgz",
+      "integrity": "sha512-dIuYhKk8TitKU/FeDpoTeWZhU42YgDN5npgWNjAmMmRktPdoxnH3/wGSiwXlqZgJWjehN7kPWDePWpJeAImGpQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.31.3.tgz",
+      "integrity": "sha512-EV6ZnwKc++2OM/OcD54n8s1B7C9LP7GKAtdEPwu0t3BYJf3sG8Ueoinf7SgGPO9oMPg96GneOkDNm1urMV167g==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.31.3.tgz",
+      "integrity": "sha512-qEyyoPapPef4LO8XKaN83bxtaNzkJ4kFn/IxLnEKd4BJ3Mvi4MH2yJYlyDqwFnMoev4pMA1zBHRAt/C0THRmZw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.31.3.tgz",
+      "integrity": "sha512-SzxOqchrD2AcN3uT67PjKmRFEMOU3vNNiwNaamZJUbZrI6Hmy+bvdHJrc3jrIddyyCrAtsnAfRI0cmorW1jGfg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.31.3.tgz",
+      "integrity": "sha512-nvknt4FhyJQjYcvxptmeUlFsIAc8ibua3E5BN4Pim374/9RWepH4cdE9X0/qUTtguHElLx0iKtSIY3rW2qGTFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.31.3.tgz",
+      "integrity": "sha512-EexgmqnyDNyGlISxo7SMrp5MygpJYmqD+0cY5jB6L1U6L4CpKKRWUt8OO1sWzEHDE1+TTvwt+WIFoIWAziOtEA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.31.3.tgz",
+      "integrity": "sha512-NWomSfu5CSC7VacnMSDzKT8qm66SzMfZwVPEtwY5bPpRTJgTiT1rNK0neDrrzfMN27MfylGyKWWf7Q5Qf8w/fg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.31.3.tgz",
+      "integrity": "sha512-rd4VJ9PGSP9Eop8ZTEwaLZcMzMXLuJKe3hUNf58rq+zANpwM+9fI+vB7g9MAc3eXwUNDxNDVACFIL2oeBqpQ3A==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.31.3.tgz",
+      "integrity": "sha512-EBXKb1FrVStsNYCcRGtd9jmzveCvR+eqgg1rVqoONrqFK6U7bga6LN+1dMKroP1kliDVgveYkP3vRYxqw+rFqg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.31.3.tgz",
+      "integrity": "sha512-QAdCvNO4+yW9ATwsrej11NTkDYFqPLIEQr3ARNrKOK1qaiS7A0fia2SEukb/hrkP3A6mbozhoQt2r2RGUf/DpQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.31.3.tgz",
+      "integrity": "sha512-rk5VHMAeQcg06SLauN6EGdD2jc0O2qY8QkZYPd0LxNvLblw2BxBx+lxUQSYwLAT9Ie5914gKIK2YbRyO2Ts3ig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.31.3.tgz",
+      "integrity": "sha512-YnHGy2KShRwvCseAmmxl9VP7R0qaj8QMp3DA6DJWZqp7r5gLGvDkAqhedxqqefqsE4Y43hjkBdjtB9Ce78LkIw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.31.3.tgz",
+      "integrity": "sha512-ibGvdvAPyfxBMUVNRI43eb9h2/Jka1MRG5GtnGqbcCX/2+Y/y0EOfFrPQPkuYphiWQYyu9+FzPKMB/pjuaLuKQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.31.3.tgz",
+      "integrity": "sha512-986wOQzTL9Zr5lf84LCLpm+YOms8A0K39/8DVoqRfebqcOe0/eq4bnztmAlfabOd+kJY92g3AgZERFUx/w+dcw==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.31.3.tgz",
+      "integrity": "sha512-LoveGnC0FVdCV4jUNBaG1ZA+KWE07+adzV3kGy6uUYFcJEjbVUHTnPDrBOob3IwOSO3sCwIkvQb6EVYeXn/4yg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.31.3.tgz",
+      "integrity": "sha512-4QlKOriJJMvg95QJTEsy9BUYPBQ6UvJyb8WURRwdUtQUkkqb8h32lg/eyQUv2FzW9IT1AdUyNZfVaxH64kRfQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.31.3.tgz",
+      "integrity": "sha512-If8UOEdDZbPJU6iYTvLtH6DOp2KBy6BKxg9UELL1AevVetGHEF/7lW8hP50Gn1tHMVpPRqmhSzVrJRpEJJgb/Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.31.3.tgz",
+      "integrity": "sha512-mp3g11NgA/PYu8rj7J7Ez3l4qBy6WfTSmHIG4PZvEGG5w2oUAIkgb9DU7nPPzjmeme27oazFYZw+AtZA0+u4tw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.31.3.tgz",
+      "integrity": "sha512-+iPku7wJfy5hbNDNLX8dveFtYVsZMmh7vztjuq8hT3mipSC4IByDehDbU8fzUCjfXiEzmI7mQn7c8LGmHULuzA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.31.3.tgz",
+      "integrity": "sha512-9jYtR8ELEw7GVaruyrm4oFkPcjig9Q+crc+dpmarhBNXUmxagCdlhVzNwCJ2WJRzvBAtx59sEYqNTU38Wx8S3A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.31.3.tgz",
+      "integrity": "sha512-G29bhKttYwcKHT+BI6emWVFol3RO/gUXxQVcmr/iT8LXXy7j8J6HFUnsKM+Kg5YlP1rxMRgsa65dbrQVahZi0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.31.3.tgz",
+      "integrity": "sha512-gdsWtF+taeaCu6V+5Ct10fGo0ACUy1GnYtbb+mcathBt8OqbT+Ws60p/yEmKesBDz2Hn+B5IcWy6+2BBZl5ZTg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.31.3.tgz",
+      "integrity": "sha512-HghdJaOwRqYzsAxqSyNyb+IWyOMcdCl8IoiBETA9BZCJAqdXzFLcuWp7CqCqJPam9dgkWosSoHqTCAO4nTBfpw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.31.3.tgz",
+      "integrity": "sha512-8sJNPGGUe8f3aDojcOW5cfVL7I5NrBbE0UWxG08qoi9Tea6qWbvQJsCR9tsrOapr/DaLr3kpbGZ9s1gEEfcNcA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/markdown": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.31.3.tgz",
+      "integrity": "sha512-rBbYSxasseUoaBo15C8Yoaqafo7mJJzxwAwV9Z1OpLBvOroW9nQ0EbOdqaSYRw3/d9pP71B/3LNSzKyfyy+dpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "marked": "^17.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.31.3.tgz",
+      "integrity": "sha512-sZime0SWsz/k62W2WvHx5Ig7G2h7kVhrrmnqy+wEgIHfDwEfOlelRjaWCiBCFlF7dxGUntJusCh9FxlLhni0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.4.1",
+        "prosemirror-commands": "^1.7.1",
+        "prosemirror-dropcursor": "^1.8.2",
+        "prosemirror-gapcursor": "^1.4.1",
+        "prosemirror-history": "^1.5.0",
+        "prosemirror-inputrules": "^1.5.1",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.11",
+        "prosemirror-schema-list": "^1.5.1",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.5",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.42.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.31.3.tgz",
+      "integrity": "sha512-QiwQqvaLFLm5EMFu5tg7nAgXJxCUiUTLD8EsK+TqVV5P4bqOoMOCM39khbhXTJyahCuYpiFWx5YOSDtC/JiPtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.31.3",
+        "@tiptap/extension-floating-menu": "^3.31.3"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.31.3",
+        "@tiptap/pm": "3.31.3",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.31.3",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.31.3.tgz",
+      "integrity": "sha512-WKof9RewdmGHvWJ1wn0/HVNG2mV+HOgVRyJkKekuM9fgr6BZAAH/xZsWE1eon+94JnQ+KtK2ThydXQM/qc6b2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "3.31.3",
+        "@tiptap/extension-blockquote": "3.31.3",
+        "@tiptap/extension-bold": "3.31.3",
+        "@tiptap/extension-bullet-list": "3.31.3",
+        "@tiptap/extension-code": "3.31.3",
+        "@tiptap/extension-code-block": "3.31.3",
+        "@tiptap/extension-document": "3.31.3",
+        "@tiptap/extension-dropcursor": "3.31.3",
+        "@tiptap/extension-gapcursor": "3.31.3",
+        "@tiptap/extension-hard-break": "3.31.3",
+        "@tiptap/extension-heading": "3.31.3",
+        "@tiptap/extension-horizontal-rule": "3.31.3",
+        "@tiptap/extension-italic": "3.31.3",
+        "@tiptap/extension-link": "3.31.3",
+        "@tiptap/extension-list": "3.31.3",
+        "@tiptap/extension-list-item": "3.31.3",
+        "@tiptap/extension-list-keymap": "3.31.3",
+        "@tiptap/extension-ordered-list": "3.31.3",
+        "@tiptap/extension-paragraph": "3.31.3",
+        "@tiptap/extension-strike": "3.31.3",
+        "@tiptap/extension-text": "3.31.3",
+        "@tiptap/extension-underline": "3.31.3",
+        "@tiptap/extensions": "3.31.3",
+        "@tiptap/pm": "3.31.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -1336,7 +1826,6 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -1346,6 +1835,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2512,6 +3007,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.2.tgz",
+      "integrity": "sha512-Ywe6jodPTWOTL9/k0bV7gdfP8twKL5Y8I8CZ933fAY5gBekICZSUQTbyH6ut2NZCNyB05mSUwAuEqdEIaOOlDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3391,6 +3895,12 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3505,6 +4015,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -4473,6 +4995,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4682,6 +5210,145 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.2.tgz",
+      "integrity": "sha512-ViYrjMSg3YFiXwIhKaluu+/mi3Yrxt6AR8ri14ulTaGcZtXO1CThl7A2gv79qx5fQnOw8woKwyBU2u+9PVCm3w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.2.tgz",
+      "integrity": "sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
+      "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
+      "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.1.tgz",
+      "integrity": "sha512-t4F5615FycnCqsX7ShTUs8+jfnwcf46kuFRvSl/3qFx2QTZ4DjgowesLHQXcFP7G//TjesqZG3WtgL7vdyVJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.42.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.3.tgz",
+      "integrity": "sha512-oTN7EtH+CpwxU9NrwEYWd0UZ4JUx7l048l5A2Xppm4p/60isZYLnth9QVQmC3VRIvdrIWCxwZSd+Uz791G31/w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.8",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4865,6 +5532,12 @@
         "@rolldown/binding-win32-arm64-msvc": "1.2.6",
         "@rolldown/binding-win32-x64-msvc": "1.2.6"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -5554,6 +6227,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,12 @@
   "dependencies": {
     "@novnc/novnc": "1.7.0",
     "@tanstack/react-query": "^5.102.6",
+    "@tiptap/extension-bubble-menu": "^3.31.3",
+    "@tiptap/extension-placeholder": "^3.31.3",
+    "@tiptap/markdown": "^3.31.3",
+    "@tiptap/pm": "^3.31.3",
+    "@tiptap/react": "^3.31.3",
+    "@tiptap/starter-kit": "^3.31.3",
     "lucide-react": "^1.34.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -361,6 +361,7 @@ export type Field =
       value: string
       placeholder: string
       rows: number
+      markdown?: boolean
     })
   | (FieldBase & {
       field: 'number'

--- a/frontend/src/druksui/Fields.tsx
+++ b/frontend/src/druksui/Fields.tsx
@@ -1,6 +1,7 @@
 import { useId, useRef, type ReactNode } from 'react'
 
 import type { Field, Option } from '../api/types'
+import { MarkdownEditor } from './MarkdownEditor'
 
 function groupedOptions(options: Option[]): { group: string; options: Option[] }[] {
   const groups: { group: string; options: Option[] }[] = []
@@ -157,6 +158,20 @@ function Input({
         />
       )
     case 'text_area':
+      if (field.markdown) {
+        return (
+          <MarkdownEditor
+            key={resets}
+            field={field}
+            id={id}
+            value={String(value ?? '')}
+            onChange={onChange}
+            onBlur={onBlur}
+            describedBy={describedBy}
+            isInvalid={isInvalid}
+          />
+        )
+      }
       return (
         <textarea
           {...shared}

--- a/frontend/src/druksui/Form.test.tsx
+++ b/frontend/src/druksui/Form.test.tsx
@@ -501,6 +501,36 @@ describe('submitting a form', () => {
     })
   })
 
+  it('renders a markdown text area as formatted text and submits markdown source', async () => {
+    renderBlocks([
+      form(
+        [
+          {
+            field: 'text_area',
+            name: 'body',
+            label: 'Description',
+            value: '**bold gist**',
+            placeholder: '',
+            helpText: '',
+            isRequired: false,
+            rows: 8,
+            markdown: true,
+          },
+        ],
+        action({ refresh: 'none' }),
+      ),
+    ])
+
+    const box = await screen.findByRole('textbox', { name: 'Description' })
+    expect(box.getAttribute('contenteditable')).toBe('true')
+    expect(screen.queryByRole('tab', { name: 'Preview' })).toBeNull()
+    await waitFor(() => expect(screen.getByText('bold gist').tagName).toBe('STRONG'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => expect(callOperation).toHaveBeenCalled())
+    const body = (callOperation.mock.calls[0]?.[2] as { body: string }).body
+    expect(body.trim()).toBe('**bold gist**')
+  })
+
   it('fills the path from the payload and sends what is left as the body', async () => {
     renderBlocks([
       form(

--- a/frontend/src/druksui/MarkdownEditor.tsx
+++ b/frontend/src/druksui/MarkdownEditor.tsx
@@ -1,0 +1,239 @@
+import { useEffect, useRef, type CSSProperties, type ReactNode } from 'react'
+import {
+  Bold,
+  Code,
+  Italic,
+  Link as LinkIcon,
+  List,
+  ListOrdered,
+  Quote,
+  Strikethrough,
+} from 'lucide-react'
+import { Markdown } from '@tiptap/markdown'
+import Placeholder from '@tiptap/extension-placeholder'
+import { EditorContent, useEditor, useEditorState } from '@tiptap/react'
+import { BubbleMenu } from '@tiptap/react/menus'
+import StarterKit from '@tiptap/starter-kit'
+
+import type { Field } from '../api/types'
+
+function MarkButton({
+  pressed,
+  label,
+  onClick,
+  children,
+}: {
+  pressed: boolean
+  label: string
+  onClick: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={pressed}
+      className="dui-markdown-mark"
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  )
+}
+
+export function MarkdownEditor({
+  field,
+  id,
+  value,
+  onChange,
+  onBlur,
+  describedBy,
+  isInvalid,
+}: {
+  field: Extract<Field, { field: 'text_area' }>
+  id: string
+  value: string
+  onChange: (name: string, value: unknown) => void
+  onBlur?: () => void
+  describedBy?: string
+  isInvalid: boolean
+}) {
+  const onChangeRef = useRef(onChange)
+  const onBlurRef = useRef(onBlur)
+  const valueRef = useRef(value)
+  useEffect(() => {
+    onChangeRef.current = onChange
+    onBlurRef.current = onBlur
+    valueRef.current = value
+  })
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit.configure({
+        underline: false,
+        heading: { levels: [1, 2, 3] },
+        link: { openOnClick: false },
+      }),
+      Markdown,
+      Placeholder.configure({ placeholder: field.placeholder }),
+    ],
+    content: value,
+    contentType: 'markdown',
+    editorProps: {
+      attributes: {
+        id,
+        class: 'dui-markdown-editor markdown-content dui-markdown',
+        role: 'textbox',
+        'aria-label': field.label,
+        'aria-multiline': 'true',
+        ...(describedBy ? { 'aria-describedby': describedBy } : {}),
+        ...(isInvalid ? { 'aria-invalid': 'true' } : {}),
+        ...(field.isRequired ? { 'aria-required': 'true' } : {}),
+      },
+      handleDOMEvents: {
+        blur: () => {
+          onBlurRef.current?.()
+          return false
+        },
+      },
+    },
+    onUpdate: ({ editor: current }) => {
+      const markdown = current.getMarkdown()
+      if (markdown.trim() === valueRef.current.trim()) return
+      onChangeRef.current(field.name, markdown)
+    },
+  })
+
+  const marks = useEditorState({
+    editor,
+    selector: ({ editor: current }) => {
+      if (!current) return null
+      return {
+        bold: current.isActive('bold'),
+        italic: current.isActive('italic'),
+        strike: current.isActive('strike'),
+        code: current.isActive('code'),
+        link: current.isActive('link'),
+        bullet: current.isActive('bulletList'),
+        ordered: current.isActive('orderedList'),
+        quote: current.isActive('blockquote'),
+        block: current.isActive('heading', { level: 1 })
+          ? '1'
+          : current.isActive('heading', { level: 2 })
+            ? '2'
+            : current.isActive('heading', { level: 3 })
+              ? '3'
+              : 'p',
+      }
+    },
+  })
+
+  return (
+    <div
+      className="dui-input dui-markdown-field"
+      style={{ '--dui-markdown-rows': field.rows } as CSSProperties}
+    >
+      {editor && marks ? (
+        <BubbleMenu
+          editor={editor}
+          className="dui-markdown-bubble"
+          options={{ placement: 'top', offset: 8 }}
+          shouldShow={({ editor: current, from, to }) =>
+            current.isEditable && from !== to && !current.isActive('codeBlock')
+          }
+        >
+          <MarkButton
+            pressed={marks.bold}
+            label="Bold"
+            onClick={() => editor.chain().focus().toggleBold().run()}
+          >
+            <Bold size={15} strokeWidth={1.8} />
+          </MarkButton>
+          <MarkButton
+            pressed={marks.italic}
+            label="Italic"
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+          >
+            <Italic size={15} strokeWidth={1.8} />
+          </MarkButton>
+          <MarkButton
+            pressed={marks.strike}
+            label="Strikethrough"
+            onClick={() => editor.chain().focus().toggleStrike().run()}
+          >
+            <Strikethrough size={15} strokeWidth={1.8} />
+          </MarkButton>
+          <MarkButton
+            pressed={marks.code}
+            label="Code"
+            onClick={() => editor.chain().focus().toggleCode().run()}
+          >
+            <Code size={15} strokeWidth={1.8} />
+          </MarkButton>
+          <MarkButton
+            pressed={marks.link}
+            label="Link"
+            onClick={() => {
+              if (editor.isActive('link')) {
+                editor.chain().focus().unsetLink().run()
+                return
+              }
+              const href = window.prompt('Link URL', editor.getAttributes('link').href ?? 'https://')
+              if (href === null) return
+              const next = href.trim()
+              if (!next) {
+                editor.chain().focus().unsetLink().run()
+                return
+              }
+              editor.chain().focus().extendMarkRange('link').setLink({ href: next }).run()
+            }}
+          >
+            <LinkIcon size={15} strokeWidth={1.8} />
+          </MarkButton>
+          <span className="dui-markdown-bubble-rule" />
+          <select
+            aria-label="Text style"
+            className="dui-markdown-block"
+            value={marks.block}
+            onChange={(event) => {
+              const next = event.target.value
+              const chain = editor.chain().focus()
+              if (next === 'p') chain.setParagraph().run()
+              else chain.setHeading({ level: Number(next) as 1 | 2 | 3 }).run()
+            }}
+          >
+            <option value="p">Text</option>
+            <option value="1">Heading 1</option>
+            <option value="2">Heading 2</option>
+            <option value="3">Heading 3</option>
+          </select>
+          <span className="dui-markdown-bubble-rule" />
+          <MarkButton
+            pressed={marks.bullet}
+            label="Bullet list"
+            onClick={() => editor.chain().focus().toggleBulletList().run()}
+          >
+            <List size={15} strokeWidth={1.8} />
+          </MarkButton>
+          <MarkButton
+            pressed={marks.ordered}
+            label="Numbered list"
+            onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          >
+            <ListOrdered size={15} strokeWidth={1.8} />
+          </MarkButton>
+          <MarkButton
+            pressed={marks.quote}
+            label="Quote"
+            onClick={() => editor.chain().focus().toggleBlockquote().run()}
+          >
+            <Quote size={15} strokeWidth={1.8} />
+          </MarkButton>
+        </BubbleMenu>
+      ) : null}
+      <EditorContent editor={editor} />
+    </div>
+  )
+}

--- a/frontend/src/druksui/catalog.json
+++ b/frontend/src/druksui/catalog.json
@@ -331,7 +331,8 @@
           "placeholder": "",
           "helpText": "",
           "isRequired": false,
-          "rows": 4
+          "rows": 4,
+          "markdown": false
         },
         {
           "field": "number",

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2239,6 +2239,44 @@ a.dui-card:hover .dui-card-title { text-decoration: underline; text-underline-of
   background: transparent; border: none; outline: none;
 }
 .dui-form-prose .dui-input:focus { box-shadow: 0 1px 0 var(--border-loud); }
+.dui-markdown-field {
+  display: block; overflow: auto;
+}
+.dui-markdown-field .tiptap { min-height: inherit; }
+.dui-markdown-editor { outline: none; min-height: inherit; max-width: none; }
+.dui-markdown-editor p.is-empty:first-child::before {
+  color: var(--text-faint); content: attr(data-placeholder); float: left; height: 0; pointer-events: none;
+}
+.dui-form-prose .dui-markdown-field {
+  min-height: calc(var(--dui-markdown-rows, 12) * 1lh); padding: 8px 0; border: none; background: transparent; border-radius: 0;
+}
+.dui-form-prose .dui-markdown-field:hover,
+.dui-form-prose .dui-markdown-field:focus-within {
+  background: transparent; border: none; outline: none;
+}
+.dui-form-prose .dui-markdown-field:focus-within { box-shadow: 0 1px 0 var(--border-loud); }
+.dui-markdown-bubble {
+  z-index: 30; display: flex; align-items: center; gap: 2px; padding: 4px;
+  background: var(--surface-2); border: 1px solid var(--border-loud);
+  border-radius: var(--dui-radius-control); color: var(--text);
+  box-shadow: 0 8px 24px color-mix(in oklch, var(--bg) 55%, transparent);
+}
+.dui-markdown-bubble-rule {
+  width: 1px; align-self: stretch; margin: 3px 4px; background: var(--border);
+}
+.dui-markdown-mark {
+  appearance: none; display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; padding: 0; border: none; border-radius: 6px;
+  background: transparent; color: var(--text-mid); cursor: pointer;
+}
+.dui-markdown-mark:hover, .dui-markdown-mark[aria-pressed='true'] {
+  background: var(--surface-3); color: var(--text);
+}
+.dui-markdown-block {
+  appearance: none; height: 28px; padding: 0 8px; border: none; border-radius: 6px;
+  background: transparent; color: var(--text); font: inherit; font-size: 13px; cursor: pointer;
+}
+.dui-markdown-block:hover { background: var(--surface-3); }
 .dui-form-row { max-width: none; margin: 0; }
 .dui-form-row .dui-field {
   display: grid; grid-template-columns: 7.5rem minmax(0, 1fr); gap: 8px 12px;
@@ -2250,6 +2288,7 @@ a.dui-card:hover .dui-card-title { text-decoration: underline; text-underline-of
 .dui-field-label { display: block; font-size: 12px; line-height: 16px; font-weight: 500; color: var(--text-mid); margin-bottom: 8px; }
 .dui-field-required { color: var(--decision-request-revision); }
 .dui-input { width: 100%; min-height: var(--dui-control-height); background: var(--surface-2); border: 1px solid var(--border-loud); border-radius: var(--dui-radius-control); color: var(--text); padding: 9px 12px; font-size: 14px; line-height: 20px; font-family: inherit; caret-color: var(--accent-violet); transition: background-color 160ms ease, border-color 160ms ease; }
+.dui-input.dui-markdown-field { min-height: calc(var(--dui-markdown-rows, 3) * 1lh + 20px); }
 .dui-input:hover { border-color: var(--text-faint); }
 .dui-input::placeholder { color: var(--text-faint); opacity: 1; }
 .dui-input[aria-invalid='true'] { border-color: var(--outcome-failed); }
@@ -2366,7 +2405,7 @@ a.dui-card:hover .dui-card-title { text-decoration: underline; text-underline-of
 
 :is(.dui-action, .dui-link, .dui-tab, .dui-retry, .dui-parent, .dui-checkbox,
     .dui-choice input, .dui-input, .dui-gallery-item, .dui-dialog-close,
-    .dui-decision .review-btn, a.dui-card):focus-visible {
+    .dui-decision .review-btn, a.dui-card, .dui-markdown-mark, .dui-markdown-block):focus-visible {
   outline: 2px solid var(--accent-violet);
   outline-offset: 2px;
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -96,6 +96,14 @@ export default defineConfig({
           ) {
             return 'markdown-vendor'
           }
+          if (
+            id.includes('node_modules/@tiptap') ||
+            id.includes('node_modules/prosemirror-') ||
+            id.includes('node_modules/marked') ||
+            id.includes('node_modules/@floating-ui')
+          ) {
+            return 'tiptap-vendor'
+          }
           if (id.includes('node_modules/@tanstack/react-query')) {
             return 'query-vendor'
           }


### PR DESCRIPTION
Linear ticket: [DRU-488](https://linear.app/fellaworks/issue/DRU-488/issues-markdown-ticket-editor)

Stacked on [DRU-487](https://github.com/czpython/druks/pull/472).

## Summary
- `TextAreaField.markdown=True` renders a Tiptap editor. Ticket description and comments edit as formatted text; submit still sends markdown source.
- `rows` sets editor height so a new-ticket description and a comment box stay short, and the ticket-page description stays tall.
- Table cells that overrun a sized column stay on one line with an ellipsis.

## Test plan
- [ ] `uv run ruff check backend`
- [ ] `uv run ruff format --check backend`
- [ ] `uv pip install -e backend/tests/druks-field_notes`
- [ ] `uv run pytest backend/tests/test_ui_actions.py`
- [ ] `npm --prefix frontend test -- src/druksui/Form.test.tsx`
- [ ] `npm --prefix frontend run build`
- [ ] On a ticket, edit the description as formatted text; reload still shows markdown source through the API.
- [ ] New-ticket description and comment boxes are short; the ticket-page description is tall.
- [ ] An overlong assignee on the list ellipsizes on one line.

Made with [Cursor](https://cursor.com)