### PR TITLE
Give each account its own token for Druks' own MCP server

### DIFF
--- a/backend/druks/accounts/dependencies.py
+++ b/backend/druks/accounts/dependencies.py
@@ -34,14 +34,17 @@ async def resolve_pat_account(
                 detail=str(error),
                 headers={"WWW-Authenticate": f'{_BEARER_CHALLENGE}, error="invalid_token"'},
             ) from error
-        if pat.tools is None:
+        if pat.allowed_tools is None:
             return pat.account
         # The MCP surface maps each agent route's endpoint to its tool name at boot.
-        if request.app.state.agent_tools.get(request.scope["endpoint"]) in pat.tools:
+        if request.app.state.agent_tools.get(request.scope["endpoint"]) in pat.allowed_tools:
             return pat.account
         raise HTTPException(
             status_code=403,
-            detail=f"Token {pat.token_prefix} is limited to these tools: {', '.join(pat.tools)}.",
+            detail=(
+                f"Token {pat.token_prefix} is limited to these tools: "
+                f"{', '.join(pat.allowed_tools)}."
+            ),
         )
     raise HTTPException(
         status_code=401,

--- a/backend/druks/accounts/models.py
+++ b/backend/druks/accounts/models.py
@@ -2,7 +2,7 @@ import base64
 import hashlib
 import hmac
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from sqlalchemy import ForeignKey, Index, LargeBinary, String, select, text
 from sqlalchemy.dialects.postgresql import CITEXT, JSONB, insert
@@ -120,9 +120,8 @@ class PersonalAccessToken(Base, Uuid7Pk):
     expires_at: Mapped[datetime]
     last_used_at: Mapped[datetime | None]
     revoked_at: Mapped[datetime | None]
-    # None: the account's whole API. A list: only these agent tools, by their
-    # MCP names. A sandbox holds such a token and reaches nothing else.
-    tools: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
+    # None is the account's whole API; a list only those agent tools, by MCP name.
+    allowed_tools: Mapped[list[str] | None] = mapped_column(JSONB, default=None)
 
     @property
     def is_expired(self) -> bool:
@@ -156,8 +155,7 @@ class PersonalAccessToken(Base, Uuid7Pk):
         *,
         account_id: str,
         name: str,
-        tools: list[str] | None = None,
-        lifetime: timedelta = PAT_LIFETIME,
+        allowed_tools: list[str] | None = None,
     ) -> "tuple[PersonalAccessToken, str]":
         """Mint ``account_id`` a token; returns (row, plaintext). The plaintext
         is shown exactly once — only its hash lands in the row."""
@@ -174,8 +172,8 @@ class PersonalAccessToken(Base, Uuid7Pk):
             token_prefix=prefix,
             token_hash=_hash_token(token),
             created_at=now,
-            expires_at=now + lifetime,
-            tools=tools,
+            expires_at=now + PAT_LIFETIME,
+            allowed_tools=allowed_tools,
         )
         session = db_session()
         session.add(row)
@@ -207,8 +205,3 @@ class PersonalAccessToken(Base, Uuid7Pk):
         # Keep the first revocation instant — a repeat revoke changes nothing.
         self.revoked_at = self.revoked_at or Base.utc_now()
         await db_session().flush()
-
-    async def delete(self) -> None:
-        session = db_session()
-        await session.delete(self)
-        await session.flush()

--- a/backend/druks/contrib/software_factory/app.py
+++ b/backend/druks/contrib/software_factory/app.py
@@ -22,7 +22,6 @@ from druks.contrib.software_factory.ticketing.linear import Linear
 from druks.core import services
 from druks.doctor import CheckResult
 from druks.services import ServiceNotConnectedError
-from druks.settings import load_settings
 
 from .services import GithubReviewer
 
@@ -57,20 +56,6 @@ async def check_review_identity() -> CheckResult:
         )
     return CheckResult(
         name="review_identity", ok=True, detail="unset — reviews publish as operator comments"
-    )
-
-
-async def check_issues_mcp() -> CheckResult:
-    """Whether ``urls.endpoint`` names the /mcp an issues build's sandbox reaches."""
-    if (await SoftwareFactory.settings()).tracker != "issues":
-        return CheckResult(name="issues_mcp", ok=True, detail="not required")
-    if endpoint := load_settings().urls.endpoint.rstrip("/"):
-        return CheckResult(name="issues_mcp", ok=True, detail=f"{endpoint}/mcp")
-    return CheckResult(
-        name="issues_mcp",
-        ok=False,
-        pending=True,
-        detail="urls.endpoint is unset. The sandbox needs it to reach /mcp.",
     )
 
 
@@ -142,7 +127,7 @@ class SoftwareFactory(App):
                 return IssuesStatus.READY_FOR_AGENT.label
             return ""
 
-    checks = [check_tracker_identity, check_review_identity, check_issues_mcp]
+    checks = [check_tracker_identity, check_review_identity]
 
     @classmethod
     async def get_tracker(cls, source: str | None = None) -> Tracker | None:

