### PR TITLE
DRU-520 - Remove the Issues list page

### DIFF
--- a/backend/druks/contrib/software_factory/issues/pages.py
+++ b/backend/druks/contrib/software_factory/issues/pages.py
@@ -16,26 +16,6 @@ BOARD_STATUSES = (
     Status.IN_REVIEW,
     Status.DONE,
 )
-# The issues page's sections, left to right through the workflow, then parked
-# and cancelled at the bottom. Ready for Agent stays: it is still a live status.
-LIST_STATUSES = (
-    Status.BACKLOG,
-    Status.READY_FOR_AGENT,
-    Status.IN_PROGRESS,
-    Status.IN_REVIEW,
-    Status.DONE,
-    Status.BLOCKED,
-    Status.CANCELLED,
-)
-
-ISSUE_COLUMNS = [
-    ui.TableColumn("Identifier", width="8rem"),
-    ui.TableColumn("Title"),
-    ui.TableColumn("Priority", width="8rem"),
-    ui.TableColumn("Assignee", width="14rem"),
-    ui.TableColumn("Repo", width="12rem"),
-    ui.TableColumn("Updated", align="end", width="9rem"),
-]
 
 # The words the screens spell a priority with. The stored value stays
 # snake_case; only these strings change when the board wants different words.
@@ -95,8 +75,8 @@ def _creator_name(creator_id: str | None, account_names: dict[str, str]) -> str:
 
 
 def _create_actions(repos: list[ProjectRepo], accounts: list[Account]) -> list[ui.Action]:
-    """Creation is a control on the board and the issues page, not a destination:
-    a page that lists nothing is not where a ticket gets written."""
+    """Creation is a control on the board, not a destination: a page that lists
+    nothing is not where a ticket gets written."""
     repo_choices = _repo_options(repos)
     return [
         ui.Action(
@@ -175,22 +155,6 @@ def _ticket_card(ticket: Ticket, account_names: dict[str, str]) -> ui.Card:
         description=" · ".join(description),
         link=_ticket_link(ticket, ticket.title),
         drag={"identifier": ticket.identifier},
-    )
-
-
-def _ticket_row(ticket: Ticket, account_names: dict[str, str]) -> ui.TableRow:
-    return ui.TableRow(
-        [
-            ui.TextValue(
-                ticket.identifier,
-                link=_ticket_link(ticket, ticket.identifier),
-            ),
-            ui.TextValue(ticket.title, link=_ticket_link(ticket, ticket.title)),
-            ui.TextValue(PRIORITY_LABELS[Priority(ticket.priority)]),
-            ui.TextValue(_assignee_name(ticket.assignee_id, account_names)),
-            ui.TextValue(ticket.repo.full_name),
-            ui.TimeValue(ticket.updated_at),
-        ]
     )
 
 
@@ -575,44 +539,4 @@ async def ticket(identifier: str):
                 layout="sidebar",
             )
         ],
-    )
-
-
-@ui.page("/issues")
-async def issues(
-    status: str = "",
-    priority: str = "",
-    updated: str = "",
-    assignee: str = "",
-    creator: str = "",
-    project: str = "",
-    repo: str = "",
-):
-    tickets, repos, accounts, filters = await _ticket_collection(
-        exclude_cancelled=False,
-        status=status,
-        priority=priority,
-        updated=updated,
-        assignee=assignee,
-        creator=creator,
-        project=project,
-        repo=repo,
-    )
-    account_names = {account.id: account.username for account in accounts}
-    sections = []
-    for item in LIST_STATUSES:
-        rows = [ticket for ticket in tickets if ticket.status == item]
-        sections.append(
-            ui.Table(
-                title=f"{item.label} ({len(rows)})",
-                columns=ISSUE_COLUMNS,
-                rows=[_ticket_row(row, account_names) for row in rows],
-                empty_text=f"No ticket is in {item.label}.",
-            )
-        )
-    return ui.Page(
-        "Issues",
-        controls=_create_actions(repos, accounts),
-        filters=filters,
-        blocks=[ui.Stack(sections, gap="large")],
     )

