### PR TITLE
Document dashboard behavior and schedule navigation (DRU-518)

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -121,7 +121,7 @@ that policy on subjectless background runs.
 The Dashboard reads current runs across the installed apps with the same identity
 gate as the shared run API. An authenticated operator sees installation-wide
 run facts. `Run.account_id` records attribution and does not restrict this
-read.
+read. Only the workflows of installed apps count.
 
 For each workflow kind and subject, the newest run counts. As a result, a newer
 successful run removes an older failure. A run without a subject counts on its
@@ -135,26 +135,34 @@ review content.
 
 Needs you is parked runs that carry a request that the operator can answer. The
 oldest request comes first. Failed is runs in the failed or orphaned state.
-Running is runs in the running state. Queued runs and parked runs without an
-operator request are not current work.
+Running is runs in the running state. In these two states, the most recently
+updated run comes first. Queued runs and parked runs without an operator
+request are not current work.
 
 The read also carries the time of the last recorded run finish and the time of
-the last recorded failure. If no record exists, the time is null. An optional
-app filter limits every fact to one installed app.
+the last recorded failure. If no record exists, the time is null. These times
+do not show an external outcome or scheduler health. An optional app filter
+limits every fact to one installed app. An unknown app is an error, not a read
+of all apps.
 
 The Dashboard shows one state as its main content. If there are requests, it
 shows the requests. If there are no requests, it shows the failures. If there
-are no requests and no failures, it shows the running work. The other states
-appear in a compact status panel with their totals.
+are no requests and no failures, it shows the running work. Each card is one
+run. The other states appear in a compact status panel with their totals.
 
-The page has no full list. Declared schedules have their own page below Usage.
+The page has no full list and no decision controls. It refreshes every 30
+seconds and on window focus. A failed refresh keeps the last read visible and
+offers Retry. Declared schedules have their own page below Usage. See
+[schedule settings](configuration.md#personal-and-installation-settings) for
+cadence, pause state, defaults, and timezone rules.
 
 Review opens the owning app at the selected run. The link names the request
 round by its `parkedAt` timestamp. The owner reads the current gate. If the
 current round is different, the owner shows a stale-link message. An answer
 echoes the round that it read, so the server rejects a stale answer.
 
-An external request opens the app-declared HTTP or HTTPS address. The Dashboard
+An external request opens the app-declared HTTP or HTTPS address. A card
+without a valid destination keeps its context and has no action. The Dashboard
 does not infer access health from configuration.
 
 ## Waiting for people and systems

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,7 +109,8 @@ overrides. The same fields remain in app settings.
 
 The page shows the installation timezone. Account timezone preferences do not
 change schedule timing. A failed save keeps your edits. A read refresh also
-preserves unsaved edits. The `?app=` filter selects one installed app.
+preserves unsaved edits. If you leave the page with unsaved edits, Druks asks
+first. The `?app=` filter selects one installed app.
 
 The API exposes installation settings at `GET/PATCH /api/settings` and your
 preferences at `GET/PATCH /api/settings/personal`. The personal route uses the

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -281,8 +281,9 @@ class Engage(Workflow):
 ```
 
 A scheduled `dispatch()` fires with no arguments, so it must be nullary. Druks
-evaluates cron expressions in the installation timezone. The dashboard can retune or
-disable a declared schedule but cannot invent a new workflow schedule.
+evaluates cron expressions in the installation timezone. An operator can change
+the cadence or pause a declared schedule on the Schedules page or in the app
+settings. Druks cannot add a schedule to a workflow that declares none.
 
 ### Background tasks
 
@@ -311,8 +312,9 @@ annotated. `enqueue()` validates them and stores JSON. A task keeps no run row
 and never reaches the timeline.
 
 It has no subject, gate, or operator settings.
-It cannot make agent calls. `every=` uses a fixed UTC cadence that the code
-owns. An operator can retune the `every=` value of a workflow.
+It cannot make agent calls. `every=` on a task is a fixed UTC cadence that the
+code owns. An operator can change only a workflow schedule, on the Schedules
+page or in the app settings.
 `retries=` sets retries after the first attempt, both here and on `@step`.
 
 A workflow can declare its own operator settings:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -69,9 +69,11 @@ existing workflow overrides.
 Schedules at `/schedules` groups declared workflows by app. The `app` query
 parameter filters the list. Operators change cadence and pause state here with
 the same controls as app settings. Each schedule saves through
-`PATCH /api/settings/apps`. Use defaults removes both overrides. A failed save
-keeps the draft. Polling and focus refresh preserve unsaved edits. The page shows
-the installation timezone beside the saved cadence.
+`PATCH /api/settings/apps`. Use defaults removes both overrides.
+
+A failed save keeps the draft. Polling and focus refresh preserve unsaved edits.
+If you leave the page with unsaved edits, the shell asks first, as Settings
+does. The page shows the installation timezone beside the saved cadence.
 
 Normal interface text uses IBM Plex Sans at 15 px. Technical values use
 IBM Plex Mono. Phone inputs use at least 16 px.


### PR DESCRIPTION
Document the delivered dashboard in the concepts guide: state priority, exact totals, bounded previews, exact destinations, recorded times, and refresh behavior. Point the app-author guide, the configuration guide, and the frontend README at the Schedules page, and note the unsaved-edit prompt.

## Decisions
- Keep current-work behavior in the concepts guide and link to the existing schedule guidance.
- Keep route names, cache headers, and UI strings out of the concepts guide. The README names the route, and the page owns its wording.
