### PR TITLE
Fix vault migration for unattributed agent calls

### DIFF
--- a/backend/migrations/versions/f1a6d3e8c2b7_vault.py
+++ b/backend/migrations/versions/f1a6d3e8c2b7_vault.py
@@ -155,6 +155,7 @@ def _move_provider_keys() -> None:
         "agent_calls_billing_source_check",
         "agent_calls",
         "(subscription_id IS NOT NULL) <> (api_key_id IS NOT NULL)",
+        postgresql_not_valid=True,
     )
     op.drop_table("provider_keys")
 
@@ -485,6 +486,7 @@ def _restore_provider_keys() -> None:
         "agent_calls_billing_source_check",
         "agent_calls",
         "(subscription_id IS NOT NULL) <> (api_key_provider IS NOT NULL)",
+        postgresql_not_valid=True,
     )
 
 


### PR DESCRIPTION
Existing agent calls without a billing source cause the vault migration to fail when it recreates `agent_calls_billing_source_check`. Add `postgresql_not_valid=True` during upgrade and downgrade to retain those rows. Postgres still enforces the exclusive billing-source rule on subsequent inserts and updates.

This change affects only the vault migration. The earlier ownership migration remains unchanged. Unattributed historical rows still require a billing source before later updates can succeed.

Validation:
- `uv run ruff check backend` passed.
- `uv run ruff format --check backend` passed.
- Python syntax parsing and `git diff --check` passed. The repo excludes migration revisions from Ruff.
- No tests added or run for this change, per operator instruction.

Fixes #490.

Tracking: [DRU-502](https://linear.app/fellaworks/issue/DRU-502/preserve-unattributed-agent-calls-through-the-vault-migration).
