### PR TITLE
Add Schedules below Usage (DRU-517)

### DIFF
--- a/backend/druks/api/dashboard.py
+++ b/backend/druks/api/dashboard.py
@@ -181,6 +181,7 @@ async def list_current_schedules(response: Response) -> DashboardSchedules:
                 app=owner.name,
                 kind=workflow.kind,
                 cron=await workflow.get_schedule(),
+                default_cron=workflow.every,
                 enabled=await workflow.has_enabled_schedule(),
                 timezone=timezone,
             )

--- a/backend/druks/api/schemas.py
+++ b/backend/druks/api/schemas.py
@@ -88,6 +88,7 @@ class DashboardSchedule(Schema):
     app: str
     kind: str
     cron: str | None
+    default_cron: str
     enabled: bool
     timezone: str
 

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -138,6 +138,7 @@ async def test_schedules_resolve_paused_override_and_operator_timezone(
         "app": "field_notes",
         "kind": Summarize.kind,
         "cron": "15 10 * * 1",
+        "defaultCron": "0 9 * * *",
         "enabled": False,
         "timezone": "Europe/Madrid",
     } in response.json()["rows"]

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -128,8 +128,6 @@ async def test_schedules_resolve_paused_override_and_operator_timezone(
     monkeypatch.setattr(Summarize, "every", "0 9 * * *")
     await SettingsOverride.set_workflow_setting(Summarize.kind, "schedule", "15 10 * * 1")
     await SettingsOverride.set_workflow_setting(Summarize.kind, "schedule_enabled", False)
-    from druks.api import dashboard
-
     settings = dashboard.load_settings().model_copy(update={"timezone": "Europe/Madrid"})
     monkeypatch.setattr(dashboard, "load_settings", lambda: settings)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,6 +101,16 @@ Your personal timezone controls timestamp display. Gate notifications use the
 run account's preferences. Unattended runs record the default account.
 Druks refuses to start a run before account setup.
 
+**Schedules**, below **Usage**, lists workflows that declare a schedule. You can
+change cadence, pause, or resume each schedule. **Save changes** applies the
+workflow overrides and updates the scheduler at once. **Use defaults** selects
+the declared cadence and enabled state. Save these changes to remove both
+overrides. The same fields remain in app settings.
+
+The page shows the installation timezone. Account timezone preferences do not
+change schedule timing. A failed save keeps your edits. A read refresh also
+preserves unsaved edits. The `?app=` filter selects one installed app.
+
 The API exposes installation settings at `GET/PATCH /api/settings` and your
 preferences at `GET/PATCH /api/settings/personal`. The personal route uses the
 authenticated account. It returns `timezone` and `gateParkDestinationId`. It

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,7 +25,7 @@ runs lint, tests, and build for PRs into `main` and `codex/` stack branches.
 
 - The work sidebar and searchable installed app roster
 - Settings
-- Dashboard, Events, and Usage
+- Dashboard, Events, Usage, and Schedules
 - Shared routing and fallback behavior.
 
 Bundled app UI lives under `src/apps/<name>/`. Its module calls
@@ -35,7 +35,8 @@ Import the module one time from `src/apps/index.ts`. The shell finds the
 registration and does not hardcode the app name.
 
 The work sidebar keeps the same destinations across app pages. The Dashboard
-opens at `/`. Events and Usage have shared routes. App-declared navigation appears below the page
+opens at `/`. Events, Usage, and Schedules have shared routes. Schedules appears
+directly below Usage. App-declared navigation appears below the page
 header. Settings opens from the bottom of the sidebar. Below 650 px, a
 navigation button opens a modal drawer. Escape closes the drawer and returns
 focus to the button.
@@ -64,6 +65,13 @@ sections share one app draft. Leaving the app form offers Save, Discard, and
 Stay. An app without controls has no Settings destination. Backend app schemas
 supply these forms without a frontend module. Schedule controls use the
 existing workflow overrides.
+
+Schedules at `/schedules` groups declared workflows by app. The `app` query
+parameter filters the list. Operators change cadence and pause state here with
+the same controls as app settings. Each schedule saves through
+`PATCH /api/settings/apps`. Use defaults removes both overrides. A failed save
+keeps the draft. Polling and focus refresh preserve unsaved edits. The page shows
+the installation timezone beside the saved cadence.
 
 Normal interface text uses IBM Plex Sans at 15 px. Technical values use
 IBM Plex Mono. Phone inputs use at least 16 px.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -16,6 +16,7 @@ vi.mock('./components/SettingsPages', () => ({ SettingsPages: () => <h1>Settings
 vi.mock('./pages/DashboardPage', () => ({ DashboardPage: () => <h1>Dashboard page</h1> }))
 vi.mock('./pages/EventsPage', () => ({ EventsPage: () => <h1>Events feed</h1> }))
 vi.mock('./pages/UsagePage', () => ({ UsagePage: () => <h1>Usage report</h1> }))
+vi.mock('./pages/SchedulesPage', () => ({ SchedulesPage: () => <h1>Schedule list</h1> }))
 vi.mock('./pages/AppHomePage', () => ({
   AppHomePage: ({ app }: { app: string }) => <h1>{app} home</h1>,
 }))
@@ -106,6 +107,24 @@ beforeEach(() => {
 })
 
 describe('command center navigation', () => {
+  it('puts Schedules below Usage in the shared navigation and phone drawer', async () => {
+    renderApp('/schedules?app=notes')
+    await screen.findByRole('heading', { name: 'Schedule list' })
+    const navigation = screen.getByRole('navigation', { name: 'Work' })
+    expect(within(navigation).getAllByRole('link').map((link) => link.textContent)).toEqual([
+      'Dashboard', 'Events', 'Usage', 'Schedules',
+    ])
+    expect(within(navigation).getByRole('link', { name: 'Schedules' }).getAttribute('aria-current')).toBe('page')
+    fireEvent.click(screen.getByRole('button', { name: 'Open navigation' }))
+    const drawer = screen.getByRole('dialog', { name: 'Druks navigation' })
+    const phoneNavigation = within(drawer).getByRole('navigation', { name: 'Work' })
+    expect(within(phoneNavigation).getAllByRole('link').map((link) => link.textContent)).toEqual([
+      'Dashboard', 'Events', 'Usage', 'Schedules',
+    ])
+    fireEvent.click(within(drawer).getByRole('link', { name: 'Schedules' }))
+    await waitFor(() => expect(drawer.hasAttribute('open')).toBe(false))
+  })
+
   it('keeps app destinations stable on list and detail pages', async () => {
     renderApp()
     const apps = await screen.findByRole('navigation', { name: 'Apps' })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import {
   type RefObject,
 } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Activity, ChartNoAxesCombined, LayoutGrid, Search, Settings } from 'lucide-react'
+import { Activity, CalendarDays, ChartNoAxesCombined, LayoutGrid, Search, Settings } from 'lucide-react'
 import { Link, Route, Router, Switch, useLocation, type RouterProps } from 'wouter'
 import { navigate as browserNavigate, useLocationProperty } from 'wouter/use-browser-location'
 
@@ -26,13 +26,16 @@ import { EventsPage } from './pages/EventsPage'
 import { DashboardPage } from './pages/DashboardPage'
 import { LoginWindowPage } from './pages/LoginWindowPage'
 import { UsagePage } from './pages/UsagePage'
+import { SchedulesPage } from './pages/SchedulesPage'
 import { appAccent } from './lib/appColors'
 import './apps'
 import { registerInstalledApps } from './apps/installed'
 import { appHome, appLabel, appOwning, getAppUI, registeredApps } from './apps/registry'
 
 const ROUTER_BASE = import.meta.env.BASE_URL.replace(/\/$/, '')
-const SHELL_PAGES: Record<string, string> = { '/': 'Dashboard', '/events': 'Events', '/usage': 'Usage' }
+const SHELL_PAGES: Record<string, string> = {
+  '/': 'Dashboard', '/events': 'Events', '/usage': 'Usage', '/schedules': 'Schedules',
+}
 
 export function App({ account }: { account: Account }) {
   const unsavedFormRef = useRef<UnsavedForm | null>(null)
@@ -247,7 +250,7 @@ function AppShell({
         return
       }
       if (event.key === 'Escape') {
-        const sharedDetail = location === '/usage' || location === '/events'
+        const sharedDetail = location === '/usage' || location === '/events' || location === '/schedules'
         const parent = ui?.parentPath?.(location) ?? (sharedDetail && app ? appHome(app) : undefined)
         if (parent) {
           if (navCount.current > 0) window.history.back()
@@ -306,6 +309,14 @@ function AppShell({
             >
               <ChartNoAxesCombined size={17} aria-hidden="true" />
               Usage
+            </Link>
+            <Link
+              href="/schedules"
+              className="sidebar-link"
+              aria-current={location === '/schedules' ? 'page' : undefined}
+            >
+              <CalendarDays size={17} aria-hidden="true" />
+              Schedules
             </Link>
           </nav>
           <div className="sidebar-apps">
@@ -430,6 +441,9 @@ function AppShell({
           </Route>
           <Route path="/usage">
             <UsagePage />
+          </Route>
+          <Route path="/schedules">
+            <SchedulesPage apps={rosterQuery.data?.map((entry) => entry.name) ?? []} />
           </Route>
           <Route path="/events">
             <EventsPage />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -443,7 +443,10 @@ function AppShell({
             <UsagePage />
           </Route>
           <Route path="/schedules">
-            <SchedulesPage apps={rosterQuery.data?.map((entry) => entry.name) ?? []} />
+            <SchedulesPage
+              apps={rosterQuery.data?.map((entry) => entry.name) ?? []}
+              unsavedFormRef={unsavedFormRef}
+            />
           </Route>
           <Route path="/events">
             <EventsPage />

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -55,6 +55,7 @@ export interface DashboardSchedule {
   app: string
   kind: string
   cron: string | null
+  defaultCron: string
   enabled: boolean
   timezone: string
 }

--- a/frontend/src/components/SettingsPanes.tsx
+++ b/frontend/src/components/SettingsPanes.tsx
@@ -58,7 +58,7 @@ const billingLabel = (billing: string) => (billing === 'api_key' ? 'API key' : '
 
 const TIMEOUTS = [600, 900, 1800, 3600]
 
-function Switch({
+export function Switch({
   on,
   onClick,
   disabled,

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -127,8 +127,8 @@ describe('Dashboard', () => {
     work.mockResolvedValue({ rows: [pending, { ...pending, run: 'other', app: 'other' }], hasMore: false })
     schedules.mockResolvedValue({
       rows: [
-        { app: 'notes', kind: 'notes.daily', cron: '0 9 * * *', enabled: false, timezone: 'Europe/Madrid' },
-        { app: 'other', kind: 'other.daily', cron: '0 9 * * *', enabled: true, timezone: 'Europe/Madrid' },
+        { app: 'notes', kind: 'notes.daily', cron: '0 9 * * *', defaultCron: '0 9 * * *', enabled: false, timezone: 'Europe/Madrid' },
+        { app: 'other', kind: 'other.daily', cron: '0 9 * * *', defaultCron: '0 9 * * *', enabled: true, timezone: 'Europe/Madrid' },
       ],
     })
     mount(['notes', 'other'])

--- a/frontend/src/pages/SchedulesPage.test.tsx
+++ b/frontend/src/pages/SchedulesPage.test.tsx
@@ -4,43 +4,33 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import { Router } from 'wouter'
 
 import { api } from '../api/client'
-import type { AppsSettingsResponse, WorkflowSettingField } from '../api/types'
+import type { UnsavedForm } from '../components/settings'
 import { SchedulesPage } from './SchedulesPage'
 
-vi.mock('../api/client', () => ({ api: {
-  dashboardSchedules: vi.fn(), getAppSettings: vi.fn(), updateAppSettings: vi.fn(),
-} }))
+vi.mock('../api/client', () => ({ api: { dashboardSchedules: vi.fn(), updateAppSettings: vi.fn() } }))
 
-const cadence: WorkflowSettingField = {
-  name: 'schedule', label: 'Daily digest schedule', help: 'Installation timezone.', type: 'cron',
-  value: '0 * * * *', default: '*/15 * * * *', choices: null, choiceDetails: {}, section: '',
-  visibleWhenField: '', visibleWhenValue: null, secretSet: null, multiline: false, overridden: true,
-}
-const settings: AppsSettingsResponse = {
-  allowedEfforts: [],
-  apps: [{
-    name: 'notes', icon: 'book', description: '', builtin: false, agents: [], settings: [],
-    workflows: [
-      { kind: 'notes.daily_digest', fields: [cadence, { ...cadence, name: 'schedule_enabled', label: 'Daily digest enabled', type: 'bool', value: false, default: true }] },
-      { kind: 'notes.manual', fields: [] },
-    ],
-  }],
+const daily = {
+  app: 'notes', kind: 'notes.daily_digest', cron: '0 * * * *', defaultCron: '*/15 * * * *',
+  enabled: false, timezone: 'Europe/Madrid',
 }
 const schedules = vi.mocked(api.dashboardSchedules)
-const appSettings = vi.mocked(api.getAppSettings)
 const save = vi.mocked(api.updateAppSettings)
 
 function mount(apps = ['notes', 'other']) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
-  render(<QueryClientProvider client={client}><Router><SchedulesPage apps={apps} /></Router></QueryClientProvider>)
-  return client
+  const unsavedForm: { current: UnsavedForm | null } = { current: null }
+  render(
+    <QueryClientProvider client={client}>
+      <Router><SchedulesPage apps={apps} unsavedFormRef={unsavedForm} /></Router>
+    </QueryClientProvider>,
+  )
+  return { client, unsavedForm }
 }
 
 beforeEach(() => {
   window.history.replaceState(null, '', '/schedules')
-  schedules.mockResolvedValue({ rows: [{ app: 'notes', kind: 'notes.daily_digest', cron: '0 * * * *', enabled: false, timezone: 'Europe/Madrid' }] })
-  appSettings.mockResolvedValue(settings)
-  save.mockResolvedValue(settings)
+  schedules.mockResolvedValue({ rows: [daily] })
+  save.mockResolvedValue({ apps: [], allowedEfforts: [] })
 })
 afterEach(() => { cleanup(); vi.clearAllMocks() })
 
@@ -48,10 +38,10 @@ it('shows declared schedules and saves cadence and pause state through app setti
   mount()
   const form = await screen.findByRole('form', { name: 'Daily Digest' })
   expect(within(form).getByText('Paused')).toBeTruthy()
+  expect(within(form).getByText('0 * * * *')).toBeTruthy()
   expect(within(form).getByText('Europe/Madrid')).toBeTruthy()
-  expect(screen.queryByText('Manual')).toBeNull()
-  fireEvent.change(within(form).getByRole('combobox', { name: cadence.label }), { target: { value: '*/5 * * * *' } })
-  fireEvent.click(within(form).getByRole('button', { name: 'Daily digest enabled' }))
+  fireEvent.change(within(form).getByRole('combobox', { name: 'Cadence' }), { target: { value: '*/5 * * * *' } })
+  fireEvent.click(within(form).getByRole('button', { name: 'Daily Digest enabled' }))
   fireEvent.click(within(form).getByRole('button', { name: 'Save changes' }))
   await screen.findByText('Schedule saved.')
   expect(save).toHaveBeenCalledWith({ workflowSettings: { 'notes.daily_digest': { schedule: '*/5 * * * *', schedule_enabled: true } } })
@@ -61,8 +51,8 @@ it('shows declared schedules and saves cadence and pause state through app setti
 it('keeps invalid cron input after a rejected save and allows recovery', async () => {
   save.mockRejectedValueOnce(new Error('Invalid cron expression.'))
   mount()
-  fireEvent.change(await screen.findByRole('combobox', { name: cadence.label }), { target: { value: 'custom' } })
-  const input = screen.getByRole('textbox', { name: `${cadence.label} (cron)` })
+  fireEvent.change(await screen.findByRole('combobox', { name: 'Cadence' }), { target: { value: 'custom' } })
+  const input = screen.getByRole('textbox', { name: 'Cadence (cron)' })
   fireEvent.change(input, { target: { value: 'bad cron' } })
   fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
   expect(await screen.findByRole('alert')).toHaveProperty('textContent', 'Invalid cron expression.')
@@ -74,8 +64,8 @@ it('keeps invalid cron input after a rejected save and allows recovery', async (
 })
 
 it('keeps dirty edits and keyboard focus during a refresh', async () => {
-  const client = mount()
-  const input = await screen.findByRole('combobox', { name: cadence.label })
+  const { client } = mount()
+  const input = await screen.findByRole('combobox', { name: 'Cadence' })
   fireEvent.change(input, { target: { value: '*/5 * * * *' } })
   input.focus()
   await act(() => client.invalidateQueries())
@@ -86,16 +76,36 @@ it('keeps dirty edits and keyboard focus during a refresh', async () => {
 it('resets both overrides to declared defaults', async () => {
   mount()
   fireEvent.click(await screen.findByRole('button', { name: 'Use defaults' }))
-  expect(screen.getByRole('combobox', { name: cadence.label })).toHaveProperty('value', cadence.default)
-  expect(screen.getByRole('button', { name: 'Daily digest enabled' }).getAttribute('aria-pressed')).toBe('true')
+  expect(screen.getByRole('combobox', { name: 'Cadence' })).toHaveProperty('value', '*/15 * * * *')
+  expect(screen.getByRole('button', { name: 'Daily Digest enabled' }).getAttribute('aria-pressed')).toBe('true')
   fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
   await screen.findByText('Schedule saved.')
   expect(save).toHaveBeenCalledWith({ workflowSettings: { 'notes.daily_digest': { schedule: null, schedule_enabled: null } } })
 })
 
+it('guards unsaved edits until they are saved or discarded', async () => {
+  const { unsavedForm } = mount()
+  const input = await screen.findByRole('combobox', { name: 'Cadence' })
+  expect(unsavedForm.current).toBeNull()
+  fireEvent.change(input, { target: { value: '*/5 * * * *' } })
+  expect(unsavedForm.current?.path).toBe('/schedules')
+  const confirm = vi.spyOn(window, 'confirm')
+  const proceed = vi.fn()
+  confirm.mockReturnValueOnce(false)
+  act(() => unsavedForm.current!.confirm(proceed))
+  expect(proceed).not.toHaveBeenCalled()
+  expect(input).toHaveProperty('value', '*/5 * * * *')
+  confirm.mockReturnValueOnce(true)
+  act(() => unsavedForm.current!.confirm(proceed))
+  expect(proceed).toHaveBeenCalledTimes(1)
+  await waitFor(() => expect(unsavedForm.current).toBeNull())
+  expect(input).toHaveProperty('value', '0 * * * *')
+  confirm.mockRestore()
+})
+
 it('shows loading, initial error, stale data, and recovery separately', async () => {
   schedules.mockReturnValueOnce(new Promise(() => {}))
-  const client = mount()
+  const { client } = mount()
   expect(screen.getByRole('status').textContent).toBe('Loading schedules…')
   expect(screen.queryByText('No app declares a workflow schedule.')).toBeNull()
   await act(() => client.cancelQueries({ queryKey: ['dashboard', 'schedules'] }))
@@ -124,7 +134,6 @@ it('filters by URL and restores the previous filter with browser Back', async ()
 
 it('shows an empty installation without an edit control', async () => {
   schedules.mockResolvedValue({ rows: [] })
-  appSettings.mockResolvedValue({ apps: [], allowedEfforts: [] })
   mount([])
   await screen.findByText('No app declares a workflow schedule.')
   expect(screen.queryByRole('button', { name: 'Save changes' })).toBeNull()

--- a/frontend/src/pages/SchedulesPage.test.tsx
+++ b/frontend/src/pages/SchedulesPage.test.tsx
@@ -1,0 +1,131 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { Router } from 'wouter'
+
+import { api } from '../api/client'
+import type { AppsSettingsResponse, WorkflowSettingField } from '../api/types'
+import { SchedulesPage } from './SchedulesPage'
+
+vi.mock('../api/client', () => ({ api: {
+  dashboardSchedules: vi.fn(), getAppSettings: vi.fn(), updateAppSettings: vi.fn(),
+} }))
+
+const cadence: WorkflowSettingField = {
+  name: 'schedule', label: 'Daily digest schedule', help: 'Installation timezone.', type: 'cron',
+  value: '0 * * * *', default: '*/15 * * * *', choices: null, choiceDetails: {}, section: '',
+  visibleWhenField: '', visibleWhenValue: null, secretSet: null, multiline: false, overridden: true,
+}
+const settings: AppsSettingsResponse = {
+  allowedEfforts: [],
+  apps: [{
+    name: 'notes', icon: 'book', description: '', builtin: false, agents: [], settings: [],
+    workflows: [
+      { kind: 'notes.daily_digest', fields: [cadence, { ...cadence, name: 'schedule_enabled', label: 'Daily digest enabled', type: 'bool', value: false, default: true }] },
+      { kind: 'notes.manual', fields: [] },
+    ],
+  }],
+}
+const schedules = vi.mocked(api.dashboardSchedules)
+const appSettings = vi.mocked(api.getAppSettings)
+const save = vi.mocked(api.updateAppSettings)
+
+function mount(apps = ['notes', 'other']) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(<QueryClientProvider client={client}><Router><SchedulesPage apps={apps} /></Router></QueryClientProvider>)
+  return client
+}
+
+beforeEach(() => {
+  window.history.replaceState(null, '', '/schedules')
+  schedules.mockResolvedValue({ rows: [{ app: 'notes', kind: 'notes.daily_digest', cron: '0 * * * *', enabled: false, timezone: 'Europe/Madrid' }] })
+  appSettings.mockResolvedValue(settings)
+  save.mockResolvedValue(settings)
+})
+afterEach(() => { cleanup(); vi.clearAllMocks() })
+
+it('shows declared schedules and saves cadence and pause state through app settings', async () => {
+  mount()
+  const form = await screen.findByRole('form', { name: 'Daily Digest' })
+  expect(within(form).getByText('Paused')).toBeTruthy()
+  expect(within(form).getByText('Europe/Madrid')).toBeTruthy()
+  expect(screen.queryByText('Manual')).toBeNull()
+  fireEvent.change(within(form).getByRole('combobox', { name: cadence.label }), { target: { value: '*/5 * * * *' } })
+  fireEvent.click(within(form).getByRole('button', { name: 'Daily digest enabled' }))
+  fireEvent.click(within(form).getByRole('button', { name: 'Save changes' }))
+  await screen.findByText('Schedule saved.')
+  expect(save).toHaveBeenCalledWith({ workflowSettings: { 'notes.daily_digest': { schedule: '*/5 * * * *', schedule_enabled: true } } })
+  expect(schedules).toHaveBeenCalledTimes(2)
+})
+
+it('keeps invalid cron input after a rejected save and allows recovery', async () => {
+  save.mockRejectedValueOnce(new Error('Invalid cron expression.'))
+  mount()
+  fireEvent.change(await screen.findByRole('combobox', { name: cadence.label }), { target: { value: 'custom' } })
+  const input = screen.getByRole('textbox', { name: `${cadence.label} (cron)` })
+  fireEvent.change(input, { target: { value: 'bad cron' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+  expect(await screen.findByRole('alert')).toHaveProperty('textContent', 'Invalid cron expression.')
+  expect(input).toHaveProperty('value', 'bad cron')
+  fireEvent.change(input, { target: { value: '15 9 * * 1' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+  await screen.findByText('Schedule saved.')
+  expect(save).toHaveBeenLastCalledWith({ workflowSettings: { 'notes.daily_digest': { schedule: '15 9 * * 1' } } })
+})
+
+it('keeps dirty edits and keyboard focus during a refresh', async () => {
+  const client = mount()
+  const input = await screen.findByRole('combobox', { name: cadence.label })
+  fireEvent.change(input, { target: { value: '*/5 * * * *' } })
+  input.focus()
+  await act(() => client.invalidateQueries())
+  expect(input).toHaveProperty('value', '*/5 * * * *')
+  expect(document.activeElement).toBe(input)
+})
+
+it('resets both overrides to declared defaults', async () => {
+  mount()
+  fireEvent.click(await screen.findByRole('button', { name: 'Use defaults' }))
+  expect(screen.getByRole('combobox', { name: cadence.label })).toHaveProperty('value', cadence.default)
+  expect(screen.getByRole('button', { name: 'Daily digest enabled' }).getAttribute('aria-pressed')).toBe('true')
+  fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+  await screen.findByText('Schedule saved.')
+  expect(save).toHaveBeenCalledWith({ workflowSettings: { 'notes.daily_digest': { schedule: null, schedule_enabled: null } } })
+})
+
+it('shows loading, initial error, stale data, and recovery separately', async () => {
+  schedules.mockReturnValueOnce(new Promise(() => {}))
+  const client = mount()
+  expect(screen.getByRole('status').textContent).toBe('Loading schedules…')
+  expect(screen.queryByText('No app declares a workflow schedule.')).toBeNull()
+  await act(() => client.cancelQueries({ queryKey: ['dashboard', 'schedules'] }))
+  schedules.mockRejectedValueOnce(new Error('Offline'))
+  await act(() => client.refetchQueries({ queryKey: ['dashboard', 'schedules'] }))
+  expect(await screen.findByRole('alert')).toHaveProperty('textContent', expect.stringContaining('No schedule data is available.'))
+  fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+  await screen.findByRole('form', { name: 'Daily Digest' })
+  schedules.mockRejectedValueOnce(new Error('Offline'))
+  await act(() => client.invalidateQueries({ queryKey: ['dashboard', 'schedules'] }))
+  expect(await screen.findByRole('alert')).toHaveProperty('textContent', expect.stringContaining('The last successful read remains visible.'))
+  expect(screen.getByRole('form', { name: 'Daily Digest' })).toBeTruthy()
+  fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+  await waitFor(() => expect(screen.queryByRole('alert')).toBeNull())
+})
+
+it('filters by URL and restores the previous filter with browser Back', async () => {
+  mount()
+  await screen.findByRole('form', { name: 'Daily Digest' })
+  fireEvent.change(screen.getByRole('combobox', { name: 'Filter by app' }), { target: { value: 'other' } })
+  expect(await screen.findByText('No declared schedules for this app.')).toBeTruthy()
+  expect(window.location.search).toBe('?app=other')
+  await act(async () => { window.history.back() })
+  expect(await screen.findByRole('form', { name: 'Daily Digest' })).toBeTruthy()
+})
+
+it('shows an empty installation without an edit control', async () => {
+  schedules.mockResolvedValue({ rows: [] })
+  appSettings.mockResolvedValue({ apps: [], allowedEfforts: [] })
+  mount([])
+  await screen.findByText('No app declares a workflow schedule.')
+  expect(screen.queryByRole('button', { name: 'Save changes' })).toBeNull()
+})

--- a/frontend/src/pages/SchedulesPage.tsx
+++ b/frontend/src/pages/SchedulesPage.tsx
@@ -1,29 +1,61 @@
-import { useState } from 'react'
+import { useEffect, useState, type RefObject } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link, useLocation, useSearch } from 'wouter'
 
 import { api } from '../api/client'
-import type { DashboardSchedule, WorkflowSettings } from '../api/types'
+import type { DashboardSchedule } from '../api/types'
 import { appLabel } from '../apps/registry'
 import { Button, Select } from '../components/Control'
 import { Page } from '../components/Page'
 import { SettingField } from '../components/SettingField'
 import { Switch } from '../components/SettingsPanes'
+import type { UnsavedForm } from '../components/settings'
 import '../schedules.css'
 
 const POLL = { refetchInterval: 30_000, refetchOnWindowFocus: true, retry: false } as const
 
-export function SchedulesPage({ apps }: { apps: string[] }) {
+// A null edit removes the override, which restores the declared value.
+interface ScheduleEdits {
+  schedule?: string | null
+  schedule_enabled?: boolean | null
+}
+
+export function SchedulesPage({
+  apps,
+  unsavedFormRef,
+}: {
+  apps: string[]
+  unsavedFormRef: RefObject<UnsavedForm | null>
+}) {
   const [, navigate] = useLocation()
   const app = new URLSearchParams(useSearch()).get('app') ?? ''
   const schedules = useQuery({
     queryKey: ['dashboard', 'schedules'], queryFn: api.dashboardSchedules, ...POLL,
   })
-  const settings = useQuery({
-    queryKey: ['appSettings'], queryFn: api.getAppSettings, ...POLL,
-  })
-  const hasData = Boolean(schedules.data && settings.data)
-  const hasError = schedules.isError || settings.isError
+  const [edits, setEdits] = useState<Record<string, ScheduleEdits>>({})
+  const isDirty = Object.keys(edits).length > 0
+  useEffect(() => {
+    if (!isDirty) return
+    const form: UnsavedForm = {
+      path: '/schedules',
+      confirm: (proceed) => {
+        if (window.confirm('You have unsaved schedule changes. Discard them?')) {
+          setEdits({})
+          proceed()
+        }
+      },
+    }
+    unsavedFormRef.current = form
+    function beforeUnload(event: BeforeUnloadEvent) {
+      event.preventDefault()
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', beforeUnload)
+    return () => {
+      window.removeEventListener('beforeunload', beforeUnload)
+      if (unsavedFormRef.current === form) unsavedFormRef.current = null
+    }
+  }, [isDirty, unsavedFormRef])
   const rows = (schedules.data?.rows ?? []).filter((row) => !app || row.app === app)
   const owners = [...new Set(rows.map((row) => row.app))]
 
@@ -44,18 +76,15 @@ export function SchedulesPage({ apps }: { apps: string[] }) {
           {app && !apps.includes(app) && <option value={app}>{appLabel(app)}</option>}
         </Select>
       </header>
-      {hasError && (
+      {schedules.isError && (
         <div className="schedules-alert" role="alert">
-          <p>Could not refresh schedules. {hasData ? 'The last successful read remains visible.' : 'No schedule data is available.'}</p>
-          <Button disabled={schedules.isFetching || settings.isFetching} onClick={() => {
-            void schedules.refetch()
-            void settings.refetch()
-          }}>Retry</Button>
+          <p>Could not refresh schedules. {schedules.data ? 'The last successful read remains visible.' : 'No schedule data is available.'}</p>
+          <Button disabled={schedules.isFetching} onClick={() => void schedules.refetch()}>Retry</Button>
         </div>
       )}
-      {!hasData && !hasError && <p role="status">Loading schedules…</p>}
-      {hasData && rows.length === 0 && <p className="schedules-empty">{app ? 'No declared schedules for this app.' : 'No app declares a workflow schedule.'}</p>}
-      {hasData && owners.map((owner) => (
+      {schedules.isPending && <p role="status">Loading schedules…</p>}
+      {schedules.data && rows.length === 0 && <p className="schedules-empty">{app ? 'No declared schedules for this app.' : 'No app declares a workflow schedule.'}</p>}
+      {owners.map((owner) => (
         <section className="schedules-app" key={owner} aria-labelledby={`schedules-${owner}`}>
           <header>
             <h2 id={`schedules-${owner}`}>{appLabel(owner)}</h2>
@@ -65,7 +94,12 @@ export function SchedulesPage({ apps }: { apps: string[] }) {
             <ScheduleForm
               key={schedule.kind}
               schedule={schedule}
-              settings={settings.data!.apps.find((entry) => entry.name === owner)!.workflows.find((workflow) => workflow.kind === schedule.kind)!}
+              edits={edits[schedule.kind] ?? {}}
+              onEdit={(next) => setEdits((all) => {
+                const rest = { ...all }
+                delete rest[schedule.kind]
+                return Object.keys(next).length > 0 ? { ...rest, [schedule.kind]: next } : rest
+              })}
             />
           ))}
         </section>
@@ -74,31 +108,40 @@ export function SchedulesPage({ apps }: { apps: string[] }) {
   )
 }
 
-function ScheduleForm({ schedule, settings }: { schedule: DashboardSchedule; settings: WorkflowSettings }) {
+function ScheduleForm({
+  schedule,
+  edits,
+  onEdit,
+}: {
+  schedule: DashboardSchedule
+  edits: ScheduleEdits
+  onEdit: (edits: ScheduleEdits) => void
+}) {
   const queryClient = useQueryClient()
-  const [edits, setEdits] = useState<{ schedule?: string | null; schedule_enabled?: boolean | null }>({})
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState('')
   const [isSaved, setIsSaved] = useState(false)
-  const cadence = settings.fields.find((field) => field.name === 'schedule')!
-  const enabled = settings.fields.find((field) => field.name === 'schedule_enabled')!
-  const cron = edits.schedule === undefined ? cadence.value : (edits.schedule ?? cadence.default)
-  const isEnabled = Boolean(edits.schedule_enabled === undefined ? enabled.value : (edits.schedule_enabled ?? enabled.default))
+  const cron = edits.schedule === undefined ? schedule.cron : (edits.schedule ?? schedule.defaultCron)
+  const isEnabled = edits.schedule_enabled === undefined ? schedule.enabled : (edits.schedule_enabled ?? true)
   const hasEdits = Object.keys(edits).length > 0
   const label = appLabel(schedule.kind.split('.').at(-1)!)
+
+  function edit(next: ScheduleEdits) {
+    onEdit(next)
+    setIsSaved(false)
+  }
 
   async function save() {
     setIsSaving(true)
     setError('')
     setIsSaved(false)
     try {
-      const saved = await api.updateAppSettings({ workflowSettings: { [schedule.kind]: edits } })
-      queryClient.setQueryData(['appSettings'], saved)
-      setEdits({})
+      await api.updateAppSettings({ workflowSettings: { [schedule.kind]: edits } })
+      onEdit({})
       setIsSaved(true)
       await queryClient.invalidateQueries({ queryKey: ['dashboard', 'schedules'] })
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not save the schedule. Try again.')
+      setError(caught instanceof Error ? caught.message : String(caught))
     } finally {
       setIsSaving(false)
     }
@@ -109,35 +152,32 @@ function ScheduleForm({ schedule, settings }: { schedule: DashboardSchedule; set
       <header>
         <h3>{label}</h3>
         <span>{schedule.enabled ? 'Enabled' : 'Paused'}</span>
-        <code>{schedule.cron ?? 'No cadence'}</code>
+        <code>{schedule.cron}</code>
         <span>{schedule.timezone}</span>
       </header>
       <div className="schedule-controls">
         <SettingField
-          label={cadence.label}
-          type={cadence.type}
-          help={cadence.help}
-          value={String(cron ?? '')}
-          onChange={(value) => { setEdits({ ...edits, schedule: value }); setIsSaved(false) }}
+          label="Cadence"
+          type="cron"
+          help="How often the scheduled run fires, in the installation timezone."
+          value={cron ?? ''}
+          onChange={(value) => edit({ ...edits, schedule: value })}
           disabled={isSaving}
         />
         <div className="schedule-enabled">
-          <span>{enabled.label}</span>
+          <span>Enabled</span>
           <Switch
             on={isEnabled}
-            label={enabled.label}
-            onClick={() => { setEdits({ ...edits, schedule_enabled: !isEnabled }); setIsSaved(false) }}
+            label={`${label} enabled`}
+            onClick={() => edit({ ...edits, schedule_enabled: !isEnabled })}
             disabled={isSaving}
           />
         </div>
       </div>
       {error && <p className="schedules-alert" role="alert">{error}</p>}
       <footer>
-        <Button disabled={isSaving} onClick={() => {
-          setEdits({ schedule: null, schedule_enabled: null })
-          setIsSaved(false)
-        }}>Use defaults</Button>
-        <Button disabled={!hasEdits || isSaving} onClick={() => { setEdits({}); setError(''); setIsSaved(false) }}>Discard</Button>
+        <Button disabled={isSaving} onClick={() => edit({ schedule: null, schedule_enabled: null })}>Use defaults</Button>
+        <Button disabled={!hasEdits || isSaving} onClick={() => { onEdit({}); setError(''); setIsSaved(false) }}>Discard</Button>
         <Button type="submit" variant="primary" disabled={!hasEdits || isSaving}>{isSaving ? 'Saving…' : 'Save changes'}</Button>
         {isSaved && <span role="status">Schedule saved.</span>}
       </footer>

--- a/frontend/src/pages/SchedulesPage.tsx
+++ b/frontend/src/pages/SchedulesPage.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Link, useLocation, useSearch } from 'wouter'
+
+import { api } from '../api/client'
+import type { DashboardSchedule, WorkflowSettings } from '../api/types'
+import { appLabel } from '../apps/registry'
+import { Button, Select } from '../components/Control'
+import { Page } from '../components/Page'
+import { SettingField } from '../components/SettingField'
+import { Switch } from '../components/SettingsPanes'
+import '../schedules.css'
+
+const POLL = { refetchInterval: 30_000, refetchOnWindowFocus: true, retry: false } as const
+
+export function SchedulesPage({ apps }: { apps: string[] }) {
+  const [, navigate] = useLocation()
+  const app = new URLSearchParams(useSearch()).get('app') ?? ''
+  const schedules = useQuery({
+    queryKey: ['dashboard', 'schedules'], queryFn: api.dashboardSchedules, ...POLL,
+  })
+  const settings = useQuery({
+    queryKey: ['appSettings'], queryFn: api.getAppSettings, ...POLL,
+  })
+  const hasData = Boolean(schedules.data && settings.data)
+  const hasError = schedules.isError || settings.isError
+  const rows = (schedules.data?.rows ?? []).filter((row) => !app || row.app === app)
+  const owners = [...new Set(rows.map((row) => row.app))]
+
+  return (
+    <Page inset className="schedules-page">
+      <header className="schedules-head">
+        <div>
+          <h1>Schedules</h1>
+          <p>Change cadence or pause a declared schedule.</p>
+        </div>
+        <Select
+          aria-label="Filter by app"
+          value={app}
+          onChange={(event) => navigate(event.target.value ? `/schedules?app=${encodeURIComponent(event.target.value)}` : '/schedules')}
+        >
+          <option value="">All apps</option>
+          {apps.map((name) => <option key={name} value={name}>{appLabel(name)}</option>)}
+          {app && !apps.includes(app) && <option value={app}>{appLabel(app)}</option>}
+        </Select>
+      </header>
+      {hasError && (
+        <div className="schedules-alert" role="alert">
+          <p>Could not refresh schedules. {hasData ? 'The last successful read remains visible.' : 'No schedule data is available.'}</p>
+          <Button disabled={schedules.isFetching || settings.isFetching} onClick={() => {
+            void schedules.refetch()
+            void settings.refetch()
+          }}>Retry</Button>
+        </div>
+      )}
+      {!hasData && !hasError && <p role="status">Loading schedules…</p>}
+      {hasData && rows.length === 0 && <p className="schedules-empty">{app ? 'No declared schedules for this app.' : 'No app declares a workflow schedule.'}</p>}
+      {hasData && owners.map((owner) => (
+        <section className="schedules-app" key={owner} aria-labelledby={`schedules-${owner}`}>
+          <header>
+            <h2 id={`schedules-${owner}`}>{appLabel(owner)}</h2>
+            <Link href={`/apps/${encodeURIComponent(owner)}/settings`}>App settings</Link>
+          </header>
+          {rows.filter((row) => row.app === owner).map((schedule) => (
+            <ScheduleForm
+              key={schedule.kind}
+              schedule={schedule}
+              settings={settings.data!.apps.find((entry) => entry.name === owner)!.workflows.find((workflow) => workflow.kind === schedule.kind)!}
+            />
+          ))}
+        </section>
+      ))}
+    </Page>
+  )
+}
+
+function ScheduleForm({ schedule, settings }: { schedule: DashboardSchedule; settings: WorkflowSettings }) {
+  const queryClient = useQueryClient()
+  const [edits, setEdits] = useState<{ schedule?: string | null; schedule_enabled?: boolean | null }>({})
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState('')
+  const [isSaved, setIsSaved] = useState(false)
+  const cadence = settings.fields.find((field) => field.name === 'schedule')!
+  const enabled = settings.fields.find((field) => field.name === 'schedule_enabled')!
+  const cron = edits.schedule === undefined ? cadence.value : (edits.schedule ?? cadence.default)
+  const isEnabled = Boolean(edits.schedule_enabled === undefined ? enabled.value : (edits.schedule_enabled ?? enabled.default))
+  const hasEdits = Object.keys(edits).length > 0
+  const label = appLabel(schedule.kind.split('.').at(-1)!)
+
+  async function save() {
+    setIsSaving(true)
+    setError('')
+    setIsSaved(false)
+    try {
+      const saved = await api.updateAppSettings({ workflowSettings: { [schedule.kind]: edits } })
+      queryClient.setQueryData(['appSettings'], saved)
+      setEdits({})
+      setIsSaved(true)
+      await queryClient.invalidateQueries({ queryKey: ['dashboard', 'schedules'] })
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not save the schedule. Try again.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <form className="schedule-form" aria-label={label} onSubmit={(event) => { event.preventDefault(); void save() }}>
+      <header>
+        <h3>{label}</h3>
+        <span>{schedule.enabled ? 'Enabled' : 'Paused'}</span>
+        <code>{schedule.cron ?? 'No cadence'}</code>
+        <span>{schedule.timezone}</span>
+      </header>
+      <div className="schedule-controls">
+        <SettingField
+          label={cadence.label}
+          type={cadence.type}
+          help={cadence.help}
+          value={String(cron ?? '')}
+          onChange={(value) => { setEdits({ ...edits, schedule: value }); setIsSaved(false) }}
+          disabled={isSaving}
+        />
+        <div className="schedule-enabled">
+          <span>{enabled.label}</span>
+          <Switch
+            on={isEnabled}
+            label={enabled.label}
+            onClick={() => { setEdits({ ...edits, schedule_enabled: !isEnabled }); setIsSaved(false) }}
+            disabled={isSaving}
+          />
+        </div>
+      </div>
+      {error && <p className="schedules-alert" role="alert">{error}</p>}
+      <footer>
+        <Button disabled={isSaving} onClick={() => {
+          setEdits({ schedule: null, schedule_enabled: null })
+          setIsSaved(false)
+        }}>Use defaults</Button>
+        <Button disabled={!hasEdits || isSaving} onClick={() => { setEdits({}); setError(''); setIsSaved(false) }}>Discard</Button>
+        <Button type="submit" variant="primary" disabled={!hasEdits || isSaving}>{isSaving ? 'Saving…' : 'Save changes'}</Button>
+        {isSaved && <span role="status">Schedule saved.</span>}
+      </footer>
+    </form>
+  )
+}

--- a/frontend/src/pages/SchedulesPage.tsx
+++ b/frontend/src/pages/SchedulesPage.tsx
@@ -15,7 +15,7 @@ import '../schedules.css'
 const POLL = { refetchInterval: 30_000, refetchOnWindowFocus: true, retry: false } as const
 
 // A null edit removes the override, which restores the declared value.
-interface ScheduleEdits {
+type ScheduleEdits = {
   schedule?: string | null
   schedule_enabled?: boolean | null
 }

--- a/frontend/src/schedules.css
+++ b/frontend/src/schedules.css
@@ -1,0 +1,30 @@
+.schedules-page .page-shell-body { max-width: 1040px; margin-inline: auto; }
+.schedules-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; }
+.schedules-head h1 { margin: 0 0 10px; font-size: 26px; font-weight: 500; }
+.schedules-head p { margin: 0; color: var(--text-mid); }
+.schedules-head > select { max-width: 240px; }
+.schedules-page .set-select { min-height: 44px; font-family: var(--font-sans); font-size: 15px; }
+.schedules-page .set-field-label { font-family: var(--font-sans); font-size: 15px; letter-spacing: 0; }
+.schedules-app { margin-top: 40px; }
+.schedules-app > header { display: flex; justify-content: space-between; align-items: baseline; gap: 16px; }
+.schedules-app h2 { margin: 0; font-size: 20px; font-weight: 500; }
+.schedules-app > header a { min-height: 44px; display: inline-flex; align-items: center; color: var(--text-mid); text-underline-offset: 3px; }
+.schedule-form { padding: 24px 0; border-top: 1px solid var(--border); }
+.schedule-form > header { display: flex; align-items: baseline; flex-wrap: wrap; gap: 10px 20px; overflow-wrap: anywhere; }
+.schedule-form h3 { margin: 0; font-size: 17px; font-weight: 500; }
+.schedule-form > header :is(span, code) { font-size: 13px; color: var(--text-mid); }
+.schedule-controls { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); align-items: start; gap: 24px; margin-top: 22px; }
+.schedule-controls .set-field { min-width: 0; }
+.schedule-enabled { display: flex; align-items: center; justify-content: space-between; gap: 16px; min-height: 44px; }
+.schedule-form footer { display: flex; align-items: center; flex-wrap: wrap; gap: 12px; margin-top: 22px; }
+.schedule-form footer .set-btn { min-height: 44px; }
+.schedule-form footer [role="status"] { color: var(--text-mid); font-size: 13px; }
+.schedules-alert { margin-top: 20px; color: var(--outcome-failed); }
+.schedules-empty { margin-top: 32px; color: var(--text-mid); }
+@media (max-width: 649px) {
+  .schedules-head { flex-direction: column; }
+  .schedules-head > select { max-width: none; width: 100%; }
+  .schedules-page .set-select { font-size: 16px; }
+  .schedule-controls { grid-template-columns: minmax(0, 1fr); gap: 16px; }
+  .schedules-app > header { flex-wrap: wrap; }
+}


### PR DESCRIPTION
Add Schedules below Usage with declared workflows grouped by app. Operators can edit cadence, pause or resume, and restore defaults through the existing app settings endpoint. Keep drafts during refresh and failed saves. Show saved cadence in the installation timezone.

## Decisions

- Edit schedules in place with the existing cron field and boolean control; keep the same fields in app settings.
- Use the workflow kind's final name as its label, as existing schedule settings do.
