### PR TITLE
Build the approved dashboard home (DRU-515)

### DIFF
--- a/backend/druks/api/dashboard.py
+++ b/backend/druks/api/dashboard.py
@@ -10,16 +10,14 @@ from druks.api.schemas import (
     DashboardSchedule,
     DashboardSchedules,
     DashboardSection,
-    DashboardWork,
 )
 from druks.apps.loader import iter_apps
 from druks.database import db_session
-from druks.durable.enums import OPEN_STATES, RunState
+from druks.durable.enums import RunState
 from druks.durable.models import Artifact, Run
 from druks.events.models import Event
 from druks.settings import load_settings
 
-PAGE_SIZE = 200
 PREVIEW_SIZE = 4
 router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
 
@@ -124,49 +122,6 @@ async def get_overview(response: Response, app: str | None = None) -> DashboardO
     times = (await session.execute(history)).one()
     return DashboardOverview(
         **sections, last_finished_at=times.last_finished_at, last_failed_at=times.last_failed_at
-    )
-
-
-@router.get("/work", response_model=DashboardWork)
-async def list_current_work(response: Response) -> DashboardWork:
-    response.headers["Cache-Control"] = "no-store"
-    owners = {workflow.kind: owner.name for owner in iter_apps() for workflow in owner.workflows()}
-    current = (
-        Run.get_open_subjects(
-            kinds=list(owners),
-            states=(*OPEN_STATES, RunState.ORPHANED),
-            include_subjectless=True,
-        )
-        .order_by(None)
-        .subquery()
-    )
-    statement = (
-        select(
-            current.c.run_id.label("run"),
-            current.c.kind,
-            current.c.state,
-            current.c.subject_type,
-            current.c.subject_id,
-            func.left(current.c.subject_label, 240).label("subject_label"),
-            current.c.updated_at,
-            current.c.input_requested_at.label("parked_at"),
-            current.c.request_label,
-            func.left(Artifact.title, 240).label("artifact_title"),
-            current.c.presentation,
-            current.c.request_url,
-            func.left(current.c.failure, 2048).label("failure"),
-        )
-        .outerjoin(Artifact, Artifact.agent_call_id == current.c.latest_call_id)
-        .order_by(current.c.updated_at.desc(), current.c.run_id.desc())
-        .limit(PAGE_SIZE + 1)
-    )
-    rows = (await db_session().execute(statement)).all()
-    return DashboardWork(
-        rows=[
-            DashboardRun.model_validate({**row._mapping, "app": owners[row.kind]})
-            for row in rows[:PAGE_SIZE]
-        ],
-        has_more=len(rows) > PAGE_SIZE,
     )
 
 

--- a/backend/druks/api/schemas.py
+++ b/backend/druks/api/schemas.py
@@ -66,11 +66,6 @@ class DashboardRun(Schema):
     failure: str | None
 
 
-class DashboardWork(Schema):
-    rows: list[DashboardRun]
-    has_more: bool
-
-
 class DashboardSection(Schema):
     total: int
     rows: list[DashboardRun]

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -21,105 +21,11 @@ def client(tmp_path, druks_db):
         yield client
 
 
-def current_work(client):
-    response = client.get("/api/dashboard/work")
-    assert response.status_code == 200
-    assert response.headers["cache-control"] == "no-store"
-    return response.json()
-
-
 def overview(client, app=None):
     response = client.get("/api/dashboard/overview", params={"app": app} if app else {})
     assert response.status_code == 200
     assert response.headers["cache-control"] == "no-store"
     return response.json()
-
-
-async def test_a_current_run_carries_bounded_labels_and_failure_details(client, druks_db):
-    note = await Note.create(body="decision")
-    run = await seed_run(
-        druks_db,
-        kind=Summarize.kind,
-        subject=note,
-        state="parked",
-        input_gate="review",
-        input_request={"presentation": "in_app", "label": "x" * 300, "questions": ["private"]},
-        failure="f" * 4000,
-    )
-    run.input_requested_at = datetime(2026, 1, 1, tzinfo=UTC)
-    await druks_db.flush()
-
-    body = current_work(client)
-
-    assert body["hasMore"] is False
-    [row] = body["rows"]
-    assert (row["run"], row["app"], row["state"]) == (run.id, "field_notes", "parked")
-    assert row["parkedAt"] == "2026-01-01T00:00:00Z"
-    assert row["presentation"] == "in_app"
-    assert row["requestLabel"] == "x" * 240
-    assert row["failure"] == "f" * 2048
-    assert "private" not in str(row)
-
-
-async def test_newer_success_hides_historical_failure(client, druks_db):
-    note = await Note.create(body="recovered")
-    failed = await seed_run(druks_db, kind=Summarize.kind, subject=note, state="failed")
-    failed.created_at = datetime(2026, 1, 1, tzinfo=UTC)
-    await seed_run(druks_db, kind=Summarize.kind, subject=note, state="finished")
-
-    assert current_work(client)["rows"] == []
-
-
-async def test_subjectless_and_orphaned_runs_each_stay_current(client, druks_db):
-    background = await seed_run(druks_db, kind=Summarize.kind, state="running")
-    orphan = Run(
-        account_id=background.account_id,
-        id=str(uuid7()),
-        kind=Summarize.kind,
-        created_at=datetime.now(UTC) - timedelta(minutes=10),
-    )
-    druks_db.add(orphan)
-    await druks_db.flush()
-
-    rows = {row["run"]: row for row in current_work(client)["rows"]}
-
-    assert rows[background.id]["state"] == "running"
-    assert rows[orphan.id]["state"] == "orphaned"
-    assert rows[orphan.id]["subjectId"] is None
-
-
-async def test_only_installed_workflow_kinds_are_read(client, druks_db):
-    other = await Account.get_or_create("another@example.invalid")
-    note = await Note.create(body="shared run")
-    included = await seed_run(druks_db, kind=Summarize.kind, subject=note)
-    included.account_id = other.id
-    await seed_run(druks_db, kind="uninstalled.sweep")
-    await druks_db.flush()
-
-    assert [row["run"] for row in current_work(client)["rows"]] == [included.id]
-
-
-async def test_changed_time_orders_current_work(client, druks_db):
-    first = await seed_run(druks_db, kind=Summarize.kind, subject=await Note.create(body="first"))
-    second = await seed_run(druks_db, kind=Summarize.kind, subject=await Note.create(body="second"))
-    await druks_db.execute(
-        workflow_status.update()
-        .where(workflow_status.c.workflow_uuid == first.id)
-        .values(updated_at=int((datetime.now(UTC) + timedelta(minutes=1)).timestamp() * 1000))
-    )
-
-    assert [row["run"] for row in current_work(client)["rows"]] == [first.id, second.id]
-
-
-async def test_the_read_is_capped(client, druks_db, monkeypatch):
-    monkeypatch.setattr(dashboard, "PAGE_SIZE", 1)
-    for body in ("one", "two"):
-        await seed_run(druks_db, kind=Summarize.kind, subject=await Note.create(body=body))
-
-    body = current_work(client)
-
-    assert len(body["rows"]) == 1
-    assert body["hasMore"] is True
 
 
 async def test_schedules_resolve_paused_override_and_operator_timezone(
@@ -151,7 +57,6 @@ def test_dashboard_requires_the_existing_identity_gate(tmp_path, druks_db):
     )
     with TestClient(app) as anonymous:
         assert anonymous.get("/api/dashboard/overview").status_code == 401
-        assert anonymous.get("/api/dashboard/work").status_code == 401
         assert anonymous.get("/api/dashboard/schedules").status_code == 401
 
 
@@ -166,6 +71,7 @@ async def test_artifact_title_comes_from_the_latest_call(client, druks_db, has_a
         input_gate="review",
         input_request={"presentation": "in_app", "controls": ["approve"]},
     )
