### PR TITLE
Store proxy CA in the shared Compose volume

### DIFF
--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -160,6 +160,7 @@ services:
     restart: unless-stopped
     network_mode: host
     environment:
+      HOME: /home/mitmproxy
       SECRETS_EXCHANGE_URL: http://127.0.0.1:8781
       SECRETS_PROXY_BIND_HOST: ${DRUKS_SECRETS_PROXY_BIND_HOST:-127.0.0.1}
     volumes:


### PR DESCRIPTION
The proxy image starts with HOME=/root, but Compose mounts its CA volume at /home/mitmproxy/.mitmproxy. The CA is written outside the shared volume, so Drukbox rejects sandbox creation with secret entries because its public certificate is missing.

Set the proxy HOME to the mounted directory. Applied the same setting in the production override and preserved the existing CA. Verified Compose configuration, matching public CA fingerprints in the proxy and Drukbox, and a real sandbox request with placeholder substitution, TLS trust, and reattachment. No tests added or run locally.

Fixes DRU-497.
