### PR TITLE
DRU-521 - Derive project prefix from the name

### DIFF
--- a/backend/druks/contrib/software_factory/exceptions.py
+++ b/backend/druks/contrib/software_factory/exceptions.py
@@ -13,7 +13,9 @@ class RepoNotFound(Exception):
 
 class InvalidPrefix(Exception):
     def __init__(self, prefix: str) -> None:
-        super().__init__(f"project prefix {prefix!r} must be 2-6 letters A-Z")
+        super().__init__(
+            f"project prefix {prefix!r} must be 2-6 letters A-Z, or two letters and a digit 1-9"
+        )
 
 
 class MissingPrefix(Exception):

--- a/backend/druks/contrib/software_factory/models.py
+++ b/backend/druks/contrib/software_factory/models.py
@@ -28,7 +28,8 @@ logger = logging.getLogger(__name__)
 # A project's prefix is the identifier namespace — Linear's team key. Short
 # enough to read at a glance, long enough to stay distinct. Null until set:
 # a GitHub project can exist before anyone mints a ticket against it.
-PREFIX_PATTERN = "^[A-Z]{2,6}$"
+# Two to six letters, or the clash walk's two letters plus a digit 1-9.
+PREFIX_PATTERN = r"^([A-Z]{2,6}|[A-Z]{2}[1-9])$"
 PREFIX_RE = re.compile(PREFIX_PATTERN)
 PREFIX_UNIQUE = "projects_prefix_key"
 
@@ -40,11 +41,40 @@ def _raise_prefix_taken(error: IntegrityError, prefix: str | None) -> None:
 
 
 def normalize_prefix(prefix: str) -> str:
-    """The stored form of an operator's prefix: uppercase, and 2-6 letters."""
+    """The stored form of an operator's prefix: uppercase, 2-6 letters, or two
+    letters and a digit 1-9."""
     normalized = prefix.strip().upper()
     if not PREFIX_RE.match(normalized):
         raise InvalidPrefix(prefix)
     return normalized
+
+
+def prefix_candidates(name: str) -> list[str]:
+    """Prefixes derived from a project name, first suggestion then clash walk.
+
+    Letters only, uppercase. First is positions 1, 2, 3. A clash retries 1, 2
+    and the next remaining letter (1+2+4, 1+2+5, …). After those, letters 1+2
+    plus a digit 1-9. A name with fewer than two letters has no candidates.
+    """
+    letters = "".join(ch for ch in name.upper() if ch.isascii() and ch.isalpha())
+    if len(letters) < 2:
+        return []
+    stem = letters[:2]
+    out: list[str] = []
+    seen: set[str] = set()
+
+    def add(candidate: str) -> None:
+        if candidate not in seen:
+            seen.add(candidate)
+            out.append(candidate)
+
+    if len(letters) >= 3:
+        add(letters[:3])
+        for extra in letters[3:]:
+            add(stem + extra)
+    for digit in "123456789":
+        add(f"{stem}{digit}")
+    return out
 
 
 # WorkItem.update() sentinel: a field left at _KEEP is untouched, while passing
@@ -90,9 +120,19 @@ class Project(Base):
     @classmethod
     async def create(cls, *, name: str, prefix: str | None = None) -> "Project":
         session = db_session()
+        submitted = None if prefix is None or not str(prefix).strip() else normalize_prefix(prefix)
+        candidates = prefix_candidates(name)
+        suggested = candidates[0] if candidates else None
+        if submitted is None or submitted == suggested:
+            taken = set(await session.scalars(select(cls.prefix).where(cls.prefix.is_not(None))))
+            chosen = next((item for item in candidates if item not in taken), None)
+            if chosen is None and (submitted is not None or candidates):
+                raise PrefixTaken(candidates[-1] if candidates else submitted or "")
+        else:
+            chosen = submitted
         # Seed the collection as loaded-empty: a fresh project has no repos, and
         # the summary read right after flush must not trigger a lazy load.
-        project = cls(name=name, prefix=prefix, repos=[])
+        project = cls(name=name, prefix=chosen, repos=[])
         session.add(project)
         try:
             await session.flush()

