### PR TITLE
DRU-392 - Docs: local issues tracker

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -53,8 +53,9 @@ name must match `App.name`. The same name scopes:
 - Provider credentials and prerequisites that are specific to the domain
 - Optional static frontend assets in the app package.
 
-The bundled `software_factory` app owns projects, work items, ticket intake,
-GitHub branches, pull requests, coding-agent policy, and dashboard pages. These
+The bundled `software_factory` app owns projects, work items, ticket intake
+(Linear, Jira, or the local board), GitHub branches, pull requests,
+coding-agent policy, and dashboard pages. These
 features are examples, not platform guarantees.
 
 ## Durability and recovery

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,7 +107,7 @@ caches, and the sandbox provisioning gate.
 
 | TOML key | Purpose |
 | --- | --- |
-| `urls.endpoint` | Browser-visible dashboard base URL used to build MCP OAuth callbacks |
+| `urls.endpoint` | Browser-visible dashboard base URL for MCP OAuth callbacks and sandbox access to this appliance's `/mcp` |
 | `urls.webhook_host` | Public webhook hostname used by `druks doctor` for its ingress probe |
 | `identity.mode` | `none` (default, no authentication, single operator), `header` (edge-asserted identity), or `jwt` (validated edge-signed assertion) |
 | `identity.header` | The trusted identity header. The shipped Caddy edge also uses it. Header and JWT modes have no default and require it |
@@ -280,16 +280,38 @@ client at another compatible GitHub API endpoint.
 
 ## Ticketing integrations
 
-Tracker credentials are service identities. Connect Linear or Jira Cloud from
+Select the tracker in **Software Factory → Settings**. The default is Linear.
+**none** leaves Software Factory without a ticket tracker.
+
+**Linear** and **Jira** are service identities. Connect them from
 **Settings → Connections → Services**. The Linear identity uses an API key
-and webhook secret. The Jira identity uses a base URL, email, API token, and webhook secret. Druks
-validates the credentials before it stores them. Select the tracker and its
-workflow statuses in **Software Factory → Settings**. Select **druks** to use
-Software Factory's local issue board on this appliance. That choice needs no
-credentials. The dashboard shows the board, the Issues list, and project ticket
-prefixes only for that tracker. `druks doctor` reports it as healthy. Each build then ships this
-appliance's `/mcp` into the sandbox so the agent can read and comment on the
-ticket. Set `urls.endpoint` so the VM can reach it.
+and webhook secret. The Jira identity uses a base URL, email, API token, and
+webhook secret. Druks validates the credentials before it stores them. Those
+trackers show status-name knobs for the trigger status and the resting status.
+
+Select **druks** to use Software Factory's local issue board on this appliance.
+The stored value is `issues`. That choice needs no credentials. Linear and Jira
+status-name knobs stay hidden. The trigger status is Ready for Agent. It is not
+a setting. `druks doctor` reports the tracker as healthy.
+
+The dashboard shows the board, the Issues list, and ticket pages only for
+**druks**. Each ticket picks a GitHub repository from a Software Factory
+project. Set that project's ticket prefix (2–6 letters A–Z) on
+**Software Factory → Projects**. Druks mints identifiers as `{prefix}-{n}` once.
+Changing the ticket's repository does not remint the identifier. A project
+without a prefix cannot mint tickets.
+
+A ticket that enters Ready for Agent opens a build against the selected
+repository. If a scheduled, running, or parked run already exists for that
+ticket, Software Factory does not start another.
+
+Each local-board build ships this appliance's `/mcp` into the sandbox as the
+`druks` server. The sandbox authenticates with a PAT for the run account. The
+agent reads the ticket with `software_factory_get_ticket` and posts with
+`software_factory_add_comment`. The Druks identifier is not a GitHub issue
+number. Linear and Jira builds do not receive this MCP. Set `urls.endpoint` so
+the VM can reach `/mcp`. `druks doctor` also checks that `/mcp` answers when the
+tracker is **druks**.
 
 Webhook URLs remain `/_external/linear/events/` and
 `/_external/jira/events/`. The Jira webhook uses a Jira Automation
