### PR TITLE
Fix shared page sizing across the dashboard

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,6 +28,14 @@ runs lint, tests, and build for PRs into `main` and `codex/` stack branches.
 - Dashboard, Events, Usage, and Schedules
 - Shared routing and fallback behavior.
 
+`src/components/Page.tsx` owns page width, outer spacing, and scrolling. Use
+`<Page inset>` for a page with outer spacing. Use the shared `--page-gutter`
+for full-width list headers and rows. Do not cap or center a page body in
+page-specific CSS. Individual controls, forms, and prose can limit their width.
+
+`DetailLayout` owns the detail rail and main pane. Its `railWidth` prop sets
+the desktop rail width. The shared CSS stacks the panes on narrow screens.
+
 Bundled app UI lives under `src/apps/<name>/`. Its module calls
 `registerAppUI()` with routes and an optional home path. The backend app class
 declares the subnav tabs. The roster supplies these tabs to the frontend.

--- a/frontend/src/apps/software_factory/projects/ProjectsPage.tsx
+++ b/frontend/src/apps/software_factory/projects/ProjectsPage.tsx
@@ -49,64 +49,62 @@ export function ProjectsPage() {
 
   if (isLoading) {
     return (
-      <Page className="page-projects">
+      <Page inset className="page-projects">
         <EmptyState glyph="…" msg="loading projects" />
       </Page>
     )
   }
   if (isError || !data) {
     return (
-      <Page className="page-projects">
+      <Page inset className="page-projects">
         <EmptyState glyph="!" msg="could not load projects" />
       </Page>
     )
   }
 
   return (
-    <Page className="page-projects">
-      <div className="pj-col">
-        {deleteError && (
-          <div className="pj-toast pj-toast-error mono" role="alert">
-            {deleteError}
-          </div>
-        )}
-        <div className="pj-head">
-          <span className="pj-head-title">Projects</span>
-          <span className="pj-head-count mono">({data.projects.length})</span>
+    <Page inset className="page-projects">
+      {deleteError && (
+        <div className="pj-toast pj-toast-error mono" role="alert">
+          {deleteError}
         </div>
-
-        {data.projects.length === 0 ? (
-          <EmptyState
-            glyph="⊞"
-            msg="No projects yet"
-            sub="A project groups the GitHub repositories a build operates on. Each work item targets one of those repos for its changes, while the rest give agents cross-repo context. Name your first one to get started."
-            action={
-              <div className="pj-empty-create">
-                <CreateRow
-                  value={draft}
-                  onChange={setDraft}
-                  onCreate={onCreate}
-                  pending={createMutation.isPending}
-                />
-                <Field error={createMutation.error && String(createMutation.error)} />
-              </div>
-            }
-          />
-        ) : (
-          <div className="pj-list">
-            <CreateRow
-              value={draft}
-              onChange={setDraft}
-              onCreate={onCreate}
-              pending={createMutation.isPending}
-            />
-            <Field error={createMutation.error && String(createMutation.error)} />
-            {data.projects.map((p) => (
-              <ProjectCard key={p.id} project={p} onDeleteError={setDeleteError} />
-            ))}
-          </div>
-        )}
+      )}
+      <div className="pj-head">
+        <span className="pj-head-title">Projects</span>
+        <span className="pj-head-count mono">({data.projects.length})</span>
       </div>
+
+      {data.projects.length === 0 ? (
+        <EmptyState
+          glyph="⊞"
+          msg="No projects yet"
+          sub="A project groups the GitHub repositories a build operates on. Each work item targets one of those repos for its changes, while the rest give agents cross-repo context. Name your first one to get started."
+          action={
+            <div className="pj-empty-create">
+              <CreateRow
+                value={draft}
+                onChange={setDraft}
+                onCreate={onCreate}
+                pending={createMutation.isPending}
+              />
+              <Field error={createMutation.error && String(createMutation.error)} />
+            </div>
+          }
+        />
+      ) : (
+        <div className="pj-list">
+          <CreateRow
+            value={draft}
+            onChange={setDraft}
+            onCreate={onCreate}
+            pending={createMutation.isPending}
+          />
+          <Field error={createMutation.error && String(createMutation.error)} />
+          {data.projects.map((p) => (
+            <ProjectCard key={p.id} project={p} onDeleteError={setDeleteError} />
+          ))}
+        </div>
+      )}
     </Page>
   )
 }

