### PR TITLE
DRU-522 - Rename ticket Assignee to Owner

### DIFF
--- a/backend/druks/contrib/software_factory/issues/models.py
+++ b/backend/druks/contrib/software_factory/issues/models.py
@@ -31,7 +31,7 @@ class Ticket(StoredSubject):
     repo_id: Mapped[int] = mapped_column(ForeignKey("project_repos.id"))
     repo: Mapped[ProjectRepo] = relationship(lazy="joined")
     # Optional: a ticket exists before anyone picks it up.
-    assignee_id: Mapped[str | None] = mapped_column(
+    owner_id: Mapped[str | None] = mapped_column(
         ForeignKey("accounts.id", ondelete="RESTRICT"), default=None
     )
     # Who opened it. Optional on the row so a ticket minted outside the HTTP
@@ -51,7 +51,7 @@ class Ticket(StoredSubject):
         description: str = "",
         status: Status = Status.BACKLOG,
         priority: Priority = Priority.NONE,
-        assignee_id: str | None = None,
+        owner_id: str | None = None,
         creator_id: str | None = None,
     ) -> "Ticket":
         session = db_session()
@@ -65,7 +65,7 @@ class Ticket(StoredSubject):
             description=description,
             status=status,
             priority=priority,
-            assignee_id=assignee_id,
+            owner_id=owner_id,
             creator_id=creator_id,
         )
         session.add(ticket)
@@ -97,7 +97,7 @@ class Ticket(StoredSubject):
         exclude_cancelled: bool = False,
         status: str = "",
         priority: str = "",
-        assignee: str = "",
+        owner: str = "",
         creator: str = "",
         project_id: int | None = None,
         repo_id: int | None = None,
@@ -105,17 +105,15 @@ class Ticket(StoredSubject):
     ) -> list["Ticket"]:
         statement = select(cls)
         if exclude_cancelled:
-            statement = statement.where(
-                cls.status.notin_((Status.CANCELLED, Status.BLOCKED))
-            )
+            statement = statement.where(cls.status.notin_((Status.CANCELLED, Status.BLOCKED)))
         if status:
             statement = statement.where(cls.status == status)
         if priority:
             statement = statement.where(cls.priority == priority)
-        if assignee == "none":
-            statement = statement.where(cls.assignee_id.is_(None))
-        elif assignee:
-            statement = statement.where(cls.assignee_id == assignee)
+        if owner == "none":
+            statement = statement.where(cls.owner_id.is_(None))
+        elif owner:
+            statement = statement.where(cls.owner_id == owner)
         if creator:
             statement = statement.where(cls.creator_id == creator)
         if repo_id:
@@ -163,7 +161,7 @@ class Ticket(StoredSubject):
 
     async def _emit_transitioned(self, status: Status) -> None:
         repo = await ProjectRepo.get(self.repo_id)
-        assignee = await Account.get(self.assignee_id) if self.assignee_id else None
+        owner = await Account.get(self.owner_id) if self.owner_id else None
         await publish(
             "ticket.transitioned",
             payload={
@@ -178,8 +176,8 @@ class Ticket(StoredSubject):
                 # find the PR target the operator picked.
                 "project_name": repo.full_name.rsplit("/", 1)[-1],
                 "labels": [],
-                "assignee_email": assignee.username if assignee else None,
-                "assignee_name": assignee.username if assignee else None,
+                "assignee_email": owner.username if owner else None,
+                "assignee_name": owner.username if owner else None,
                 "completed": status.completed,
                 "terminal": status.terminal,
             },
@@ -190,8 +188,8 @@ class Ticket(StoredSubject):
         self.updated_at = Base.utc_now()
         await db_session().flush()
 
-    async def assign(self, assignee_id: str | None) -> None:
-        self.assignee_id = assignee_id
+    async def set_owner(self, owner_id: str | None) -> None:
+        self.owner_id = owner_id
         self.updated_at = Base.utc_now()
         await db_session().flush()
 

--- a/backend/druks/contrib/software_factory/issues/pages.py
+++ b/backend/druks/contrib/software_factory/issues/pages.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from druks import ui
+from druks.accounts.context import current_account_id
 from druks.accounts.models import Account
 from druks.contrib.software_factory.issues.enums import Priority, Status
 from druks.contrib.software_factory.issues.models import Comment, Ticket
@@ -27,14 +28,14 @@ PRIORITY_LABELS: dict[Priority, str] = {
     Priority.LOW: "Low",
 }
 
-UNASSIGNED = "Unassigned"
+UNOWNED = "Unowned"
 # An account that has since gone, or druks' own system actor: the row still
 # reads, it just carries no name.
 UNATTRIBUTED = "Unattributed"
-# Empty value on a page filter: any ticket. Assignee uses ``none`` for
-# unassigned because this empty value already means "no filter".
+# Empty value on a page filter: any ticket. Owner uses ``none`` for
+# unowned because this empty value already means "no filter".
 FILTER_ANY = "Any"
-UNASSIGNED_FILTER = "none"
+UNOWNED_FILTER = "none"
 UPDATED_WINDOWS = ("today", "week", "month")
 
 
@@ -46,10 +47,10 @@ def _repo_options(repos: list[ProjectRepo]) -> list[ui.Option]:
     ]
 
 
