### PR TITLE
DRU-386 - Chat: Docs and doctor

### DIFF
--- a/backend/druks/contrib/chat/app.py
+++ b/backend/druks/contrib/chat/app.py
@@ -1,6 +1,47 @@
+import httpx
+
 from druks.agents import Agent
 from druks.apps import App
 from druks.contrib.chat.contracts import TurnOutput
+from druks.doctor import CheckResult
+from druks.settings import load_settings
+
+
+async def check_appliance_mcp() -> CheckResult:
+    """Whether this appliance's /mcp answers, so a Talk sandbox can operate
+    as the signed-in operator. Skip when sandbox execution is off."""
+    settings = load_settings()
+    if not settings.sandbox.service_url:
+        return CheckResult(
+            name="appliance_mcp",
+            ok=True,
+            detail="skipped — sandbox execution is off",
+        )
+    endpoint = settings.urls.endpoint.rstrip("/")
+    if not endpoint:
+        return CheckResult(
+            name="appliance_mcp",
+            ok=False,
+            pending=True,
+            detail="urls.endpoint is unset — the sandbox needs it to reach /mcp.",
+        )
+    url = f"{endpoint}/mcp"
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(url)
+    except httpx.RequestError as error:
+        return CheckResult(
+            name="appliance_mcp",
+            ok=False,
+            detail=f"{url} is unreachable: {error}. Chat Talk needs it.",
+        )
+    if response.status_code >= 500:
+        return CheckResult(
+            name="appliance_mcp",
+            ok=False,
+            detail=f"{url} returned {response.status_code}. Chat Talk needs it.",
+        )
+    return CheckResult(name="appliance_mcp", ok=True, detail=url)
 
 
 class Chat(App):
@@ -11,6 +52,7 @@ class Chat(App):
     # schema can never collide with core's or another app's.
     prefix_tables = True
     navigation = ["list"]
+    checks = [check_appliance_mcp]
 
     reply = Agent(
         description="replies to the operator on one conversation turn",

--- a/backend/druks/doctor.py
+++ b/backend/druks/doctor.py
@@ -529,6 +529,20 @@ def check_capability_modules(settings: Settings) -> CheckResult:
     )
 
 
