### PR TITLE
Resolve JWT account identity with JSON Pointer

### DIFF
--- a/backend/druks/accounts/jwt.py
+++ b/backend/druks/accounts/jwt.py
@@ -1,6 +1,8 @@
+import re
 from functools import lru_cache
 
 from fastmcp.server.auth.providers.jwt import JWTVerifier
+from jsonpointer import JsonPointer
 
 from druks.accounts.exceptions import InvalidAssertionError
 from druks.settings import Settings
@@ -8,6 +10,7 @@ from druks.settings import Settings
 # RS256 is the pinned profile — an untrusted token never chooses its own
 # algorithm.
 _ALGORITHM = "RS256"
+_ARRAY_INDEX = re.compile(r"0|[1-9][0-9]*")
 
 
 @lru_cache(maxsize=1)
@@ -28,7 +31,14 @@ async def verify_assertion(token: str, settings: Settings) -> str:
     # our contract additionally requires exp and a nonblank string identity.
     if not access or "exp" not in access.claims:
         raise InvalidAssertionError("Assertion rejected.")
-    claim = access.claims.get(settings.identity.jwt_identity_claim)
+    claim: object = access.claims
+    for part in JsonPointer(settings.identity.jwt_identity_claim).parts:
+        if isinstance(claim, dict) and part in claim:
+            claim = claim[part]
+        elif isinstance(claim, list) and _ARRAY_INDEX.fullmatch(part) and int(part) < len(claim):
+            claim = claim[int(part)]
+        else:
+            raise InvalidAssertionError("Assertion carries no value at the identity pointer.")
     if isinstance(claim, str) and claim.strip():
         return claim.strip()
     raise InvalidAssertionError(

--- a/backend/druks/settings.py
+++ b/backend/druks/settings.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal
 
 import asyncssh
+from jsonpointer import JsonPointer, JsonPointerException
 from pydantic import AfterValidator, BaseModel, BeforeValidator, Field, model_validator
 from pydantic_settings import (
     BaseSettings,
@@ -85,7 +86,7 @@ class Identity(BaseModel):
     jwks_url: str = ""
     jwt_issuer: str = ""
     jwt_audience: str = ""
-    jwt_identity_claim: str = "email"
+    jwt_identity_claim: str = "/email"
 
     @model_validator(mode="after")
     def _auth_mode_is_fully_configured(self) -> "Identity":
@@ -108,6 +109,12 @@ class Identity(BaseModel):
             missing = [name for name, value in required.items() if not value.strip()]
             if missing:
                 raise ValueError(f"identity.mode=jwt requires {', '.join(missing)}")
+            try:
+                JsonPointer(self.jwt_identity_claim)
+            except JsonPointerException as error:
+                raise ValueError(
+                    "identity.jwt_identity_claim must be a JSON Pointer, such as /email"
+                ) from error
         return self
 
 

--- a/backend/druks/setup_env.py
+++ b/backend/druks/setup_env.py
@@ -175,7 +175,7 @@ header = ""
 jwks_url = ""
 jwt_issuer = ""
 jwt_audience = ""
-jwt_identity_claim = "email"
+jwt_identity_claim = "/email"
 
 # Public dashboard and webhook ingress addresses.
 [urls]

--- a/backend/tests/test_identity_jwt.py
+++ b/backend/tests/test_identity_jwt.py
@@ -45,7 +45,7 @@ def _token(key=_PRIVATE_KEY, **claim_overrides) -> str:
     return pyjwt.encode(claims, key, algorithm="RS256", headers={"kid": KID})
 
 
-def _jwt_client(tmp_path: Path) -> TestClient:
+def _jwt_client(tmp_path: Path, *, identity_claim: str = "/email") -> TestClient:
     app = configure_app_for_test(
         settings=make_settings(
             tmp_path,
@@ -55,6 +55,7 @@ def _jwt_client(tmp_path: Path) -> TestClient:
                 "jwks_url": "https://edge.example.com/jwks.json",
                 "jwt_issuer": ISSUER,
                 "jwt_audience": AUDIENCE,
+                "jwt_identity_claim": identity_claim,
             },
         ),
         authenticated=False,
@@ -74,6 +75,46 @@ async def test_a_valid_assertion_open_enrolls_its_subject(tmp_path, druks_db):
 
 
 @pytest.mark.parametrize(
+    ("pointer", "claims"),
+    [
+        ("/email", {"email": "  op@example.com  "}),
+        ("/traits/email", {"traits": {"email": "op@example.com"}}),
+        ("/people/1/email", {"people": [{}, {"email": "op@example.com"}]}),
+    ],
+)
+async def test_identity_pointer_selects_the_account(tmp_path, druks_db, pointer, claims):
+    token = _token(**{"email": "fallback@example.com", **claims})
+
+    with _jwt_client(tmp_path, identity_claim=pointer) as client:
+        response = client.get("/api/auth/me", headers={HEADER: token})
+
+    assert response.status_code == 200
+    assert response.json()["account"]["username"] == "op@example.com"
+    assert [account.username for account in await Account.list_all()] == ["op@example.com"]
+
+
+@pytest.mark.parametrize(
+    ("pointer", "claims"),
+    [
+        ("/email/0", {"email": "op@example.com"}),
+        ("/people/1/email", {"people": [{"email": "op@example.com"}]}),
+    ],
+)
+async def test_an_unresolvable_pointer_rejects_without_enrolling(
+    tmp_path, druks_db, pointer, claims
+):
+    token = _token(**claims)
+
+    with _jwt_client(tmp_path, identity_claim=pointer) as client:
+        response = client.get("/api/auth/me", headers={HEADER: token})
+
+    assert response.status_code == 401
+    assert "op@example.com" not in response.json()["detail"]
+    assert token.split(".")[1] not in response.json()["detail"]
+    assert not await Account.list_all()
+
+
+@pytest.mark.parametrize(
     "token",
     [
         _token(key=_FOREIGN_KEY),  # signature it can't verify
@@ -83,6 +124,8 @@ async def test_a_valid_assertion_open_enrolls_its_subject(tmp_path, druks_db):
         _token(aud="not-druks"),
         _token(email=None),  # missing identity claim
         _token(email={"nested": "never"}),  # non-string identity claim
+        _token(email=["op@example.com"]),  # array identity claim
+        _token(email="  "),  # blank identity claim
         "not.a.jwt",
     ],
 )

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -29,7 +29,7 @@ def test_jwt_mode_requires_its_verification_targets(tmp_path):
         "jwt_audience": "druks",
     }
     settings = make_settings(tmp_path, identity={"mode": "jwt", **complete})
-    assert settings.identity.jwt_identity_claim == "email"
+    assert settings.identity.jwt_identity_claim == "/email"
     # Each required field, blanked in turn, refuses jwt mode.
     for name in complete:
         with pytest.raises(ValidationError):
@@ -37,6 +37,8 @@ def test_jwt_mode_requires_its_verification_targets(tmp_path):
                 tmp_path,
                 identity={"mode": "jwt", **complete, name: "  "},
             )
