### PR TITLE
Preserve OAuth connection IDs during vault migration

### DIFF
--- a/backend/migrations/versions/f1a6d3e8c2b7_vault.py
+++ b/backend/migrations/versions/f1a6d3e8c2b7_vault.py
@@ -192,7 +192,7 @@ def _move_oauth_grants() -> None:
             ),
         }
     for row in _read(
-        "SELECT provider, account_id, refresh_token, scopes, identity, connected_at, "
+        "SELECT id, provider, account_id, refresh_token, scopes, identity, connected_at, "
         "revoked_at, revoked_reason FROM oauth_connections"
     ):
         provider = row["provider"]
@@ -206,6 +206,7 @@ def _move_oauth_grants() -> None:
             secrets.update(clients.get((provider.partition(":")[2], row["account_id"]), {}))
         _row(
             kind="oauth",
+            secret_id=row["id"],
             audience=audience,
             secrets=secrets,
             account_id=row["account_id"],


### PR DESCRIPTION
The vault migration assigned new IDs to OAuth grants. Inbox Manager and X Me retain the old connection IDs, so their accounts lose access after an upgrade. Preserve each OAuth connection ID when inserting its vault row.

Verified the full upgrade on a production database copy: all five OAuth IDs and refresh tokens survive, both app account references resolve, and all vault entries decrypt. Ruff lint and diff checks pass. The format check reports existing formatting outside this change. No tests added or run.

Fixes DRU-495.