--- a/backend/tests/software_factory/test_issues_pages.py
+++ b/backend/tests/software_factory/test_issues_pages.py
@@ -10,15 +10,6 @@ BOARD_COLUMNS = [
     "In Review",
     "Done",
 ]
-LIST_SECTIONS = [
-    "Backlog",
-    "Ready for Agent",
-    "In Progress",
-    "In Review",
-    "Done",
-    "Blocked",
-    "Cancelled",
-]
 
 _PAGES = "/api/software_factory/pages"
 _TICKETS = "/api/software_factory/tickets"
@@ -51,22 +42,6 @@ def _columns(page: dict) -> list[dict]:
 
 def _cards_in(column: dict) -> list[dict]:
     return column["blocks"][0]["cards"]
-
-
-def _tables(page: dict) -> list[dict]:
-    return page["blocks"][0]["blocks"]
-
-
-def _section_name(title: str) -> str:
-    return title[: title.rindex(" (")]
-
-
-def _by_section(page: dict) -> dict[str, dict]:
-    return {_section_name(table["title"]): table for table in _tables(page)}
-
-
-def _section_titles(counts: dict[str, int]) -> list[str]:
-    return [f"{label} ({counts.get(label, 0)})" for label in LIST_SECTIONS]
 
 
 def _comments(page: dict) -> dict:
@@ -109,7 +84,7 @@ async def test_empty_board_shows_columns_and_create_actions(druks_client):
     ]
 
 
-async def test_created_ticket_lands_in_backlog_on_board_and_issues(druks_client):
+async def test_created_ticket_lands_in_backlog_on_the_board(druks_client):
     repo = await _open_repo(druks_client)
     ticket = await _open_ticket(druks_client, repo["id"], title="Ship the board")
 
@@ -125,22 +100,8 @@ async def test_created_ticket_lands_in_backlog_on_board_and_issues(druks_client)
         if title != "Backlog":
             assert _cards_in(by_title[title]) == []
 
-    listed = (await druks_client.get(f"{_PAGES}/issues")).json()
-    by_section = _by_section(listed)
-    assert listed["title"] == "Issues"
-    assert listed["description"] == ""
-    assert [table["title"] for table in _tables(listed)] == _section_titles({"Backlog": 1})
-    (row,) = by_section["Backlog"]["rows"]
-    assert row["cells"][0]["text"] == "DRU-1"
-    assert row["cells"][1]["text"] == "Ship the board"
-    assert row["cells"][1]["link"]["arguments"] == {"identifier": ticket["identifier"]}
-    assert row["cells"][4]["text"] == "acme/druks"
-    for title in LIST_SECTIONS:
-        if title != "Backlog":
-            assert by_section[title]["rows"] == []
 
