### PR TITLE
Remove duplicate App settings index

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -56,7 +56,7 @@ parameter selects the active tab. The Browser profiles page manages saved browse
 and login windows at `/settings/connections?tab=browser`.
 
 App settings use `/apps/<name>/settings` in the work context. A gear beside the
-app name in the header and the central App settings index link to this same route.
+app name in the header opens this route. Settings search also links to app settings.
 Options and Agents appear only when the app declares those controls. Both
 sections share one app draft. Leaving the app form offers Save, Discard, and
 Stay. An app without controls has no Settings destination. Backend app schemas

--- a/frontend/src/components/SettingsPages.test.tsx
+++ b/frontend/src/components/SettingsPages.test.tsx
@@ -476,23 +476,23 @@ describe('SettingsPages app fields', () => {
     expect(window.location.search).toBe('?tab=browser')
   })
 
-  it('spells an underscored app name out in the index and its options group', async () => {
+  it('opens app settings from the header gear and spells out the app name', async () => {
     stubFetch()
-    renderSettings()
+    renderSettings('/field_notes')
 
-    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'Field Notes' }))
+    const settings = await screen.findByRole('link', { name: 'Field Notes settings' })
+    expect(settings.getAttribute('href')).toBe('/apps/field_notes/settings')
+    fireEvent.click(settings)
 
-    expect(screen.getByText('Field Notes options')).toBeTruthy()
+    expect(await screen.findByText('Field Notes options')).toBeTruthy()
+    expect(settings.getAttribute('aria-current')).toBe('page')
   })
 
   it('renders every 422 message under the field named by the backend', async () => {
     stubFetch()
-    renderSettings()
+    renderSettings('/apps/review/settings')
 
-    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'Review' }))
-    const appIdField = screen.getByText('Review App ID').closest('.set-field')
+    const appIdField = (await screen.findByText('Review App ID')).closest('.set-field')
     const appIdInput = appIdField?.querySelector('input')
     expect(appIdInput).toBeTruthy()
     fireEvent.change(appIdInput as HTMLInputElement, { target: { value: '42' } })
