### PR TITLE
DRU-490 - Issues: Ready for Agent on a live build

### DIFF
--- a/backend/druks/contrib/software_factory/issues/pages.py
+++ b/backend/druks/contrib/software_factory/issues/pages.py
@@ -4,7 +4,7 @@ from druks import ui
 from druks.accounts.models import Account
 from druks.contrib.software_factory.issues.enums import Priority, Status
 from druks.contrib.software_factory.issues.models import Comment, Ticket
-from druks.contrib.software_factory.models import Project, ProjectRepo
+from druks.contrib.software_factory.models import Project, ProjectRepo, WorkItem
 from druks.db import Base
 
 # The board's columns, worked-on left to right. Cancelled and blocked are off
@@ -419,12 +419,16 @@ async def ticket(identifier: str):
     thread = _comment_blocks(comments, account_names) or [
         ui.EmptyState("No comments yet", description="Say something about this ticket.")
     ]
+    build = await WorkItem.get_for_ticket_key(source="issues", ticket_key=found.identifier)
 
     return ui.Page(
         found.identifier,
         # The whole page follows the ticket, so a status write from anywhere —
         # Software Factory included — redraws it without a navigation.
         follows=found,
+        controls=(
+            [ui.Link("Open build", url=f"/software_factory/work-items/{build.id}")] if build else []
+        ),
         blocks=[
             ui.Columns(
                 [

--- a/backend/druks/contrib/software_factory/workflows.py
+++ b/backend/druks/contrib/software_factory/workflows.py
@@ -13,7 +13,9 @@ from druks.contrib.software_factory.enums import (
     ReviewDecision,
 )
 from druks.contrib.software_factory.models import ProjectRepo, WorkItem
+from druks.contrib.software_factory.ticketing.enums import TicketStatus
 from druks.core.apis.github import GITHUB, get_github_client
+from druks.durable.enums import RunState
 from druks.sandbox.datastructures import RequiredMcpServer
 from druks.sandbox.layout import get_related_root, get_work_root
 from druks.services.exceptions import ServiceNotConnectedError
@@ -155,7 +157,8 @@ class Build(Workflow):
     @classmethod
     async def dispatch(cls, *, ticket: dict) -> str | None:
         # The tracker funnel's entry: a ticket at the trigger status opens a build.
-        # Resolve-or-refresh the item, then start (start() dedups a live run).
+        # A live run already holds the queue slot — start() would return it
+        # without announcing, so mirror the ticket onto that run instead.
         item = await WorkItem.get_for_ticket_key(
             source=ticket["source"], ticket_key=ticket["identifier"]
         )
@@ -166,6 +169,17 @@ class Build(Workflow):
                 )
                 return
             await item.update(title=ticket["title"], ticket_url=ticket["url"])
+            status = await item.get_status(workflow=cls)
+            if status.is_parked:
+                await item.set_ticket_status(
+                    TicketStatus.IN_REVIEW
+                    if status.gate == ReviewWork.name
+                    else TicketStatus.IN_PROGRESS
+                )
+                return
+            if status.state in (RunState.SCHEDULED, RunState.RUNNING):
+                await item.set_ticket_status(TicketStatus.IN_PROGRESS)
+                return
         else:
             repo = await ProjectRepo.lookup(
                 project_name=ticket["project_name"], labels=ticket["labels"]

--- a/backend/tests/software_factory/test_build_dispatch.py
+++ b/backend/tests/software_factory/test_build_dispatch.py
@@ -1,11 +1,12 @@
 from datetime import UTC, datetime
 
+from druks.contrib.software_factory.contracts import ReviewWork
 from druks.contrib.software_factory.workflows import Build
 from druks.services.models import ServiceIdentity
 from druks.signals import publish
 from druks.testing import seed_run
 
-from software_factory.factories import make_test_work_item
+from software_factory.factories import make_test_work_item, seed_build_run
 
 
 async def _connect_github() -> None:
@@ -122,6 +123,22 @@ async def test_dispatch_merged_noop_still_precedes_the_identity_guard(
         assert await Build.dispatch(ticket=_ticket(item)) is None
 
     assert any("already merged" in record.getMessage() for record in caplog.records)
+
+
+async def test_dispatch_syncs_a_parked_build_instead_of_restarting(druks_db, monkeypatch) -> None:
+    await _connect_github()
+    item = await make_test_work_item(repo="o/r", title="t", ticket_key="ACME-12")
+    await seed_build_run(druks_db, work_item_id=item.id, state="parked", input_gate=ReviewWork.name)
+    started = []
+
+    async def fake_start(cls, **kwargs):
+        started.append(kwargs)
+        return "should-not-run"
+
+    monkeypatch.setattr(Build, "start", classmethod(fake_start))
+
+    assert await Build.dispatch(ticket=_ticket(item)) is None
+    assert started == []
 
 
 async def test_dispatch_unroutable_noop_still_precedes_the_identity_guard(

--- a/backend/tests/software_factory/test_issues_pages.py
+++ b/backend/tests/software_factory/test_issues_pages.py
@@ -1,5 +1,7 @@
 from druks.contrib.software_factory.issues.models import Ticket
 
+from software_factory.factories import make_test_work_item
+
 BOARD_COLUMNS = [
     "Backlog",
     "Todo",
@@ -208,6 +210,30 @@ async def test_ticket_page_follows_the_row_and_comments_refresh_the_region(druks
     after = (await druks_client.get(f"{_PAGES}/tickets/{created['identifier']}")).json()
     thread = _comments(after)
     assert thread["blocks"][0]["blocks"][0]["text"] == "looks good"
+
+
+async def test_ticket_page_links_the_open_build(druks_client):
+    repo = await _open_repo(druks_client)
+    created = await _open_ticket(druks_client, repo["id"], title="Follow me")
+    item = await make_test_work_item(
+        repo="acme/druks",
+        source="issues",
+        ticket_key=created["identifier"],
+        title="Follow me",
+    )
+
+    page = (await druks_client.get(f"{_PAGES}/tickets/{created['identifier']}")).json()
+
+    assert page["controls"] == [
+        {
+            "block": "link",
+            "label": "Open build",
+            "page": "",
+            "arguments": {},
+            "url": f"/software_factory/work-items/{item.id}",
+            "subject": None,
+        }
+    ]
 
 
 async def test_new_ticket_groups_repos_by_github_project(druks_client):

--- a/backend/tests/software_factory/test_issues_tracker.py
+++ b/backend/tests/software_factory/test_issues_tracker.py
@@ -1,6 +1,7 @@
 import druks.contrib.software_factory.subscribers  # noqa: F401
 import pytest
 from druks.contrib.software_factory.app import SoftwareFactory
+from druks.contrib.software_factory.contracts import ReviewWork
 from druks.contrib.software_factory.issues.enums import Status
 from druks.contrib.software_factory.issues.models import Ticket
 from druks.contrib.software_factory.models import Project, ProjectRepo, WorkItem
@@ -10,7 +11,7 @@ from druks.contrib.software_factory.workflows import Build
 from druks.core.apis.exceptions import UnknownTicketError
 from druks.services.models import ServiceIdentity
 
-from software_factory.factories import make_test_work_item
+from software_factory.factories import make_test_work_item, seed_build_run
 
 
 async def _open_ticket(*, project="Acme", prefix="WID", full_name="acme/widget", title="one"):
@@ -103,3 +104,30 @@ async def test_ready_for_agent_opens_a_build_against_the_selected_repo(druks_db,
     assert item.ticket_key == "WID-1"
     assert item.repo == "acme/widget"
     assert started[0]["subject"].id == item.id
+
+
+async def test_ready_for_agent_on_a_parked_build_moves_the_ticket_to_in_review(
+    druks_db, monkeypatch
+):
+    await _connect_github()
+    _pin_software_factory_settings(monkeypatch, tracker="issues")
+    ticket = await _open_ticket(title="Add an endpoint")
+    item = await make_test_work_item(
+        repo="acme/widget",
+        source="issues",
+        ticket_key=ticket.identifier,
+        title=ticket.title,
+    )
+    await seed_build_run(druks_db, work_item_id=item.id, state="parked", input_gate=ReviewWork.name)
+    started = []
+
+    async def fake_start(cls, **kwargs):
+        started.append(kwargs)
+        return "should-not-run"
+
+    monkeypatch.setattr(Build, "start", classmethod(fake_start))
+
+    await ticket.transition(Status.READY_FOR_AGENT)
+
+    assert started == []
+    assert (await Ticket.get_for_identifier(ticket.identifier)).status == Status.IN_REVIEW


### PR DESCRIPTION
Linear ticket: [DRU-490](https://linear.app/fellaworks/issue/DRU-490/issues-ready-for-agent-on-a-live-build)

Stacked on [DRU-488](https://github.com/czpython/druks/pull/473).

## Summary
- If a ticket already has a scheduled, running, or parked build, Ready for Agent mirrors the ticket onto that run instead of calling `Build.start` again.
- Parked on `review_work` moves the ticket to In Review; a scheduled or running build moves it to In Progress.
- The ticket page links Open build when a work item exists.

## Test plan
- [ ] `uv run ruff check backend`
- [ ] `uv run ruff format --check backend`
- [ ] `uv pip install -e backend/tests/druks-field_notes`
- [ ] `uv run pytest backend/tests/software_factory/test_build_dispatch.py backend/tests/software_factory/test_issues_tracker.py backend/tests/software_factory/test_issues_pages.py`
- [ ] Move a ticket with a parked review build into Ready for Agent: ticket becomes In Review, no second start.
- [ ] A scheduled or running build becomes In Progress the same way.
- [ ] First Ready for Agent with no work item still opens a build.
- [ ] Ticket page shows Open build when a work item exists.

Made with [Cursor](https://cursor.com)