@@ -297,8 +319,9 @@ Webhook URLs remain `/_external/linear/events/` and
 
 Select **Issue data (Jira format)** as its body.
 Druks accepts the REST issue JSON under `issue`. Put the shared token in the
-`x-druks-webhook-token` header. `druks doctor` treats a disconnected tracker as
-optional. It reports pending setup if the selected tracker lacks a connection.
+`x-druks-webhook-token` header. `druks doctor` treats a disconnected Linear or
+Jira identity as optional when that tracker is not selected. It reports pending
+setup if the selected tracker is Linear or Jira and that identity is missing.
 
 ## Harnesses
 

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -153,6 +153,12 @@ workflow and its trigger. In the bundled distribution, `software_factory` is
 the reference app. Register a project in its dashboard. Use its configured
 ticket or GitHub trigger.
 
+To run without Linear or Jira, select **druks** in
+**Software Factory → Settings** and use the local board. GitHub remains
+required for pull requests. Set a ticket prefix on the project before you mint
+tickets. See
+[ticketing integrations](configuration.md#ticketing-integrations).
+
 The run appears on the subject page and in the Events
 feed. Agent-call pages stream transcript and artifact data.
 
@@ -185,8 +191,10 @@ value.
 ## Webhook caveat
 
 GitHub, Linear, and Jira cannot connect to a loopback listener. Dashboard-initiated
-actions work locally, but provider-driven flows need an HTTPS tunnel forwarding
-to `127.0.0.1:8001`. Connect tracker credentials under **Settings → Connections → Services** and
+actions work locally, including Software Factory's **druks** board, which needs
+no tracker credentials. Provider-driven Linear and Jira flows need an HTTPS
+tunnel forwarding to `127.0.0.1:8001`. Connect Linear or Jira under
+**Settings → Connections → Services** when you use those trackers, and
 keep the exact public paths:
 
 ```text

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -78,7 +78,9 @@ To use it:
 4. Open **Software Factory → Projects**.
 5. Create a project and add the repository.
 6. Profile the repository. Then use the configured ticket or GitHub trigger to
-   start work.
+   start work. For a tracker that needs no credentials, select **druks** in
+   **Software Factory → Settings**. See
+   [ticketing integrations](configuration.md#ticketing-integrations).
 7. Watch the work item, event feed, agent calls, and each parked gate in the
    dashboard.
 

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -10,6 +10,10 @@ Druks supplies durable execution and shared operating services. Read
 [the app boundary](concepts.md#the-app-boundary)
 before you assign ownership of a capability.
 
+The bundled `software_factory` app owns its local issue board and the GitHub PR
+funnel. That board is not a second app, not an author-surface namespace, and
+not a `Service` kind.
+
 ## Scaffold and prove the package
 
 ```bash


### PR DESCRIPTION
## Summary
- Rewrite the public guides so the local board matches `integration/issues`: Software Factory tracker **druks** (stored as `issues`), prefix on the GitHub project, tickets select a repo, Ready for Agent opens a build.
- Full-local and quickstart no longer imply every tracker needs Settings → Services. Local-board builds use this appliance's `/mcp` (`software_factory_get_ticket` / `software_factory_add_comment`), not Linear MCP.
- Author guide: the board is Software Factory policy, not a second app or a `Service` kind.

## Test plan
- [ ] Read [Ticketing integrations](docs/configuration.md) against Software Factory → Settings with tracker **druks**.
- [ ] Confirm full-local webhook caveat still lists GitHub/Linear/Jira paths and states the local board needs no tracker credentials.
- [ ] Confirm writing-an-app does not introduce an Issues namespace.


Made with [Cursor](https://cursor.com)