### PR TITLE
DRU-523 - Remove Cancelled; put Blocked on the board

### DIFF
--- a/backend/druks/contrib/software_factory/issues/enums.py
+++ b/backend/druks/contrib/software_factory/issues/enums.py
@@ -8,10 +8,9 @@ class Status(StrEnum):
     BACKLOG = "backlog"
     READY_FOR_AGENT = "ready_for_agent"
     IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"
     IN_REVIEW = "in_review"
     DONE = "done"
-    BLOCKED = "blocked"
-    CANCELLED = "cancelled"
 
     @property
     def label(self) -> str:
@@ -20,8 +19,7 @@ class Status(StrEnum):
 
     @property
     def completed(self) -> bool:
-        """The work got done. Cancelled is finished but not completed — the
-        difference is what a funnel counts."""
+        """The work got done. Funnel readers count this, not the display label."""
         return self is Status.DONE
 
     @property
@@ -30,7 +28,7 @@ class Status(StrEnum):
         enum, not on the display label: a board that renames a column has not
         changed its workflow, and every reader of ``ticket.transitioned`` reads
         this rather than guessing from a string."""
-        return self in (Status.DONE, Status.CANCELLED)
+        return self is Status.DONE
 
 
 # Pinned display labels — the stored value stays snake_case forever; only these
@@ -39,10 +37,9 @@ STATUS_LABELS: dict[Status, str] = {
     Status.BACKLOG: "Backlog",
     Status.READY_FOR_AGENT: "Ready for Agent",
     Status.IN_PROGRESS: "In Progress",
+    Status.BLOCKED: "Blocked",
     Status.IN_REVIEW: "In Review",
     Status.DONE: "Done",
-    Status.BLOCKED: "Blocked",
-    Status.CANCELLED: "Cancelled",
 }
 
 

--- a/backend/druks/contrib/software_factory/issues/models.py
+++ b/backend/druks/contrib/software_factory/issues/models.py
@@ -94,7 +94,6 @@ class Ticket(StoredSubject):
     async def list_matching(
         cls,
         *,
-        exclude_cancelled: bool = False,
         status: str = "",
         priority: str = "",
         owner: str = "",
@@ -104,8 +103,6 @@ class Ticket(StoredSubject):
         updated_since: datetime | None = None,
     ) -> list["Ticket"]:
         statement = select(cls)
-        if exclude_cancelled:
-            statement = statement.where(cls.status.notin_((Status.CANCELLED, Status.BLOCKED)))
         if status:
             statement = statement.where(cls.status == status)
         if priority:
@@ -129,9 +126,8 @@ class Ticket(StoredSubject):
 
     @classmethod
     async def list_board(cls) -> list["Ticket"]:
-        """Everything on the board — cancelled and blocked tickets are off it.
-        The page groups these by status; the model just says which rows are live."""
-        return await cls.list_matching(exclude_cancelled=True)
+        """Every ticket. The page groups these by status."""
+        return await cls.list_matching()
 
     @classmethod
     async def list_for_status(cls, status: Status) -> list["Ticket"]:

--- a/backend/druks/contrib/software_factory/issues/pages.py
+++ b/backend/druks/contrib/software_factory/issues/pages.py
@@ -8,12 +8,13 @@ from druks.contrib.software_factory.issues.models import Comment, Ticket
 from druks.contrib.software_factory.models import Project, ProjectRepo, WorkItem
 from druks.db import Base
 
-# The board's columns, worked-on left to right. Cancelled and blocked are off
-# it: ``Ticket.list_board`` leaves those rows out.
+# The board's columns, worked-on left to right. Blocked sits next to In
+# Progress so stuck work stays visible beside work in flight.
 BOARD_STATUSES = (
     Status.BACKLOG,
     Status.READY_FOR_AGENT,
     Status.IN_PROGRESS,
+    Status.BLOCKED,
     Status.IN_REVIEW,
     Status.DONE,
 )
@@ -258,7 +259,6 @@ def _ticket_filters(
 
 async def _ticket_collection(
     *,
-    exclude_cancelled: bool,
     status: str = "",
     priority: str = "",
     updated: str = "",
@@ -284,7 +284,6 @@ async def _ticket_collection(
     repos = await ProjectRepo.list_for_tickets()
     accounts = await Account.list_all()
     tickets = await Ticket.list_matching(
-        exclude_cancelled=exclude_cancelled and not status,
         status=status,
         priority=priority,
         owner=owner,
@@ -323,7 +322,6 @@ async def board(
     repo: str = "",
 ):
     tickets, repos, accounts, filters = await _ticket_collection(
-        exclude_cancelled=True,
         status=status,
         priority=priority,
         updated=updated,
@@ -333,9 +331,6 @@ async def board(
         repo=repo,
     )
     account_names = {account.id: account.username for account in accounts}
-    columns = BOARD_STATUSES
-    if status in {Status.CANCELLED, Status.BLOCKED}:
-        columns = BOARD_STATUSES + (Status(status),)
     return ui.Page(
         "Board",
         # Built from the repos and accounts alone, so an empty install still
@@ -368,7 +363,7 @@ async def board(
                             )
                         ],
                     )
-                    for item in columns
+                    for item in BOARD_STATUSES
                 ]
             )
         ],

--- a/backend/druks/contrib/software_factory/ticketing/issues.py
+++ b/backend/druks/contrib/software_factory/ticketing/issues.py
@@ -7,7 +7,7 @@ from druks.core.apis.exceptions import UnknownTicketError
 _BOARD = {
     TicketStatus.TRIGGER: Status.READY_FOR_AGENT,
     TicketStatus.BACKLOG: Status.BACKLOG,
-    TicketStatus.CANCELED: Status.CANCELLED,
+    TicketStatus.CANCELED: Status.DONE,
     TicketStatus.IN_PROGRESS: Status.IN_PROGRESS,
     TicketStatus.IN_REVIEW: Status.IN_REVIEW,
     TicketStatus.DONE: Status.DONE,

--- a/backend/migrations/versions/b8f3c6d1a047_drop_cancelled_status.py
+++ b/backend/migrations/versions/b8f3c6d1a047_drop_cancelled_status.py
@@ -1,0 +1,23 @@
+"""Move leftover Cancelled tickets onto Done.
+
+Revision ID: b8f3c6d1a047
+Revises: a3c9e1f4b072
+Create Date: 2026-09-10
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "b8f3c6d1a047"
+down_revision: str | Sequence[str] | None = "a3c9e1f4b072"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE issues_tickets SET status = 'done' WHERE status = 'cancelled'")
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Cancelled is no longer a status.")