+def check_chat(settings: Settings) -> CheckResult:
+    """Chat ships in this distribution. A missing roster entry is a
+    packaging fault, not an optional install."""
+    if any(app.name == "chat" for app in iter_apps()):
+        return CheckResult(name="chat", ok=True, detail="bundled")
+    return CheckResult(
+        name="chat",
+        ok=False,
+        detail=(
+            "chat is missing from the app roster — it ships with Druks, not as an optional package."
+        ),
+    )
+
+
 async def check_apps(settings: Settings) -> list[CheckResult]:
     """Each installed app's resolved settings and own checks, namespaced under it.
     Read off the class headlessly through the loader, so doctor never imports an
@@ -598,6 +612,7 @@ CHECKS = (
     check_drukbox,
     check_secrets_exchange,
     check_capability_modules,
+    check_chat,
     check_apps,
     check_declared_sandboxes,
 )

--- a/backend/tests/chat/test_doctor.py
+++ b/backend/tests/chat/test_doctor.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+from druks import doctor
+from druks.contrib.chat.app import check_appliance_mcp
+from druks.testing import make_settings
+
+
+def test_chat_is_in_the_roster(tmp_path):
+    result = doctor.check_chat(make_settings(tmp_path))
+
+    assert result.ok
+    assert result.detail == "bundled"
+
+
+def test_chat_missing_from_the_roster_is_a_fault(tmp_path, monkeypatch):
+    monkeypatch.setattr(doctor, "iter_apps", lambda: iter(()))
+
+    result = doctor.check_chat(make_settings(tmp_path))
+
+    assert not result.ok
+    assert not result.pending
+    assert "optional" in result.detail
+
+
+def test_check_chat_is_in_the_battery():
+    assert doctor.check_chat in doctor.CHECKS
+
+
+def _settings(*, service_url: str, endpoint: str):
+    return SimpleNamespace(
+        sandbox=SimpleNamespace(service_url=service_url),
+        urls=SimpleNamespace(endpoint=endpoint),
+    )
+
+
+async def test_appliance_mcp_skips_when_sandbox_execution_is_off(monkeypatch):
+    monkeypatch.setattr(
+        "druks.contrib.chat.app.load_settings",
+        lambda: _settings(service_url="", endpoint="http://127.0.0.1:8001"),
+    )
+
+    result = await check_appliance_mcp()
+
+    assert result.ok
+    assert result.detail.startswith("skipped")
+
+
+async def test_appliance_mcp_pends_without_an_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        "druks.contrib.chat.app.load_settings",
+        lambda: _settings(service_url="http://127.0.0.1:8780", endpoint=""),
+    )
+
+    result = await check_appliance_mcp()
+
+    assert not result.ok
+    assert result.pending
+    assert "/mcp" in result.detail
+
+
+async def test_appliance_mcp_names_an_unreachable_url(monkeypatch):
+    monkeypatch.setattr(
+        "druks.contrib.chat.app.load_settings",
+        lambda: _settings(service_url="http://127.0.0.1:8780", endpoint="http://druks.test:8001"),
+    )
+
+    async def fake_get(self, url):
+        raise httpx.ConnectError("connection refused", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    result = await check_appliance_mcp()
+
+    assert not result.ok
+    assert not result.pending
+    assert "http://druks.test:8001/mcp" in result.detail
+
+
+async def test_appliance_mcp_accepts_a_live_endpoint(monkeypatch):
+    monkeypatch.setattr(
+        "druks.contrib.chat.app.load_settings",
+        lambda: _settings(service_url="http://127.0.0.1:8780", endpoint="http://127.0.0.1:8001"),
+    )
+
+    async def fake_get(self, url):
+        return MagicMock(status_code=401)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    result = await check_appliance_mcp()
+
+    assert result.ok
+    assert result.detail == "http://127.0.0.1:8001/mcp"

--- a/backend/tests/test_app_doctor_checks.py
+++ b/backend/tests/test_app_doctor_checks.py
@@ -150,6 +150,7 @@ async def test_app_checks_are_wired_into_the_check_battery(installed, tmp_path: 
     app_results = await doctor.check_apps(settings)
     assert isinstance(app_results, list)
     assert "field_notes:summary_api_key" in {result.name for result in app_results}
+    assert "chat:appliance_mcp" in {result.name for result in app_results}
 
 
 async def test_raising_app_check_is_isolated_and_does_not_stop_siblings(

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -616,3 +616,4 @@ async def test_run_checks_includes_sandbox_e2e_only_when_flagged(tmp_path: Path)
 
     assert "sandbox_e2e" not in default
     assert "sandbox_e2e" in flagged
+    assert "chat" in default

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -1,0 +1,59 @@
+---
+title: "Chat"
+description: "Start operator conversations, set autonomy, and reuse a warm sandbox across turns."
+icon: "message-square"
+---
+
+Chat is a bundled app. It ships with Druks. It is not an optional package.
+
+Open **Chat** in the dashboard rail. Each conversation belongs to the signed-in
+operator. Other accounts cannot read it.
+
+## Start a conversation
+
+1. Open **Chat → Conversations**.
+2. Choose **New**.
+3. Enter the first message. A title is optional. An empty title is filled from
+   the first user line after the first assistant reply.
+4. Choose **Start**.
+
+That start creates the thread and one Talk run. Later lines answer the parked
+turn. **Send** appends your line and continues. **Stop** ends Talk and reaps
+the sandbox. Stop does not write a message.
+
+## Autonomy
+
+Each conversation has a mode. A change applies on the next agent call.
+
+| Mode | Tools |
+| --- | --- |
+| **propose** (default) | Read tools only. Mutating tools do not run. The agent proposes the action in the thread. You commit it in the real dashboard. |
+| **confirm** | The live catalog is visible. Mutating tools stash the call. After the turn, a confirm gate asks you to approve or reject before the next user line. |
+| **full** | Tools run immediately as your account. |
+
+Set the mode on the conversation. The next Talk call reads the live row.
+
+Chat uses the same `/mcp` catalog as an external agent. It is not a second
+catalog and it does not replace [Connect your agent](connect-your-agent.md).
+The sandbox talks inward to this appliance as you, through a call-scoped token
+that dies with the agent call.
+
+## Idle window
+
+Talk parks each turn with `hold_sandbox` of 15 minutes. The park itself still
+lasts days. The hold only clips the Drukbox lease so the warm VM stays up for
+a short idle window.
+
+Send inside that window and Talk reuses the same host. It does not provision
+a new one. After the clipped lease ends, the next line provisions a cold host
+and still works.
+
+**Stop** reaps the host. A worker crash still frees the VM when the Drukbox
+lease lapses. `review()` and any park without `hold_sandbox` still delete the
+host at once.
+
+`druks doctor` reports that Chat is bundled. It also probes `/mcp` when sandbox
+execution is on. Set `urls.endpoint` so a sandbox can reach this appliance.
+A Docker sandbox rewrites a loopback dashboard URL to
+`host.docker.internal`. See
+[public URLs](configuration.md#public-urls-and-access-control).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -54,8 +54,9 @@ name must match `App.name`. The same name scopes:
 - Optional static frontend assets in the app package.
 
 The bundled `software_factory` app owns projects, work items, ticket intake,
-GitHub branches, pull requests, coding-agent policy, and dashboard pages. These
-features are examples, not platform guarantees.
+GitHub branches, pull requests, coding-agent policy, and dashboard pages. The
+bundled `chat` app owns operator conversations. These features are examples, not
+platform guarantees.
 
 ## Durability and recovery
 
@@ -170,11 +171,16 @@ does not infer access health from configuration.
 A `Gate` defines a typed reply and a durable receive topic. When a workflow
 waits at a gate, Druks:
 
-1. Releases each warm sandbox that the workflow holds.
+1. Releases each warm sandbox that the workflow holds, unless the wait passes
+   `hold_sandbox`. A hold clips the Drukbox lease. It is shorter than the
+   remaining lease. The park itself still lasts up to 14 days.
 2. Records `parked` and the request for the operator.
 3. Sends an optional notification.
 4. Suspends the workflow until a reply arrives or the 14-day timeout expires.
 5. Clears the gate and returns the validated reply after the workflow resumes.
+
+`review()` does not pass `hold_sandbox`, so it still reaps. See
+[`Gate.wait`](writing-an-app.md#wait-for-input).
 
 Each parked round accepts one answer through an idempotency key. In-app review
 requires a subject because the subject read-side is where the question appears.
@@ -205,8 +211,10 @@ not write provider-specific execution code.
 
 By default, each agent call uses an ephemeral sandbox. A workflow can retain one
 warm sandbox across a segment. Druks releases it before a gate and at workflow
-exit. Druks also rotates it before the lease becomes too short for another
-call. Store durable state in an external system such as Git, not only on the VM.
+exit, unless that gate wait passes `hold_sandbox`. A hold clips the lease. It
+never extends it. Druks also rotates the host before the lease becomes too
+short for another call. Store durable state in an external system such as Git,
+not only on the VM.
 
 A sandbox never holds a subscription token. Druks gives each sandbox that
 fetches one an identity at its issuer, before Drukbox provisions it. The

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,7 +137,7 @@ caches, and the sandbox provisioning gate.
 
 | TOML key | Purpose |
 | --- | --- |
-| `urls.endpoint` | Browser-visible dashboard base URL used to build MCP OAuth callbacks |
+| `urls.endpoint` | Browser-visible dashboard base URL. MCP OAuth callbacks and sandbox hops to this appliance's `/mcp` use it |
 | `urls.webhook_host` | Public webhook hostname used by `druks doctor` for its ingress probe |
 | `identity.mode` | `none` (default, no authentication, single operator), `header` (edge-asserted identity), or `jwt` (validated edge-signed assertion) |
 | `identity.header` | The trusted identity header. The shipped Caddy edge also uses it. Header and JWT modes have no default and require it |
@@ -152,6 +152,10 @@ address, collides with it on port 443. One of the two stops. To keep the
 other addresses free, set `DRUKS_WEBHOOK_BIND_HOST` in `[env]` to the public
 address. Caddy then serves only that address. To keep IPv6, list the IPv4
 and the IPv6 addresses.
+
+A Docker sandbox cannot use the host loopback. Druks rewrites a loopback
+`urls.endpoint` to `host.docker.internal` for that hop. An exe VM uses
+`urls.endpoint` as given. See [Chat](chat.md).
 
 `urls.endpoint` and `urls.webhook_host` are different. The first is where an
 operator's browser reaches Druks. The second is the public ingress host for

--- a/docs/connect-your-agent.md
+++ b/docs/connect-your-agent.md
@@ -70,3 +70,12 @@ Three details matter when an agent uses the MCP endpoint:
   and `RUN_NOT_ACTIVE` are stable match values. App tools use the API shape
   `{"error", "detail"}` for refusals. Shape errors contain
   `VALIDATION_ERROR` detail.
+
+## Chat uses the same catalog inward
+
+Dashboard [Chat](chat.md) is not a replacement for this external MCP connection.
+A Talk sandbox calls the same `/mcp` tools as the signed-in operator. Mint a
+personal access token when Claude Code or Codex should talk *into* Druks from
+your laptop. Chat does not use that token. It mints a call-scoped credential
+that dies with the agent call.
+

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -66,6 +66,7 @@
           "deployment",
           "configuration",
           "connect-your-agent",
+          "chat",
           "troubleshooting"
         ]
       },

--- a/docs/full-local.md
+++ b/docs/full-local.md
@@ -156,6 +156,9 @@ ticket or GitHub trigger.
 The run appears on the subject page and in the Events
 feed. Agent-call pages stream transcript and artifact data.
 
+Open **Chat** to start an operator conversation on this appliance. See
+[Chat](chat.md).
+
 If you develop a different app, install that distribution into a
 development Druks environment and invoke its documented trigger or
 `Workflow.start()` path. See [writing an app](writing-an-app.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,8 +47,9 @@ isolated agent calls, or waits. Examples include software delivery, incident
 investigation, research review, approval flows, and periodic operational checks.
 
 The bundled **Software Factory** app coordinates coding agents from a work item
-to a reviewed pull request. It demonstrates the framework. GitHub policy and
-software-delivery behavior belong to the app, not to Druks.
+to a reviewed pull request. The bundled **Chat** app keeps operator conversations
+on this appliance. Both demonstrate the framework. Domain policy belongs to the
+app, not to Druks.
 
 ## Choose a path
 
@@ -58,6 +59,7 @@ software-delivery behavior belong to the app, not to Druks.
 - **Give it screens:** Read the [Druks UI contract](druks-ui.md).
 - **Run a production stack:** Follow the [deployment runbook](deployment.md).
 - **Diagnose a failure:** Use [troubleshooting](troubleshooting.md).
+- **Chat on this appliance:** Read [Chat](chat.md).
 
 ## What Druks is not
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,8 +15,9 @@ docker compose logs --tail=200 web
 
 `druks doctor` examines the full platform. It covers settings, secrets, service
 credentials, data-directory writes, Postgres, Redis, Drukbox, harnesses, app
-imports, capability modules, and app-owned checks. A failed check exits with a
-nonzero status.
+imports, capability modules, bundled Chat, and app-owned checks. A failed
+check exits with a nonzero status. Chat is always installed. Its `/mcp` probe
+skips with a reason when sandbox execution is off.
 
 If the normal Drukbox check passes but real execution fails, use the opt-in
 sandbox check:
@@ -173,6 +174,14 @@ The exchange binds `127.0.0.1:8781` on the Druks host. Until it answers, a
 sandbox gets no value for its placeholders, and each agent call fails at the
 provider with an authentication error.
 
+### Chat cannot reach `/mcp`
+
+Talk injects this appliance's `/mcp` into the sandbox. `druks doctor` reports
+`chat:appliance_mcp`. A skip means sandbox execution is off. Pending means
+`urls.endpoint` is unset. An unreachable URL means the VM cannot operate as the
+operator. Set `urls.endpoint`. A Docker sandbox rewrites loopback to
+`host.docker.internal`. See [Chat](chat.md).
+
 ### A sandbox process appears stuck
 
 Druks copies the dashboard transcript from files that a detached VM process writes.
@@ -185,7 +194,8 @@ agent process. Recovery follows the durable operation boundary.
 
 `parked` means that DBOS suspended the workflow on a gate. The workflow did not stall.
 Open the subject detail page to see its current ask. In-app review offers
-approve, request changes, or cancel. The owner system answers an external gate.
+approve, request changes, or cancel. Chat parks send and stop. Confirm parks
+approve and reject. The owner system answers an external gate.
 
 If no notification arrived:
 

--- a/docs/writing-an-app.md
+++ b/docs/writing-an-app.md
@@ -10,6 +10,9 @@ Druks supplies durable execution and shared operating services. Read
 [the app boundary](concepts.md#the-app-boundary)
 before you assign ownership of a capability.
 
+The bundled `chat` and `software_factory` apps register through the same
+`druks.apps` entry point. They ship with Druks. They are not optional packages.
+
 ## Scaffold and prove the package
 
 ```bash
@@ -544,7 +547,8 @@ Override it to deliver none.
 
 Keep durable state outside the VM. A workflow can set
 `steps_reuse_sandbox = True` to retain one host across a segment. Druks releases
-the host at a gate and at workflow exit. It rotates the host near lease expiry,
+the host at a gate and at workflow exit, unless `Gate.wait` passes
+`hold_sandbox`. It rotates the host near lease expiry,
 and when the next agent call needs other secret entries.
 
 ### Borrow a browser session
@@ -632,7 +636,31 @@ reply = await ApproveReport.wait(
 ```
 
 `on_wait()` is a checkpointed notification step. The workflow then parks
-durably and releases its warm sandbox. The owning external system resumes the
+durably. By default it releases its warm sandbox. Pass `hold_sandbox` to keep
+the VM across a short idle window instead:
+
+```python
+from datetime import timedelta
+
+reply = await ApproveReport.wait(
+    input_request={
+        "presentation": "external",
+        "label": "Review the night-watch report",
+        "url": review_url,
+    },
+    hold_sandbox=timedelta(minutes=15),
+)
+```
+
+Default `False` reaps. `True` holds for as long as the remaining
+lease could still cover one more worst-case agent call. A `timedelta` holds
+for at most that span. A hold never extends the lease Drukbox already granted.
+The park itself still lasts up to 14 days. The clipped lease is what ends the
+hold if nobody answers.
+
+`review()` calls the park path without `hold_sandbox`, so it still reaps.
+
+The owning external system resumes the
 workflow through the gate and its subject:
 
 ```python


### PR DESCRIPTION
## Summary
- Document Chat as a bundled app: start a conversation, autonomy modes, the 15-minute idle hold, and cold provision after the clipped lease.
- Record that a park still lasts days, `Gate.wait(..., hold_sandbox=…)` is optional and shorter than the lease, and `review()` still reaps.
- Tell operators Chat uses the same `/mcp` catalog inward and is not a replacement for an external PAT.
- Make `druks doctor` fail if Chat is missing from the roster, and probe `/mcp` (skip with a reason when sandbox execution is off).

Linear: DRU-386

## Test plan
- [ ] `uv pip install -e backend/tests/druks-field_notes && uv run pytest backend/tests/chat/test_doctor.py backend/tests/test_app_doctor_checks.py backend/tests/test_doctor.py::test_run_checks_includes_sandbox_e2e_only_when_flagged`
- [ ] `druks doctor` reports `chat` as bundled and `chat:appliance_mcp` as skipped or a `/mcp` URL
- [ ] Docs preview: Chat page, concepts park/hold, writing-an-app `hold_sandbox`, connect-your-agent inward catalog


Made with [Cursor](https://cursor.com)