--- a/backend/migrations/versions/a3c9e1f4b072_allow_digit_project_prefixes.py
+++ b/backend/migrations/versions/a3c9e1f4b072_allow_digit_project_prefixes.py
@@ -1,0 +1,26 @@
+"""Allow a two-letter prefix plus a digit 1-9.
+
+Revision ID: a3c9e1f4b072
+Revises: f2b8d5c0e394
+Create Date: 2026-09-10
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "a3c9e1f4b072"
+down_revision: str | Sequence[str] | None = "f2b8d5c0e394"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_PREFIX_SHAPE = "(prefix IS NULL) OR (prefix ~ '^([A-Z]{2,6}|[A-Z]{2}[1-9])$')"
+
+
+def upgrade() -> None:
+    op.drop_constraint("projects_prefix_shape", "projects", type_="check")
+    op.create_check_constraint("projects_prefix_shape", "projects", _PREFIX_SHAPE)
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Digit prefixes stay legal.")

--- a/backend/tests/software_factory/test_issues_models.py
+++ b/backend/tests/software_factory/test_issues_models.py
@@ -11,7 +11,7 @@ from druks.contrib.software_factory.exceptions import (
 )
 from druks.contrib.software_factory.issues.enums import Status
 from druks.contrib.software_factory.issues.models import Comment, Ticket
-from druks.contrib.software_factory.models import Project, ProjectRepo
+from druks.contrib.software_factory.models import Project, ProjectRepo, prefix_candidates
 from sqlalchemy.exc import IntegrityError
 
 
@@ -46,7 +46,7 @@ async def test_unknown_repo_refuses_a_ticket():
 
 
 async def test_a_project_without_a_prefix_refuses_a_ticket():
-    project = await Project.create(name="bare")
+    project = await Project.create(name="A")
     repo = await ProjectRepo.create(project_id=project.id, full_name="acme/bare")
     with pytest.raises(MissingPrefix):
         await Ticket.create(repo_id=repo.id, title="orphan")
@@ -73,11 +73,46 @@ async def test_set_prefix_refuses_a_prefix_another_project_holds():
         await acme.set_prefix("box")
 
 
-async def test_prefix_must_be_two_to_six_letters():
+async def test_prefix_must_be_two_to_six_letters_or_two_letters_and_a_digit():
     with pytest.raises(InvalidPrefix):
         await Project.create(name="short", prefix="A")
     with pytest.raises(InvalidPrefix):
-        await Project.create(name="digits", prefix="DR1")
+        await Project.create(name="zero", prefix="DR0")
+    with pytest.raises(InvalidPrefix):
+        await Project.create(name="long", prefix="ABCDEFG")
+    project = await Project.create(name="digits", prefix="DR1")
+    assert project.prefix == "DR1"
+
+
+def test_prefix_candidates_walk_letters_then_digits():
+    assert prefix_candidates("Acme") == [
+        "ACM",
+        "ACE",
+        "AC1",
+        "AC2",
+        "AC3",
+        "AC4",
+        "AC5",
+        "AC6",
+        "AC7",
+        "AC8",
+        "AC9",
+    ]
+    assert prefix_candidates("Go") == [f"GO{digit}" for digit in range(1, 10)]
+    assert prefix_candidates("A") == []
+    assert prefix_candidates("Acme Tools")[0] == "ACM"
+    assert prefix_candidates("Acme Tools")[1] == "ACE"
+
+
+async def test_create_walks_derived_prefixes_on_clash():
+    first = await Project.create(name="Acme")
+    assert first.prefix == "ACM"
+    second = await Project.create(name="Acme Tools")
+    assert second.prefix == "ACE"
+    third = await Project.create(name="Go")
+    assert third.prefix == "GO1"
+    fourth = await Project.create(name="Go 2")
+    assert fourth.prefix == "GO2"
 
 
 async def test_prefix_cannot_change_after_a_ticket_is_minted():

--- a/backend/tests/software_factory/test_project_repo_routes.py
+++ b/backend/tests/software_factory/test_project_repo_routes.py
@@ -68,7 +68,7 @@ async def test_a_taken_prefix_is_a_conflict(client: TestClient):
     assert "already in use" in refused.json()["detail"]
     assert (await client.get(f"/api/software_factory/projects/{acme['id']}")).json()[
         "prefix"
-    ] is None
+    ] == "ACM"
 
     created = await client.post(
         "/api/software_factory/projects", json={"name": "Other", "prefix": "BOX"}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -296,8 +296,10 @@ a setting. `druks doctor` reports the tracker as healthy.
 
 The dashboard shows the board and ticket pages only for
 **druks**. Each ticket picks a GitHub repository from a Software Factory
-project. Set that project's ticket prefix (2–6 letters A–Z) on
-**Software Factory → Projects**. Druks mints identifiers as `{prefix}-{n}` once.
+project. Set that project's ticket prefix (2–6 letters A–Z, or two letters and a
+digit 1–9) on **Software Factory → Projects**. Creating a project fills the
+first three letters of its name; change the field before save if you want
+another. Druks mints identifiers as `{prefix}-{n}` once.
 Changing the ticket's repository does not remint the identifier. A project
 without a prefix cannot mint tickets.
 

--- a/frontend/src/apps/software_factory/projects/ProjectsPage.test.tsx
+++ b/frontend/src/apps/software_factory/projects/ProjectsPage.test.tsx
@@ -116,6 +116,7 @@ describe('ProjectsPage create row', () => {
     fireEvent.change(await screen.findByPlaceholderText(/new project name/), {
       target: { value: 'Acme' },
     })
+    expect((screen.getByPlaceholderText(/prefix/) as HTMLInputElement).value).toBe('ACM')
     const create = screen.getByText('+ create').closest('button')!
     await waitFor(() => expect(create.disabled).toBe(false))
     fireEvent.click(create)
@@ -123,7 +124,22 @@ describe('ProjectsPage create row', () => {
     // react-query hands the mutationFn a context argument too; the payload is
     // the first one.
     await waitFor(() => expect(createMock).toHaveBeenCalled())
-    expect(createMock.mock.calls[0]![0]).toEqual({ name: 'Acme' })
+    expect(createMock.mock.calls[0]![0]).toEqual({ name: 'Acme', prefix: 'ACM' })
+  })
+
+  it('does not overwrite a prefix the operator edited', async () => {
+    renderPage([project()])
+
+    fireEvent.change(await screen.findByPlaceholderText(/new project name/), {
+      target: { value: 'Acme' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/prefix/), {
+      target: { value: 'box' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/new project name/), {
+      target: { value: 'Acme Tools' },
+    })
+    expect((screen.getByPlaceholderText(/prefix/) as HTMLInputElement).value).toBe('box')
   })
 
   it('sends the prefix when one is typed', async () => {

--- a/frontend/src/apps/software_factory/projects/ProjectsPage.tsx
+++ b/frontend/src/apps/software_factory/projects/ProjectsPage.tsx
@@ -14,6 +14,13 @@ function pickPlaceholder(loading: boolean, available: number): string {
   return '— pick a repo —'
 }
 
+function suggestedPrefix(name: string): string {
+  const letters = name.toUpperCase().replace(/[^A-Z]/g, '')
+  if (letters.length >= 3) return letters.slice(0, 3)
+  if (letters.length === 2) return `${letters}1`
+  return ''
+}
+
 function splitRepo(full: string): { org: string; short: string } {
   const i = full.indexOf('/')
   if (i < 0) return { org: '', short: full }
@@ -35,6 +42,7 @@ export function ProjectsPage() {
 
   const [draftName, setDraftName] = useState('')
   const [draftPrefix, setDraftPrefix] = useState('')
+  const [prefixDirty, setPrefixDirty] = useState(false)
   // A project delete can still fail (a race, a server error); surface it here at
   // page level as a transient error toast so it's never a silent no-op.
   const [deleteError, setDeleteError] = useFlashNote<string>()
@@ -43,6 +51,7 @@ export function ProjectsPage() {
     onSuccess: () => {
       setDraftName('')
       setDraftPrefix('')
+      setPrefixDirty(false)
       void queryClient.invalidateQueries({ queryKey: ['projects'] })
     },
   })
@@ -52,6 +61,14 @@ export function ProjectsPage() {
       const prefix = isDruksIssues ? draftPrefix.trim() : ''
       createMutation.mutate(prefix ? { name, prefix } : { name })
     }
+  }
+  const onNameChange = (value: string) => {
+    setDraftName(value)
+    if (isDruksIssues && !prefixDirty) setDraftPrefix(suggestedPrefix(value))
+  }
+  const onPrefixChange = (value: string) => {
+    setPrefixDirty(true)
+    setDraftPrefix(value)
   }
 
   if (isLoading) {
@@ -93,8 +110,8 @@ export function ProjectsPage() {
                   name={draftName}
                   prefix={draftPrefix}
                   showPrefix={isDruksIssues}
-                  onNameChange={setDraftName}
-                  onPrefixChange={setDraftPrefix}
+                  onNameChange={onNameChange}
+                  onPrefixChange={onPrefixChange}
                   onCreate={onCreate}
                   pending={createMutation.isPending}
                 />
@@ -108,8 +125,8 @@ export function ProjectsPage() {
               name={draftName}
               prefix={draftPrefix}
               showPrefix={isDruksIssues}
-              onNameChange={setDraftName}
-              onPrefixChange={setDraftPrefix}
+              onNameChange={onNameChange}
+              onPrefixChange={onPrefixChange}
               onCreate={onCreate}
               pending={createMutation.isPending}
             />


### PR DESCRIPTION
## Summary
- Creating a project fills a prefix from the name: first three letters, then 1+2+4, 1+2+5, … then two letters plus 1–9.
- The prefix field stays editable. A dirty value is not overwritten as the name changes.
- An operator-chosen prefix that is already taken still errors. Linear/Jira create hides the field and does not fill it.

Stacks on agent/DRU-522.
https://linear.app/fellaworks/issue/DRU-521/derive-project-prefix-from-the-project-name

## Test plan
- [ ] Typing “Acme” fills ACM. Save stores ACM.
- [ ] A second project that would also be ACM walks to the next candidate (ACE, then digits).
- [ ] Editing the filled prefix, then changing the name, keeps the edited value.
- [ ] A custom taken prefix still 409s.
- [ ] Linear/Jira tracker does not show or fill the prefix field.


Made with [Cursor](https://cursor.com)