### PR TITLE
DRU-519 - Remove Todo status

### DIFF
--- a/backend/druks/contrib/software_factory/issues/enums.py
+++ b/backend/druks/contrib/software_factory/issues/enums.py
@@ -6,7 +6,6 @@ class Status(StrEnum):
     column can never hold a status no screen knows how to render."""
 
     BACKLOG = "backlog"
-    TODO = "todo"
     READY_FOR_AGENT = "ready_for_agent"
     IN_PROGRESS = "in_progress"
     IN_REVIEW = "in_review"
@@ -38,7 +37,6 @@ class Status(StrEnum):
 # strings change when the board wants different words.
 STATUS_LABELS: dict[Status, str] = {
     Status.BACKLOG: "Backlog",
-    Status.TODO: "Todo",
     Status.READY_FOR_AGENT: "Ready for Agent",
     Status.IN_PROGRESS: "In Progress",
     Status.IN_REVIEW: "In Review",

--- a/backend/druks/contrib/software_factory/issues/models.py
+++ b/backend/druks/contrib/software_factory/issues/models.py
@@ -24,7 +24,7 @@ class Ticket(StoredSubject):
     # Status and priority are String columns driven by this app's closed
     # StrEnums, not native PG enum types: the workflow stays in code and a label
     # change never needs an ALTER TYPE.
-    status: Mapped[str] = mapped_column(default=Status.TODO)
+    status: Mapped[str] = mapped_column(default=Status.BACKLOG)
     priority: Mapped[str] = mapped_column(default=Priority.NONE)
     # Required: a ticket names the repo its PR will land in, and the identifier
     # is minted from that repo's project.
@@ -49,7 +49,7 @@ class Ticket(StoredSubject):
         repo_id: int,
         title: str,
         description: str = "",
-        status: Status = Status.TODO,
+        status: Status = Status.BACKLOG,
         priority: Priority = Priority.NONE,
         assignee_id: str | None = None,
         creator_id: str | None = None,
@@ -71,7 +71,7 @@ class Ticket(StoredSubject):
         session.add(ticket)
         await session.flush()
         # Creating already in Ready for Agent is arriving at the trigger, the
-        # same as a later move into it. Todo and the rest stay quiet: drafting
+        # same as a later move into it. Backlog and the rest stay quiet: drafting
         # is not a funnel event.
         if status == Status.READY_FOR_AGENT:
             await ticket._emit_transitioned(status)

--- a/backend/druks/contrib/software_factory/issues/pages.py
+++ b/backend/druks/contrib/software_factory/issues/pages.py
@@ -11,7 +11,6 @@ from druks.db import Base
 # it: ``Ticket.list_board`` leaves those rows out.
 BOARD_STATUSES = (
     Status.BACKLOG,
-    Status.TODO,
     Status.READY_FOR_AGENT,
     Status.IN_PROGRESS,
     Status.IN_REVIEW,
@@ -21,7 +20,6 @@ BOARD_STATUSES = (
 # and cancelled at the bottom. Ready for Agent stays: it is still a live status.
 LIST_STATUSES = (
     Status.BACKLOG,
-    Status.TODO,
     Status.READY_FOR_AGENT,
     Status.IN_PROGRESS,
     Status.IN_REVIEW,
@@ -122,7 +120,7 @@ def _create_actions(repos: list[ProjectRepo], accounts: list[Account]) -> list[u
                     name="status",
                     label="Status",
                     options=_status_options(),
-                    value=Status.TODO.value,
+                    value=Status.BACKLOG.value,
                 ),
                 ui.SelectField(
                     name="priority",

--- a/backend/druks/contrib/software_factory/issues/routes.py
+++ b/backend/druks/contrib/software_factory/issues/routes.py
@@ -93,14 +93,14 @@ async def create_ticket(
         ..., embed=True, description="the GitHub repo this ticket's PR will target"
     ),
     description: str = Body("", embed=True),
-    status: Status = Body(Status.TODO, embed=True),
+    status: Status = Body(Status.BACKLOG, embed=True),
     priority: Priority = Body(Priority.NONE, embed=True),
     assignee_id: str | None = Body(None, embed=True),
     account: Account = Depends(current_account),
 ) -> TicketDetail:
     """Write a ticket down. It takes the next number in its repo's project's
     sequence. Creating in Ready for Agent is a transition into the trigger, so a