-def _assignee_options(accounts: list[Account]) -> list[ui.Option]:
-    """Who work can be handed to, plus nobody. Unassigned carries the empty
-    value the doors read back as "no assignee"."""
-    return [ui.Option(UNASSIGNED, value="")] + [
+def _owner_options(accounts: list[Account]) -> list[ui.Option]:
+    """Who work can be handed to, plus nobody. Unowned carries the empty
+    value the doors read back as "no owner"."""
+    return [ui.Option(UNOWNED, value="")] + [
         ui.Option(account.username, value=account.id) for account in accounts
     ]
 
@@ -62,10 +63,10 @@ def _status_options() -> list[ui.Option]:
     return [ui.Option(status.label, value=status.value) for status in Status]
 
 
-def _assignee_name(assignee_id: str | None, account_names: dict[str, str]) -> str:
-    if not assignee_id:
-        return UNASSIGNED
-    return account_names.get(assignee_id, UNATTRIBUTED)
+def _owner_name(owner_id: str | None, account_names: dict[str, str]) -> str:
+    if not owner_id:
+        return UNOWNED
+    return account_names.get(owner_id, UNATTRIBUTED)
 
 
 def _creator_name(creator_id: str | None, account_names: dict[str, str]) -> str:
@@ -109,9 +110,10 @@ def _create_actions(repos: list[ProjectRepo], accounts: list[Account]) -> list[u
                     value=Priority.NONE.value,
                 ),
                 ui.SelectField(
-                    name="assignee_id",
-                    label="Assignee",
-                    options=_assignee_options(accounts),
+                    name="owner_id",
+                    label="Owner",
+                    options=_owner_options(accounts),
+                    value=current_account_id.get() or "",
                 ),
             ],
         ),
@@ -148,8 +150,8 @@ def _ticket_card(ticket: Ticket, account_names: dict[str, str]) -> ui.Card:
     priority = Priority(ticket.priority)
     if priority is not Priority.NONE:
         description.append(PRIORITY_LABELS[priority])