@@ -508,11 +508,9 @@ describe('SettingsPages app fields', () => {
 
   it('reveals the chosen section immediately and prunes edits hidden before save', async () => {
     stubFetch(false)
-    renderSettings()
+    renderSettings('/apps/software_factory/settings')
 
-    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'Software Factory' }))
-    const options = screen.getByText('Software Factory options').closest('.set-group')
+    const options = (await screen.findByText('Software Factory options')).closest('.set-group')
     expect(options?.textContent?.indexOf('Tracker')).toBeLessThan(
       options?.textContent?.indexOf('Linear') ?? -1,
     )
@@ -545,11 +543,9 @@ describe('SettingsPages app fields', () => {
 
   it('renders a multiline secret as a textarea and PATCHes the paste with newlines intact', async () => {
     stubFetch(false)
-    renderSettings()
+    renderSettings('/apps/review/settings')
 
-    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'Review' }))
-    const pemField = screen.getByText('Review App private key').closest('.set-field')
+    const pemField = (await screen.findByText('Review App private key')).closest('.set-field')
     const textarea = pemField?.querySelector('textarea')
     expect(textarea).toBeTruthy()
     expect((textarea as HTMLTextAreaElement).value).toBe('')
@@ -578,11 +574,9 @@ describe('SettingsPages app fields', () => {
 
   it('renders a 422 message for a field hidden by the tracker selection', async () => {
     stubFetch(true, { software_factory: { linear_trigger_status: 'Not a Linear status name.' } })
-    renderSettings()
+    renderSettings('/apps/software_factory/settings')
 
-    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'Software Factory' }))
-    const trackerField = screen.getByText('Tracker').closest('.set-field')
+    const trackerField = (await screen.findByText('Tracker')).closest('.set-field')
     fireEvent.change(trackerField?.querySelector('select') as HTMLSelectElement, {
       target: { value: 'jira' },
     })
@@ -664,9 +658,7 @@ describe('SettingsPages agents', () => {
 
   it('the app page carries harness and billing cells that follow the chosen harness', async () => {
     stubFetch()
-    renderSettings()
-    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    fireEvent.click(await screen.findByRole('link', { name: 'Software Factory' }))
+    renderSettings('/apps/software_factory/settings')
     fireEvent.click(await screen.findByRole('link', { name: 'Agents' }))
     await screen.findByText('coder')
     const harnessCell = screen.getByText('codex').closest('button')!
@@ -994,6 +986,27 @@ it('restores the work return URL when a settings fragment route reloads', async 
 })
 
 describe('canonical app settings', () => {
+  it('removes the central index and its navigation and search destination', async () => {
+    stubFetch(false)
+    renderSettings('/settings/apps')
+
+    expect(await screen.findByText('No settings page matches this address.')).toBeTruthy()
+    const navigation = within(screen.getByRole('navigation', { name: 'Settings' }))
+    expect(navigation.queryByText('Apps')).toBeNull()
+    expect(navigation.queryByRole('link', { name: 'App settings' })).toBeNull()
+    expect(screen.queryByRole('heading', { name: 'App settings' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'Field Notes' })).toBeNull()
+
+    fireEvent.change(screen.getByLabelText('Search settings'), {
+      target: { value: 'app settings' },
+    })
+    const results = within(screen.getByLabelText('Settings search results'))
+    expect(results.queryByRole('link', { name: 'App settings Apps · Section' })).toBeNull()
+    fireEvent.click(results.getByRole('link', { name: 'Field Notes App settings · Section' }))
+    expect(await screen.findByLabelText('Notebook')).toBeTruthy()
+    expect(window.location.pathname).toBe('/apps/field_notes/settings')
+  })
+
   it('shows a load failure with Retry on a direct app settings link', async () => {
     stubFetch(false)
     vi.spyOn(api, 'getAppSettings')
@@ -1031,10 +1044,8 @@ describe('canonical app settings', () => {
       ...appSettings,
       apps: appSettings.apps.filter((entry) => entry.name !== 'software_factory'),
     })
-    renderSettings('/settings/apps')
-    expect(await screen.findByRole('link', { name: 'Review' })).toBeTruthy()
-    expect(screen.queryByRole('link', { name: 'Software Factory' })).toBeNull()
-    fireEvent.click(screen.getByRole('link', { name: 'Back to Druks' }))
+    renderSettings('/events')
+    await screen.findByRole('heading', { name: 'Current work' })
     const appLink = await screen.findByRole('link', { name: 'Software Factory' })
     fireEvent.click(appLink)
     await waitFor(() => expect(window.location.pathname).toBe('/software_factory'))
@@ -1175,11 +1186,13 @@ describe('canonical app settings', () => {
     fireEvent.change(await screen.findByLabelText('Timezone'), {
       target: { value: 'Europe/Madrid' },
     })
-    fireEvent.click(screen.getByRole('link', { name: 'App settings' }))
-    const destination = await screen.findByRole('link', { name: 'Field Notes' })
+    fireEvent.change(screen.getByLabelText('Search settings'), {
+      target: { value: 'field notes' },
+    })
+    const destination = await screen.findByRole('link', { name: 'Field Notes App settings · Section' })
     expect(destination.getAttribute('href')).toBe('/apps/field_notes/settings')
     fireEvent.click(destination)
-    expect(window.location.pathname).toBe('/settings/apps')
+    expect(window.location.pathname).toBe('/settings/general')
     fireEvent.click(
       within(screen.getByRole('dialog', { name: 'Save your changes?' })).getByRole('button', {
         name: 'Save',

--- a/frontend/src/components/SettingsPages.tsx
+++ b/frontend/src/components/SettingsPages.tsx
@@ -47,7 +47,6 @@ const SECTIONS = [
   { id: 'general', label: 'General', group: 'Installation' },
   { id: 'personal', label: 'Preferences', group: 'Personal' },
   { id: 'api-tokens', label: 'API tokens', group: 'Personal' },
-  { id: 'apps', label: 'App settings', group: 'Apps' },
 ]
 
 const CONNECTION_TABS = [
@@ -508,7 +507,7 @@ export function SettingsPages({
               </Link>
               <h2 className="settings-sidebar-title">Settings</h2>
               <nav className="settings-navigation" aria-label="Settings">
-                {['AI execution', 'Tools & access', 'Installation', 'Personal', 'Apps'].map((group) => (
+                {['AI execution', 'Tools & access', 'Installation', 'Personal'].map((group) => (
                   <div key={group}>
                     <div className="sidebar-group-title">{group}</div>
                     {SECTIONS.filter((entry) => entry.group === group).map((entry) => (
@@ -520,11 +519,7 @@ export function SettingsPages({
                         }
                         href={`/settings/${entry.id}`}
                         className="sidebar-link"
-                        aria-current={
-                          section === entry.id || (entry.id === 'apps' && Boolean(app))
-                            ? 'page'
-                            : undefined
-                        }
+                        aria-current={section === entry.id ? 'page' : undefined}
                       >
                         {entry.label}
                         {dirtyPages.includes(entry.id) && <span aria-hidden="true">•</span>}
@@ -629,7 +624,7 @@ export function SettingsPages({
             ))}
           {(settingsQuery.isError || appsQuery.isError) &&
             !executionPage &&
-            (appName || formPage || section === 'apps') && (
+            (appName || formPage) && (
               <p role="alert" className="settings-error">
                 Could not load settings.{' '}
                 <button
@@ -756,24 +751,6 @@ export function SettingsPages({
               {page === 'mcp' && <McpServersPane />}
               {page === 'skills' && <SkillsPane />}
               {page === 'api-tokens' && <AgentAccessPane />}
-              {page === 'apps' && !search.trim() && (
-                <div className="settings-app-index">
-                  {apps.map((entry) => (
-                    <Link
-                      key={entry.name}
-                      aria-label={appLabel(entry.name)}
-                      href={`/apps/${entry.name}/settings`}
-                    >
-                      <strong>{appLabel(entry.name)}</strong>
-                      <span>{entry.description}</span>
-                    </Link>
-                  ))}
-                  {appsQuery.isPending && <p role="status">Loading app settings…</p>}
-                  {!appsQuery.isPending && !appsQuery.isError && apps.length === 0 && (
-                    <p>No installed app declares settings.</p>
-                  )}
-                </div>
-              )}
               {apps
                 .filter(
                   (entry) =>

--- a/frontend/src/settings.css
+++ b/frontend/src/settings.css
@@ -37,10 +37,6 @@
 .settings-tabs { display: flex; gap: 24px; border-bottom: 1px solid var(--border); margin-bottom: 28px; }
 .settings-tabs button { min-height: 44px; color: var(--text-dim); border-bottom: 2px solid transparent; }
 .settings-tabs button[aria-current="page"] { color: var(--text); border-color: var(--text); }
-.settings-app-index { display: flex; flex-direction: column; }
-.settings-app-index a { display: flex; flex-direction: column; gap: 6px; padding: 18px 0; color: var(--text); text-decoration: none; border-bottom: 1px solid var(--border); }
-.settings-app-index strong { font-size: 18px; font-weight: 500; text-transform: capitalize; }
-.settings-app-index span { color: var(--text-dim); }
 .settings-error { color: var(--outcome-failed); padding: 12px 0; }
 .settings-error button { text-decoration: underline; }
 .settings-save-bar { display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; gap: 16px; min-height: 72px; padding: 12px var(--page-gutter); border-top: 1px solid var(--border); background: var(--surface); }


### PR DESCRIPTION
## What changed

Global Settings no longer has the duplicate Apps group or App settings index. Each app retains its header gear, settings form, and direct links from settings search. The change also removes the unused index styles and updates the frontend guide and navigation tests.

Closes DRU-503.

## Risk

The removed `/settings/apps` address shows the existing unknown-page message. This change only affects the frontend and its guide.

## Verification

All frontend checks passed with Node 22.23.2:

- `npm exec --yes --package=node@22 -- npm --prefix frontend run lint`
- `npm exec --yes --package=node@22 -- npm --prefix frontend test` — 395 tests passed across 40 files.
- `npm exec --yes --package=node@22 -- npm --prefix frontend run build`
- `git diff --check`

Browser checks passed at 1440 px and 390 px with the production build and mocked API responses. These checks covered the sidebar, direct app search, header gear, app form, removed address, and horizontal overflow. I also examined the screenshots. Backend tests and live API checks were not run.