--- a/frontend/src/components/DetailLayout.tsx
+++ b/frontend/src/components/DetailLayout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 
 /**
  * DetailLayout — the rail + main grid every detail page sits inside.
@@ -16,8 +16,7 @@ interface DetailLayoutProps {
 }
 
 export function DetailLayout({ rail, main, railWidth = 384 }: DetailLayoutProps) {
-  const style =
-    railWidth !== 384 ? { gridTemplateColumns: `${railWidth}px 1fr` } : undefined
+  const style = { '--detail-rail-width': `${railWidth}px` } as CSSProperties
   return (
     <div className="detail-body" style={style}>
       <aside className="detail-rail">{rail}</aside>

--- a/frontend/src/dashboard.css
+++ b/frontend/src/dashboard.css
@@ -1,4 +1,4 @@
-.dashboard .page-shell-body { width: min(100%, 1040px); margin-inline: auto; padding-block: 12px 40px; }
+.dashboard .page-shell-body { padding-block: 12px 40px; }
 .dashboard-head { display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; }
 .dashboard h1 { margin: 0 0 10px; font-size: 32px; font-weight: 500; letter-spacing: -.02em; }
 .dashboard-head p { margin: 0; color: var(--text-mid); font-size: 17px; }

--- a/frontend/src/schedules.css
+++ b/frontend/src/schedules.css
@@ -1,4 +1,3 @@
-.schedules-page .page-shell-body { max-width: 1040px; margin-inline: auto; }
 .schedules-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; }
 .schedules-head h1 { margin: 0 0 10px; font-size: 26px; font-weight: 500; }
 .schedules-head p { margin: 0; color: var(--text-mid); }

--- a/frontend/src/settings.css
+++ b/frontend/src/settings.css
@@ -164,7 +164,7 @@
 .app-settings-description { margin: 0 0 24px; color: var(--text-mid); }
 .settings-tabs a { display: flex; align-items: center; min-height: 44px; color: var(--text-dim); text-decoration: none; border-bottom: 2px solid transparent; }
 .settings-tabs a[aria-current="page"] { color: var(--text); border-color: var(--text); }
-.app-settings-layout { display: flex; flex-direction: column; gap: 24px; max-width: 1100px; }
+.app-settings-layout { display: flex; flex-direction: column; gap: 24px; }
 .app-settings-layout > .set-pane { min-width: 0; padding: 0; }
 .app-settings-layout .set-group { padding: 24px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); }
 .app-settings-layout .set-group-label { font-size: 18px; margin-bottom: 20px; }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -145,7 +145,7 @@ button { background: none; border: none; color: inherit; cursor: pointer; font: 
 
 .detail-body {
   display: grid;
-  grid-template-columns: 384px 1fr;
+  grid-template-columns: var(--detail-rail-width) minmax(0, 1fr);
   flex: 1;
   min-height: 0;
 }
@@ -1653,8 +1653,6 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .wic-call-label { font-size: 12px; color: var(--text-mid); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .wic-call-ledger { display: flex; gap: 10px; white-space: nowrap; }
 
-.pj-col { padding: 24px 20px 80px; }
-
 .pj-head {
   display: flex; align-items: baseline; gap: 12px;
   padding-bottom: 16px; border-bottom: 1px solid var(--border); margin-bottom: 24px;
@@ -1772,6 +1770,12 @@ textarea.set-textarea { background-image: none; height: auto; min-height: 96px; 
 .pj-addform-foot { display: flex; align-items: center; gap: 8px; margin-top: 2px; }
 
 .pj-empty-create { display: grid; gap: 8px; width: 100%; max-width: 440px; text-align: left; }
+
+@media (max-width: 940px) {
+  .pj-repo { grid-template-columns: minmax(0, 1fr) auto 24px; gap: 12px; }
+  .pj-repo-name { grid-column: 1 / -1; }
+  .pj-addform-fields { grid-template-columns: minmax(0, 1fr); gap: 12px; }
+}
 
 :root {
   --ins-scheduled: var(--text-faint);


### PR DESCRIPTION
Several dashboard pages override the shared layout, leaving unused space or clipping content on narrow screens.

- Remove the page-body width limits from Schedules, Dashboard, and app settings.
- Use Page inset for Projects, and reflow repository rows and the add-repository form on narrow screens.
- Let DetailLayout's shared breakpoint stack the panes when a custom desktop rail width is supplied. Previously, the inline columns left the information rail only 70 px wide on a 390 px screen.
- Document which layout properties the shared components own. Keep individual control, form, media, and prose width limits.

Validation: frontend lint, all 422 tests, and the production build pass on Node 22. Browser checks of the built pages with fixture data confirm the affected desktop and 390 px phone layouts. Projects controls fit, app settings fills the shared body, and work-item detail panes stack correctly. Backend tests were not run because this change only affects frontend layout and documentation.

Fixes DRU-527.