-
-async def test_moving_a_ticket_updates_board_and_issues(druks_client):
+async def test_moving_a_ticket_updates_the_board(druks_client):
     repo = await _open_repo(druks_client)
     ticket = await _open_ticket(druks_client, repo["id"], title="In flight")
     moved = await druks_client.post(
@@ -154,13 +115,8 @@ async def test_moving_a_ticket_updates_board_and_issues(druks_client):
     assert [card["title"] for card in _cards_in(by_title["In Progress"])] == ["In flight"]
     assert _cards_in(by_title["Backlog"]) == []
 
-    listed = (await druks_client.get(f"{_PAGES}/issues")).json()
-    by_section = _by_section(listed)
-    assert [row["cells"][1]["text"] for row in by_section["In Progress"]["rows"]] == ["In flight"]
-    assert by_section["Backlog"]["rows"] == []
 
-
-async def test_cancelled_tickets_are_off_the_board_and_last_on_issues(druks_client):
+async def test_cancelled_tickets_are_off_the_board(druks_client):
     repo = await _open_repo(druks_client)
     await _open_ticket(druks_client, repo["id"], title="live")
     gone = await _open_ticket(druks_client, repo["id"], title="gone")
@@ -172,12 +128,6 @@ async def test_cancelled_tickets_are_off_the_board_and_last_on_issues(druks_clie
     board = (await druks_client.get(f"{_PAGES}/board")).json()
     cards = [card["title"] for column in _columns(board) for card in _cards_in(column)]
     assert cards == ["live"]
-
-    listed = (await druks_client.get(f"{_PAGES}/issues")).json()
-    tables = _tables(listed)
-    assert [table["title"] for table in tables] == _section_titles({"Backlog": 1, "Cancelled": 1})
-    assert _section_name(tables[-1]["title"]) == "Cancelled"
-    assert [row["cells"][1]["text"] for row in tables[-1]["rows"]] == ["gone"]
 
 
 async def test_ticket_page_follows_the_row_and_comments_refresh_the_region(druks_client):
@@ -304,12 +254,11 @@ async def test_unknown_ticket_page_is_an_empty_state(druks_client):
     assert page["blocks"][0]["controls"][0]["page"] == "board"
 
 
-async def test_roster_names_the_board_and_issues_pages(druks_client):
+async def test_roster_names_the_board_and_ticket_pages(druks_client):
     roster = {entry["name"]: entry for entry in (await druks_client.get("/api/apps")).json()}
 
     names = [page["name"] for page in roster["software_factory"]["pages"]]
-    # Route-match order: the static issues page wins over the parameterized ticket.
-    assert names == ["board", "issues", "ticket"]
+    assert names == ["board", "ticket"]
     assert roster["software_factory"]["navigation"] == []
 
 
@@ -359,6 +308,6 @@ async def test_board_filters_by_repo_assignee_and_creator(druks_client):
     titles = [card["title"] for column in _columns(mine) for card in _cards_in(column)]
     assert set(titles) == {"assigned", "open", "elsewhere"}
 
-    issues = (await druks_client.get(f"{_PAGES}/issues", params={"project": acme["id"]})).json()
-    titles = [row["cells"][1]["text"] for table in _tables(issues) for row in table["rows"]]
+    by_project = (await druks_client.get(f"{_PAGES}/board", params={"project": acme["id"]})).json()
+    titles = [card["title"] for column in _columns(by_project) for card in _cards_in(column)]
     assert set(titles) == {"assigned", "open"}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -294,7 +294,7 @@ The stored value is `issues`. That choice needs no credentials. Linear and Jira
 status-name knobs stay hidden. The trigger status is Ready for Agent. It is not
 a setting. `druks doctor` reports the tracker as healthy.
 
-The dashboard shows the board, the Issues list, and ticket pages only for
+The dashboard shows the board and ticket pages only for
 **druks**. Each ticket picks a GitHub repository from a Software Factory
 project. Set that project's ticket prefix (2–6 letters A–Z) on
 **Software Factory → Projects**. Druks mints identifiers as `{prefix}-{n}` once.

--- a/frontend/src/apps/software_factory/projects/ProjectsPage.test.tsx
+++ b/frontend/src/apps/software_factory/projects/ProjectsPage.test.tsx
@@ -144,19 +144,19 @@ describe('ProjectsPage create row', () => {
 })
 
 describe('ProjectsPage prefix note', () => {
-  it('notes that a project without a prefix cannot be selected in Issues', async () => {
+  it('notes that a project without a prefix cannot be selected on the board', async () => {
     renderPage([project({ name: 'Bare' })])
 
     expect(
-      await screen.findByText(/cannot be selected in Issues/),
+      await screen.findByText(/cannot be selected on the board/),
     ).toBeTruthy()
   })
 
-  it('does not note Issues when the project has a prefix', async () => {
+  it('does not note the board when the project has a prefix', async () => {
     renderPage([project({ name: 'Acme', prefix: 'ACM' })])
 
     expect(await screen.findByText('Acme')).toBeTruthy()
-    expect(screen.queryByText(/cannot be selected in Issues/)).toBeNull()
+    expect(screen.queryByText(/cannot be selected on the board/)).toBeNull()
   })
 
   it('hides the prefix field and note when the tracker is not druks', async () => {
@@ -164,7 +164,7 @@ describe('ProjectsPage prefix note', () => {
 
     expect(await screen.findByText('Bare')).toBeTruthy()
     expect(screen.queryByPlaceholderText(/prefix/)).toBeNull()
-    expect(screen.queryByText(/cannot be selected in Issues/)).toBeNull()
+    expect(screen.queryByText(/cannot be selected on the board/)).toBeNull()
     expect(screen.queryByText('prefix')).toBeNull()
   })
 

--- a/frontend/src/apps/software_factory/projects/ProjectsPage.tsx
+++ b/frontend/src/apps/software_factory/projects/ProjectsPage.tsx
@@ -324,7 +324,7 @@ function ProjectCard({
           showPrefix &&
           !project.prefix && (
             <p className="pj-prefix-note">
-              Without a prefix, this project's repos cannot be selected in Issues.
+              Without a prefix, this project's repos cannot be selected on the board.
             </p>
           )
         )}

--- a/frontend/src/apps/software_factory/tracker.test.ts
+++ b/frontend/src/apps/software_factory/tracker.test.ts
@@ -28,7 +28,7 @@ describe('isDruksIssuesTracker', () => {
 })
 
 describe('softwareFactoryNavigation', () => {
-  it('omits board and issues until the tracker is druks', () => {
+  it('omits board until the tracker is druks', () => {
     expect(softwareFactoryNavigation()).toEqual([
       [`/${SOFTWARE_FACTORY}`, 'Overview'],
       [`/${SOFTWARE_FACTORY}/history`, 'history'],
@@ -41,11 +41,10 @@ describe('softwareFactoryNavigation', () => {
     ])
   })
 
-  it('inserts board and issues after Overview when the tracker is druks', () => {
+  it('inserts board after Overview when the tracker is druks', () => {
     expect(softwareFactoryNavigation(settingsWithTracker('issues'))).toEqual([
       [`/${SOFTWARE_FACTORY}`, 'Overview'],
       [`/${SOFTWARE_FACTORY}/board`, 'board'],
-      [`/${SOFTWARE_FACTORY}/issues`, 'issues'],
       [`/${SOFTWARE_FACTORY}/history`, 'history'],
       [`/${SOFTWARE_FACTORY}/projects`, 'projects'],
     ])

--- a/frontend/src/apps/software_factory/tracker.ts
+++ b/frontend/src/apps/software_factory/tracker.ts
@@ -22,7 +22,6 @@ export function softwareFactoryNavigation(settings?: AppsSettingsResponse): [str
     return [
       overview,
       [`/${SOFTWARE_FACTORY}/board`, 'board'],
-      [`/${SOFTWARE_FACTORY}/issues`, 'issues'],
       history,
       projects,
     ]

--- a/frontend/src/apps/software_factory/ui.tsx
+++ b/frontend/src/apps/software_factory/ui.tsx
@@ -27,7 +27,6 @@ registerAppUI({
   routes: [
     { path: `/${SOFTWARE_FACTORY}`, render: () => <WorkItemsPage /> },
     { path: `/${SOFTWARE_FACTORY}/board`, render: () => <DruksIssuesPage page="board" /> },
-    { path: `/${SOFTWARE_FACTORY}/issues`, render: () => <DruksIssuesPage page="issues" /> },
     {
       path: `/${SOFTWARE_FACTORY}/tickets/:identifier`,
       render: () => <DruksIssuesPage page="ticket" />,


### PR DESCRIPTION
## Summary
- Remove the Issues list page. The board is the only ticket surface.
- Drop the Issues nav item and `/software_factory/issues` route.
- Point the projects prefix note and docs at the board.

Stacks on agent/DRU-519.
https://linear.app/fellaworks/issue/DRU-520/remove-the-issues-list-page-keep-board

## Test plan
- [ ] Tracker `issues` nav is Overview, board, history, projects.
- [ ] `/software_factory/issues` is gone.
- [ ] Board still lists columns and create.
- [ ] Ticket detail still opens from a card.


Made with [Cursor](https://cursor.com)