-    build can open. Creating in Todo publishes nothing."""
+    build can open. Creating in Backlog publishes nothing."""
     title = required_text(title, "title")
     # An assignee select with nobody picked submits "", and the shell sends
     # every field the form shows. Blank is nobody, not an account id to look up.

--- a/backend/migrations/versions/e1a7c4b9d283_drop_todo_status.py
+++ b/backend/migrations/versions/e1a7c4b9d283_drop_todo_status.py
@@ -1,0 +1,23 @@
+"""Move leftover Todo tickets onto Backlog.
+
+Revision ID: e1a7c4b9d283
+Revises: d4a9e2b8c173
+Create Date: 2026-09-10
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "e1a7c4b9d283"
+down_revision: str | Sequence[str] | None = "d4a9e2b8c173"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE issues_tickets SET status = 'backlog' WHERE status = 'todo'")
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Todo is no longer a status.")

--- a/backend/tests/software_factory/test_issues_pages.py
+++ b/backend/tests/software_factory/test_issues_pages.py
@@ -5,7 +5,6 @@ from software_factory.factories import make_test_work_item
 
 BOARD_COLUMNS = [
     "Backlog",
-    "Todo",
     "Ready for Agent",
     "In Progress",
     "In Review",
@@ -13,7 +12,6 @@ BOARD_COLUMNS = [
 ]
 LIST_SECTIONS = [
     "Backlog",
-    "Todo",
     "Ready for Agent",
     "In Progress",
     "In Review",
@@ -104,7 +102,6 @@ async def test_empty_board_shows_columns_and_create_actions(druks_client):
         assert cards["empty"]["title"] == "Nothing here"
     assert [column["blocks"][0]["drop"]["arguments"]["status"] for column in columns] == [
         "backlog",
-        "todo",
         "ready_for_agent",
         "in_progress",
         "in_review",
@@ -112,34 +109,34 @@ async def test_empty_board_shows_columns_and_create_actions(druks_client):
     ]
 
 
-async def test_created_ticket_lands_in_todo_on_board_and_issues(druks_client):
+async def test_created_ticket_lands_in_backlog_on_board_and_issues(druks_client):
     repo = await _open_repo(druks_client)
     ticket = await _open_ticket(druks_client, repo["id"], title="Ship the board")
 
     board = (await druks_client.get(f"{_PAGES}/board")).json()
     by_title = {column["title"]: column for column in _columns(board)}
-    (card,) = _cards_in(by_title["Todo"])
+    (card,) = _cards_in(by_title["Backlog"])
     assert card["title"] == "Ship the board"
     assert card["description"].startswith("DRU-1")
     assert card["link"]["arguments"] == {"identifier": ticket["identifier"]}
     assert card["drag"] == {"identifier": ticket["identifier"]}
     assert card["controls"] == []
     for title in BOARD_COLUMNS:
-        if title != "Todo":
+        if title != "Backlog":
             assert _cards_in(by_title[title]) == []
 
     listed = (await druks_client.get(f"{_PAGES}/issues")).json()
     by_section = _by_section(listed)
     assert listed["title"] == "Issues"
     assert listed["description"] == ""
-    assert [table["title"] for table in _tables(listed)] == _section_titles({"Todo": 1})
-    (row,) = by_section["Todo"]["rows"]
+    assert [table["title"] for table in _tables(listed)] == _section_titles({"Backlog": 1})
+    (row,) = by_section["Backlog"]["rows"]
     assert row["cells"][0]["text"] == "DRU-1"
     assert row["cells"][1]["text"] == "Ship the board"
     assert row["cells"][1]["link"]["arguments"] == {"identifier": ticket["identifier"]}
     assert row["cells"][4]["text"] == "acme/druks"
     for title in LIST_SECTIONS:
-        if title != "Todo":
+        if title != "Backlog":
             assert by_section[title]["rows"] == []
 
 
@@ -155,12 +152,12 @@ async def test_moving_a_ticket_updates_board_and_issues(druks_client):
     board = (await druks_client.get(f"{_PAGES}/board")).json()
     by_title = {column["title"]: column for column in _columns(board)}
     assert [card["title"] for card in _cards_in(by_title["In Progress"])] == ["In flight"]
-    assert _cards_in(by_title["Todo"]) == []
+    assert _cards_in(by_title["Backlog"]) == []
 
     listed = (await druks_client.get(f"{_PAGES}/issues")).json()
     by_section = _by_section(listed)
     assert [row["cells"][1]["text"] for row in by_section["In Progress"]["rows"]] == ["In flight"]
-    assert by_section["Todo"]["rows"] == []
+    assert by_section["Backlog"]["rows"] == []
 
 
 async def test_cancelled_tickets_are_off_the_board_and_last_on_issues(druks_client):
@@ -178,7 +175,7 @@ async def test_cancelled_tickets_are_off_the_board_and_last_on_issues(druks_clie
 
     listed = (await druks_client.get(f"{_PAGES}/issues")).json()
     tables = _tables(listed)
-    assert [table["title"] for table in tables] == _section_titles({"Todo": 1, "Cancelled": 1})
+    assert [table["title"] for table in tables] == _section_titles({"Backlog": 1, "Cancelled": 1})
     assert _section_name(tables[-1]["title"]) == "Cancelled"
     assert [row["cells"][1]["text"] for row in tables[-1]["rows"]] == ["gone"]
 
@@ -325,10 +322,10 @@ async def test_board_status_filter_keeps_columns_and_shows_cancelled_when_asked(
         json={"status": "cancelled"},
     )
 
-    todo = (await druks_client.get(f"{_PAGES}/board", params={"status": "todo"})).json()
-    cards = [card["title"] for column in _columns(todo) for card in _cards_in(column)]
+    backlog = (await druks_client.get(f"{_PAGES}/board", params={"status": "backlog"})).json()
+    cards = [card["title"] for column in _columns(backlog) for card in _cards_in(column)]
     assert cards == ["live"]
-    assert [column["title"] for column in _columns(todo)] == BOARD_COLUMNS
+    assert [column["title"] for column in _columns(backlog)] == BOARD_COLUMNS
 
     cancelled = (await druks_client.get(f"{_PAGES}/board", params={"status": "cancelled"})).json()
     assert [column["title"] for column in _columns(cancelled)] == [*BOARD_COLUMNS, "Cancelled"]

--- a/backend/tests/software_factory/test_issues_routes.py
+++ b/backend/tests/software_factory/test_issues_routes.py
@@ -46,13 +46,13 @@ def test_get_and_comment_are_agent_operations():
     assert add_comment["operationId"] in {"add_comment", "software_factory_add_comment"}
 
 
-async def test_create_as_todo_does_not_publish(druks_client, monkeypatch):
+async def test_create_as_backlog_does_not_publish(druks_client, monkeypatch):
     events = _published(monkeypatch)
     repo = await _open_repo(druks_client)
     ticket = await _open_ticket(druks_client, repo["id"], title="quiet")
 
     assert ticket["identifier"] == "DRU-1"
-    assert ticket["status"] == "todo"
+    assert ticket["status"] == "backlog"
     assert ticket["comments"] == []
     assert events == []
 
@@ -157,7 +157,7 @@ async def test_update_ticket_never_publishes_and_cannot_set_status(druks_client,
     body = edited.json()
     assert body["title"] == "new"
     assert body["priority"] == "high"
-    assert body["status"] == "todo"
+    assert body["status"] == "backlog"
     assert events == []
 
 


### PR DESCRIPTION
## Summary
- Drop `Status.TODO` so Backlog is the only waiting pile on the local board.
- New tickets default to Backlog. Creating there still publishes nothing.
- Migrate leftover `todo` rows onto `backlog`.

https://linear.app/fellaworks/issue/DRU-519/remove-todo-status

## Test plan
- [ ] Empty board has no Todo column.
- [ ] A new ticket with no status lands in Backlog.
- [ ] After migrate, a ticket that was Todo is in Backlog.


Made with [Cursor](https://cursor.com)