--- a/backend/tests/software_factory/test_issues_models.py
+++ b/backend/tests/software_factory/test_issues_models.py
@@ -143,16 +143,16 @@ async def test_comments_are_rows_and_empty_is_a_list():
     assert all(isinstance(comment, Comment) for comment in listed)
 
 
-async def test_list_board_omits_cancelled():
+async def test_list_board_includes_blocked():
     repo = await _open_repo(name="Board", prefix="brd", full_name="acme/board")
     live = await Ticket.create(repo_id=repo.id, title="live")
-    gone = await Ticket.create(repo_id=repo.id, title="gone")
-    await gone.set_status(Status.CANCELLED)
+    stuck = await Ticket.create(repo_id=repo.id, title="stuck")
+    await stuck.set_status(Status.BLOCKED)
 
     board = await Ticket.list_board()
     identifiers = {ticket.identifier for ticket in board}
     assert live.identifier in identifiers
-    assert gone.identifier not in identifiers
+    assert stuck.identifier in identifiers
     found = await Ticket.get_for_identifier(live.identifier)
     assert found is not None
     assert found.id == live.id

--- a/backend/tests/software_factory/test_issues_pages.py
+++ b/backend/tests/software_factory/test_issues_pages.py
@@ -7,6 +7,7 @@ BOARD_COLUMNS = [
     "Backlog",
     "Ready for Agent",
     "In Progress",
+    "Blocked",
     "In Review",
     "Done",
 ]