-    if ticket.assignee_id:
-        description.append(_assignee_name(ticket.assignee_id, account_names))
+    if ticket.owner_id:
+        description.append(_owner_name(ticket.owner_id, account_names))
     return ui.Card(
         title=ticket.title,
         description=" · ".join(description),
@@ -195,7 +197,7 @@ def _ticket_filters(
     status: str,
     priority: str,
     updated: str,
-    assignee: str,
+    owner: str,
     creator: str,
     project: str,
     repo: str,
@@ -229,14 +231,14 @@ def _ticket_filters(
             value=updated,
         ),
         ui.SelectField(
-            name="assignee",
-            label="Assignee",
+            name="owner",
+            label="Owner",
             options=[
                 ui.Option(FILTER_ANY, value=""),
-                ui.Option(UNASSIGNED, value=UNASSIGNED_FILTER),
+                ui.Option(UNOWNED, value=UNOWNED_FILTER),
                 *[ui.Option(account.username, value=account.id) for account in accounts],
             ],
-            value=assignee,
+            value=owner,
         ),
         _filter_select(
             "creator",
@@ -260,7 +262,7 @@ async def _ticket_collection(
     status: str = "",
     priority: str = "",
     updated: str = "",
-    assignee: str = "",
+    owner: str = "",
     creator: str = "",
     project: str = "",
     repo: str = "",
@@ -285,7 +287,7 @@ async def _ticket_collection(
         exclude_cancelled=exclude_cancelled and not status,
         status=status,
         priority=priority,
-        assignee=assignee,
+        owner=owner,
         creator=creator,
         project_id=_optional_int(project),
         repo_id=_optional_int(repo),
@@ -299,7 +301,7 @@ async def _ticket_collection(
             status=status,
             priority=priority,
             updated=updated,
-            assignee=assignee,
+            owner=owner,
             creator=creator,
             project=project,
             repo=repo,
@@ -315,7 +317,7 @@ async def board(
     status: str = "",
     priority: str = "",
     updated: str = "",
-    assignee: str = "",
+    owner: str = "",
     creator: str = "",
     project: str = "",
     repo: str = "",
@@ -325,7 +327,7 @@ async def board(
         status=status,
         priority=priority,
         updated=updated,
-        assignee=assignee,
+        owner=owner,
         creator=creator,
         project=project,
         repo=repo,
@@ -498,10 +500,10 @@ async def ticket(identifier: str):
                             _live_form(
                                 found,
                                 ui.SelectField(
-                                    name="assignee_id",
-                                    label="Assignee",
-                                    options=_assignee_options(accounts),
-                                    value=found.assignee_id or "",
+                                    name="owner_id",
+                                    label="Owner",
+                                    options=_owner_options(accounts),
+                                    value=found.owner_id or "",
                                 ),
                                 operation="update_ticket",
                                 layout="row",

--- a/backend/druks/contrib/software_factory/issues/routes.py
+++ b/backend/druks/contrib/software_factory/issues/routes.py
@@ -39,12 +39,12 @@ async def require_ticket(identifier: str) -> Ticket:
     return ticket
 
 
-async def require_assignee(assignee_id: str) -> None:
-    """A ticket is assigned to a real account or to nobody. The assignee FK is
+async def require_owner(owner_id: str) -> None:
+    """A ticket is owned by a real account or by nobody. The owner FK is
     RESTRICT, so a bad id would surface as a 500 IntegrityError on write —
     check it here instead, where the answer is a 404 the form can show."""
-    if not await Account.get(assignee_id):
-        raise HTTPException(http_status.HTTP_404_NOT_FOUND, f"no account {assignee_id!r}")
+    if not await Account.get(owner_id):
+        raise HTTPException(http_status.HTTP_404_NOT_FOUND, f"no account {owner_id!r}")
 
 
 async def ticket_detail(ticket: Ticket) -> TicketDetail:
@@ -68,7 +68,7 @@ async def ticket_detail(ticket: Ticket) -> TicketDetail:
         status=Status(ticket.status),
         priority=Priority(ticket.priority),
         repo_id=ticket.repo_id,
-        assignee_id=ticket.assignee_id,
+        owner_id=ticket.owner_id,
         comments=[
             CommentRead(
                 id=comment.id,
@@ -95,18 +95,18 @@ async def create_ticket(
     description: str = Body("", embed=True),
     status: Status = Body(Status.BACKLOG, embed=True),
     priority: Priority = Body(Priority.NONE, embed=True),
-    assignee_id: str | None = Body(None, embed=True),
+    owner_id: str | None = Body(None, embed=True),
     account: Account = Depends(current_account),
 ) -> TicketDetail:
     """Write a ticket down. It takes the next number in its repo's project's
     sequence. Creating in Ready for Agent is a transition into the trigger, so a
     build can open. Creating in Backlog publishes nothing."""
     title = required_text(title, "title")
-    # An assignee select with nobody picked submits "", and the shell sends
+    # An owner select with nobody picked submits "", and the shell sends
     # every field the form shows. Blank is nobody, not an account id to look up.
-    assignee_id = assignee_id or None
-    if assignee_id is not None:
-        await require_assignee(assignee_id)
+    owner_id = owner_id or None
+    if owner_id is not None:
+        await require_owner(owner_id)
     try:
         ticket = await Ticket.create(
             repo_id=repo_id,
@@ -114,7 +114,7 @@ async def create_ticket(
             description=description,
             status=status,
             priority=priority,
-            assignee_id=assignee_id,
+            owner_id=owner_id,
             creator_id=account.id,
         )
     except RepoNotFound as error:
@@ -126,13 +126,13 @@ async def create_ticket(
 
 @router.patch("/tickets/{identifier}", operation_id="update_ticket", tags=["agent"])
 async def update_ticket(identifier: str, edit: TicketEdit) -> TicketDetail:
-    """Edit what a ticket says — title, description, priority, assignee, repo.
+    """Edit what a ticket says — title, description, priority, owner, repo.
     What you leave out stays as it was, and a title cannot be edited away. Status
     is not here: a title edit is not a state transition, and ``set_status`` is the
     one door that moves a ticket. Moving the repo does not remint the identifier."""
     ticket = await require_ticket(identifier)
-    if edit.assignee_id is not None:
-        await require_assignee(edit.assignee_id)
+    if edit.owner_id is not None:
+        await require_owner(edit.owner_id)
     if edit.repo_id is not None:
         repo = await ProjectRepo.get(edit.repo_id)
         if not repo:
@@ -148,16 +148,16 @@ async def update_ticket(identifier: str, edit: TicketEdit) -> TicketDetail:
     if edit.description is not None:
         ticket.description = edit.description
     if edit.title is not None or edit.description is not None:
-        # Ticket carries setters for priority and assignee but not for its
+        # Ticket carries setters for priority and owner but not for its
         # content; stamp and flush the way those setters do.
         ticket.updated_at = Base.utc_now()
         await db_session().flush()
     if edit.priority is not None:
         await ticket.set_priority(edit.priority)
-    # A null assignee_id means "unassign", so this field reads the caller's
+    # A null owner_id means "unowned", so this field reads the caller's
     # set of fields rather than the value: omitted keeps whoever holds it.
-    if "assignee_id" in edit.model_fields_set:
-        await ticket.assign(edit.assignee_id)
+    if "owner_id" in edit.model_fields_set:
+        await ticket.set_owner(edit.owner_id)
     if edit.repo_id is not None and ticket.repo_id != edit.repo_id:
         ticket.repo_id = edit.repo_id
         ticket.updated_at = Base.utc_now()

--- a/backend/druks/contrib/software_factory/issues/schemas.py
+++ b/backend/druks/contrib/software_factory/issues/schemas.py
@@ -36,26 +36,26 @@ class TicketDetail(BaseModel):
     status: Status
     priority: Priority
     repo_id: int
-    assignee_id: str | None
+    owner_id: str | None
     comments: list[CommentRead]
 
 
 class TicketEdit(BaseModel):
     """A partial edit — what a caller leaves out stays as it was. Status is not
     here: moving a ticket is ``set_status``'s job, the one door that publishes
-    ``ticket.transitioned``. A null ``assignee_id`` is the one null that says
-    something: it unassigns."""
+    ``ticket.transitioned``. A null ``owner_id`` is the one null that says
+    something: it clears the owner."""
 
     title: str | None = None
     description: str | None = None
     priority: Priority | None = None
-    assignee_id: str | None = None
+    owner_id: str | None = None
     repo_id: int | None = None
 
-    @field_validator("assignee_id", mode="before")
+    @field_validator("owner_id", mode="before")
     @classmethod
     def _blank_is_nobody(cls, value: str | None) -> str | None:
-        # An assignee select with nobody picked submits "", and the shell sends
-        # every field the form shows. Blank means unassign, not an account id to
-        # look up — the field still counts as given, so it still unassigns.
+        # An owner select with nobody picked submits "", and the shell sends
+        # every field the form shows. Blank means unowned, not an account id to
+        # look up — the field still counts as given, so it still clears.
         return value or None

--- a/backend/migrations/versions/f2b8d5c0e394_rename_ticket_assignee_to_owner.py
+++ b/backend/migrations/versions/f2b8d5c0e394_rename_ticket_assignee_to_owner.py
@@ -1,0 +1,23 @@
+"""Rename ticket assignee_id to owner_id.
+
+Revision ID: f2b8d5c0e394
+Revises: e1a7c4b9d283
+Create Date: 2026-09-10
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "f2b8d5c0e394"
+down_revision: str | Sequence[str] | None = "e1a7c4b9d283"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column("issues_tickets", "assignee_id", new_column_name="owner_id")
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Owner is the name of this column.")

--- a/backend/tests/software_factory/test_issues_models.py
+++ b/backend/tests/software_factory/test_issues_models.py
@@ -125,19 +125,19 @@ async def test_list_board_omits_cancelled():
     assert found.get_summary().title == "live"
 
 
-async def test_list_matching_filters_by_assignee_creator_and_repo():
+async def test_list_matching_filters_by_owner_creator_and_repo():
     account = await Account.get_or_create("op@example.com")
     dru = await _open_repo(name="Filter", prefix="flt", full_name="acme/filter")
     other = await _open_repo(name="Other", prefix="oth", full_name="acme/other")
-    await Ticket.create(repo_id=dru.id, title="mine", assignee_id=account.id, creator_id=account.id)
+    await Ticket.create(repo_id=dru.id, title="mine", owner_id=account.id, creator_id=account.id)
     await Ticket.create(repo_id=dru.id, title="open")
     await Ticket.create(repo_id=other.id, title="elsewhere")
 
-    assert {ticket.title for ticket in await Ticket.list_matching(assignee="none")} == {
+    assert {ticket.title for ticket in await Ticket.list_matching(owner="none")} == {
         "open",
         "elsewhere",
     }
-    assert {ticket.title for ticket in await Ticket.list_matching(assignee=account.id)} == {"mine"}
+    assert {ticket.title for ticket in await Ticket.list_matching(owner=account.id)} == {"mine"}
     assert {ticket.title for ticket in await Ticket.list_matching(creator=account.id)} == {"mine"}
     assert {ticket.title for ticket in await Ticket.list_matching(repo_id=other.id)} == {
         "elsewhere"

--- a/backend/tests/software_factory/test_issues_pages.py
+++ b/backend/tests/software_factory/test_issues_pages.py
@@ -58,7 +58,7 @@ async def test_empty_board_shows_columns_and_create_actions(druks_client):
         "status",
         "priority",
         "updated",
-        "assignee",
+        "owner",
         "creator",
         "project",
         "repo",
@@ -66,6 +66,11 @@ async def test_empty_board_shows_columns_and_create_actions(druks_client):
     assert [control["label"] for control in page["controls"]] == ["New ticket"]
     assert [control["operation"] for control in page["controls"]] == ["create_ticket"]
     assert page["controls"][0]["fields"][1]["name"] == "repo_id"
+    me = (await druks_client.get("/api/auth/me")).json()["account"]["id"]
+    owner = next(field for field in page["controls"][0]["fields"] if field["name"] == "owner_id")
+    assert owner["label"] == "Owner"
+    assert owner["value"] == me
+    assert owner["options"][0]["label"] == "Unowned"
     columns = _columns(page)
     assert [column["title"] for column in columns] == BOARD_COLUMNS
     for column in columns:
@@ -151,6 +156,9 @@ async def test_ticket_page_follows_the_row_and_comments_refresh_the_region(druks
     status = columns["blocks"][1]["blocks"][0]
     assert status["action"]["operation"] == "set_status"
     assert status["submit"] == "change"
+    owner = columns["blocks"][1]["blocks"][2]
+    assert owner["fields"][0]["name"] == "owner_id"
+    assert owner["fields"][0]["label"] == "Owner"
     repo = columns["blocks"][1]["blocks"][3]
     assert repo["fields"][0]["name"] == "repo_id"
     assert repo["fields"][0]["options"][0]["group"] == "Acme"
@@ -282,14 +290,14 @@ async def test_board_status_filter_keeps_columns_and_shows_cancelled_when_asked(
     assert cards == ["gone"]
 
 
-async def test_board_filters_by_repo_assignee_and_creator(druks_client):
+async def test_board_filters_by_repo_owner_and_creator(druks_client):
     acme = (await druks_client.post(_PROJECTS, json={"name": "Acme", "prefix": "acm"})).json()
     acme_repo = (
         await druks_client.post(f"{_PROJECTS}/{acme['id']}/repos", json={"fullName": "acme/one"})
     ).json()
     beta_repo = await _open_repo(druks_client, project="Beta", prefix="bet", repo="beta/app")
     me = (await druks_client.get("/api/auth/me")).json()["account"]["id"]
-    await _open_ticket(druks_client, acme_repo["id"], title="assigned", assignee_id=me)
+    await _open_ticket(druks_client, acme_repo["id"], title="assigned", owner_id=me)
     await _open_ticket(druks_client, acme_repo["id"], title="open")
     await _open_ticket(druks_client, beta_repo["id"], title="elsewhere")
 
@@ -298,8 +306,8 @@ async def test_board_filters_by_repo_assignee_and_creator(druks_client):
         "elsewhere"
     ]
 
-    unassigned = (await druks_client.get(f"{_PAGES}/board", params={"assignee": "none"})).json()
-    assert {card["title"] for column in _columns(unassigned) for card in _cards_in(column)} == {
+    unowned = (await druks_client.get(f"{_PAGES}/board", params={"owner": "none"})).json()
+    assert {card["title"] for column in _columns(unowned) for card in _cards_in(column)} == {
         "elsewhere",
         "open",
     }

--- a/backend/tests/software_factory/test_issues_routes.py
+++ b/backend/tests/software_factory/test_issues_routes.py
@@ -161,31 +161,31 @@ async def test_update_ticket_never_publishes_and_cannot_set_status(druks_client,
     assert events == []
 
 
-async def test_blank_assignee_is_nobody(druks_client):
+async def test_blank_owner_is_nobody(druks_client):
     repo = await _open_repo(druks_client)
     created = await druks_client.post(
         _TICKETS,
-        json={"title": "unheld", "repo_id": int(repo["id"]), "assignee_id": ""},
+        json={"title": "unheld", "repo_id": int(repo["id"]), "owner_id": ""},
     )
 
     assert created.status_code == 201
-    assert created.json()["assignee_id"] is None
+    assert created.json()["owner_id"] is None
 
     ticket = created.json()
     assigned = await Account.get_or_create("dev@example.com")
     held = await druks_client.patch(
         f"{_TICKETS}/{ticket['identifier']}",
-        json={"assignee_id": assigned.id},
+        json={"owner_id": assigned.id},
     )
     assert held.status_code == 200
-    assert held.json()["assignee_id"] == assigned.id
+    assert held.json()["owner_id"] == assigned.id
 
     cleared = await druks_client.patch(
         f"{_TICKETS}/{ticket['identifier']}",
-        json={"assignee_id": ""},
+        json={"owner_id": ""},
     )
     assert cleared.status_code == 200
-    assert cleared.json()["assignee_id"] is None
+    assert cleared.json()["owner_id"] is None
 
 
 async def test_update_can_move_a_ticket_to_another_repo(druks_client):
@@ -246,7 +246,7 @@ async def test_blank_title_and_body_are_refused(druks_client):
     assert commented.status_code == 422
 
 
-async def test_unknown_ticket_and_unknown_assignee_are_404(druks_client):
+async def test_unknown_ticket_and_unknown_owner_are_404(druks_client):
     missing = await druks_client.get(f"{_TICKETS}/DRU-99")
     assert missing.status_code == 404
 
@@ -256,7 +256,7 @@ async def test_unknown_ticket_and_unknown_assignee_are_404(druks_client):
         json={
             "title": "handed to nobody real",
             "repo_id": int(repo["id"]),
-            "assignee_id": "not-an-account",
+            "owner_id": "not-an-account",
         },
     )
     assert assigned.status_code == 404
@@ -264,7 +264,7 @@ async def test_unknown_ticket_and_unknown_assignee_are_404(druks_client):
     ticket = await _open_ticket(druks_client, repo["id"])
     updated = await druks_client.patch(
         f"{_TICKETS}/{ticket['identifier']}",
-        json={"assignee_id": "not-an-account"},
+        json={"owner_id": "not-an-account"},
     )
     assert updated.status_code == 404
 


### PR DESCRIPTION
## Summary
- Rename the local-board holder from Assignee to Owner in the UI and in code (`owner_id`).
- New ticket form defaults Owner to the signed-in operator. Unowned remains an option.
- Leave Linear/Jira `assignee_email` / `assignee_name` on `ticket.transitioned` alone.

Stacks on agent/DRU-520.
https://linear.app/fellaworks/issue/DRU-522/rename-ticket-assignee-to-owner

## Test plan
- [ ] New ticket form Owner is the operator.
- [ ] Clearing Owner stores null.
- [ ] Board filter and ticket sidebar spell Owner.
- [ ] PATCH `owner_id` with empty still clears the owner.


Made with [Cursor](https://cursor.com)