+    with pytest.raises(ValidationError, match="jwt_identity_claim must be a JSON Pointer"):
+        make_settings(tmp_path, identity={"mode": "jwt", **complete, "jwt_identity_claim": "email"})
 
 
 @pytest.mark.parametrize("mode", ["header", "jwt"])
@@ -132,7 +134,7 @@ secrets_key = "{_SECRETS_KEY}"
 
     settings = Settings()
 
-    assert settings.identity.jwt_identity_claim == "email"
+    assert settings.identity.jwt_identity_claim == "/email"
 
 
 def test_harness_config_root_expands_the_environment_path(tmp_path, monkeypatch):

--- a/backend/tests/test_setup_env.py
+++ b/backend/tests/test_setup_env.py
@@ -11,7 +11,7 @@ DROPPED_RENDER_KEYS = {
     "DRUKS_AUTH_JWKS_URL": ("identity.jwks_url", "https://edge.example/jwks"),
     "DRUKS_AUTH_JWT_ISSUER": ("identity.jwt_issuer", "https://edge.example"),
     "DRUKS_AUTH_JWT_AUDIENCE": ("identity.jwt_audience", "druks"),
-    "DRUKS_AUTH_JWT_IDENTITY_CLAIM": ("identity.jwt_identity_claim", "sub"),
+    "DRUKS_AUTH_JWT_IDENTITY_CLAIM": ("identity.jwt_identity_claim", "/sub"),
     "DRUKS_ENDPOINT": ("urls.endpoint", "https://druks.example"),
     "DRUKS_SECRETS_KEY": ("secrets.secrets_key", "secrets-key"),
     "DRUKS_SANDBOX_SERVICE_URL": ("sandbox.service_url", "http://sandbox:8000"),
@@ -46,6 +46,7 @@ def test_fresh_exe_render_matches_the_deployment_contract(tmp_path):
 
     values = read_env(env_path)
     config = _read_toml(tmp_path / "druks.toml")
+    assert config["identity"]["jwt_identity_claim"] == "/email"
     assert values["DEFAULT_HOST_PROVIDER"] == "exe"
     assert values["TAILSCALE_ENABLED"] == "true"
     assert values["EXE_API_URL"] == "https://exe.dev"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,7 +144,7 @@ caches, and the sandbox provisioning gate.
 | `identity.jwks_url` | `jwt` mode: where the edge publishes its signing keys |
 | `identity.jwt_issuer` | `jwt` mode: required `iss` claim value |
 | `identity.jwt_audience` | `jwt` mode: required `aud` claim value |
-| `identity.jwt_identity_claim` | `jwt` mode: the claim mapped to the account (default `email`) |
+| `identity.jwt_identity_claim` | `jwt` mode: the JSON Pointer to the account identity in the verified payload (default `/email`) |
 
 The `urls.webhook_host` listener binds every interface. A second TLS
 terminator on the same box, for example `tailscale serve` on the tailnet
@@ -176,8 +176,9 @@ order:
    rotation.
 
    The `exp`, `iss`, and `aud` claims must match the configuration.
-   Druks maps `identity.jwt_identity_claim` to an account. A validation error
-   returns a 401 with the error class, not the token. Druks uses a fixed RS256
+   Druks resolves `identity.jwt_identity_claim` in the verified payload and maps
+   the selected value to an account. A validation error
+   returns a 401 without token material. Druks uses a fixed RS256
    configuration and does not negotiate it.
 4. **No-authentication mode (`none`).** This mode has no authentication or identity edge. Druks
    resolves the only account. Zero accounts is the setup state. The
@@ -186,6 +187,27 @@ order:
 
    More than one account is configuration
    drift. Druks refuses requests and startup in this state.
+
+In JWT mode, `identity.jwt_identity_claim` uses
+[JSON Pointer (RFC 6901)](https://www.rfc-editor.org/rfc/rfc6901.html).
+Set it in the deployment's `druks.toml`:
+
+```toml
+[identity]
+jwt_identity_claim = "/traits/email"
+```
+
+`/email` selects a top-level claim. `/traits/email` selects a nested claim.
+`/people/0/email` selects a claim from the first object in an array. Dots are
+literal key characters. Within a key, encode `/` as `~1` and `~` as `~0`.
+For example, `/https:~1~1id.example~1email` selects the key
+`https://id.example/email`. Druks refuses invalid pointer syntax at startup
+in JWT mode. Bare claim names and dot paths are not accepted.
+
+The selected value must be a nonblank string. Druks removes its outer
+whitespace. A missing path, invalid traversal, or another result shape
+returns a 401 without creating an account. The extraction has no
+provider-specific behavior.
 
 A subscription is always one person's. An API key is the installation's:
 one per provider, owned by no account, and visible to every account in

--- a/druks.toml.example
+++ b/druks.toml.example
@@ -10,7 +10,7 @@ header = ""
 jwks_url = ""
 jwt_issuer = ""
 jwt_audience = ""
-jwt_identity_claim = "email"
+jwt_identity_claim = "/email"
 
 [urls]
 endpoint = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "cryptography>=48.0.1",
     "fastmcp>=4.0.2,<5",
     "sqlalchemy-encrypted-field==1.0.2",
+    "jsonpointer>=3.1.1",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,7 @@ dependencies = [
     { name = "httpx" },
     { name = "httpx2" },
     { name = "jinja2" },
+    { name = "jsonpointer" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -590,6 +591,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "httpx2", specifier = ">=2.12.0" },
     { name = "jinja2", specifier = ">=3.1" },
+    { name = "jsonpointer", specifier = ">=3.1.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
@@ -1047,6 +1049,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/e0/27a6a081ae25420eda6768ceae05d7022a7f2447f420588843f2a44e4298/joserfc-1.7.4.tar.gz", hash = "sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed", size = 234027, upload-time = "2026-07-19T15:43:02.739Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/bf/249dcd99b3376375910b7fa922383b57792975c8758f50d44612e749226c/joserfc-1.7.4-py3-none-any.whl", hash = "sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463", size = 71000, upload-time = "2026-07-19T15:43:01.299Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

JWT account identity can now come from nested objects and arrays through RFC 6901 JSON Pointer. For example, `identity.jwt_identity_claim = "/traits/email"` selects `traits.email` from the verified JWT payload.

The default is `/email`. The selected value must be a nonblank string; Druks removes its outer whitespace. Missing paths, invalid traversal, and other result shapes return 401 without creating an account. Configuration defaults, examples, documentation, and tests use the same contract.

Closes #519. Tracking: [DRU-524](https://linear.app/fellaworks/issue/DRU-524/resolve-jwt-account-identity-with-json-pointer).

## Risk

This is an intentional configuration break. JWT deployments must replace bare claim names such as `email` with pointers such as `/email`. Bare names and dot paths fail configuration validation. There is no compatibility behavior or database migration.

Signature, issuer, audience, expiry, and bearer precedence stay unchanged. Traversal is restricted to JSON objects and arrays. No provider-specific extraction or account-linking behavior is added.