+    run.input_requested_at = datetime(2026, 1, 2, tzinfo=UTC)
     first_call = await seed_call(druks_db, run=run, agent="summarize")
     druks_db.add(
         Artifact(
@@ -185,7 +91,9 @@ async def test_artifact_title_comes_from_the_latest_call(client, druks_db, has_a
         )
     await druks_db.flush()
 
-    [row] = current_work(client)["rows"]
+    response = client.get("/api/dashboard/overview")
+    assert response.status_code == 200
+    [row] = response.json()["needsYou"]["rows"]
     assert row["requestLabel"] is None
     assert row["artifactTitle"] == ("Reply with the confirmed date" if has_artifact else None)
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -123,25 +123,39 @@ gate as the shared run API. An authenticated operator sees installation-wide
 run facts. `Run.account_id` records attribution and does not restrict this
 read.
 
-For each workflow kind and subject, the newest run counts. A newer successful
-run therefore removes an older failure from Problems. A run without a subject,
-including one whose DBOS record is missing, counts on its own until it is
-cancelled. The read returns the 200 most recently changed current runs with
-labels and artifact titles of at most 240 characters, and failure text of at
-most 2,048 characters. It never carries transcripts or complete review content.
+For each workflow kind and subject, the newest run counts. As a result, a newer
+successful run removes an older failure. A run without a subject counts on its
+own until an operator cancels it. This includes a run whose DBOS record is
+missing. The read groups current runs into three states. For each state, it
+returns an exact total and at most four preview runs.
 
-Needs you lists parked runs that carry a request the operator can act on,
-oldest request first. Other parked work is Waiting. Active work is running and
-queued runs. Problems is failed and orphaned runs. Scheduled work lists
-declared schedules with resolved cadence, pause state, and installation timezone.
-These are configuration facts, not proof that a future run will succeed.
+Labels and artifact titles are at most 240 characters long. Failure text is at
+most 2,048 characters long. The read never carries transcripts or complete
+review content.
 
-Review opens the owning app at the selected run and names the request round
-by its `parkedAt` timestamp. The owner reads the current gate. A different
-round shows a stale-link message, and an answer echoes the round it read, so
-the server rejects a stale one. An external request opens the app-declared
-HTTP or HTTPS address. The Dashboard does not infer access health from
-configuration.
+Needs you is parked runs that carry a request that the operator can answer. The
+oldest request comes first. Failed is runs in the failed or orphaned state.
+Running is runs in the running state. Queued runs and parked runs without an
+operator request are not current work.
+
+The read also carries the time of the last recorded run finish and the time of
+the last recorded failure. If no record exists, the time is null. An optional
+app filter limits every fact to one installed app.
+
+The Dashboard shows one state as its main content. If there are requests, it
+shows the requests. If there are no requests, it shows the failures. If there
+are no requests and no failures, it shows the running work. The other states
+appear in a compact status panel with their totals.
+
+The page has no full list. Declared schedules have their own page below Usage.
+
+Review opens the owning app at the selected run. The link names the request
+round by its `parkedAt` timestamp. The owner reads the current gate. If the
+current round is different, the owner shows a stale-link message. An answer
+echoes the round that it read, so the server rejects a stale answer.
+
+An external request opens the app-declared HTTP or HTTPS address. The Dashboard
+does not infer access health from configuration.
 
 ## Waiting for people and systems
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -93,17 +93,32 @@ supplies one shared React instance. See the app-author guide.
 
 ## Dashboard and owner links
 
-The Dashboard makes one current-work read and one schedule read, refreshed every
-30 seconds and on window focus, and sorts the rows into sections in the
-browser. A failed refresh keeps the last read visible and offers Retry. See
-[the current-work contract](../docs/concepts.md#current-work-on-the-dashboard) for
-selection, authorization, and limits.
+The Dashboard reads `/api/dashboard/overview` every 30 seconds and on window
+focus. The `app` query parameter filters exact totals, previews, and recorded
+timestamps on the server.
+
+Requests get the main space. If there are no requests, failures get it. If there
+are no failures, running work gets it. The main section shows at most four
+cards. The compact status panel shows the other totals and at most two names
+per state. Overflow is plain text, and the Dashboard has no full-list
+destination.
+
+Initial loading and read failure do not show an empty result. A failed refresh
+keeps the last successful read visible, marks it stale, and offers Retry.
+Recovery clears the stale message. The account timezone controls the greeting
+and the time labels. If the API supplies a recorded timestamp, the Dashboard
+shows its age. See [the current-work contract](../docs/concepts.md#current-work-on-the-dashboard)
+for selection, authorization, and limits.
 
 An app's `subjectPath(subject, target?)` returns its own destination. For
 the Dashboard, `target` carries `run` and, for a decision, `parkedAt`. Build the
 query with `targetQuery` from the registry. The owner selects that run and
-passes `parkedAt` to `GateControls`, which shows a stale-link message when the
-current round differs. Return `undefined` when the app has no destination.
+passes `parkedAt` to `GateControls`. If the current round is different,
+`GateControls` shows a stale-link message.
+
+If the app has no destination, return `undefined`. The Dashboard then keeps the
+context of the card without an action. External requests open only their
+supplied HTTP(S) URL. The home page has no decision controls.
 
 Python apps can select a decision page with
 [`@ui.page(..., subject=...)`](../docs/druks-ui.md#declare-pages).

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -38,7 +38,6 @@ import type {
   InstallationSettings,
   DashboardOverview,
   DashboardSchedules,
-  DashboardWork,
 } from './types'
 
 // A 401 means the request's identity did not resolve: typed to branch on,
@@ -229,7 +228,6 @@ export const api = {
   dashboardOverview: (app?: string) => getJSON<DashboardOverview>(
     `/api/dashboard/overview${app ? `?app=${encodeURIComponent(app)}` : ''}`,
   ),
-  dashboardWork: () => getJSON<DashboardWork>('/api/dashboard/work'),
   dashboardSchedules: () => getJSON<DashboardSchedules>('/api/dashboard/schedules'),
   listApps: () => getJSON<App[]>('/api/apps'),
   // ``path`` is the location under the app's own root: "" for the landing

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -33,11 +33,6 @@ export interface DashboardRun {
   failure: string | null
 }
 
-export interface DashboardWork {
-  rows: DashboardRun[]
-  hasMore: boolean
-}
-
 export interface DashboardSection {
   total: number
   rows: DashboardRun[]

--- a/frontend/src/dashboard.css
+++ b/frontend/src/dashboard.css
@@ -1,59 +1,47 @@
+.dashboard .page-shell-body { width: min(100%, 1040px); margin-inline: auto; padding-block: 12px 40px; }
 .dashboard-head { display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; }
-.dashboard h1 { margin: 0 0 10px; font-size: 26px; font-weight: 500; letter-spacing: -.02em; }
-.dashboard-head p { margin: 0; color: var(--text-mid); }
-.dashboard-filter select { min-height: 44px; max-width: 240px; padding: 0 12px; border: 1px solid var(--border-loud); border-radius: 5px; background: var(--surface); color: var(--text); font: inherit; }
-.dashboard-counts { display: flex; flex-wrap: wrap; gap: 12px 24px; padding: 36px 0 18px; border-bottom: 1px solid var(--border); color: var(--text-mid); }
-.dashboard-counts strong { color: var(--text); font-weight: 500; }
-.dashboard-section { margin-top: 30px; }
-.dashboard-section > header { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; }
-.dashboard h2 { margin: 0; font-size: 18px; font-weight: 500; }
-.dashboard-section > header > span { font-size: 13px; color: var(--text-dim); }
-.dashboard-alert { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 16px; margin: 18px 0 0; color: var(--outcome-failed); font-size: 13px; }
-.dashboard-alert button { display: inline-flex; align-items: center; gap: 6px; min-height: 40px; color: var(--text); text-decoration: underline; }
-.dashboard-row { display: grid; grid-template-columns: 18px minmax(0, 1fr) auto 110px; gap: 16px; align-items: center; padding: 20px 0; border-top: 1px solid var(--border); }
-.dashboard-row > svg { color: var(--text-dim); }
-.dashboard-parked > svg { color: var(--bucket-human); }
-.dashboard-running > svg, .dashboard-scheduled > svg { color: var(--bucket-run); }
-.dashboard-failed > svg, .dashboard-orphaned > svg { color: var(--bucket-dead); }
-.dashboard-identity { min-width: 0; display: flex; flex-direction: column; gap: 6px; overflow-wrap: anywhere; }
-.dashboard-identity strong { font-weight: 500; }
-.dashboard-identity strong.mono { font-size: 13px; }
-.dashboard-identity > span, .dashboard-identity p, .dashboard-age, .dashboard-schedule, .dashboard-unavailable { font-size: 13px; color: var(--text-mid); }
-.dashboard-identity p { margin: 0; white-space: pre-wrap; }
-.dashboard-age { text-align: right; }
-.dashboard-action { display: inline-flex; align-items: center; justify-content: center; min-height: 40px; padding: 0 14px; color: var(--text); text-decoration: none; border: 1px solid transparent; border-radius: 4px; }
-.dashboard-action:hover { background: var(--surface-2); }
-.dashboard-action.primary { background: color-mix(in oklch, var(--accent-violet) 20%, var(--surface)); border-color: color-mix(in oklch, var(--accent-violet) 40%, var(--border)); }
-.dashboard-schedule { display: flex; flex-direction: column; gap: 5px; text-align: right; }
-.dashboard-unavailable { display: flex; flex-direction: column; gap: 6px; }
-.dashboard-unavailable a { color: var(--text); min-height: 32px; display: inline-flex; align-items: center; }
-.dashboard-empty, .dashboard-more { color: var(--text-dim); }
-.dashboard-empty { margin: 0; padding: 18px 0; border-top: 1px solid var(--border); }
-.dashboard-more { font-size: 13px; }
-@media (max-width: 1024px) {
-  .dashboard-row { grid-template-columns: 18px minmax(0, 1fr) 110px; }
-  .dashboard-age, .dashboard-schedule { grid-column: 2; text-align: left; }
-  .dashboard-action, .dashboard-unavailable { grid-column: 3; grid-row: 1 / 3; }
-}
+.dashboard h1 { margin: 0 0 10px; font-size: 32px; font-weight: 500; letter-spacing: -.02em; }
+.dashboard-head p { margin: 0; color: var(--text-mid); font-size: 17px; }
+.dashboard-filter { min-height: 44px; max-width: 240px; padding: 0 12px; border: 1px solid var(--border-loud); border-radius: 8px; background: var(--surface); color: var(--text); font: inherit; }
+.dashboard-alert { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 16px; margin: 24px 0 0; color: var(--outcome-failed); }
+.dashboard-alert button { display: inline-flex; align-items: center; gap: 6px; min-height: 44px; color: var(--text); text-decoration: underline; }
+.dashboard-alert button:disabled { cursor: wait; opacity: .6; }
+.dashboard-primary { display: flex; flex-direction: column; gap: 12px; margin-top: 36px; }
+.dashboard-card { display: grid; grid-template-columns: 52px minmax(0, 1fr) auto; gap: 24px; align-items: center; min-height: 124px; padding: 24px; border: 1px solid var(--border-loud); border-radius: 14px; background: var(--surface); }
+.dashboard-app-mark { display: grid; place-items: center; width: 52px; height: 52px; border-radius: 12px; background: var(--surface-2); color: var(--text-mid); font-size: 16px; font-weight: 500; }
+.dashboard-card-failed .dashboard-app-mark { background: color-mix(in oklch, var(--outcome-failed) 10%, var(--surface)); color: color-mix(in oklch, var(--outcome-failed) 65%, var(--text-mid)); }
+.dashboard-identity { min-width: 0; overflow-wrap: anywhere; }
+.dashboard h2 { margin: 0; font-size: 17px; font-weight: 500; }
+.dashboard-identity p { margin: 6px 0 0; color: var(--text-mid); }
+.dashboard-identity .dashboard-meta { margin-top: 10px; color: var(--text-dim); font-size: 14px; }
+.dashboard-failure { display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3; overflow: hidden; white-space: pre-wrap; }
+.dashboard-action { display: inline-flex; align-items: center; justify-content: center; min-width: 106px; min-height: 44px; padding: 0 20px; color: var(--text); text-decoration: none; border: 1px solid var(--border-loud); border-radius: 999px; background: var(--surface-2); }
+.dashboard-action:hover { background: var(--surface-3); }
+.dashboard-action.primary { color: color-mix(in oklch, var(--accent-amber) 60%, var(--text)); background: color-mix(in oklch, var(--accent-amber) 12%, var(--surface)); border-color: color-mix(in oklch, var(--accent-amber) 40%, var(--border)); }
+.dashboard-action.primary:hover { background: color-mix(in oklch, var(--accent-amber) 20%, var(--surface)); }
+.dashboard :is(a, button, select):focus-visible { outline: 2px solid var(--text); outline-offset: 4px; }
+.dashboard-unavailable { max-width: 130px; color: var(--text-dim); font-size: 13px; }
+.dashboard-more { margin: 12px 0 0; color: var(--text-mid); }
+.dashboard-quiet { margin: 36px 0 0; color: var(--text-mid); }
+.dashboard-status { margin-top: 24px; padding: 8px 24px; border: 1px solid var(--border-loud); border-radius: 14px; background: var(--surface); }
+.dashboard-status ul { list-style: none; padding: 0; margin: 0; }
+.dashboard-status-row { display: flex; gap: 14px; align-items: baseline; padding: 18px 0; }
+.dashboard-status-row + .dashboard-status-row { border-top: 1px solid var(--border); }
+.dashboard-status-row > div { min-width: 0; overflow-wrap: anywhere; }
+.dashboard-status-row strong { font-weight: 500; }
+.dashboard-status-row p { margin: 6px 0 0; color: var(--text-mid); font-size: 14px; }
+.dashboard-status-dot { flex: 0 0 6px; height: 6px; border-radius: 50%; background: var(--text-faint); }
+.dashboard-status-failed .dashboard-status-dot { background: var(--bucket-dead); }
+.dashboard-status-running .dashboard-status-dot { background: var(--bucket-run); }
 @media (max-width: 649px) {
+  .dashboard .page-shell-body { padding-top: 4px; }
   .dashboard-head { flex-wrap: wrap; gap: 20px; }
-  .dashboard-filter, .dashboard-filter select { width: 100%; max-width: none; }
-  .dashboard-filter select { font-size: 16px; }
-  .dashboard-counts { padding-top: 24px; gap: 10px 20px; }
-  .dashboard-row { grid-template-columns: 18px minmax(0, 1fr); gap: 10px 14px; }
-  .dashboard-action, .dashboard-unavailable { grid-column: 2; grid-row: auto; justify-self: start; }
-  .dashboard-action, .dashboard-unavailable a, .dashboard-alert button { min-height: 44px; }
-  .dashboard-section > header { flex-wrap: wrap; gap: 6px; }
-}
-
-.dashboard-section-empty { display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px 20px; margin-top: 20px; }
-.dashboard-section-empty .dashboard-empty { padding: 0; border: 0; font-size: 14px; }
-.dashboard-identity .dashboard-request { font-size: 15px; color: var(--text); }
-.dashboard-failure-details { font-size: 13px; color: var(--text-mid); }
-.dashboard-failure-details summary { cursor: pointer; display: flex; align-items: center; min-height: 40px; text-decoration: underline; text-underline-offset: 3px; }
-.dashboard-failure-details > div { margin-top: 12px; padding: 12px; border: 1px solid var(--border); border-radius: 4px; }
-.dashboard-failure-details p { margin: 8px 0; }
-.dashboard-failure-details code { font-size: 13px; }
-@media (max-width: 649px) {
-  .dashboard-failure-details summary { min-height: 44px; }
+  .dashboard h1 { font-size: 28px; }
+  .dashboard-filter { width: 100%; max-width: none; font-size: 16px; }
+  .dashboard-primary { margin-top: 28px; }
+  .dashboard-card { grid-template-columns: 40px minmax(0, 1fr); gap: 16px; padding: 20px 16px; }
+  .dashboard-app-mark { width: 40px; height: 40px; font-size: 14px; }
+  .dashboard-action, .dashboard-unavailable { grid-column: 2; justify-self: start; }
+  .dashboard-unavailable { max-width: none; }
+  .dashboard-status { padding-inline: 16px; }
 }

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -1,42 +1,46 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { focusManager, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Router } from 'wouter'
 
 import { api } from '../api/client'
-import type { DashboardRun } from '../api/types'
+import type { DashboardOverview, DashboardRun, DashboardSection } from '../api/types'
 import { registerAppUI, targetQuery } from '../apps/registry'
+import { absTime } from '../lib/format'
+import { UserPreferencesProvider } from '../lib/preferences'
 import { DashboardPage } from './DashboardPage'
 
-vi.mock('../api/client', () => ({ api: { dashboardWork: vi.fn(), dashboardSchedules: vi.fn() } }))
+vi.mock('../api/client', () => ({ api: { dashboardOverview: vi.fn(), getPersonalSettings: vi.fn() } }))
 
 const pending: DashboardRun = {
-  app: 'notes',
-  run: 'run-one',
-  kind: 'summarize',
-  state: 'parked',
-  subjectType: 'note',
-  subjectId: '7',
-  subjectLabel: 'One long subject',
-  updatedAt: '2026-09-01T00:00:00Z',
-  parkedAt: '2026-09-01T12:34:56.123456Z',
-  requestLabel: 'Review this note',
-  artifactTitle: null,
-  presentation: 'in_app',
-  requestUrl: null,
-  failure: null,
+  app: 'notes', run: 'run-one', kind: 'summarize', state: 'parked',
+  subjectType: 'note', subjectId: '7', subjectLabel: 'One long subject',
+  updatedAt: '2026-09-01T00:00:00Z', parkedAt: '2026-09-01T12:34:56.123456Z',
+  requestLabel: 'Review this note', artifactTitle: null, presentation: 'in_app',
+  requestUrl: null, failure: null,
 }
-const work = vi.mocked(api.dashboardWork)
-const schedules = vi.mocked(api.dashboardSchedules)
+const empty: DashboardOverview = {
+  needsYou: { total: 0, rows: [] }, running: { total: 0, rows: [] }, failed: { total: 0, rows: [] },
+  lastFinishedAt: null, lastFailedAt: null,
+}
+const overview = vi.mocked(api.dashboardOverview)
 const href = (link: HTMLElement) => new URL(link.getAttribute('href')!, window.location.origin)
 
-function mount(apps: string[] = ['notes']) {
+function section(total: number, state: DashboardRun['state']): DashboardSection {
+  return { total, rows: Array.from({ length: Math.min(total, 4) }, (_, index) => ({
+    ...pending, run: `${state}-${index}`, state, subjectLabel: `${state} subject ${index}`,
+    failure: state === 'failed' ? `Failure context ${index}` : null,
+  })) }
+}
+
+function mount(apps: string[] = ['notes'], timezone = 'UTC') {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  client.setQueryData(['personalSettings'], { timezone })
   render(
     <QueryClientProvider client={client}>
-      <Router>
-        <DashboardPage apps={apps} />
-      </Router>
+      <UserPreferencesProvider>
+        <Router><DashboardPage apps={apps} /></Router>
+      </UserPreferencesProvider>
     </QueryClientProvider>,
   )
   return client
@@ -44,142 +48,230 @@ function mount(apps: string[] = ['notes']) {
 
 beforeEach(() => {
   window.history.replaceState(null, '', '/')
-  work.mockResolvedValue({ rows: [], hasMore: false })
-  schedules.mockResolvedValue({ rows: [] })
+  overview.mockReset().mockResolvedValue(empty)
   registerAppUI({
-    name: 'notes',
-    routes: [],
+    name: 'notes', routes: [],
     subjectPath: ({ type, id }, target) => `/${type}/${id}${targetQuery(target)}`,
   })
 })
 afterEach(() => {
   cleanup()
-  vi.clearAllMocks()
+  focusManager.setFocused(undefined)
+  vi.useRealTimers()
+  vi.restoreAllMocks()
 })
 
 describe('Dashboard', () => {
-  it('groups related failures with the latest occurrence and complete error details', async () => {
-    const failure = 'Connection failed. '.repeat(60)
-    work.mockResolvedValue({
-      rows: [
-        { ...pending, state: 'failed', run: 'older', subjectType: '', subjectId: '', updatedAt: '2026-09-01T00:00:00Z', failure: 'Earlier error' },
-        { ...pending, state: 'failed', run: 'latest', subjectType: '', subjectId: '', updatedAt: '2026-09-02T00:00:00Z', failure },
-        { ...pending, state: 'failed', run: 'separate', kind: 'other', failure: 'Separate workflow' },
-      ],
-      hasMore: false,
+  it.each([
+    ['Quiet', 0, 0, 0, null],
+    ['Today', 3, 0, 2, 'Needs you'],
+    ['Busy', 3, 5, 2, 'Needs you'],
+    ['Heavy', 12, 12, 8, 'Needs you'],
+    ['Waiting only', 20, 0, 0, 'Needs you'],
+    ['Failure-heavy', 0, 1, 15, 'Failed work'],
+    ['Running only', 0, 9, 0, 'Running work'],
+    ['One item', 1, 0, 0, 'Needs you'],
+  ] as const)('renders %s with exact totals and bounded previews', async (_, waiting, running, failed, primary) => {
+    overview.mockResolvedValue({ ...empty,
+      needsYou: section(waiting, 'parked'), running: section(running, 'running'), failed: section(failed, 'failed'),
     })
     mount()
-    const problems = await screen.findByRole('region', { name: 'Problems' })
-    await within(problems).findByText(/2 failures/)
-    const details = problems.querySelectorAll('details')
-    expect(details).toHaveLength(2)
-    expect(details[0]!.textContent).toContain(failure)
-    expect(details[0]!.querySelectorAll('code')[0]!.textContent).toBe('latest')
-    expect(details[0]!.textContent).toContain('Earlier error')
-    expect(within(problems).getAllByRole('link', { name: 'Open' })[0]!.getAttribute('href')).toBe('/events?app=notes')
-    expect(details[0]!.open).toBe(false)
+    const status = await screen.findByRole('region', { name: 'Current status' })
+    expect(within(status).queryByRole('link')).toBeNull()
+    expect(within(status).queryByRole('button')).toBeNull()
+    expect(within(status).getAllByRole('listitem')).toHaveLength(2)
+    const total = waiting || failed || running
+    expect(screen.queryAllByRole('article')).toHaveLength(Math.min(total, 4))
+    if (primary) {
+      const cards = screen.getByRole('region', { name: primary })
+      const state = waiting ? 'parked' : failed ? 'failed' : 'running'
+      expect(within(cards).getAllByRole('article').map((card) => card.getAttribute('aria-label')))
+        .toEqual(Array.from({ length: Math.min(total, 4) }, (_, index) => `${state} subject ${index}`))
+      if (total > 4) {
+        const overflow = screen.getByText(`${total - 4} more ${waiting ? 'waiting' : failed ? 'failed' : 'running'}`)
+        expect(overflow.tagName).toBe('P')
+        expect(overflow.closest('a, button')).toBeNull()
+      }
+    } else {
+      expect(screen.getByText('Nothing needs you right now.')).toBeTruthy()
+    }
+    if (waiting) {
+      expect(screen.getByText(`${waiting} ${waiting === 1 ? 'thing is' : 'things are'} waiting on you.`)).toBeTruthy()
+      expect(screen.getAllByRole('link', { name: 'Review' }).filter((link) => link.classList.contains('primary'))).toHaveLength(1)
+    }
+    if (!failed) expect(screen.getByText('No current failures')).toBeTruthy()
+    if (failed && waiting) expect(within(status).getByText(`${failed} failed`)).toBeTruthy()
+    if (running && (waiting || failed)) {
+      expect(within(status).getByText(`${running} running`)).toBeTruthy()
+      expect(status.textContent).toContain('running subject 0')
+      expect(status.textContent).not.toContain('running subject 2')
+      if (running > 2) expect(status.textContent).toContain(`and ${running - 2} more`)
+    }
+    expect(screen.queryByText(/Last (run finished|failure)/)).toBeNull()
+    expect(screen.queryByText(/Scheduled work|installed apps|See them|sample data/i)).toBeNull()
   })
 
-  it('sorts one read into sections and links a decision to its run and round', async () => {
-    work.mockResolvedValue({
-      rows: [
-        { ...pending, run: 'later', parkedAt: '2026-09-02T00:00:00Z' },
-        pending,
-        { ...pending, run: 'waiting', presentation: null, requestLabel: null },
-        { ...pending, run: 'running', state: 'running' },
-        { ...pending, run: 'failed', state: 'failed', failure: 'Stopped' },
-      ],
-      hasMore: true,
-    })
+  it('puts the requested action first and preserves the exact run and request round', async () => {
+    overview.mockResolvedValue({ ...empty, needsYou: { total: 1, rows: [pending] } })
     mount()
-    await screen.findAllByRole('link', { name: 'Review' })
-    const needsYou = screen.getByRole('region', { name: 'Needs you' })
-    const links = within(needsYou).getAllByRole('link', { name: 'Review' })
-    expect(links.map((link) => href(link).searchParams.get('run'))).toEqual(['run-one', 'later'])
-    expect(href(links[0]!).pathname).toBe('/note/7')
-    expect(href(links[0]!).searchParams.get('parkedAt')).toBe(pending.parkedAt)
-    const waiting = screen.getByRole('region', { name: 'Waiting' })
-    expect(href(within(waiting).getByRole('link', { name: 'Open' })).search).toBe('?run=waiting')
-    expect(within(screen.getByRole('region', { name: 'Active work' })).getByText(/Running/)).toBeTruthy()
-    expect(within(screen.getByRole('region', { name: 'Problems' })).getByText('Stopped')).toBeTruthy()
-    expect(screen.getByLabelText('Current work counts').textContent).toContain('2 need you')
-    expect(screen.getByText(/Showing the 200/)).toBeTruthy()
+    const card = await screen.findByRole('article')
+    expect(within(card).getByRole('heading').textContent).toBe('Review this note')
+    expect(card.textContent!.indexOf('Review this note')).toBeLessThan(card.textContent!.indexOf('One long subject'))
+    const url = href(within(card).getByRole('link', { name: 'Review' }))
+    expect(url.pathname).toBe('/note/7')
+    expect(url.searchParams.get('run')).toBe('run-one')
+    expect(url.searchParams.get('parkedAt')).toBe(pending.parkedAt)
+    expect(within(card).getAllByRole('link')).toHaveLength(1)
+    expect(within(card).queryByRole('button')).toBeNull()
   })
 
-  it('keeps the last read visible after a failed refresh and retries both reads', async () => {
-    work.mockResolvedValue({ rows: [pending], hasMore: false })
+  it('uses artifact and input fallbacks and keeps external HTTP(S) destinations exact', async () => {
+    const requestUrl = 'https://example.com/review?request=one&round=two'
+    overview.mockResolvedValue({ ...empty, needsYou: { total: 4, rows: [
+      { ...pending, requestLabel: null, artifactTitle: 'Confirm the date' },
+      { ...pending, run: 'empty', requestLabel: null },
+      { ...pending, run: 'external', presentation: 'external', requestLabel: null, requestUrl },
+      { ...pending, run: 'http', presentation: 'external', requestUrl: 'http://example.com/review' },
+    ] } })
+    mount()
+    expect(await screen.findByRole('heading', { name: 'Review: Confirm the date' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Review' })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Input requested' })).toBeTruthy()
+    const links = screen.getAllByRole('link', { name: 'Open' })
+    expect(links[0]!.getAttribute('href')).toBe(requestUrl)
+    expect(links[0]!.getAttribute('target')).toBe('_blank')
+    expect(links[0]!.getAttribute('rel')).toBe('noreferrer')
+    expect(links[1]!.getAttribute('href')).toBe('http://example.com/review')
+  })
+
+  it('keeps long context without an active action when a destination is missing or unsafe', async () => {
+    const subjectLabel = 'A long subject '.repeat(16)
+    const failure = 'The remote service did not accept the request. '.repeat(40)
+    overview.mockResolvedValue({ ...empty, needsYou: { total: 3, rows: [
+      { ...pending, app: 'no_route', subjectLabel },
+      { ...pending, run: 'unsafe', presentation: 'external', requestUrl: 'javascript:alert(1)' },
+      { ...pending, run: 'missing', presentation: 'external', requestUrl: null },
+    ] } })
+    const client = mount(['notes', 'no_route'])
+    await screen.findByText(subjectLabel.trim())
+    expect(screen.queryByRole('link')).toBeNull()
+    expect(screen.getAllByText('Review destination unavailable')).toHaveLength(3)
+    overview.mockResolvedValue({ ...empty, failed: { total: 2, rows: [
+      { ...pending, run: 'failed', subjectType: null, subjectId: null, state: 'failed', failure },
+      { ...pending, run: 'orphaned', subjectType: null, subjectId: null, state: 'orphaned' },
+    ] } })
+    await act(() => client.invalidateQueries({ queryKey: ['dashboard', 'overview'] }))
+    await screen.findByText(failure.trim())
+    expect(screen.getByText('The workflow record is missing.')).toBeTruthy()
+    expect(screen.getAllByRole('article')).toHaveLength(2)
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+
+  it('uses a workflow label for subjectless running work and an exact owner link when available', async () => {
+    overview.mockResolvedValue({ ...empty, running: { total: 2, rows: [
+      { ...pending, run: 'subjectless', state: 'running', subjectLabel: null, subjectType: null, subjectId: null },
+      { ...pending, run: 'running', state: 'running' },
+    ] } })
+    mount()
+    expect(await screen.findByRole('heading', { name: 'summarize' })).toBeTruthy()
+    const url = href(screen.getByRole('link', { name: 'Open' }))
+    expect(url.searchParams.get('run')).toBe('running')
+    expect(url.searchParams.has('parkedAt')).toBe(false)
+    expect(screen.queryByText(/started|%|retries/i)).toBeNull()
+  })
+
+  it('filters on the server and keeps the URL selection through refresh and Back', async () => {
+    window.history.replaceState(null, '', '/?app=notes')
+    const client = mount(['notes', 'other'])
+    await screen.findByText('No current work for this app.')
+    expect(overview).toHaveBeenLastCalledWith('notes')
+    const filter = screen.getByRole('combobox') as HTMLSelectElement
+    filter.focus()
+    await act(() => client.invalidateQueries({ queryKey: ['dashboard', 'overview'] }))
+    expect(document.activeElement).toBe(filter)
+    expect(filter.value).toBe('notes')
+    fireEvent.change(filter, { target: { value: 'other' } })
+    await waitFor(() => expect(overview).toHaveBeenLastCalledWith('other'))
+    expect(window.location.search).toBe('?app=other')
+    await act(async () => {
+      window.history.replaceState(null, '', '/?app=notes')
+      window.dispatchEvent(new PopStateEvent('popstate'))
+    })
+    expect(filter.value).toBe('notes')
+    fireEvent.change(filter, { target: { value: '' } })
+    await waitFor(() => expect(overview).toHaveBeenLastCalledWith(undefined))
+  })
+
+  it('distinguishes loading, initial error, stale data, and recovery', async () => {
+    overview.mockReturnValueOnce(new Promise(() => {}))
+    const loading = mount()
+    expect(screen.getByRole('status').textContent).toBe('Loading Dashboard…')
+    expect(screen.queryByText('No current failures')).toBeNull()
+    cleanup()
+    loading.clear()
+    overview.mockRejectedValueOnce(new Error('offline'))
     const client = mount()
-    await screen.findByRole('link', { name: 'Review' })
-    work.mockRejectedValue(new Error('Offline'))
-    await act(() => client.invalidateQueries({ queryKey: ['dashboard'] }))
-    expect((await screen.findByRole('alert')).textContent).toContain(
-      'last successful read remains visible',
-    )
-    expect(screen.getByRole('link', { name: 'Review' })).toBeTruthy()
-    work.mockResolvedValue({ rows: [], hasMore: false })
+    expect((await screen.findByRole('alert')).textContent).toContain('No data is available.')
+    expect(screen.queryByText('Nothing needs you right now.')).toBeNull()
+    overview.mockResolvedValue({ ...empty, needsYou: { total: 1, rows: [pending] } })
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
-    expect(await screen.findByText('No current input requests.')).toBeTruthy()
-    expect(screen.queryByRole('alert')).toBeNull()
-    expect(schedules).toHaveBeenCalledTimes(3)
+    await screen.findByRole('link', { name: 'Review' })
+    overview.mockRejectedValueOnce(new Error('offline'))
+    await act(() => client.invalidateQueries({ queryKey: ['dashboard', 'overview'] }))
+    expect((await screen.findByRole('alert')).textContent).toContain('This data is stale.')
+    expect(screen.getByRole('article')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull())
+    expect(screen.getByRole('article')).toBeTruthy()
   })
 
-  it('filters every section by app and shows paused schedule facts', async () => {
-    work.mockResolvedValue({ rows: [pending, { ...pending, run: 'other', app: 'other' }], hasMore: false })
-    schedules.mockResolvedValue({
-      rows: [
-        { app: 'notes', kind: 'notes.daily', cron: '0 9 * * *', defaultCron: '0 9 * * *', enabled: false, timezone: 'Europe/Madrid' },
-        { app: 'other', kind: 'other.daily', cron: '0 9 * * *', defaultCron: '0 9 * * *', enabled: true, timezone: 'Europe/Madrid' },
-      ],
-    })
-    mount(['notes', 'other'])
-    expect(await screen.findByText('Paused')).toBeTruthy()
-    expect(screen.getByText('Enabled')).toBeTruthy()
-    expect(screen.getByText('Review destination unavailable')).toBeTruthy()
-    fireEvent.change(screen.getByRole('combobox', { name: 'Filter by app' }), {
-      target: { value: 'notes' },
-    })
-    await waitFor(() => expect(screen.queryByText('Enabled')).toBeNull())
-    expect(screen.queryByText('Review destination unavailable')).toBeNull()
-    expect(screen.getByLabelText('Current work counts').textContent).toContain('1 needs you')
-    expect(screen.getByRole('link', { name: 'Settings' }).getAttribute('href')).toBe(
-      '/apps/notes/settings',
-    )
-    expect(screen.getByText('Europe/Madrid')).toBeTruthy()
-  })
-
-  it('does not invent a review destination or accept an unsafe external URL', async () => {
-    work.mockResolvedValue({
-      rows: [
-        { ...pending, app: 'unsupported' },
-        { ...pending, run: 'external', presentation: 'external', requestUrl: 'javascript:alert(1)' },
-        {
-          ...pending,
-          run: 'external-safe',
-          presentation: 'external',
-          requestUrl: 'https://example.invalid/review',
-        },
-      ],
-      hasMore: false,
-    })
+  it('shows the reason when the app filter is rejected', async () => {
+    window.history.replaceState(null, '', '/?app=gone')
+    overview.mockRejectedValue(new Error("Unknown app 'gone'. Select an installed app."))
     mount()
-    expect(await screen.findAllByText('Review destination unavailable')).toHaveLength(2)
-    expect(screen.queryByRole('link', { name: 'Review' })).toBeNull()
-    expect(screen.getAllByRole('link', { name: 'Open' }).map((link) => link.getAttribute('href'))).toEqual([
-      '/unsupported',
-      '/notes',
-      'https://example.invalid/review',
-    ])
+    expect((await screen.findByRole('alert')).textContent).toContain("Unknown app 'gone'. Select an installed app.")
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('gone')
   })
-})
 
-it.each([
-  ['Explicit request', 'A proposal', 'Explicit request'],
-  [null, 'A proposal', 'Review: A proposal'],
-  [null, null, 'Review'],
-])('shows one request label for %s and %s', async (requestLabel, artifactTitle, label) => {
-  work.mockResolvedValue({ rows: [{ ...pending, requestLabel, artifactTitle }], hasMore: false })
-  schedules.mockResolvedValue({ rows: [] })
-  mount()
-  const section = await screen.findByRole('region', { name: 'Needs you' })
-  await waitFor(() => expect(section.querySelector('.dashboard-request')?.textContent).toBe(label))
+  it('refills a preview from the API and preserves focus on a remaining request', async () => {
+    const before = section(5, 'parked')
+    overview.mockResolvedValue({ ...empty, needsYou: before })
+    const client = mount()
+    const links = await screen.findAllByRole('link', { name: 'Review' })
+    links[1]!.focus()
+    const after = [...before.rows.slice(1), { ...pending, run: 'next', subjectLabel: 'Next request' }]
+    overview.mockResolvedValue({ ...empty, needsYou: { total: 4, rows: after } })
+    await act(() => client.invalidateQueries({ queryKey: ['dashboard', 'overview'] }))
+    await screen.findByText('Next request')
+    expect(screen.queryByText('parked subject 0')).toBeNull()
+    expect(screen.queryByText('1 more waiting')).toBeNull()
+    expect(document.activeElement).toBe(links[1])
+    expect(screen.getAllByRole('article')).toHaveLength(4)
+  })
+
+  it('polls at 30 seconds and refreshes on window focus', async () => {
+    vi.useFakeTimers()
+    await act(async () => { mount() })
+    expect(overview).toHaveBeenCalledTimes(1)
+    await act(async () => { await vi.advanceTimersByTimeAsync(30_000) })
+    expect(overview).toHaveBeenCalledTimes(2)
+    await act(async () => {
+      focusManager.setFocused(false)
+      focusManager.setFocused(true)
+    })
+    expect(overview).toHaveBeenCalledTimes(3)
+  })
+
+  it('uses the account timezone for the greeting and recorded time labels', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-10T20:00:00Z'))
+    overview.mockResolvedValue({ ...empty, lastFinishedAt: pending.updatedAt, lastFailedAt: pending.parkedAt })
+    await act(async () => { mount(['notes'], 'America/Los_Angeles') })
+    await act(async () => { await vi.advanceTimersByTimeAsync(1) })
+    expect(screen.getByRole('heading', { name: 'Good afternoon.' })).toBeTruthy()
+    expect(screen.getByText(/Last run finished/).querySelector('time')!.title)
+      .toBe(absTime(pending.updatedAt, 'America/Los_Angeles'))
+    expect(screen.getByText(/Last failure/).querySelector('time')!.title)
+      .toBe(absTime(pending.parkedAt!, 'America/Los_Angeles'))
+  })
 })

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,262 +1,164 @@
-import { useQuery } from '@tanstack/react-query'
-import { CircleAlert, Clock3, RefreshCw } from 'lucide-react'
+import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { RefreshCw } from 'lucide-react'
 import { Link, useLocation, useSearch } from 'wouter'
 
 import { api } from '../api/client'
-import type { DashboardRun } from '../api/types'
-import { appHome, appLabel, getAppUI } from '../apps/registry'
+import type { DashboardRun, DashboardSection } from '../api/types'
+import { appLabel, getAppUI } from '../apps/registry'
 import { Page } from '../components/Page'
 import { relTimeFromIso } from '../lib/format'
 import { useFormatters } from '../lib/preferences'
 import '../dashboard.css'
-
-const isPending = (row: DashboardRun) =>
-  row.state === 'parked' && Boolean(row.parkedAt && row.presentation)
-
-const SECTIONS: {
-  id: string
-  title: string
-  empty: string
-  select: (rows: DashboardRun[]) => DashboardRun[]
-}[] = [
-  {
-    id: 'pending',
-    title: 'Needs you',
-    empty: 'No current input requests.',
-    select: (rows) =>
-      rows.filter(isPending).sort((a, b) => Date.parse(a.parkedAt!) - Date.parse(b.parkedAt!)),
-  },
-  {
-    id: 'active',
-    title: 'Active work',
-    empty: 'No running or queued work.',
-    select: (rows) => rows.filter((row) => row.state === 'running' || row.state === 'scheduled'),
-  },
-  {
-    id: 'waiting',
-    title: 'Waiting',
-    empty: 'No other parked work.',
-    select: (rows) => rows.filter((row) => row.state === 'parked' && !isPending(row)),
-  },
-  {
-    id: 'problems',
-    title: 'Problems',
-    empty: 'No current failed or orphaned runs.',
-    select: (rows) => rows.filter((row) => row.state === 'failed' || row.state === 'orphaned'),
-  },
-]
-
-const STATE_LABEL: Record<string, string> = {
-  scheduled: 'Queued',
-  running: 'Running',
-  parked: 'Waiting',
-  failed: 'Failed',
-  orphaned: 'Orphaned',
-}
 
 const POLL = { refetchInterval: 30_000, refetchOnWindowFocus: true, retry: false } as const
 
 export function DashboardPage({ apps }: { apps: string[] }) {
   const [, navigate] = useLocation()
   const app = new URLSearchParams(useSearch()).get('app') ?? ''
-  const work = useQuery({ queryKey: ['dashboard', 'work'], queryFn: api.dashboardWork, ...POLL })
-  const schedules = useQuery({
-    queryKey: ['dashboard', 'schedules'],
-    queryFn: api.dashboardSchedules,
+  const overview = useQuery({
+    queryKey: ['dashboard', 'overview', app],
+    queryFn: () => api.dashboardOverview(app || undefined),
+    placeholderData: keepPreviousData,
     ...POLL,
   })
-  const rows = (work.data?.rows ?? []).filter((row) => !app || row.app === app)
-  const scheduleRows = (schedules.data?.rows ?? []).filter((row) => !app || row.app === app)
-  const sections = SECTIONS.map((section) => ({ ...section, rows: section.select(rows) }))
-  const problemGroups = new Map<string, DashboardRun[]>()
-  for (const row of sections.find((section) => section.id === 'problems')!.rows) {
-    const key = JSON.stringify([row.app, row.kind, row.subjectType, row.subjectId, row.state])
-    const group = problemGroups.get(key) ?? []
-    group.push(row)
-    problemGroups.set(key, group)
-  }
-  const problems = [...problemGroups.values()].map((group) =>
-    group.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt)),
-  ).sort((a, b) => Date.parse(b[0]!.updatedAt) - Date.parse(a[0]!.updatedAt))
-  const [needsYou, active] = sections
-  const pendingCount = needsYou!.rows.length
-  const failed = work.isError || schedules.isError
+  const { timezone } = useFormatters()
+  const hour = Number(new Intl.DateTimeFormat('en', {
+    timeZone: timezone, hour: 'numeric', hourCycle: 'h23',
+  }).format(new Date()))
+  const greeting = hour < 12 ? 'Good morning.' : hour < 18 ? 'Good afternoon.' : 'Good evening.'
+  const data = overview.data
+  const primary = data && (data.needsYou.total ? 'needsYou' : data.failed.total ? 'failed' : data.running.total ? 'running' : null)
+  const section = data && primary ? data[primary] : null
+  const heading = primary === 'needsYou' ? 'Needs you' : primary === 'failed' ? 'Failed work' : 'Running work'
+  const overflow = primary === 'needsYou' ? 'waiting' : primary === 'failed' ? 'failed' : 'running'
 
   return (
     <Page inset className="dashboard">
       <header className="dashboard-head">
         <div>
-          <h1>Dashboard</h1>
-          <p>Your apps, active work, and decisions in one place.</p>
+          <h1>{greeting}</h1>
+          {data && <p>{data.needsYou.total
+            ? `${data.needsYou.total} ${data.needsYou.total === 1 ? 'thing is' : 'things are'} waiting on you.`
+            : data.failed.total
+              ? `${data.failed.total} ${data.failed.total === 1 ? 'run failed' : 'runs failed'}.`
+              : data.running.total
+                ? `${data.running.total} ${data.running.total === 1 ? 'run is' : 'runs are'} running.`
+                : app ? 'No current work for this app.' : 'Nothing needs you right now.'}</p>}
         </div>
-        <label className="dashboard-filter">
-          <select
-            aria-label="Filter by app"
-            value={app}
-            onChange={(event) =>
-              navigate(event.target.value ? `/?app=${encodeURIComponent(event.target.value)}` : '/')
-            }
-          >
-            <option value="">All apps</option>
-            {apps.map((name) => (
-              <option key={name} value={name}>
-                {appLabel(name)}
-              </option>
-            ))}
-            {app && !apps.includes(app) && <option value={app}>{appLabel(app)}</option>}
-          </select>
-        </label>
+        <select
+          className="dashboard-filter"
+          aria-label="Filter by app"
+          value={app}
+          onChange={(event) => navigate(event.target.value ? `/?app=${encodeURIComponent(event.target.value)}` : '/')}
+        >
+          <option value="">All apps</option>
+          {apps.map((name) => <option key={name} value={name}>{appLabel(name)}</option>)}
+          {app && !apps.includes(app) && <option value={app}>{appLabel(app)}</option>}
+        </select>
       </header>
-      <div className="dashboard-counts" aria-label="Current work counts">
-        <span>
-          <strong>{work.data ? pendingCount : '—'}</strong> {pendingCount === 1 ? 'needs' : 'need'}{' '}
-          you
-        </span>
-        <span>
-          <strong>{work.data ? active!.rows.length : '—'}</strong> active
-        </span>
-        <span>
-          <strong>{schedules.data ? scheduleRows.length : '—'}</strong>{' '}
-          {scheduleRows.length === 1 ? 'schedule' : 'schedules'}
-        </span>
-        <span>
-          <strong>{apps.length}</strong> installed apps
-        </span>
-      </div>
-      {failed && (
+      {overview.isError && (
         <p className="dashboard-alert" role="alert">
-          Could not refresh Dashboard.{' '}
-          {work.data ? 'The last successful read remains visible.' : 'No data is available.'}{' '}
-          <button
-            disabled={work.isFetching || schedules.isFetching}
-            onClick={() => {
-              void work.refetch()
-              void schedules.refetch()
-            }}
-          >
-            <RefreshCw size={14} aria-hidden="true" />
-            Retry
+          Could not refresh Dashboard. {overview.error.message}{' '}
+          {data ? 'This data is stale.' : 'No data is available.'}
+          <button disabled={overview.isFetching} onClick={() => { void overview.refetch() }}>
+            <RefreshCw size={14} aria-hidden="true" /> Retry
           </button>
         </p>
       )}
-      {work.isPending && <p role="status">Loading…</p>}
-      {sections.map((section) => (
-        <section
-          key={section.id}
-          className={`dashboard-section${work.data && section.rows.length === 0 ? ' dashboard-section-empty' : ''}`}
-          aria-labelledby={`dashboard-${section.id}`}
-        >
-          <header>
-            <h2 id={`dashboard-${section.id}`}>{section.title}</h2>
-            {section.id === 'pending' && <span>Oldest first</span>}
-          </header>
-          {work.data && section.rows.length === 0 && (
-            <p className="dashboard-empty">{section.empty}</p>
-          )}
-          {section.id === 'problems' ? problems.map((group) => (
-            <WorkRow key={group[0]!.run} row={group[0]!} pending={false} failures={group} />
-          )) : section.rows.map((row) => (
-            <WorkRow key={row.run} row={row} pending={section.id === 'pending'} />
-          ))}
+      {overview.isPending && <p role="status">Loading Dashboard…</p>}
+      {data && <>
+        {section ? (
+          <section className="dashboard-primary" aria-label={heading}>
+            {section.rows.map((row, index) => (
+              <WorkCard key={row.run} row={row} isPending={primary === 'needsYou'} isFirst={index === 0} />
+            ))}
+            {section.total > section.rows.length && (
+              <p className="dashboard-more">{section.total - section.rows.length} more {overflow}</p>
+            )}
+          </section>
+        ) : <p className="dashboard-quiet">Your apps will put anything they need right here.</p>}
+        <section className="dashboard-status" aria-label="Current status">
+          <ul>
+            {primary !== 'failed' && <StatusRow name="failed" section={data.failed} lastAt={data.lastFailedAt} />}
+            {primary !== 'running' && <StatusRow name="running" section={data.running} lastAt={data.lastFinishedAt} />}
+            {(primary === 'failed' || primary === 'running') && (
+              <li className="dashboard-status-row dashboard-status-empty">
+                <span className="dashboard-status-dot" aria-hidden="true" />
+                <div><strong>No current requests</strong></div>
+              </li>
+            )}
+          </ul>
         </section>
-      ))}
-      {work.data?.hasMore && (
-        <p className="dashboard-more">
-          Showing the 200 most recently changed runs. Older current work is not listed.
-        </p>
-      )}
-      <section className="dashboard-section" aria-labelledby="dashboard-schedules">
-        <header>
-          <h2 id="dashboard-schedules">Scheduled work</h2>
-          <span>Configured cadence</span>
-        </header>
-        {schedules.data && scheduleRows.length === 0 && (
-          <p className="dashboard-empty">No app declares a workflow schedule.</p>
-        )}
-        {scheduleRows.map((schedule) => (
-          <div className="dashboard-row" key={schedule.kind}>
-            <Clock3 size={17} aria-hidden="true" />
-            <div className="dashboard-identity">
-              <strong className="mono">{schedule.kind}</strong>
-              <span className="app-name">{appLabel(schedule.app)}</span>
-            </div>
-            <div className="dashboard-schedule">
-              <span>{schedule.enabled ? 'Enabled' : 'Paused'}</span>
-              <code>{schedule.cron ?? 'No cadence'}</code>
-              <span>{schedule.timezone}</span>
-            </div>
-            <Link className="dashboard-action" href={`/apps/${schedule.app}/settings`}>
-              Settings
-            </Link>
-          </div>
-        ))}
-      </section>
+      </>}
     </Page>
   )
 }
 
-function WorkRow({ row, pending, failures }: { row: DashboardRun; pending: boolean; failures?: DashboardRun[] }) {
-  const { absTime } = useFormatters()
-  const subject =
-    row.subjectType && row.subjectId ? { type: row.subjectType, id: row.subjectId } : null
-  const target = { run: row.run, parkedAt: pending ? (row.parkedAt ?? undefined) : undefined }
+function WorkCard({ row, isPending, isFirst }: { row: DashboardRun; isPending: boolean; isFirst: boolean }) {
+  const subject = row.subjectType && row.subjectId ? { type: row.subjectType, id: row.subjectId } : null
+  const target = { run: row.run, parkedAt: isPending ? row.parkedAt! : undefined }
   const owner = subject ? getAppUI(row.app)?.subjectPath?.(subject, target) : undefined
-  const external = pending && row.presentation === 'external'
-  const externalUrl =
-    external && row.requestUrl && /^https?:\/\//i.test(row.requestUrl) ? row.requestUrl : undefined
-  const destination = external ? externalUrl : owner
+  const isExternal = isPending && row.presentation === 'external'
+  const externalUrl = isExternal && row.requestUrl && /^https?:\/\//i.test(row.requestUrl) ? row.requestUrl : undefined
+  const destination = isExternal ? externalUrl : owner
   const label = row.subjectLabel || row.kind
   const request = row.requestLabel || (row.presentation === 'in_app'
     ? (row.artifactTitle ? `Review: ${row.artifactTitle}` : 'Review')
     : 'Input requested')
+  const isFailed = row.state === 'failed' || row.state === 'orphaned'
+  const actionClass = `dashboard-action${isPending && isFirst ? ' primary' : ''}`
+
   return (
-    <div className={`dashboard-row dashboard-${row.state}`}>
-      <CircleAlert size={17} aria-hidden="true" />
-      <div className="dashboard-identity">
-        <strong>{label}</strong>
-        {pending && <span className="dashboard-request">{request}</span>}
-        <span>
-          <span className="app-name">{appLabel(row.app)}</span>
-          {` · ${row.kind}`}
-          {failures && ` · ${failures.length} ${failures.length === 1 ? 'failure' : 'failures'}`}
-        </span>
-        {failures && (
-          <details className="dashboard-failure-details">
-            <summary>Failure details</summary>
-            {failures.map((failure) => (
-              <div key={failure.run}>
-                <time dateTime={failure.updatedAt}>{absTime(failure.updatedAt)}</time>
-                <p>{failure.failure || (failure.state === 'orphaned' ? 'The workflow record is missing.' : 'No error detail was recorded.')}</p>
-                <code>{failure.run}</code>
-              </div>
-            ))}
-          </details>
-        )}
-      </div>
-      <span className="dashboard-age" title={pending ? (row.parkedAt ?? undefined) : row.updatedAt}>
-        {STATE_LABEL[row.state]} ·{' '}
-        {relTimeFromIso(pending ? row.parkedAt : row.updatedAt)}
+    <article className={`dashboard-card${isFailed ? ' dashboard-card-failed' : ''}`} aria-label={label}>
+      <span className="dashboard-app-mark" aria-hidden="true">
+        {appLabel(row.app).split(' ').slice(0, 2).map((word) => word[0]).join('')}
       </span>
-      {destination ? (
-        external ? (
-          <a className="dashboard-action" href={destination} target="_blank" rel="noreferrer">
-            Open
-          </a>
-        ) : (
-          <Link className={`dashboard-action${pending ? ' primary' : ''}`} href={destination}>
-            {pending ? 'Review' : 'Open'}
-          </Link>
-        )
-      ) : failures ? (
-        <Link className="dashboard-action" href={`/events?app=${encodeURIComponent(row.app)}`}>
-          Open
-        </Link>
+      <div className="dashboard-identity">
+        <h2>{isPending ? request : label}</h2>
+        {isPending && <p>{label}</p>}
+        {isFailed && <p className="dashboard-failure">{row.failure || (row.state === 'orphaned'
+          ? 'The workflow record is missing.' : 'No error detail was recorded.')}</p>}
+        <p className="dashboard-meta">
+          {appLabel(row.app)} · {isPending ? 'asked' : 'updated'} <Age at={isPending ? row.parkedAt! : row.updatedAt} />
+        </p>
+      </div>
+      {destination ? (isExternal ? (
+        <a className={actionClass} href={destination} target="_blank" rel="noreferrer">Open</a>
       ) : (
-        <div className="dashboard-unavailable">
-          <span>{pending ? 'Review destination unavailable' : 'Run destination unavailable'}</span>
-          <Link href={appHome(row.app)}>Open</Link>
-        </div>
+        <Link className={actionClass} href={destination}>{isPending ? 'Review' : 'Open'}</Link>
+      )) : (
+        <span className="dashboard-unavailable">{isPending ? 'Review' : 'Run'} destination unavailable</span>
       )}
-    </div>
+    </article>
   )
+}
+
+function StatusRow({ name, section, lastAt }: {
+  name: 'running' | 'failed'; section: DashboardSection; lastAt: string | null
+}) {
+  const labels = {
+    failed: { total: `${section.total} failed`, empty: 'No current failures' },
+    running: { total: `${section.total} running`, empty: 'Nothing running' },
+  }
+  const previews = section.rows.slice(0, 2)
+  return (
+    <li className={`dashboard-status-row dashboard-status-${section.total ? name : 'empty'}`}>
+      <span className="dashboard-status-dot" aria-hidden="true" />
+      <div>
+        <strong>{section.total ? labels[name].total : labels[name].empty}</strong>
+        {section.total > 0 && <p>
+          {previews.map((row) => row.subjectLabel || row.kind).join(' · ')}
+          {section.total > previews.length && ` and ${section.total - previews.length} more`}
+        </p>}
+        {section.total === 0 && lastAt && <p>
+          {name === 'failed' ? 'Last failure' : 'Last run finished'} <Age at={lastAt} />
+        </p>}
+      </div>
+    </li>
+  )
+}
+
+function Age({ at }: { at: string }) {
+  const { absTime } = useFormatters()
+  return <time dateTime={at} title={absTime(at)}>{relTimeFromIso(at)}</time>
 }


### PR DESCRIPTION
Build the dashboard home with four primary cards, exact totals, and a compact status panel. Put requests first, then failures, then running work. Preserve exact review links, account timezone display, app filtering, and stale-read recovery. Remove the old work endpoint and home schedule list.

## Decisions
- Use the plan's plain overflow text and recorded API times where the mockups differ.
- Keep card context without an action when no exact destination is available.