@@ -84,9 +85,16 @@ async def test_empty_board_shows_columns_and_create_actions(druks_client):
         "backlog",
         "ready_for_agent",
         "in_progress",
+        "blocked",
         "in_review",
         "done",
     ]
+    status_filter = next(field for field in page["filters"] if field["name"] == "status")
+    assert [option["label"] for option in status_filter["options"]] == ["Any", *BOARD_COLUMNS]
+    create_status = next(
+        field for field in page["controls"][0]["fields"] if field["name"] == "status"
+    )
+    assert [option["label"] for option in create_status["options"]] == BOARD_COLUMNS
 
 
 async def test_created_ticket_lands_in_backlog_on_the_board(druks_client):
@@ -121,18 +129,20 @@ async def test_moving_a_ticket_updates_the_board(druks_client):
     assert _cards_in(by_title["Backlog"]) == []
 
 
-async def test_cancelled_tickets_are_off_the_board(druks_client):
+async def test_blocked_tickets_stay_on_the_board(druks_client):
     repo = await _open_repo(druks_client)
     await _open_ticket(druks_client, repo["id"], title="live")
-    gone = await _open_ticket(druks_client, repo["id"], title="gone")
-    await druks_client.post(
-        f"{_TICKETS}/{gone['identifier']}/status",
-        json={"status": "cancelled"},
+    stuck = await _open_ticket(druks_client, repo["id"], title="stuck")
+    moved = await druks_client.post(
+        f"{_TICKETS}/{stuck['identifier']}/status",
+        json={"status": "blocked"},
     )
+    assert moved.status_code == 200
 
     board = (await druks_client.get(f"{_PAGES}/board")).json()
-    cards = [card["title"] for column in _columns(board) for card in _cards_in(column)]
-    assert cards == ["live"]
+    by_title = {column["title"]: column for column in _columns(board)}
+    assert [card["title"] for card in _cards_in(by_title["Blocked"])] == ["stuck"]
+    assert [card["title"] for card in _cards_in(by_title["Backlog"])] == ["live"]
 
 
 async def test_ticket_page_follows_the_row_and_comments_refresh_the_region(druks_client):
@@ -270,13 +280,13 @@ async def test_roster_names_the_board_and_ticket_pages(druks_client):
     assert roster["software_factory"]["navigation"] == []
 
 
-async def test_board_status_filter_keeps_columns_and_shows_cancelled_when_asked(druks_client):
+async def test_board_status_filter_keeps_columns(druks_client):
     repo = await _open_repo(druks_client)
     await _open_ticket(druks_client, repo["id"], title="live")
-    gone = await _open_ticket(druks_client, repo["id"], title="gone")
+    stuck = await _open_ticket(druks_client, repo["id"], title="stuck")
     await druks_client.post(
-        f"{_TICKETS}/{gone['identifier']}/status",
-        json={"status": "cancelled"},
+        f"{_TICKETS}/{stuck['identifier']}/status",
+        json={"status": "blocked"},
     )
 
     backlog = (await druks_client.get(f"{_PAGES}/board", params={"status": "backlog"})).json()
@@ -284,10 +294,10 @@ async def test_board_status_filter_keeps_columns_and_shows_cancelled_when_asked(
     assert cards == ["live"]
     assert [column["title"] for column in _columns(backlog)] == BOARD_COLUMNS
 
-    cancelled = (await druks_client.get(f"{_PAGES}/board", params={"status": "cancelled"})).json()
-    assert [column["title"] for column in _columns(cancelled)] == [*BOARD_COLUMNS, "Cancelled"]
-    cards = [card["title"] for column in _columns(cancelled) for card in _cards_in(column)]
-    assert cards == ["gone"]
+    blocked = (await druks_client.get(f"{_PAGES}/board", params={"status": "blocked"})).json()
+    assert [column["title"] for column in _columns(blocked)] == BOARD_COLUMNS
+    cards = [card["title"] for column in _columns(blocked) for card in _cards_in(column)]
+    assert cards == ["stuck"]
 
 
 async def test_board_filters_by_repo_owner_and_creator(druks_client):

--- a/backend/tests/software_factory/test_issues_routes.py
+++ b/backend/tests/software_factory/test_issues_routes.py
@@ -122,25 +122,26 @@ async def test_set_status_publishes_one_transition_with_display_labels(druks_cli
     assert len(events) == 1
 
 
-async def test_set_status_marks_done_completed_and_cancelled_terminal(druks_client, monkeypatch):
+async def test_set_status_marks_done_completed_and_terminal(druks_client, monkeypatch):
     events = _published(monkeypatch)
     repo = await _open_repo(druks_client)
     ticket = await _open_ticket(druks_client, repo["id"])
+    stuck = await _open_ticket(druks_client, repo["id"])
 
     done = await druks_client.post(
         f"{_TICKETS}/{ticket['identifier']}/status",
         json={"status": "done"},
     )
-    cancelled = await druks_client.post(
-        f"{_TICKETS}/{ticket['identifier']}/status",
-        json={"status": "cancelled"},
+    blocked = await druks_client.post(
+        f"{_TICKETS}/{stuck['identifier']}/status",
+        json={"status": "blocked"},
     )
 
     assert done.status_code == 200
-    assert cancelled.status_code == 200
-    assert [payload["status"] for _, payload in events] == ["Done", "Cancelled"]
+    assert blocked.status_code == 200
+    assert [payload["status"] for _, payload in events] == ["Done", "Blocked"]
     assert [payload["completed"] for _, payload in events] == [True, False]
-    assert [payload["terminal"] for _, payload in events] == [True, True]
+    assert [payload["terminal"] for _, payload in events] == [True, False]
 
 
 async def test_update_ticket_never_publishes_and_cannot_set_status(druks_client, monkeypatch):

--- a/backend/tests/software_factory/test_issues_tracker.py
+++ b/backend/tests/software_factory/test_issues_tracker.py
@@ -45,7 +45,7 @@ async def _connect_github() -> None:
         (TicketStatus.IN_REVIEW, Status.IN_REVIEW),
         (TicketStatus.DONE, Status.DONE),
         (TicketStatus.BACKLOG, Status.BACKLOG),
-        (TicketStatus.CANCELED, Status.CANCELLED),
+        (TicketStatus.CANCELED, Status.DONE),
     ],
 )
 async def test_issues_tracker_maps_ticket_status_onto_the_board(druks_db, asked, board):


### PR DESCRIPTION
Linear ticket: [DRU-523](https://linear.app/fellaworks/issue/DRU-523/remove-cancelled-put-blocked-on-the-board)

## Summary
- Drop `Status.CANCELLED`. Create options, the ticket sidebar, and filters no longer offer it.
- Migrate leftover `cancelled` rows to `done` without publishing `ticket.transitioned`.
- Blocked is a board column after In Progress. `Status.terminal` is Done only.
- A funnel `TicketStatus.CANCELED` write lands on Done, matching Jira.

## Test plan
- [x] `uv run ruff check backend`
- [x] `uv run ruff format --check backend`
- [x] `uv pip install -e backend/tests/druks-field_notes`
- [x] `uv run pytest backend/`
- [ ] Empty board columns are Backlog, Ready for Agent, In Progress, Blocked, In Review, Done.
- [ ] Status filter and New ticket do not offer Cancelled.
- [ ] Drag onto Blocked stays there.
- [ ] A leftover cancelled ticket is in Done after migrate.


Made with [Cursor](https://cursor.com)