--- a/backend/druks/contrib/software_factory/constants.py
+++ b/backend/druks/contrib/software_factory/constants.py
@@ -1,20 +1,13 @@
-from datetime import timedelta
-
 # The github MCP server build ships into its own runs — build's requirement
 # (there is no build without github), not an operator-facing catalog entry.
 # Its token is per-repo, minted at workspace setup from the identity reviews
 # act as (druks.contrib.software_factory.github).
 GITHUB_MCP_NAME = "github"
 GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
-# The appliance /mcp, required when the tracker is issues. The sandbox holds a
-# token limited to these tools, minted per agent call and deleted after it.
-APPLIANCE_MCP_NAME = "druks"
-APPLIANCE_MCP_TOOLS = (
+TICKET_TOOLS = (
     "software_factory_get_ticket",
     "software_factory_add_comment",
     "software_factory_set_status",
     "software_factory_update_ticket",
     "software_factory_create_ticket",
 )
-# The backstop for a call that dies before deleting its token.
-APPLIANCE_MCP_TOKEN_LIFETIME = timedelta(days=1)

--- a/backend/druks/contrib/software_factory/workflows.py
+++ b/backend/druks/contrib/software_factory/workflows.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
-from druks.accounts.models import Account, PersonalAccessToken
+from druks.accounts.models import Account
 from druks.contrib.software_factory.contracts import ImplementationOutput, ReviewWork
 from druks.contrib.software_factory.enums import (
     EvaluationVerdict,
@@ -16,8 +16,8 @@ from druks.contrib.software_factory.ticketing.enums import TicketStatus
 from druks.core.apis.github import get_github_client
 from druks.core.services import Github
 from druks.durable.enums import RunState
-from druks.mcp.helpers import get_bearer_token_env_var
-from druks.sandbox.datastructures import McpServer, RequiredMcpServer
+from druks.mcp.inbound import get_druks_mcp_server
+from druks.sandbox.datastructures import RequiredMcpServer
 from druks.sandbox.layout import get_related_root, get_work_root
 from druks.sandbox.models import SecretRef
 from druks.services.exceptions import ServiceNotConnectedError
@@ -27,13 +27,7 @@ from druks.workflows import FatalError, Workflow, step
 from druks.workspaces import RepoWorkspace
 
 from .app import SoftwareFactory
-from .constants import (
-    APPLIANCE_MCP_NAME,
-    APPLIANCE_MCP_TOKEN_LIFETIME,
-    APPLIANCE_MCP_TOOLS,
-    GITHUB_MCP_NAME,
-    GITHUB_MCP_URL,
-)
+from .constants import GITHUB_MCP_NAME, GITHUB_MCP_URL, TICKET_TOOLS
 from .datastructures import PullRequest
 from .github import get_review_actor
 from .journal import BuildJournal
@@ -46,22 +40,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def appliance_mcp_url() -> str:
-    """The appliance /mcp at ``urls.endpoint``, an address the sandbox reaches."""
-    if endpoint := load_settings().urls.endpoint.rstrip("/"):
-        return f"{endpoint}/mcp"
-    raise FatalError(
-        "urls.endpoint is unset. Set it to an address the sandbox reaches, so the "
-        "issues tracker tools can call /mcp."
-    )
-
-
 @dataclass(frozen=True, kw_only=True)
 class BuildWorkspace(RepoWorkspace):
     skills: tuple[str, ...]
-    # The appliance /mcp, set only when the tracker is issues. Its token is
-    # minted per agent call in run_agent, so it never rides a vault row.
-    appliance_mcp_url: str = ""
 
     @property
     def workspace_root(self) -> str:
@@ -71,52 +52,20 @@ class BuildWorkspace(RepoWorkspace):
     async def get_required_mcp_servers(cls, subject: Any) -> tuple[RequiredMcpServer, ...]:
         # GitHub MCP acts as the review actor; the clone acts as the operator.
         actor = await get_review_actor()
-        return (
-            RequiredMcpServer(
-                name=GITHUB_MCP_NAME,
-                url=GITHUB_MCP_URL,
-                secret_id=(await actor.service.get()).id,
-                resource=cls.get_repo(subject),
-            ),
+        github = RequiredMcpServer(
+            name=GITHUB_MCP_NAME,
+            url=GITHUB_MCP_URL,
+            secret_id=(await actor.service.get()).id,
+            resource=cls.get_repo(subject),
         )
-
-    async def with_mcp_servers(self, account_id: str | None, **kwargs: Any) -> dict[str, Any]:
-        kwargs = await super().with_mcp_servers(account_id, **kwargs)
-        if self.appliance_mcp_url:
-            servers = [
-                server
-                for server in kwargs.get("mcp_servers") or ()
-                if server.name != APPLIANCE_MCP_NAME
-            ]
-            servers.append(
-                McpServer(
-                    name=APPLIANCE_MCP_NAME,
-                    url=self.appliance_mcp_url,
-                    bearer_token_env_var=get_bearer_token_env_var(APPLIANCE_MCP_NAME),
-                )
-            )
-            kwargs["mcp_servers"] = tuple(servers)
-        return kwargs
+        if (await SoftwareFactory.settings()).tracker == "issues":
+            return (github, get_druks_mcp_server(allowed_tools=TICKET_TOOLS))
+        return (github,)
 
     async def run_agent(self, *, account_id: str | None, **kwargs: Any):
         # Agents clone related repos on demand; Claude's --add-dir target must exist first.
         related_root = get_related_root(self.host.ssh_username)
         await self.host.exec(["mkdir", "-p", related_root], timeout=10.0)
-        if self.appliance_mcp_url:
-            # One token per agent call, limited to the ticket tools, deleted when
-            # the call ends. The lifetime is the backstop for a call that dies.
-            account = await Account.get_for_run(account_id)
-            pat, token = await PersonalAccessToken.create(
-                account_id=account.id,
-                name="issues sandbox",
-                tools=list(APPLIANCE_MCP_TOOLS),
-                lifetime=APPLIANCE_MCP_TOKEN_LIFETIME,
-            )
-            kwargs["extra_env"] = {get_bearer_token_env_var(APPLIANCE_MCP_NAME): token}
-            try:
-                return await super().run_agent(account_id=account_id, **kwargs)
-            finally:
-                await pat.delete()
         return await super().run_agent(account_id=account_id, **kwargs)
 
     def get_agent_run_kwargs(self, **kwargs: Any) -> dict[str, Any]:
@@ -263,8 +212,6 @@ class Build(Workflow):
             "branch": self.branch,
             "skills": tuple(self._profile.get("recommended_skills", [])),
         }
-        if (await SoftwareFactory.settings()).tracker == "issues":
-            kwargs["appliance_mcp_url"] = appliance_mcp_url()
         return kwargs
 
     async def get_prompt_context(self, **context: Any) -> dict[str, Any]:

--- a/backend/druks/mcp/constants.py
+++ b/backend/druks/mcp/constants.py
@@ -11,6 +11,9 @@ TOKEN_ENV_SUFFIX = "_TOKEN"
 # two names never collapse to one env var.
 NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 
+# Druks' own MCP server, as a box names it.
+DRUKS_SERVER_NAME = "druks"
+
 # The header a server's bearer fills, and its prefix. A secret header keeps
 # its own name and no prefix.
 BEARER_HEADER = "Authorization"

--- a/backend/druks/mcp/exceptions.py
+++ b/backend/druks/mcp/exceptions.py
@@ -33,6 +33,15 @@ class MissingTokenError(McpServerError):
         self.name = name
 
 
+class MissingEndpointError(McpServerError):
+    def __init__(self, name: str):
+        super().__init__(
+            f"MCP server {name!r} is this appliance; set urls.endpoint to an address "
+            "its sandboxes reach."
+        )
+        self.name = name
+
+
 class InvalidCatalogError(McpServerError):
     # The catalog declares a deployment's default servers; a file that can't be
     # read or an entry that would emit a broken config stops boot by name —

--- a/backend/druks/mcp/inbound.py
+++ b/backend/druks/mcp/inbound.py
@@ -1,0 +1,39 @@
+from druks.accounts.models import PersonalAccessToken
+from druks.mcp.constants import BEARER_HEADER, DRUKS_SERVER_NAME
+from druks.mcp.exceptions import MissingEndpointError
+from druks.sandbox.datastructures import RequiredMcpServer
+from druks.secrets.datastructures import Audience
+from druks.secrets.enums import SecretKind
+from druks.secrets.models import VaultSecret
+from druks.settings import load_settings
+
+
+def get_druks_mcp_server(*, allowed_tools: tuple[str, ...]) -> RequiredMcpServer:
+    """Druks' own `/mcp` as a workspace requires it, at the address a box reaches."""
+    if endpoint := load_settings().urls.endpoint.rstrip("/"):
+        return RequiredMcpServer(
+            name=DRUKS_SERVER_NAME, url=f"{endpoint}/mcp", allowed_tools=allowed_tools
+        )
+    raise MissingEndpointError(DRUKS_SERVER_NAME)
+
+
+async def get_druks_account_token(account_id: str, allowed_tools: tuple[str, ...]) -> VaultSecret:
+    """This account's token row, minted when a run of theirs first needs it."""
+    audience = Audience.mcp(DRUKS_SERVER_NAME)
+    row = await VaultSecret.lookup(SecretKind.STATIC, audience, account_id, BEARER_HEADER)
+    held = await PersonalAccessToken.get_for_prefix(row.identity["token_prefix"]) if row else None
+    if held and held.status == "active":
+        return row
+    minted, token = await PersonalAccessToken.create(
+        account_id=account_id,
+        name=f"{DRUKS_SERVER_NAME} MCP",
+        allowed_tools=list(allowed_tools) or None,
+    )
+    return await VaultSecret.store(
+        SecretKind.STATIC,
+        audience,
+        secrets={"value": token},
+        identity={"token_prefix": minted.token_prefix},
+        account_id=account_id,
+        header=BEARER_HEADER,
+    )

--- a/backend/druks/mcp/models.py
+++ b/backend/druks/mcp/models.py
@@ -61,7 +61,7 @@ class McpServer(Base, Uuid7Pk):
         rows = {server.name: server for server in await cls.list_all()}
         tokens: dict[str, VaultSecret] = {}
         secret_headers: dict[str, dict[str, VaultSecret]] = {}
-        for secret in await VaultSecret.list_tokens():
+        for secret in await VaultSecret.list_installation_tokens():
             if secret.header == BEARER_HEADER:
                 tokens[secret.audience_name] = secret
             else:

--- a/backend/druks/sandbox/datastructures.py
+++ b/backend/druks/sandbox/datastructures.py
@@ -154,15 +154,17 @@ class McpServer:
 
 @dataclass(frozen=True)
 class RequiredMcpServer:
-    """An MCP server a workspace requires for its runs. ``secret_id`` names
-    the vault row the box's entry issues from, and ``resource`` what the token
-    is for: Software Factory's review identity and the repo. It owns its
-    name: a same-named registry entry is not delivered."""
+    """An MCP server a workspace requires for its runs. ``secret_id`` names the
+    vault row the box's entry issues from and ``resource`` what its token is for;
+    no ``secret_id`` names this appliance, whose token Druks mints for the run's
+    account, limited to ``allowed_tools``. It owns its name: a same-named
+    registry entry is not delivered."""
 
     name: str
     url: str
-    secret_id: str
+    secret_id: str = ""
     resource: str = ""
+    allowed_tools: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/backend/druks/secrets/models.py
+++ b/backend/druks/secrets/models.py
@@ -99,6 +99,14 @@ class VaultSecret(Base, Uuid7Pk):
         return await cls._list(SecretKind.STATIC, where)
 
     @classmethod
+    async def list_installation_tokens(cls) -> list["VaultSecret"]:
+        """The MCP bearers and secret headers the installation holds. An account's
+        own token is theirs, and never stands in for one of these."""
+        return await cls._list(
+            SecretKind.STATIC, cls.audience.startswith("mcp:"), cls.account_id.is_(None)
+        )
+
+    @classmethod
     async def list_subscriptions(
         cls, audience: str | None = None, *, account_id: str | None = None
     ) -> list["VaultSecret"]:

--- a/backend/druks/workspaces.py
+++ b/backend/druks/workspaces.py
@@ -23,6 +23,7 @@ from druks.mcp.constants import TOKEN_ENV_PREFIX
 from druks.mcp.enums import IdentityMode, TokenSource
 from druks.mcp.exceptions import MissingGrantError, MissingTokenError
 from druks.mcp.helpers import get_bearer_token_env_var, get_grant_account
+from druks.mcp.inbound import get_druks_account_token
 from druks.sandbox import repo as checkout
 from druks.sandbox.datastructures import AgentResult, McpServer, RequiredMcpServer
 from druks.sandbox.exceptions import ExecFailed
@@ -178,10 +179,16 @@ class Workspace:
         for server in required:
             variable = get_bearer_token_env_var(server.name)
             wire.append(McpServer(name=server.name, url=server.url, bearer_token_env_var=variable))
+            if server.secret_id:
+                secret_id = server.secret_id
+            else:
+                account = await Account.get_for_run(account_id)
+                row = await get_druks_account_token(account.id, server.allowed_tools)
+                secret_id = row.id
             refs.append(
                 SecretRef(
                     name=variable.lower(),
-                    secret_id=server.secret_id,
+                    secret_id=secret_id,
                     resource=server.resource,
                     host=urlsplit(server.url).hostname,
                 )

--- a/backend/migrations/versions/9c4e7a1b5d28_sandbox_token_tools_and_generated_prefixes.py
+++ b/backend/migrations/versions/9c4e7a1b5d28_sandbox_token_tools_and_generated_prefixes.py
@@ -30,7 +30,7 @@ def _derive_prefix(name: str, taken: set[str]) -> str:
 def upgrade() -> None:
     op.add_column(
         "personal_access_tokens",
-        sa.Column("tools", postgresql.JSONB(), nullable=True),
+        sa.Column("allowed_tools", postgresql.JSONB(), nullable=True),
     )
 
     bind = op.get_bind()

--- a/backend/tests/software_factory/test_build_workspace.py
+++ b/backend/tests/software_factory/test_build_workspace.py
@@ -7,14 +7,11 @@ from typing import Any
 import pytest
 from conftest import connect_service
 from druks import workspaces as workspace_mod
-from druks.accounts.exceptions import InvalidPatError
-from druks.accounts.models import Account, PersonalAccessToken
 from druks.contrib.software_factory.app import SoftwareFactory
 from druks.contrib.software_factory.constants import (
-    APPLIANCE_MCP_NAME,
-    APPLIANCE_MCP_TOOLS,
     GITHUB_MCP_NAME,
     GITHUB_MCP_URL,
+    TICKET_TOOLS,
 )
 from druks.contrib.software_factory.services import GithubReviewer
 from druks.contrib.software_factory.workflows import Build, BuildWorkspace, ReviewWorkspace
@@ -22,7 +19,6 @@ from druks.core.services import Github
 from druks.mcp.helpers import get_bearer_token_env_var
 from druks.sandbox import host as host_mod
 from druks.sandbox.layout import get_related_root, get_repo_root
-from druks.workflows import FatalError
 from druks.workspaces import RepoWorkspace
 
 
@@ -118,61 +114,6 @@ async def test_get_workspace_kwargs_carries_the_build_fields():
     }
 
 
-async def test_issues_tracker_requires_appliance_mcp(druks_db):
-    await connect_service(
-        "github", identity={"app_id": "1", "slug": "druks-operator"}, secrets={"private_key": "pem"}
-    )
-    await connect_service(
-        "github_reviewer",
-        identity={"app_id": "2", "slug": "druks-reviewer"},
-        secrets={"private_key": "reviewer-pem"},
-    )
-    workspace = BuildWorkspace(
-        host=_FakeSandbox(),  # type: ignore[arg-type]
-        subject=SimpleNamespace(repo="o/main"),
-        branch="b",
-        skills=("python-house-rules",),
-        appliance_mcp_url="http://druks.test/mcp",
-    )
-    kwargs = await workspace.with_mcp_servers(None, **workspace.get_agent_run_kwargs())
-
-    appliance = next(s for s in kwargs["mcp_servers"] if s.name == APPLIANCE_MCP_NAME)
-    assert appliance.url == "http://druks.test/mcp"
-    assert appliance.bearer_token_env_var == get_bearer_token_env_var(APPLIANCE_MCP_NAME)
-    assert "extra_env" not in kwargs
-
-
-async def test_an_issues_agent_call_holds_a_ticket_token_only_while_it_runs(
-    druks_db, monkeypatch: pytest.MonkeyPatch
-):
-    account = await Account.get_or_create("op@example.com")
-    seen: dict[str, Any] = {}
-
-    async def fake_exec(self: Any, argv: list[str], **_kw: Any) -> None:
-        return
-
-    async def base_run_agent(self: Any, **kwargs: Any) -> str:
-        seen["token"] = kwargs["extra_env"][get_bearer_token_env_var(APPLIANCE_MCP_NAME)]
-        pat = await PersonalAccessToken.authenticate(seen["token"])
-        seen["holder"] = (pat.account_id, pat.tools)
-        return "ran"
-
-    monkeypatch.setattr(host_mod.Host, "exec", fake_exec)
-    monkeypatch.setattr(RepoWorkspace, "run_agent", base_run_agent)
-    workspace = BuildWorkspace(
-        host=host_mod.Host(record=SimpleNamespace(id="h1", ssh_username="exedev")),  # type: ignore[arg-type]
-        subject=SimpleNamespace(repo="o/main"),
-        branch="b",
-        skills=(),
-        appliance_mcp_url="http://druks.test/mcp",
-    )
-
-    assert await workspace.run_agent(account_id=account.id) == "ran"
-    assert seen["holder"] == (account.id, list(APPLIANCE_MCP_TOOLS))
-    with pytest.raises(InvalidPatError):
-        await PersonalAccessToken.authenticate(seen["token"])
-
-
 def _pin_tracker(monkeypatch: pytest.MonkeyPatch, tracker: str) -> None:
     settings = SoftwareFactory.Settings(tracker=tracker)
 
@@ -182,50 +123,39 @@ def _pin_tracker(monkeypatch: pytest.MonkeyPatch, tracker: str) -> None:
     monkeypatch.setattr(SoftwareFactory, "settings", classmethod(_settings))
 
 
-def _issues_workspace(monkeypatch: pytest.MonkeyPatch) -> tuple[Build, Any]:
-    _pin_tracker(monkeypatch, "issues")
-    monkeypatch.setattr(
-        "druks.contrib.software_factory.workflows.load_settings",
-        lambda: SimpleNamespace(urls=SimpleNamespace(endpoint="http://127.0.0.1:8001")),
+async def _required_servers(monkeypatch: pytest.MonkeyPatch, tracker: str):
+    await connect_service(
+        "github", identity={"app_id": "1", "slug": "druks-operator"}, secrets={"private_key": "pem"}
     )
-    sandbox = host_mod.Host(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
-    workflow = Build()
-    workflow.input = Build._run_input_model()
-    workflow.subject = SimpleNamespace(repo="o/app")
-    workflow._profile = {"recommended_skills": ["python-house-rules"]}
-    workflow.account_id = None
-    return workflow, sandbox
-
-
-async def test_get_workspace_kwargs_names_the_appliance_mcp(druks_db, monkeypatch):
-    workflow, sandbox = _issues_workspace(monkeypatch)
-
-    kwargs = await workflow.get_workspace_kwargs(sandbox)
-
-    assert kwargs["appliance_mcp_url"] == "http://127.0.0.1:8001/mcp"
-
-
-async def test_get_workspace_kwargs_fails_when_endpoint_is_unset(druks_db, monkeypatch):
-    workflow, sandbox = _issues_workspace(monkeypatch)
+    await connect_service(
+        "github_reviewer",
+        identity={"app_id": "2", "slug": "druks-reviewer"},
+        secrets={"private_key": "reviewer-pem"},
+    )
     monkeypatch.setattr(
-        "druks.contrib.software_factory.workflows.load_settings",
-        lambda: SimpleNamespace(urls=SimpleNamespace(endpoint="")),
+        "druks.mcp.inbound.load_settings",
+        lambda: SimpleNamespace(urls=SimpleNamespace(endpoint="https://druks.test")),
+    )
+    _pin_tracker(monkeypatch, tracker)
+    return await BuildWorkspace.get_required_mcp_servers(SimpleNamespace(repo="o/main"))
+
+
+async def test_a_board_build_requires_the_appliance_mcp(druks_db, monkeypatch):
+    servers = await _required_servers(monkeypatch, "issues")
+
+    assert [server.name for server in servers] == [GITHUB_MCP_NAME, "druks"]
+    board = servers[-1]
+    assert (board.url, board.secret_id, board.allowed_tools) == (
+        "https://druks.test/mcp",
+        "",
+        TICKET_TOOLS,
     )
 
-    with pytest.raises(FatalError, match="/mcp"):
-        await workflow.get_workspace_kwargs(sandbox)
 
+async def test_a_linear_build_requires_github_alone(druks_db, monkeypatch):
+    servers = await _required_servers(monkeypatch, "linear")
 
-async def test_linear_tracker_does_not_require_appliance_mcp(druks_db, monkeypatch):
-    sandbox = host_mod.Host(record=SimpleNamespace(id="h1", ssh_username="exedev"))  # type: ignore[arg-type]
-    workflow = Build()
-    workflow.input = Build._run_input_model()
-    workflow.subject = SimpleNamespace(repo="o/app")
-    workflow._profile = {"recommended_skills": ["python-house-rules"]}
-
-    kwargs = await workflow.get_workspace_kwargs(sandbox)
-
-    assert "appliance_mcp_url" not in kwargs
+    assert [server.name for server in servers] == [GITHUB_MCP_NAME]
 
 
 def _review_actor_stub(monkeypatch: pytest.MonkeyPatch, *, review_actor) -> None:

--- a/backend/tests/software_factory/test_ticketing.py
+++ b/backend/tests/software_factory/test_ticketing.py
@@ -1,15 +1,10 @@
 import json
-from types import SimpleNamespace
 
 import httpx
 import pytest
 from conftest import connect_service
 from druks.apps.settings import field_choices, field_visibility
-from druks.contrib.software_factory.app import (
-    SoftwareFactory,
-    check_issues_mcp,
-    check_tracker_identity,
-)
+from druks.contrib.software_factory.app import SoftwareFactory, check_tracker_identity
 from druks.contrib.software_factory.ticketing.enums import TicketStatus
 from druks.contrib.software_factory.ticketing.issues import IssuesTracker
 from druks.contrib.software_factory.ticketing.jira import Jira
@@ -241,42 +236,6 @@ async def test_tracker_builds_issues_without_credentials(druks_db, monkeypatch):
 
     assert isinstance(tracker, IssuesTracker)
     assert await SoftwareFactory.get_tracker("linear") is None
-
-
-async def test_issues_mcp_check_skips_when_tracker_is_not_issues(monkeypatch):
-    _pin_software_factory_settings(monkeypatch, tracker="linear")
-
-    result = await check_issues_mcp()
-
-    assert result.ok
-    assert result.detail == "not required"
-
-
-async def test_issues_mcp_check_pends_without_an_endpoint(monkeypatch):
-    _pin_software_factory_settings(monkeypatch, tracker="issues")
-    monkeypatch.setattr(
-        "druks.contrib.software_factory.app.load_settings",
-        lambda: SimpleNamespace(urls=SimpleNamespace(endpoint="")),
-    )
-
-    result = await check_issues_mcp()
-
-    assert not result.ok
-    assert result.pending
-    assert "/mcp" in result.detail
-
-
-async def test_issues_mcp_check_reports_the_endpoint(monkeypatch):
-    _pin_software_factory_settings(monkeypatch, tracker="issues")
-    monkeypatch.setattr(
-        "druks.contrib.software_factory.app.load_settings",
-        lambda: SimpleNamespace(urls=SimpleNamespace(endpoint="http://druks.test:8001/")),
-    )
-
-    result = await check_issues_mcp()
-
-    assert result.ok
-    assert result.detail == "http://druks.test:8001/mcp"
 
 
 # --- Linear provider --------------------------------------------------------

--- a/backend/tests/test_auth_pats.py
+++ b/backend/tests/test_auth_pats.py
@@ -110,7 +110,9 @@ async def test_a_tools_limited_token_is_refused_outside_its_tools(tmp_path, druk
     with _client(tmp_path) as client:
         account = await Account.get_or_create("agent@example.com")
         _, token = await PersonalAccessToken.create(
-            account_id=account.id, name="sandbox", tools=["software_factory_get_ticket"]
+            account_id=account.id,
+            name="sandbox",
+            allowed_tools=["software_factory_get_ticket"],
         )
         for path in ("/api/auth/me", "/api/settings"):
             response = client.get(path, headers=_bearer(token))

--- a/backend/tests/test_mcp_endpoint.py
+++ b/backend/tests/test_mcp_endpoint.py
@@ -261,7 +261,9 @@ async def test_a_ticket_token_reaches_only_its_tools(app, account):
     repo = await ProjectRepo.create(project_id=project.id, full_name="acme/widget")
     ticket = await Ticket.create(repo=repo, title="Add an endpoint")
     _, token = await PersonalAccessToken.create(
-        account_id=account.id, name="issues sandbox", tools=["software_factory_get_ticket"]
+        account_id=account.id,
+        name="issues sandbox",
+        allowed_tools=["software_factory_get_ticket"],
     )
 
     async with live(app), _client(app, token) as client:

--- a/backend/tests/test_mcp_servers.py
+++ b/backend/tests/test_mcp_servers.py
@@ -1,20 +1,24 @@
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from conftest import connect_service
+from druks.accounts.models import Account, PersonalAccessToken
 from druks.apps.registry import mcp_servers
 from druks.harnesses.claude import ClaudeHarness
 from druks.harnesses.codex import CodexHarness
 from druks.harnesses.datastructures import SandboxSettings
 from druks.mcp.catalog import load_mcp_catalog
-from druks.mcp.constants import BEARER_HEADER
+from druks.mcp.constants import BEARER_HEADER, DRUKS_SERVER_NAME
 from druks.mcp.exceptions import (
     InvalidCatalogError,
     InvalidServerNameError,
+    MissingEndpointError,
     MissingTokenError,
 )
 from druks.mcp.helpers import get_bearer_token_env_var
+from druks.mcp.inbound import get_druks_mcp_server
 from druks.mcp.models import McpServer
 from druks.sandbox.datastructures import RequiredMcpServer
 from druks.sandbox.models import SecretRef
@@ -603,3 +607,83 @@ async def test_catalog_enabled_false_ships_the_entry_dark(tmp_path, registry_sta
     enabled_names = {s["name"] for s in await McpServer.list_enabled()}
     assert "dark_test" not in enabled_names
     assert "lit_test" in enabled_names
+
+
+# --- druks' own server: each account's token, on first use -----------------
+
+
+def _requiring_druks(monkeypatch, allowed_tools=()) -> type[Workspace]:
+    monkeypatch.setattr(
+        "druks.mcp.inbound.load_settings",
+        lambda: SimpleNamespace(urls=SimpleNamespace(endpoint="https://druks.test/")),
+    )
+    return _requiring(get_druks_mcp_server(allowed_tools=allowed_tools))
+
+
+async def _druks_row(account_id: str) -> VaultSecret:
+    return await VaultSecret.lookup(
+        SecretKind.STATIC, Audience.mcp(DRUKS_SERVER_NAME), account_id, BEARER_HEADER
+    )
+
+
+def test_druks_needs_an_address_a_box_reaches(monkeypatch):
+    monkeypatch.setattr(
+        "druks.mcp.inbound.load_settings",
+        lambda: SimpleNamespace(urls=SimpleNamespace(endpoint="")),
+    )
+
+    with pytest.raises(MissingEndpointError):
+        get_druks_mcp_server(allowed_tools=())
+
+
+async def test_delivery_mints_the_run_account_its_own_token(druks_db, monkeypatch):
+    allowed_tools = ("software_factory_get_ticket",)
+    workspace = _requiring_druks(monkeypatch, allowed_tools)
+    account = await Account.get_or_create("op@example.com")
+
+    wire, refs = await workspace.get_mcp_delivery(None, account.id)
+
+    row = await _druks_row(account.id)
+    minted = await PersonalAccessToken.authenticate(row.secrets["value"])
+    assert (minted.account_id, minted.allowed_tools) == (account.id, list(allowed_tools))
+    server = next(one for one in wire if one.name == DRUKS_SERVER_NAME)
+    assert server.url == "https://druks.test/mcp"
+    assert server.bearer_token_env_var == "MCP_DRUKS_TOKEN"
+    assert {ref.name: ref.secret_id for ref in refs}["mcp_druks_token"] == row.id
+    # An account's own row never stands in for the installation's.
+    assert not await _bearer_row(DRUKS_SERVER_NAME)
+
+
+async def test_a_later_run_reuses_the_token_and_a_retired_one_is_replaced(druks_db, monkeypatch):
+    workspace = _requiring_druks(monkeypatch)
+    account = await Account.get_or_create("op@example.com")
+    await workspace.get_mcp_delivery(None, account.id)
+    first = (await _druks_row(account.id)).secrets["value"]
+    # No tools: the token carries the account's whole API.
+    assert (await PersonalAccessToken.authenticate(first)).allowed_tools is None
+
+    await workspace.get_mcp_delivery(None, account.id)
+
+    assert (await _druks_row(account.id)).secrets["value"] == first
+    assert len(await PersonalAccessToken.list_for_account(account.id)) == 1
+
+    await (await PersonalAccessToken.authenticate(first)).revoke()
+    await workspace.get_mcp_delivery(None, account.id)
+
+    assert (await _druks_row(account.id)).secrets["value"] != first
+    assert len(await PersonalAccessToken.list_for_account(account.id)) == 2
+
+
+async def test_two_accounts_hold_their_own_tokens(druks_db, monkeypatch):
+    workspace = _requiring_druks(monkeypatch)
+    first = await Account.get_or_create("first@example.com")
+    second = await Account.get_or_create("second@example.com")
+
+    await workspace.get_mcp_delivery(None, first.id)
+    await workspace.get_mcp_delivery(None, second.id)
+
+    rows = [await _druks_row(first.id), await _druks_row(second.id)]
+    holders = [
+        (await PersonalAccessToken.authenticate(row.secrets["value"])).account_id for row in rows
+    ]
+    assert holders == [first.id, second.id]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,7 +137,7 @@ caches, and the sandbox provisioning gate.
 
 | TOML key | Purpose |
 | --- | --- |
-| `urls.endpoint` | Browser-visible dashboard base URL for MCP OAuth callbacks and sandbox access to this appliance's `/mcp` |
+| `urls.endpoint` | Browser-visible dashboard base URL. MCP OAuth callbacks and this appliance's own `/mcp` address come from it |
 | `urls.webhook_host` | Public webhook hostname used by `druks doctor` for its ingress probe |
 | `identity.mode` | `none` (default, no authentication, single operator), `header` (edge-asserted identity), or `jwt` (validated edge-signed assertion) |
 | `identity.header` | The trusted identity header. The shipped Caddy edge also uses it. Header and JWT modes have no default and require it |
@@ -344,14 +344,15 @@ A ticket that enters Ready for Agent opens a build against the selected
 repository. If a scheduled, running, or parked run already exists for that
 ticket, Software Factory does not start another.
 
-Each local-board build ships this appliance's `/mcp` into the sandbox as the
-`druks` server. The sandbox holds a token for the run account that is limited
-to the ticket tools. Druks mints it for each agent call and deletes it after.
-The agent reads the ticket with `software_factory_get_ticket` and posts with
-`software_factory_add_comment`. The Druks identifier is not a GitHub issue
-number. Linear and Jira builds do not receive this MCP. Set `urls.endpoint` to
-an address the sandbox can reach; `druks doctor` reports it when the tracker
-is **druks**.
+An agent reads and answers a board ticket through this appliance's own `/mcp`.
+A build whose tracker is **druks** requires that server, so there is nothing to
+paste, connect, or declare. Druks mints the token of the account the run belongs
+to, limited to the five ticket tools, so a comment the agent writes carries that
+person's name. The token appears in that person's API tokens, and Druks mints
+another once they retire it. The server's address comes from `urls.endpoint`, so
+set it to an address the sandboxes reach. The agent reads the ticket with
+`software_factory_get_ticket` and posts with `software_factory_add_comment`. A
+Druks identifier is not a GitHub issue number.
 
 Webhook URLs remain `/_external/linear/events/` and
 `/_external/jira/events/`. The Jira webhook uses a Jira Automation


### PR DESCRIPTION
Each account holds its own token for Druks' own `/mcp`. A comment the agent writes on a board ticket then carries the name of the person the run belongs to, instead of one name for the whole installation.

## How it works

A workspace asks for that server the way it asks for any other, and it names no vault row:

```python
return (github, get_druks_mcp_server(allowed_tools=TICKET_TOOLS))
```

Delivery mints the token of the account the run belongs to, stores it as that account's vault row, and reuses it until the account retires it. The server's address comes from `urls.endpoint`. Nothing is pasted, connected, or declared by an operator.

## What changed

- `RequiredMcpServer` takes `allowed_tools` and no longer needs a `secret_id`: without one it names this appliance, and delivery resolves the run account's row.
- `druks/mcp/inbound.py` holds both halves: `get_druks_mcp_server` for the declaration, and `get_druks_account_token` for the account's row, minted on first use and again once the token it holds is no longer active. It imports no web framework, so the workspace module stays light.
- `VaultSecret.list_installation_tokens` is the installation's own read, so an account's token never stands in for one of them.
- Software Factory asks for that server when its tracker is the board. What it used to do by hand is gone: the server's name and address, the token it minted for each agent call, and the `issues_mcp` doctor check.
- A token's tool list is `allowed_tools`, on the column and in the declaration. The rename reaches #476's column and migration, which this branch sits on.

## Out of scope

- Shared mode stays. An outside server whose key only one person holds still uses the shared row.
- Nothing can create a person's own pasted token yet, so a registry server with a static token still reads the shared row.

## Verification

- [x] `uv run ruff check backend`
- [x] `uv run ruff format --check backend`
- [x] `pytest` on MCP servers, MCP OAuth, sandbox identities, the MCP endpoint, auth tokens, identity, Software Factory, doctor, and apps: 499 passed
- [x] Migration chain on a scratch database: upgrade to head creates `allowed_tools`
- [x] `npm --prefix frontend run lint`
- [x] `npm --prefix frontend test`: 443 passed
- [x] `npm --prefix frontend run build`
- [ ] On the box: run a board build, then check that the agent's comment carries the owner's name and that a `druks MCP` token shows in their API tokens.

Stacked on #476, which it depends on: it deletes the per-call token that branch added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)